### PR TITLE
fix(server): Preserve C++ Server Pre-Opened Thinking State

### DIFF
--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -95,6 +95,19 @@ static std::string context_overflow_message(int max_ctx, int prompt_tokens, int 
            " in the completion). Please reduce the length of the messages or completion.";
 }
 
+static bool prompt_ends_in_open_think(const std::string & prompt) {
+    static constexpr const char * kThinkOpen = "<think>";
+    static constexpr size_t kThinkOpenLen = 7;
+    size_t end = prompt.size();
+    while (end > 0) {
+        char c = prompt[end - 1];
+        if (c != ' ' && c != '\n' && c != '\r' && c != '\t') break;
+        --end;
+    }
+    return end >= kThinkOpenLen &&
+           prompt.compare(end - kThinkOpenLen, kThinkOpenLen, kThinkOpen) == 0;
+}
+
 // ─── piecewise keep-ratio curve ─────────────────────────────────────────
 
 static float pflash_keep_ratio(const ServerConfig & cfg, int n_tokens) {
@@ -1700,6 +1713,7 @@ bool HttpServer::route_request(int fd, const HttpRequest & hr) {
                                             true, enable_thinking,
                                             tools_json);
         }
+        req.started_in_thinking = prompt_ends_in_open_think(rendered);
         req.prompt_tokens = tokenizer_.encode(rendered);
 
         // count_tokens: short-circuit after tokenization. Skip generation
@@ -1734,7 +1748,7 @@ bool HttpServer::route_request(int fd, const HttpRequest & hr) {
 
     std::fprintf(stderr,
         "[server] chat %s format=%s stream=%s msgs=%zu tools=%zu prompt_tokens=%zu "
-        "max_tokens=%d max_ctx=%d thinking=%s stops=%zu model=%s\n",
+        "max_tokens=%d max_ctx=%d thinking=%s started_in_thinking=%s stops=%zu model=%s\n",
         req.response_id.c_str(),
         api_format_name(req.format),
         req.stream ? "true" : "false",
@@ -1744,6 +1758,7 @@ bool HttpServer::route_request(int fd, const HttpRequest & hr) {
         req.max_output,
         config_.max_ctx,
         req.thinking_enabled ? "true" : "false",
+        req.started_in_thinking ? "true" : "false",
         req.stop_sequences.size(),
         req.model.c_str());
 
@@ -1850,7 +1865,8 @@ void HttpServer::worker_loop() {
         SseEmitter emitter(req.format, req.response_id, req.model,
                            (int)req.prompt_tokens.size(), req.tools,
                            &tool_memory_,
-                           req.stop_sequences);
+                           req.stop_sequences,
+                           req.started_in_thinking);
 
         // Emit initial SSE events (skip when proxying).
         if (req.stream && config_.pflash_upstream_base.empty()) {

--- a/server/src/server/http_server.h
+++ b/server/src/server/http_server.h
@@ -208,6 +208,7 @@ struct ParsedRequest {
     std::string               response_id;
     // Thinking/reasoning state
     bool                      thinking_enabled = true;
+    bool                      started_in_thinking = false;
     // True when the request opted in to the thinking-budget envelope via
     // `thinking: {type: "enabled"}`. Distinct from thinking_enabled (which
     // can be set via the chat template kwarg alone). When true, the response

--- a/server/src/server/sse_emitter.cpp
+++ b/server/src/server/sse_emitter.cpp
@@ -76,15 +76,16 @@ SseEmitter::SseEmitter(ApiFormat format,
                        int prompt_tokens,
                        const json & tools,
                        ToolMemory * tool_memory,
-                       const std::vector<std::string> & stop_sequences)
+                       const std::vector<std::string> & stop_sequences,
+                       bool started_in_thinking)
     : format_(format)
     , request_id_(request_id)
     , model_name_(model_name)
     , prompt_tokens_(prompt_tokens)
     , tools_(tools)
     , tool_memory_(tool_memory)
-    , mode_(StreamMode::CONTENT)
-    , active_kind_("text")
+    , mode_(started_in_thinking ? StreamMode::REASONING : StreamMode::CONTENT)
+    , active_kind_(started_in_thinking ? "thinking" : "text")
     , stop_sequences_(stop_sequences)
     , created_at_(unix_timestamp())
     , msg_item_id_(gen_item_id())

--- a/server/src/server/sse_emitter.h
+++ b/server/src/server/sse_emitter.h
@@ -60,7 +60,8 @@ public:
                int prompt_tokens,
                const json & tools,
                ToolMemory * tool_memory,
-               const std::vector<std::string> & stop_sequences = {});
+               const std::vector<std::string> & stop_sequences = {},
+               bool started_in_thinking = false);
 
     // Emit the initial SSE events (role delta, message_start, etc.)
     // Returns the formatted SSE strings to send.

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -114,9 +114,10 @@ static json weather_tools() {
     });
 }
 
-static SseEmitter make_emitter(ApiFormat fmt, json tools = json::array()) {
+static SseEmitter make_emitter(ApiFormat fmt, json tools = json::array(),
+                               bool started_in_thinking = false) {
     return SseEmitter(fmt, "test_id_001", "test-model", 10,
-                      tools, nullptr);
+                      tools, nullptr, {}, started_in_thinking);
 }
 
 // Concatenate all SSE chunks into a single string.
@@ -208,6 +209,21 @@ static void test_reasoning_started_in_thinking() {
     TEST_ASSERT(r.has_reasoning);
     TEST_ASSERT(r.reasoning == "thinking body");
     TEST_ASSERT(r.content == "content here");
+}
+
+static void test_emitter_started_in_thinking_without_open_tag() {
+    auto em = make_emitter(ApiFormat::OPENAI_CHAT, json::array(), true);
+    auto chunks = em.emit_token("Thinking Process: calculate 9 + 6.");
+    auto close = em.emit_token("</think>");
+    auto answer = em.emit_token("15");
+    em.emit_finish(3);
+
+    std::string all = concat(chunks) + concat(close) + concat(answer);
+    TEST_ASSERT(em.reasoning_text().find("Thinking Process") != std::string::npos);
+    TEST_ASSERT(em.accumulated_text() == "15");
+    TEST_ASSERT(em.first_content_token_index() == 2);
+    TEST_ASSERT(all.find("reasoning_content") != std::string::npos);
+    TEST_ASSERT(all.find("\"content\":\"Thinking Process") == std::string::npos);
 }
 
 static void test_reasoning_unclosed_think() {
@@ -3958,6 +3974,7 @@ int main() {
     RUN_TEST(test_reasoning_basic);
     RUN_TEST(test_reasoning_no_tags);
     RUN_TEST(test_reasoning_started_in_thinking);
+    RUN_TEST(test_emitter_started_in_thinking_without_open_tag);
     RUN_TEST(test_reasoning_unclosed_think);
     RUN_TEST(test_reasoning_empty_thinking);
     RUN_TEST(test_reasoning_whitespace_in_think);


### PR DESCRIPTION
Fixes C++ server handling for Qwen3.6 thinking-enabled prompts where the chat template pre-opens the assistant response with:

```text
<think>
```

Before this change, the stream/non-stream emitter started in normal content mode and waited for the model to emit a fresh `<think>` opener. With Qwen3.6, the opener can already be part of the rendered prompt, so generated reasoning text was emitted as visible assistant content and `reasoning_content` stayed empty.

## User-Visible Bug

Clients that enable thinking could receive reasoning text in `message.content` instead of `message.reasoning_content`.

Observed before the fix:

```json
{
  "content": "Here's a thinking process: ... 2 + 3 = 5",
  "reasoning_content": null,
  "finish_details": {
    "content_tokens": 159,
    "thinking_tokens": 0
  }
}
```

This also made Open WebUI / Pi / other OpenAI-compatible clients unable to separate hidden reasoning from the final answer.

## Root Cause

The Qwen3.6 chat template intentionally renders the generation prompt differently depending on thinking mode:

```text
thinking enabled:  assistant\n<think>\n
thinking disabled: assistant\n<think>\n\n</think>\n\n
```

When thinking is enabled, the model continues from an already-open reasoning block. The C++ `SseEmitter` did not know that state and initialized as `CONTENT`, so text before the closing `</think>` was treated as visible content.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

