### PR TITLE
fix(docker): Expose C++ Server Default Max Tokens In Docker Entrypoint

### DIFF
--- a/server/scripts/entrypoint.sh
+++ b/server/scripts/entrypoint.sh
@@ -290,6 +290,9 @@ fi
 : "${DFLASH_PREFILL_KEEP:=0.05}"
 : "${DFLASH_PREFILL_THRESHOLD:=32000}"
 : "${DFLASH_PREFILL_DRAFTER:=}"
+# Optional server default for requests that omit max_tokens. When unset,
+# the C++ server uses the model-card default.
+: "${DFLASH_DEFAULT_MAX_TOKENS:=}"
 # Phase-1 (thinking) cap when a request opts into thinking. Default mirrors
 # antirez/ds4 ds4_eval.c: think_max_tokens = max_tokens(16000) - hard_limit
 # reply budget(512) = 15488. The server's own hardcoded default is 10000;
@@ -491,6 +494,7 @@ CMD=("$DFLASH_SERVER_BIN" "$DFLASH_TARGET"
 
 [ -n "$DRAFT_ARG" ]                && CMD+=(--draft "$DRAFT_ARG")
 [ -n "$DRAFT_ARG" ]                && CMD+=(--ddtree --ddtree-budget "$DFLASH_BUDGET")
+[ -n "$DFLASH_DEFAULT_MAX_TOKENS" ] && CMD+=(--default-max-tokens "$DFLASH_DEFAULT_MAX_TOKENS")
 # `--lazy-draft` is silently dropped by the C++ server unless both
 # `--prefill-drafter` and `--draft` are present (look for the runtime
 # warning `--lazy-draft ignored: requires both --prefill-drafter and


### PR DESCRIPTION
The C++ server already supports:

```text
--default-max-tokens <N>
```

This controls the completion budget used when a client omits `max_tokens`.

The Docker entrypoint did not expose that existing server flag through an environment variable. This PR adds an optional environment variable:

```text
DFLASH_DEFAULT_MAX_TOKENS
```

When set, the entrypoint passes:

```text
--default-max-tokens "$DFLASH_DEFAULT_MAX_TOKENS"
```

When unset, behavior is unchanged.

## Why

Some model cards set a large default completion budget, for example `32768`. That is useful as a capability limit, but it is often too large as an implicit default for agent clients near the context limit.

Observed with Pi against a 98k context server:

```text
Error: 400 This model's maximum context length is 98304 tokens. However, you requested 98377 tokens (65609 in the messages, 32768 in the completion). Please reduce the length of the messages or completion.
```

The client did not explicitly need a 32k answer in that request. It just omitted `max_tokens`, and the server reserved the model-card default.

This env var lets Docker deployments choose a more practical omitted-request default, such as 8192, without replacing the entrypoint or overriding the whole command.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

