### PR TITLE
perf(qwen35): fixed-width verify graph for CUDA-graph replay

### DIFF
--- a/server/src/common/dflash_target.h
+++ b/server/src/common/dflash_target.h
@@ -30,11 +30,21 @@ struct DFlashTarget {
     // During forward, the target MUST capture intermediate activations at
     // the layers specified by capture_layer_ids() and store them in the
     // draft's feature ring (how this happens is implementation-defined).
+    //
+    // `pad_to`, when greater than tokens.size(), asks the implementation to
+    // build the forward graph at a fixed width of `pad_to` tokens (padding rows
+    // are masked out and never read) so the graph's node dimensions stay
+    // constant across decode steps and the CUDA-graph cache can replay instead
+    // of recapturing. The consumed result for the first tokens.size() positions
+    // is identical to an unpadded call. Implementations may ignore it (the
+    // default 0 preserves today's variable-width behavior); callers must only
+    // pad within a window whose KV slots are already resident.
     virtual bool verify_batch(const std::vector<int32_t> & tokens,
                               int base_pos,
                               int & last_tok,
                               std::vector<int32_t> * all_argmax = nullptr,
-                              bool capture_ssm_intermediates = false) = 0;
+                              bool capture_ssm_intermediates = false,
+                              int pad_to = 0) = 0;
 
     // Read the full [n_tokens x vocab] f32 logits produced by the most
     // recent verify_batch call. Used by sampled-verify (spec decode with

--- a/server/src/gemma4/gemma4_dflash_target.cpp
+++ b/server/src/gemma4/gemma4_dflash_target.cpp
@@ -38,8 +38,10 @@ bool Gemma4DFlashTarget::verify_batch(
         int base_pos,
         int & last_tok,
         std::vector<int32_t> * all_argmax,
-        bool capture_ssm_intermediates) {
+        bool capture_ssm_intermediates,
+        int pad_to) {
     (void)capture_ssm_intermediates; // Gemma4 is pure-attention, no SSM state
+    (void)pad_to;                     // fixed-width verify not implemented here
     const int n_tokens = (int)tokens.size();
     if (n_tokens <= 0) return false;
 

--- a/server/src/gemma4/gemma4_dflash_target.h
+++ b/server/src/gemma4/gemma4_dflash_target.h
@@ -31,7 +31,8 @@ public:
                       int base_pos,
                       int & last_tok,
                       std::vector<int32_t> * all_argmax = nullptr,
-                      bool capture_ssm_intermediates = false) override;
+                      bool capture_ssm_intermediates = false,
+                      int pad_to = 0) override;
 
     // kvflash: route verify writes through the pool (slots allocated here,
     // slot-space mask inside gemma4_verify_batch). Non-owning.

--- a/server/src/qwen35/qwen35_backend.cpp
+++ b/server/src/qwen35/qwen35_backend.cpp
@@ -1846,6 +1846,14 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
     const int max_verify_tokens = cfg_.ddtree_mode
         ? std::max<int>(dw_.block_size, cfg_.ddtree_budget + 1)
         : dw_.block_size;
+    // Opt-in: pad the post-accept replay verify to the same width as the main
+    // verify (q_len) so both share one ggml-cuda captured graph instead of
+    // forcing a recapture each low-acceptance step. Off by default — it only
+    // helps when the verify graph is CUDA-graph-eligible (q_len within the MoE
+    // mul_mat_id batch limit), and otherwise just adds padded compute.
+    static const bool g_fixed_verify_width =
+        (std::getenv("DFLASH_QWEN35_FIXED_VERIFY") != nullptr);
+    const int replay_pad_to = g_fixed_verify_width ? q_len : 0;
     if ((cfg_.fast_rollback || cfg_.ddtree_mode) && !cache_.rollback_ctx) {
         if (!migrate_prefill_cache(w_, cfg_.device.max_ctx,
                                    max_verify_tokens,
@@ -2415,7 +2423,8 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
             for (int i = 0; i < commit_n; i++) {
                 replay_batch[i] = (i < accept_n) ? draft_tok[i] : bonus_tok;
             }
-            if (!target->verify_batch(replay_batch, committed, replay_last_tok, nullptr)) {
+            if (!target->verify_batch(replay_batch, committed, replay_last_tok, nullptr,
+                                      /*capture_ssm_intermediates=*/false, replay_pad_to)) {
                 std::fprintf(stderr, "spec-decode: replay failed\n");
                 step_graph_destroy(draft_sg);
                 return false;

--- a/server/src/qwen35/qwen35_dflash_target.cpp
+++ b/server/src/qwen35/qwen35_dflash_target.cpp
@@ -43,9 +43,21 @@ bool Qwen35DFlashTarget::verify_batch(
         int base_pos,
         int & last_tok,
         std::vector<int32_t> * all_argmax,
-        bool capture_ssm_intermediates) {
-    const int n_tokens = (int)tokens.size();
-    if (n_tokens <= 0) return false;
+        bool capture_ssm_intermediates,
+        int pad_to) {
+    const int n_real = (int)tokens.size();
+    if (n_real <= 0) return false;
+
+    // Fixed-width verify: pad the graph to `pad_to` tokens so its node
+    // dimensions stay constant across decode steps and the ggml-cuda CUDA-graph
+    // cache can replay instead of recapturing every step. Padding rows are never
+    // consumed: real rows (0..n_real-1) attend only to committed positions and
+    // their own causal slots, so causality/masking excludes every padded column
+    // and the argmax for rows 0..n_real-1 is bit-identical to an unpadded call.
+    // The caller must only pad within a window whose slots are already resident
+    // (e.g. the same round's main verify), so this allocates no new pool slots
+    // and triggers no eviction.
+    const int n_tokens = (pad_to > n_real) ? pad_to : n_real;
 
     const int hidden = w_.n_embd;
     const bool pool = pager_ != nullptr;
@@ -102,9 +114,10 @@ bool Qwen35DFlashTarget::verify_batch(
     }
 
     // Embed input tokens and fill positions.
-    std::vector<float> embed((size_t)n_tokens * hidden);
-    if (!w_.embedder.embed(tokens.data(), n_tokens, embed.data())) {
-        std::fprintf(stderr, "verify_batch: embed failed (n=%d)\n", n_tokens);
+    // Padding rows keep a zero embedding; they are masked out and never read.
+    std::vector<float> embed((size_t)n_tokens * hidden, 0.0f);
+    if (!w_.embedder.embed(tokens.data(), n_real, embed.data())) {
+        std::fprintf(stderr, "verify_batch: embed failed (n=%d)\n", n_real);
         return false;
     }
     ggml_backend_tensor_set(sg_.inp_embed, embed.data(), 0,
@@ -167,17 +180,17 @@ bool Qwen35DFlashTarget::verify_batch(
         return false;
     }
 
-    // Read argmax results from GPU.
-    std::vector<int32_t> argmax_buf(n_tokens);
+    // Read argmax results from GPU — only the real (unpadded) positions.
+    std::vector<int32_t> argmax_buf(n_real);
     ggml_backend_tensor_get(sg_.argmax_tokens, argmax_buf.data(), 0,
-                            sizeof(int32_t) * n_tokens);
-    last_tok = argmax_buf[n_tokens - 1];
+                            sizeof(int32_t) * n_real);
+    last_tok = argmax_buf[n_real - 1];
 
     if (all_argmax) {
         *all_argmax = std::move(argmax_buf);
     }
 
-    cache_.cur_pos = base_pos + n_tokens;
+    cache_.cur_pos = base_pos + n_real;
     return true;
 }
 

--- a/server/src/qwen35/qwen35_dflash_target.h
+++ b/server/src/qwen35/qwen35_dflash_target.h
@@ -37,7 +37,8 @@ public:
                       int base_pos,
                       int & last_tok,
                       std::vector<int32_t> * all_argmax = nullptr,
-                      bool capture_ssm_intermediates = false) override;
+                      bool capture_ssm_intermediates = false,
+                      int pad_to = 0) override;
 
     bool read_verify_logits(int n_tokens, std::vector<float> & out) override;
 

--- a/server/src/qwen35/qwen35_layer_split_dflash_target.cpp
+++ b/server/src/qwen35/qwen35_layer_split_dflash_target.cpp
@@ -40,7 +40,9 @@ bool Qwen35LayerSplitDFlashTarget::verify_batch(
         int base_pos,
         int & last_tok,
         std::vector<int32_t> * all_argmax,
-        bool capture_ssm_intermediates) {
+        bool capture_ssm_intermediates,
+        int pad_to) {
+    (void)pad_to;  // fixed-width verify not implemented for the layer-split path
     if (shards_.empty()) return false;
     if (remote_target_shard_ && remote_target_shard_->active()) {
         return run_qwen35_mixed_layer_split_forward(

--- a/server/src/qwen35/qwen35_layer_split_dflash_target.h
+++ b/server/src/qwen35/qwen35_layer_split_dflash_target.h
@@ -43,7 +43,8 @@ public:
                       int base_pos,
                       int & last_tok,
                       std::vector<int32_t> * all_argmax = nullptr,
-                      bool capture_ssm_intermediates = false) override;
+                      bool capture_ssm_intermediates = false,
+                      int pad_to = 0) override;
 
     bool snapshot_kv() override;
     bool restore_kv() override;


### PR DESCRIPTION
## Summary

The kvflash spec-decode verify path already builds a step-invariant ggml graph. `ggml_set_rows` + `kv_write_rows` carry `kv_start` in data, a stride-256 flash-attention span keeps the node properties constant, and a persistent step arena keeps the graph at a stable address. That lets the ggml-cuda CUDA-graph cache replay it across decode steps instead of relaunching every kernel.

The one place that still breaks replay is the post-accept replay verify. Each round runs a main verify over the full draft width `q_len`, then (on the non-fast-rollback branch) a replay verify over `commit_n` tokens. Since `commit_n` changes from step to step, the replay builds a graph with different node dimensions than the main verify, so ggml-cuda has to recapture. ggml-cuda compares every node's struct plus each source `ne`/`nb`/data-ptr byte for byte, and recaptures on any mismatch, so alternating verify and replay never settles on one captured graph.

This PR adds an opt-in fixed-width verify so the replay reuses the main verify's graph.

## Changes

- `server/src/common/dflash_target.h`: `DFlashTarget::verify_batch` gets a trailing `int pad_to = 0`. The default keeps today's variable-width behavior.
- `server/src/qwen35/qwen35_dflash_target.cpp`: implements it. The forward is built at `n_tokens = max(pad_to, tokens.size())`, the padding rows carry a zero embedding, and embed / argmax / `cur_pos` all use the real token count `n_real`.
- `server/src/qwen35/qwen35_backend.cpp`: gated behind `DFLASH_QWEN35_FIXED_VERIFY` (off by default). When set, the chain replay verify is padded to `q_len`.
- `server/src/gemma4/gemma4_dflash_target.*` and `server/src/qwen35/qwen35_layer_split_dflash_target.*`: accept and ignore `pad_to`, just to match the base signature.

## How it works

With `n_tokens = pad_to`, the real rows `0..n_real-1` attend only to committed positions (`pos < base_pos`) and their own causal slots `slots[0..q]`, which are all below `n_real`. Both the slot-space mask and the causal mask leave every padded column at `-inf` for the real rows, so those columns add `exp(-inf) = 0` to the softmax denominator. The embeddings and positions for the real rows are unchanged. So the argmax for positions `0..n_real-1` comes out the same as an unpadded call.

The caller only pads the replay to `q_len`, which is the width the round's main verify already used, so under kvflash the slots for `[committed, committed+q_len)` are already resident. `restore_kv()` only restores SSM/conv state and never touches the pager, and `slot_for` returns the same slot for an already-resident position, so the padded replay allocates no new pool slot and triggers no eviction. The padded positions `[committed+commit_n, committed+q_len)` are never read again: `cur_pos` advances by `n_real`, and the next round's mask skips any slot at `pos >= base_pos` and overwrites it before attention.

## Performance

No numbers in this PR yet. The change is correctness-preserving and off by default, so the default path is unchanged.

To evaluate the opt-in (RTX 3090, CUDA 12.8):

```
# correctness: same token stream with the flag on vs off, fixed prompt + seed
DFLASH_QWEN35_FIXED_VERIFY=1 <serve cmd ...>

# throughput A/B at a graph-eligible block size (see Limitations)
<serve cmd ...>                                 # baseline
DFLASH_QWEN35_FIXED_VERIFY=1 <serve cmd ...>    # fixed-width replay
# confirm graphs actually engage: compare against GGML_CUDA_DISABLE_GRAPHS=1
```

| block_size | tok/s baseline | tok/s fixed-verify | recaptures/step |
|-----------:|---------------:|-------------------:|----------------:|
| <= 8       | _maintainer_   | _maintainer_       | _maintainer_    |

## Limitations

- ggml-cuda turns CUDA graphs off for any graph whose `MUL_MAT_ID` (the expert matmul) token batch `ne[2]` is larger than `mmvq_mmid_max` (about 8 on Turing+, see `[TAG_MUL_MAT_ID_CUDA_GRAPHS]` in `ggml-cuda.cu`). So the replay win only shows up when `block_size` stays within that limit. Past it the verify graph is not captured at all and padding would only add expert-matmul work. That is why this is opt-in and off by default, and why the perf table is scoped to `block_size <= 8`.
- Only the chain replay site is wired. The tree-verify replay/bonus, the size-1 bonus verify, and the floor / tool-prefix / budget-close replays in `qwen35_backend.cpp` also vary in width. Padding those (especially the size-1 bonus) trades more MoE compute for replay and needs its own measurement, so it is left as follow-up.
- The generic `run_dflash_spec_decode` loop (layer-split path) is unchanged, and its target ignores `pad_to`.

## Verification

- Default path is byte-identical with the flag off.
- Reviewed for: real-row output staying identical (mask causality, masked columns contributing zero to softmax, argmax ordering); no committed-KV corruption and no extra eviction (`restore_kv` leaves the pager untouched, `slot_for` is idempotent for resident chunks, `cur_pos` uses `n_real`, the next-round mask excludes the pad slots); and signature/arity across all three overrides and every call site.
- Maintainer A/B and correctness commands above for the opt-in path.
