### PR TITLE
Add speed profiler

### DIFF
--- a/.github/workflows/speed-profile.yml
+++ b/.github/workflows/speed-profile.yml
@@ -55,6 +55,16 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release
           cmake --build build --target test_dflash test_generate -j"$(nproc)"
 
+      - name: Install profiler Python deps (isolated venv)
+        run: |
+          cd server
+          # The profiler only needs a tokenizer, so we use a tiny isolated venv
+          # rather than installing into the shared runner's Python or pulling the
+          # full project env (torch, datasets, ...). Matches the deps validated locally.
+          python3 -m venv .profiler-venv
+          .profiler-venv/bin/pip install --quiet --upgrade pip
+          .profiler-venv/bin/pip install --quiet transformers tokenizers sentencepiece tiktoken protobuf
+
       - name: Run speed profiler
         env:
           MODELS: ${{ vars.LUCEBOX_MODELS_DIR || '/opt/models' }}
@@ -62,7 +72,7 @@ jobs:
           cd server
           # Keep n_gen small: the 3090 is serialized across PRs. The nsys pass adds a
           # separate short profiled run; tok/s is measured on clean passes.
-          python3 scripts/profile.py \
+          .profiler-venv/bin/python scripts/profile.py \
             --target "$MODELS/Qwen3.5-27B-Q4_K_M.gguf" \
             --draft  "$MODELS/draft/qwen35_dflash/model.safetensors" \
             --tokenizer "Qwen/Qwen3.5-27B" \

--- a/.github/workflows/speed-profile.yml
+++ b/.github/workflows/speed-profile.yml
@@ -32,11 +32,16 @@ jobs:
     timeout-minutes: 30
     continue-on-error: true   # report-only: a slow/failed profile must not block the PR
 
+    # Model paths live on the runner, not in the repo (multi-GB weights). They are
+    # overridable via repo variables so the runner owner can point at whatever is
+    # staged without editing this workflow. Prefer the repo-documented Qwen3.6 GGUF
+    # draft path; keep the older LUCEBOX_SPEED_PROFILE_* variable names as aliases
+    # so existing repo settings continue to work.
     env:
-      MODELS_DIR: ${{ vars.LUCEBOX_MODELS_DIR || '/opt/models' }}
-      TARGET_MODEL: ${{ vars.LUCEBOX_SPEED_PROFILE_TARGET || 'Qwen3.6-27B-Q4_K_M.gguf' }}
-      DRAFT_MODEL: ${{ vars.LUCEBOX_SPEED_PROFILE_DRAFT || 'draft/qwen35_dflash/model.safetensors' }}
-      TOKENIZER_ID: ${{ vars.LUCEBOX_SPEED_PROFILE_TOKENIZER || 'Qwen/Qwen3.6-27B' }}
+      MODELS: ${{ vars.LUCEBOX_MODELS_DIR || '/opt/models' }}
+      TARGET_MODEL: ${{ vars.LUCEBOX_TARGET_MODEL || vars.LUCEBOX_SPEED_PROFILE_TARGET || 'Qwen3.6-27B-Q4_K_M.gguf' }}
+      DRAFT_MODEL: ${{ vars.LUCEBOX_DRAFT_MODEL || vars.LUCEBOX_SPEED_PROFILE_DRAFT || 'draft/dflash-draft-3.6-q4_k_m.gguf' }}
+      TOKENIZER: ${{ vars.LUCEBOX_TOKENIZER || vars.LUCEBOX_SPEED_PROFILE_TOKENIZER || 'Qwen/Qwen3.6-27B' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -51,7 +56,46 @@ jobs:
           # runner user can't run nvidia-smi -lgc; the profiler still records the power cap.
           sudo nvidia-smi -lgc 1395 2>/dev/null || echo "clock lock not permitted; continuing"
 
+      - name: Check model weights are staged on the runner
+        id: models
+        run: |
+          # The weights are staged on the self-hosted runner out of band. If they are
+          # absent the engine binary aborts with a cryptic gguf "No such file" error, so
+          # check up front and SKIP cleanly instead — this job is report-only, and a
+          # missing model on the runner is an environment issue, not a PR defect.
+          target="$MODELS/$TARGET_MODEL"
+          draft="$MODELS/$DRAFT_MODEL"
+          present=true
+          missing_list=""
+          for f in "$target" "$draft"; do
+            if [ ! -f "$f" ]; then
+              present=false
+              missing_list="${missing_list}  - \`$f\`"$'\n'
+            fi
+          done
+          echo "present=$present" >> "$GITHUB_OUTPUT"
+          if [ "$present" = "false" ]; then
+            {
+              echo "## 🏎️ Speed profile — skipped (model weights not on runner)"
+              echo ""
+              echo "The profiler needs the target + draft weights staged on the self-hosted"
+              echo "runner, but these file(s) were not found:"
+              echo ""
+              printf '%s' "$missing_list"
+              echo ""
+              echo "Stage the weights at those paths, or set the repo variables"
+              echo "\`LUCEBOX_MODELS_DIR\` / \`LUCEBOX_TARGET_MODEL\` / \`LUCEBOX_DRAFT_MODEL\`"
+              echo "to point at where they live. Legacy \`LUCEBOX_SPEED_PROFILE_*\` variables also work."
+              echo "This job is report-only, so the PR is not blocked."
+              echo ""
+              echo "Available draft candidates under \`$MODELS\`:"
+              find "$MODELS" -maxdepth 4 -type f \( -name '*.gguf' -o -name '*.safetensors' \) -print 2>/dev/null | sort | sed 's/^/  - /' || true
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning title=Speed profile skipped::Model weights not found under $MODELS — see the run summary."
+          fi
+
       - name: Build engine binaries (sm_86, Release)
+        if: steps.models.outputs.present == 'true'
         run: |
           cd server
           cmake -B build \
@@ -61,7 +105,8 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release
           cmake --build build --target test_dflash test_generate -j"$(nproc)"
 
-      - name: Install profiler Python deps (isolated venv)
+      - name: Install profiler Python deps (isolated, pinned venv)
+        if: steps.models.outputs.present == 'true'
         run: |
           cd server
           # The profiler only needs a tokenizer, so we use a tiny isolated venv
@@ -70,49 +115,29 @@ jobs:
           # benchmark setup is reproducible and resilient to upstream releases.
           python3 -m venv .profiler-venv
           .profiler-venv/bin/pip install --quiet --upgrade pip==25.1.1
-          .profiler-venv/bin/pip install --quiet \
+          .profiler-venv/bin/pip install --quiet --require-virtualenv \
             transformers==4.52.4 \
             tokenizers==0.21.1 \
             sentencepiece==0.2.0 \
             tiktoken==0.9.0 \
             protobuf==6.31.1
 
-      - name: Validate profiler model inputs
-        run: |
-          target="$MODELS_DIR/$TARGET_MODEL"
-          draft="$MODELS_DIR/$DRAFT_MODEL"
-
-          if [ ! -f "$target" ]; then
-            echo "Missing speed-profile target model: $target" >&2
-            echo "Set LUCEBOX_SPEED_PROFILE_TARGET to a GGUF under $MODELS_DIR, or restore the expected model." >&2
-            echo "Available GGUF files in $MODELS_DIR:" >&2
-            find "$MODELS_DIR" -maxdepth 3 -type f -name '*.gguf' -print 2>/dev/null | sort >&2 || true
-            exit 1
-          fi
-
-          if [ ! -f "$draft" ]; then
-            echo "Missing speed-profile draft model: $draft" >&2
-            echo "Set LUCEBOX_SPEED_PROFILE_DRAFT to a safetensors file under $MODELS_DIR, or restore the expected model." >&2
-            echo "Available safetensors files in $MODELS_DIR:" >&2
-            find "$MODELS_DIR" -maxdepth 4 -type f -name '*.safetensors' -print 2>/dev/null | sort >&2 || true
-            exit 1
-          fi
-
       - name: Run speed profiler
+        if: steps.models.outputs.present == 'true'
         run: |
           cd server
           # Keep n_gen small: the 3090 is serialized across PRs. The nsys pass adds a
           # separate short profiled run; tok/s is measured on clean passes.
           .profiler-venv/bin/python scripts/profile.py \
-            --target "$MODELS_DIR/$TARGET_MODEL" \
-            --draft  "$MODELS_DIR/$DRAFT_MODEL" \
-            --tokenizer "$TOKENIZER_ID" \
+            --target "$MODELS/$TARGET_MODEL" \
+            --draft  "$MODELS/$DRAFT_MODEL" \
+            --tokenizer "$TOKENIZER" \
             --n-gen 48 --budget 22 --reps 3 \
             --nsys --check-lossless \
             --out-json profile.json --out-md profile.md
 
       - name: Publish report to the run summary
-        if: always()
+        if: always() && steps.models.outputs.present == 'true'
         run: |
           if [ -f server/profile.md ]; then
             { echo "## 🏎️ Speed profile"; echo ""; cat server/profile.md; } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/speed-profile.yml
+++ b/.github/workflows/speed-profile.yml
@@ -32,6 +32,12 @@ jobs:
     timeout-minutes: 30
     continue-on-error: true   # report-only: a slow/failed profile must not block the PR
 
+    env:
+      MODELS_DIR: ${{ vars.LUCEBOX_MODELS_DIR || '/opt/models' }}
+      TARGET_MODEL: ${{ vars.LUCEBOX_SPEED_PROFILE_TARGET || 'Qwen3.6-27B-Q4_K_M.gguf' }}
+      DRAFT_MODEL: ${{ vars.LUCEBOX_SPEED_PROFILE_DRAFT || 'draft/qwen35_dflash/model.safetensors' }}
+      TOKENIZER_ID: ${{ vars.LUCEBOX_SPEED_PROFILE_TOKENIZER || 'Qwen/Qwen3.6-27B' }}
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -60,22 +66,47 @@ jobs:
           cd server
           # The profiler only needs a tokenizer, so we use a tiny isolated venv
           # rather than installing into the shared runner's Python or pulling the
-          # full project env (torch, datasets, ...). Matches the deps validated locally.
+          # full project env (torch, datasets, ...). Keep versions pinned so
+          # benchmark setup is reproducible and resilient to upstream releases.
           python3 -m venv .profiler-venv
-          .profiler-venv/bin/pip install --quiet --upgrade pip
-          .profiler-venv/bin/pip install --quiet transformers tokenizers sentencepiece tiktoken protobuf
+          .profiler-venv/bin/pip install --quiet --upgrade pip==25.1.1
+          .profiler-venv/bin/pip install --quiet \
+            transformers==4.52.4 \
+            tokenizers==0.21.1 \
+            sentencepiece==0.2.0 \
+            tiktoken==0.9.0 \
+            protobuf==6.31.1
+
+      - name: Validate profiler model inputs
+        run: |
+          target="$MODELS_DIR/$TARGET_MODEL"
+          draft="$MODELS_DIR/$DRAFT_MODEL"
+
+          if [ ! -f "$target" ]; then
+            echo "Missing speed-profile target model: $target" >&2
+            echo "Set LUCEBOX_SPEED_PROFILE_TARGET to a GGUF under $MODELS_DIR, or restore the expected model." >&2
+            echo "Available GGUF files in $MODELS_DIR:" >&2
+            find "$MODELS_DIR" -maxdepth 3 -type f -name '*.gguf' -print 2>/dev/null | sort >&2 || true
+            exit 1
+          fi
+
+          if [ ! -f "$draft" ]; then
+            echo "Missing speed-profile draft model: $draft" >&2
+            echo "Set LUCEBOX_SPEED_PROFILE_DRAFT to a safetensors file under $MODELS_DIR, or restore the expected model." >&2
+            echo "Available safetensors files in $MODELS_DIR:" >&2
+            find "$MODELS_DIR" -maxdepth 4 -type f -name '*.safetensors' -print 2>/dev/null | sort >&2 || true
+            exit 1
+          fi
 
       - name: Run speed profiler
-        env:
-          MODELS: ${{ vars.LUCEBOX_MODELS_DIR || '/opt/models' }}
         run: |
           cd server
           # Keep n_gen small: the 3090 is serialized across PRs. The nsys pass adds a
           # separate short profiled run; tok/s is measured on clean passes.
           .profiler-venv/bin/python scripts/profile.py \
-            --target "$MODELS/Qwen3.5-27B-Q4_K_M.gguf" \
-            --draft  "$MODELS/draft/qwen35_dflash/model.safetensors" \
-            --tokenizer "Qwen/Qwen3.5-27B" \
+            --target "$MODELS_DIR/$TARGET_MODEL" \
+            --draft  "$MODELS_DIR/$DRAFT_MODEL" \
+            --tokenizer "$TOKENIZER_ID" \
             --n-gen 48 --budget 22 --reps 3 \
             --nsys --check-lossless \
             --out-json profile.json --out-md profile.md

--- a/.github/workflows/speed-profile.yml
+++ b/.github/workflows/speed-profile.yml
@@ -138,19 +138,27 @@ jobs:
           else
             echo "No baseline at $baseline — regression flagging disabled this run."
           fi
-          # Keep n_gen small: the 3090 is serialized across PRs. The nsys pass adds a
-          # separate short profiled run; tok/s is measured on clean passes.
+          # Use 128 generated tokens per prompt by default: long enough to reduce
+          # startup/noise effects while keeping the serialized 3090 queue bounded.
+          # The nsys pass adds a separate short profiled run; tok/s is measured on clean passes. Run 5
+          # timing reps by default so the report can distinguish real deltas from
+          # thermal/clock jitter; repo variables can trim this for temporary smoke runs.
           .profiler-venv/bin/python scripts/profile.py \
             --target "$MODELS/$TARGET_MODEL" \
             --draft  "$MODELS/$DRAFT_MODEL" \
             --tokenizer "$TOKENIZER" \
-            --n-gen 48 --budget 22 --reps 3 \
+            --n-gen "${LUCEBOX_SPEED_N_GEN:-128}" --budget 22 \
+            --reps "${LUCEBOX_SPEED_REPS:-5}" \
+            --noise-rsd-pct "${LUCEBOX_SPEED_NOISE_RSD_PCT:-0.05}" \
             --nsys --check-lossless \
             "${baseline_arg[@]}" \
             --out-json profile.json --out-md profile.md
         env:
           LUCEBOX_SPEED_BASELINE: ${{ vars.LUCEBOX_SPEED_BASELINE || '' }}
           LUCEBOX_SPEED_REGRESS_PCT: ${{ vars.LUCEBOX_SPEED_REGRESS_PCT || '' }}
+          LUCEBOX_SPEED_N_GEN: ${{ vars.LUCEBOX_SPEED_N_GEN || '' }}
+          LUCEBOX_SPEED_REPS: ${{ vars.LUCEBOX_SPEED_REPS || '' }}
+          LUCEBOX_SPEED_NOISE_RSD_PCT: ${{ vars.LUCEBOX_SPEED_NOISE_RSD_PCT || '' }}
 
       - name: Publish report to the run summary
         if: always() && steps.models.outputs.present == 'true'
@@ -172,7 +180,7 @@ jobs:
           python3 - <<'PY'
           import json
           d = json.load(open("server/profile.json"))
-          ll, reg = d.get("lossless", {}), d.get("regression", {})
+          ll, reg, noise = d.get("lossless", {}), d.get("regression", {}), d.get("summary", {}).get("noise", {})
           if ll and not ll.get("lossless", True):
               print(f"::warning title=Losslessness::spec-decode output differs from greedy AR on "
                     f"{','.join(ll.get('prompts_failed', []))} (first token #{ll.get('first_divergence')}); "
@@ -180,6 +188,10 @@ jobs:
           if reg.get("regressed"):
               print(f"::warning title=Speed regression::{','.join(reg.get('metrics', []))} moved past "
                     f"±{reg.get('threshold_pct',0)*100:.0f}% vs baseline {reg.get('baseline_commit','?')}.")
+          if noise.get("noisy"):
+              print(f"::warning title=Noisy speed profile::{','.join(noise.get('metrics', []))} exceeded "
+                    f"the relative stddev threshold ({noise.get('threshold_rsd', 0)*100:.1f}%). "
+                    "Treat small deltas as below the profiler detection threshold.")
           PY
 
       - name: Reset GPU clocks

--- a/.github/workflows/speed-profile.yml
+++ b/.github/workflows/speed-profile.yml
@@ -126,6 +126,18 @@ jobs:
         if: steps.models.outputs.present == 'true'
         run: |
           cd server
+          # Use a committed baseline if one is staged so the report can flag a
+          # regression. Seed it once from a green `main` run's profile.json artifact
+          # (see docs/specs/speed-profile.md); without it the delta is simply skipped.
+          # The path is overridable so the runner owner can point elsewhere.
+          baseline="${LUCEBOX_SPEED_BASELINE:-scripts/speed-baseline.json}"
+          baseline_arg=""
+          if [ -f "$baseline" ]; then
+            baseline_arg="--baseline $baseline --regress-pct ${LUCEBOX_SPEED_REGRESS_PCT:-0.10}"
+            echo "Regression check against baseline: $baseline"
+          else
+            echo "No baseline at $baseline — regression flagging disabled this run."
+          fi
           # Keep n_gen small: the 3090 is serialized across PRs. The nsys pass adds a
           # separate short profiled run; tok/s is measured on clean passes.
           .profiler-venv/bin/python scripts/profile.py \
@@ -134,7 +146,11 @@ jobs:
             --tokenizer "$TOKENIZER" \
             --n-gen 48 --budget 22 --reps 3 \
             --nsys --check-lossless \
+            $baseline_arg \
             --out-json profile.json --out-md profile.md
+        env:
+          LUCEBOX_SPEED_BASELINE: ${{ vars.LUCEBOX_SPEED_BASELINE || '' }}
+          LUCEBOX_SPEED_REGRESS_PCT: ${{ vars.LUCEBOX_SPEED_REGRESS_PCT || '' }}
 
       - name: Publish report to the run summary
         if: always() && steps.models.outputs.present == 'true'
@@ -144,6 +160,27 @@ jobs:
           else
             echo "Profiler produced no report (the run failed earlier — see logs)." >> "$GITHUB_STEP_SUMMARY"
           fi
+
+      - name: Flag losslessness / regressions (annotations, non-blocking)
+        if: always() && steps.models.outputs.present == 'true'
+        run: |
+          [ -f server/profile.json ] || exit 0
+          # Report-only: emit warnings, never fail. A losslessness FAIL means the fast
+          # path changed the output and it is NOT run-to-run noise (AR agreed with
+          # itself) — worth triaging (real bug vs batched-verify FP). Inconclusive
+          # prompts (engine intrinsically nondeterministic) are NOT failures.
+          python3 - <<'PY'
+          import json
+          d = json.load(open("server/profile.json"))
+          ll, reg = d.get("lossless", {}), d.get("regression", {})
+          if ll and not ll.get("lossless", True):
+              print(f"::warning title=Losslessness::spec-decode output differs from greedy AR on "
+                    f"{','.join(ll.get('prompts_failed', []))} (first token #{ll.get('first_divergence')}); "
+                    f"not run-to-run noise — triage bug vs batched-verify FP.")
+          if reg.get("regressed"):
+              print(f"::warning title=Speed regression::{','.join(reg.get('metrics', []))} moved past "
+                    f"±{reg.get('threshold_pct',0)*100:.0f}% vs baseline {reg.get('baseline_commit','?')}.")
+          PY
 
       - name: Reset GPU clocks
         if: always()

--- a/.github/workflows/speed-profile.yml
+++ b/.github/workflows/speed-profile.yml
@@ -131,9 +131,9 @@ jobs:
           # (see docs/specs/speed-profile.md); without it the delta is simply skipped.
           # The path is overridable so the runner owner can point elsewhere.
           baseline="${LUCEBOX_SPEED_BASELINE:-scripts/speed-baseline.json}"
-          baseline_arg=""
+          baseline_arg=()
           if [ -f "$baseline" ]; then
-            baseline_arg="--baseline $baseline --regress-pct ${LUCEBOX_SPEED_REGRESS_PCT:-0.10}"
+            baseline_arg=(--baseline "$baseline" --regress-pct "${LUCEBOX_SPEED_REGRESS_PCT:-0.10}")
             echo "Regression check against baseline: $baseline"
           else
             echo "No baseline at $baseline — regression flagging disabled this run."
@@ -146,7 +146,7 @@ jobs:
             --tokenizer "$TOKENIZER" \
             --n-gen 48 --budget 22 --reps 3 \
             --nsys --check-lossless \
-            $baseline_arg \
+            "${baseline_arg[@]}" \
             --out-json profile.json --out-md profile.md
         env:
           LUCEBOX_SPEED_BASELINE: ${{ vars.LUCEBOX_SPEED_BASELINE || '' }}

--- a/.github/workflows/speed-profile.yml
+++ b/.github/workflows/speed-profile.yml
@@ -73,11 +73,15 @@ jobs:
       - name: Publish report to the run summary
         if: always()
         run: |
-          {
-            echo "## 🏎️ Speed profile"
-            echo ""
-            cat server/profile.md
-          } >> "$GITHUB_STEP_SUMMARY"
+          if [ -f server/profile.md ]; then
+            { echo "## 🏎️ Speed profile"; echo ""; cat server/profile.md; } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Profiler produced no report (the run failed earlier — see logs)." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Reset GPU clocks
+        if: always()
+        run: sudo nvidia-smi -rgc 2>/dev/null || true
 
       - name: Upload artifacts (json + markdown + nsys trace)
         if: always()
@@ -87,6 +91,6 @@ jobs:
           path: |
             server/profile.json
             server/profile.md
-            /tmp/lucebox_profile/profile.nsys-rep
+            server/profile.nsys-rep
           if-no-files-found: warn
           retention-days: 30

--- a/.github/workflows/speed-profile.yml
+++ b/.github/workflows/speed-profile.yml
@@ -1,0 +1,92 @@
+name: Speed Profile
+
+# Report-only speed profile for the inference engine. Runs on the self-hosted
+# RTX 3090 (lucebox3) on PRs that touch the engine or the optimizations, and on
+# manual dispatch. It NEVER blocks a PR (continue-on-error: true) — it publishes a
+# report to the run summary + uploads the JSON / markdown / nsys trace as artifacts.
+#
+# Why report-only: perf has run-to-run variance (thermals, clocks, scheduling).
+# Gating a merge on a noisy absolute number produces false failures. We surface the
+# trend first; a soft threshold can come later once a baseline + variance band exist.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'server/**'
+      - 'optimizations/**'
+      - '.github/workflows/speed-profile.yml'
+  workflow_dispatch:
+
+# Share the single physical 3090 with the existing gpu-tests job so two runs never
+# fight over the GPU. cancel-in-progress=false: let a queued profile finish rather
+# than killing it mid-measurement.
+concurrency:
+  group: lucebox3-gpu-runner
+  cancel-in-progress: false
+
+jobs:
+  speed-profile:
+    name: Speed profile (self-hosted RTX 3090, sm_86)
+    runs-on: [self-hosted, gpu, sm86]
+    timeout-minutes: 30
+    continue-on-error: true   # report-only: a slow/failed profile must not block the PR
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          token: ${{ secrets.SUBMODULE_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: GPU info (and pin clocks to cut variance, if permitted)
+        run: |
+          nvidia-smi --query-gpu=name,driver_version,memory.total,power.limit --format=csv
+          # Locking clocks makes the numbers comparable run-to-run. Safe to skip if the
+          # runner user can't run nvidia-smi -lgc; the profiler still records the power cap.
+          sudo nvidia-smi -lgc 1395 2>/dev/null || echo "clock lock not permitted; continuing"
+
+      - name: Build engine binaries (sm_86, Release)
+        run: |
+          cd server
+          cmake -B build \
+            -DCMAKE_CUDA_ARCHITECTURES="86" \
+            -DDFLASH27B_ENABLE_BSA=OFF \
+            -DDFLASH27B_FA_ALL_QUANTS=OFF \
+            -DCMAKE_BUILD_TYPE=Release
+          cmake --build build --target test_dflash test_generate -j"$(nproc)"
+
+      - name: Run speed profiler
+        env:
+          MODELS: ${{ vars.LUCEBOX_MODELS_DIR || '/opt/models' }}
+        run: |
+          cd server
+          # Keep n_gen small: the 3090 is serialized across PRs. The nsys pass adds a
+          # separate short profiled run; tok/s is measured on clean passes.
+          python3 scripts/profile.py \
+            --target "$MODELS/Qwen3.5-27B-Q4_K_M.gguf" \
+            --draft  "$MODELS/draft/qwen35_dflash/model.safetensors" \
+            --tokenizer "Qwen/Qwen3.5-27B" \
+            --n-gen 48 --budget 22 --reps 3 \
+            --nsys --check-lossless \
+            --out-json profile.json --out-md profile.md
+
+      - name: Publish report to the run summary
+        if: always()
+        run: |
+          {
+            echo "## 🏎️ Speed profile"
+            echo ""
+            cat server/profile.md
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload artifacts (json + markdown + nsys trace)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: speed-profile-${{ github.run_id }}
+          path: |
+            server/profile.json
+            server/profile.md
+            /tmp/lucebox_profile/profile.nsys-rep
+          if-no-files-found: warn
+          retention-days: 30

--- a/docs/specs/speed-profile.md
+++ b/docs/specs/speed-profile.md
@@ -14,7 +14,9 @@ Three layers, coarse to fine:
 
 1. **Headline latency/throughput** — prefill time, model-side TTFT estimate, decode
    tok/s, ms/token, plus the speculative-decoding **acceptance length (AL)** and
-   accept %. (`AL` is how many tokens the target commits per draft+verify step; decode
+   accept %. Repeated timing passes report **mean ± stddev**, not a single-point
+   estimate, so reviewers can tell whether a small delta is real or just jitter.
+   (`AL` is how many tokens the target commits per draft+verify step; decode
    throughput ≈ `AL / step_time`.)
 2. **Per-step phase breakdown** — `draft_compute`, `draft_logits`, `verify_compute`,
    … from the engine's own timers. Tells you *which phase* dominates a step.
@@ -31,15 +33,26 @@ and they stay fixed so every run is comparable over time:
   per target pass. 22 is the `dflash_server` default. Bigger = a bigger bet (higher
   potential acceptance length) but more draft+verify cost; tuning it is a separate sweep,
   not the CI job.
-- **`--n-gen 48`** — tokens generated per prompt. Long enough to be past warmup, short
-  enough to keep the shared 3090 fast. (Very short n_gen under-counts spec-decode because
-  fixed startup costs aren't amortized.)
-- **`--reps 3`** — repeats the decode and takes the **median** tok/s to absorb run-to-run
-  GPU variance (thermals, clock boosting, scheduler jitter).
+- **`--n-gen 128`** — requested generated tokens per prompt. This is long enough
+  to amortize startup costs and reduce very-short-generation bias, while still
+  keeping the shared 3090 CI queue bounded. The argument is passed as `<n_gen>`
+  to both `test_dflash` and `test_generate`, where it controls the response length
+  generated for each benchmark prompt.
+- **`--reps 5`** — repeats each prompt enough times to expose run-to-run GPU
+  variance (thermals, clock boosting, scheduler jitter), then reports mean and
+  stddev for the headline metrics. Use `--reps 3` for a faster smoke profile when
+  needed, but PR comparisons should prefer 5+.
+- **`--noise-rsd-pct 0.05`** — report-only noise threshold. If any tracked
+  headline metric has relative stddev above 5%, the markdown calls the profile
+  **NOISY** and tells reviewers to treat small deltas as below the profiler
+  detection threshold.
 
 **Rule:** keep these consistent. A delta vs the baseline is only a valid regression
 signal if both runs used the same config — if you ever change a parameter, re-seed the
-baseline (you cannot compare across configs).
+baseline (you cannot compare across configs). When baseline and current 1σ intervals
+overlap and the delta is smaller than `--regress-pct`, the report marks that row as
+**noisy / overlap** instead of inviting reviewers to chase a ghost regression. All of
+these states are warnings only; the profiler remains report-only.
 
 ## Losslessness gate (and why a bit-exact compare is too strict on its own)
 
@@ -74,6 +87,14 @@ one-at-a-time). Classifying a FAIL as bug-vs-FP needs the **logit gap** at the f
 mismatch (near-tie = FP, clear gap = bug) — a follow-up the binaries don't emit yet. CI
 surfaces a FAIL as a non-blocking `::warning::` for triage; it stays report-only.
 
+## CI settings
+
+The `Speed Profile` workflow uses the same profiler defaults as the local recipe:
+`--n-gen 128`, `--reps 5`, and `--noise-rsd-pct 0.05`. Runner owners can
+temporarily override those values with repo variables `LUCEBOX_SPEED_N_GEN`,
+`LUCEBOX_SPEED_REPS`, and `LUCEBOX_SPEED_NOISE_RSD_PCT`, but PR-to-PR comparisons
+should keep them fixed.
+
 ## Run it locally
 
 ```bash
@@ -82,7 +103,7 @@ python3 scripts/profile.py \
   --target /opt/models/Qwen3.6-27B-Q4_K_M.gguf \
   --draft  /opt/models/draft/dflash-draft-3.6-q4_k_m.gguf \
   --tokenizer Qwen/Qwen3.6-27B \
-  --n-gen 48 --budget 22 --reps 3 \
+  --n-gen 128 --budget 22 --reps 5 --noise-rsd-pct 0.05 \
   --nsys --check-lossless \
   --baseline scripts/speed-baseline.json --regress-pct 0.10 \
   --out-json profile.json --out-md profile.md

--- a/docs/specs/speed-profile.md
+++ b/docs/specs/speed-profile.md
@@ -22,43 +22,67 @@ Three layers, coarse to fine:
    token** (kernel-fusion signal), **host↔device copy time per token** (CPU/GPU-overlap
    signal), and sync-heavy CUDA APIs (CPU-stall signal). Tells you *why* a phase is slow.
 
-It also includes an optional **losslessness gate**: greedy speculative decode must
-produce the exact same token stream as greedy autoregressive decode. A mismatch means
-the "fast" path is changing the model's output, which a lossless-spec-decode claim
-should never do.
+## Parameters (and why they are fixed defaults)
+
+The defaults mirror the **shipping config** so the numbers are production-representative,
+and they stay fixed so every run is comparable over time:
+
+- **`--budget 22`** — DDTree speculation budget = how many draft positions are verified
+  per target pass. 22 is the `dflash_server` default. Bigger = a bigger bet (higher
+  potential acceptance length) but more draft+verify cost; tuning it is a separate sweep,
+  not the CI job.
+- **`--n-gen 48`** — tokens generated per prompt. Long enough to be past warmup, short
+  enough to keep the shared 3090 fast. (Very short n_gen under-counts spec-decode because
+  fixed startup costs aren't amortized.)
+- **`--reps 3`** — repeats the decode and takes the **median** tok/s to absorb run-to-run
+  GPU variance (thermals, clock boosting, scheduler jitter).
+
+**Rule:** keep these consistent. A delta vs the baseline is only a valid regression
+signal if both runs used the same config — if you ever change a parameter, re-seed the
+baseline (you cannot compare across configs).
+
+## Losslessness gate (and why a bit-exact compare is too strict on its own)
+
+The gate checks that greedy speculative decode produces the same token stream as
+greedy autoregressive (AR) decode — a lossless-spec-decode claim should never change
+the model's output.
+
+A naive bit-exact compare **flags false failures**, and the engine itself explains
+why: the target sees draft tokens as a *batch* in the verify step but one-at-a-time in
+AR decode, and different GEMM shapes reduce in a different order. IEEE FP is
+non-associative, so when the top-2 logits sit within epsilon the argmax tie can flip —
+one token diverges and everything after it follows. See
+`server/src/qwen35/qwen35_backend.cpp` ("different GPU batch sizes → FP-nondeterministic
+state divergence → different greedy output") and `server/eval/README.md`, which runs an
+identical `baseline_2` config precisely because "cache-induced divergence and intrinsic
+noise are indistinguishable."
+
+So the gate runs a **determinism control**: a second, identical-config AR pass (reusing
+the AR baseline run — no extra GPU cost). For each prompt:
+
+| AR vs AR (control) | DFlash vs AR | verdict |
+|---|---|---|
+| identical | identical | **PASS** |
+| identical | diverges | **FAIL** — output changed and it is not run-to-run noise (triage needed) |
+| diverges | (either) | **inconclusive** — engine is intrinsically nondeterministic here, can't judge |
+
+The gate fails **only** on the middle row, which answers "real bug or too-strict check?":
+it no longer flags run-to-run noise (that becomes *inconclusive*). A FAIL means the fast
+path genuinely changed the output — but that is still not proven a logic bug: it can be
+the batched-verify FP effect above (verify scores draft tokens as a batch vs AR
+one-at-a-time). Classifying a FAIL as bug-vs-FP needs the **logit gap** at the first
+mismatch (near-tie = FP, clear gap = bug) — a follow-up the binaries don't emit yet. CI
+surfaces a FAIL as a non-blocking `::warning::` for triage; it stays report-only.
 
 ## Run it locally
 
 ```bash
 cd server
 python3 scripts/profile.py \
-  --target /opt/models/Qwen3.5-27B-Q4_K_M.gguf \
-  --draft  /opt/models/draft/qwen35_dflash/model.safetensors \
+  --target /opt/models/Qwen3.6-27B-Q4_K_M.gguf \
+  --draft  /opt/models/draft/dflash-draft-3.6-q4_k_m.gguf \
+  --tokenizer Qwen/Qwen3.6-27B \
   --n-gen 48 --budget 22 --reps 3 \
   --nsys --check-lossless \
+  --baseline scripts/speed-baseline.json --regress-pct 0.10 \
   --out-json profile.json --out-md profile.md
-```
-
-Requirements: `transformers` (tokenizer), built `test_dflash` + `test_generate`,
-and `nsys` on PATH for the kernel layer (the profiler degrades gracefully without it).
-
-Regression view: pass `--baseline path/to/previous/profile.json` to print the delta
-vs a stored run (e.g. the latest `main`).
-
-## CI
-
-`.github/workflows/speed-profile.yml` runs on the self-hosted RTX 3090 for PRs that
-touch `server/**` or `optimizations/**`. It is **report-only** (`continue-on-error`)
-— it publishes the report to the Actions run summary and uploads `profile.json`,
-`profile.md`, and the `.nsys-rep` trace as artifacts. It never blocks a merge.
-
-To wire it into the existing `ci.yml` instead of a standalone workflow, drop the
-`speed-profile` job into that file (it already has the matching `[self-hosted, gpu,
-sm86]` runner and `lucebox3-gpu-runner` concurrency group).
-
-## Scope (MVP)
-
-Starts with one path — Qwen3.5-27B Q4_K_M + DFlash/DDTree. The runner is parametrized
-by `--target/--draft/--budget`, so the same tool extends to Qwen3.6-27B, the MoE target,
-and the pflash / kvflash paths by changing flags. Per-PR runs can be gated to only the
-path the PR touches.

--- a/docs/specs/speed-profile.md
+++ b/docs/specs/speed-profile.md
@@ -5,8 +5,11 @@ speed on one GPU and produces a report that shows **where the time goes**, so a
 reviewer can see at a glance whether a PR moved the needle and where the next
 optimization margin is.
 
-It runs the engine **binaries directly** (no HTTP) so the numbers reflect compute,
-not server/network noise.
+It runs the engine **binaries directly** — `test_dflash` (the speculative / DFlash
+decode path) and `test_generate` (the plain autoregressive baseline) — with **no
+HTTP**, so the numbers reflect compute, not server/network noise. Both are CMake
+build targets under `server/build/` and can be overridden with `--df-bin` /
+`--ar-bin` (or the `DFLASH_BIN` / `DFLASH_BIN_AR` environment variables).
 
 ## What it reports
 
@@ -108,3 +111,37 @@ python3 scripts/profile.py \
   --baseline scripts/speed-baseline.json --regress-pct 0.10 \
   --out-json profile.json --out-md profile.md
 ```
+
+## Comparing against a baseline
+
+The profiler is **report-only**, but it can diff the current run against a saved
+profile so reviewers see a single regression table instead of two separate reports.
+The comparison is a JSON round-trip:
+
+1. **Capture a baseline.** Run the profiler on the reference commit and keep its
+   JSON output:
+
+   ```bash
+   python3 scripts/profile.py ... --out-json scripts/speed-baseline.json
+   ```
+
+   Commit `scripts/speed-baseline.json` so every later run compares against the same
+   reference. Re-seed it whenever you change a profiler parameter (`--budget`,
+   `--n-gen`, `--reps`, …): you cannot compare across configs.
+
+2. **Compare a later run.** Point `--baseline` at that file and set the regression
+   threshold:
+
+   ```bash
+   python3 scripts/profile.py ... \
+     --baseline scripts/speed-baseline.json --regress-pct 0.10
+   ```
+
+3. **Read the delta.** The report adds a **"Delta vs baseline"** table with, per
+   headline metric, `baseline ± σ`, `now ± σ`, the absolute Δ and Δ%. A row is
+   flagged as a regression only when the move exceeds `--regress-pct` **and** the
+   baseline/current 1σ intervals do **not** overlap — a delta inside the noise band
+   is marked **noisy / overlap** instead, so reviewers don't chase jitter.
+
+Both runs must use the same parameters for the delta to be a valid signal (see the
+**Rule** under *Parameters* above).

--- a/docs/specs/speed-profile.md
+++ b/docs/specs/speed-profile.md
@@ -1,0 +1,64 @@
+# Lucebox speed profiler (MVP)
+
+A small, CI-runnable profiler for the inference engine. It measures forward-pass
+speed on one GPU and produces a report that shows **where the time goes**, so a
+reviewer can see at a glance whether a PR moved the needle and where the next
+optimization margin is.
+
+It runs the engine **binaries directly** (no HTTP) so the numbers reflect compute,
+not server/network noise.
+
+## What it reports
+
+Three layers, coarse to fine:
+
+1. **Headline latency/throughput** — prefill time, model-side TTFT estimate, decode
+   tok/s, ms/token, plus the speculative-decoding **acceptance length (AL)** and
+   accept %. (`AL` is how many tokens the target commits per draft+verify step; decode
+   throughput ≈ `AL / step_time`.)
+2. **Per-step phase breakdown** — `draft_compute`, `draft_logits`, `verify_compute`,
+   … from the engine's own timers. Tells you *which phase* dominates a step.
+3. **Kernel-level (nsys)** — top CUDA kernels by GPU time, **kernel launches per
+   token** (kernel-fusion signal), **host↔device copy time per token** (CPU/GPU-overlap
+   signal), and sync-heavy CUDA APIs (CPU-stall signal). Tells you *why* a phase is slow.
+
+It also includes an optional **losslessness gate**: greedy speculative decode must
+produce the exact same token stream as greedy autoregressive decode. A mismatch means
+the "fast" path is changing the model's output, which a lossless-spec-decode claim
+should never do.
+
+## Run it locally
+
+```bash
+cd server
+python3 scripts/profile.py \
+  --target /opt/models/Qwen3.5-27B-Q4_K_M.gguf \
+  --draft  /opt/models/draft/qwen35_dflash/model.safetensors \
+  --n-gen 48 --budget 22 --reps 3 \
+  --nsys --check-lossless \
+  --out-json profile.json --out-md profile.md
+```
+
+Requirements: `transformers` (tokenizer), built `test_dflash` + `test_generate`,
+and `nsys` on PATH for the kernel layer (the profiler degrades gracefully without it).
+
+Regression view: pass `--baseline path/to/previous/profile.json` to print the delta
+vs a stored run (e.g. the latest `main`).
+
+## CI
+
+`.github/workflows/speed-profile.yml` runs on the self-hosted RTX 3090 for PRs that
+touch `server/**` or `optimizations/**`. It is **report-only** (`continue-on-error`)
+— it publishes the report to the Actions run summary and uploads `profile.json`,
+`profile.md`, and the `.nsys-rep` trace as artifacts. It never blocks a merge.
+
+To wire it into the existing `ci.yml` instead of a standalone workflow, drop the
+`speed-profile` job into that file (it already has the matching `[self-hosted, gpu,
+sm86]` runner and `lucebox3-gpu-runner` concurrency group).
+
+## Scope (MVP)
+
+Starts with one path — Qwen3.5-27B Q4_K_M + DFlash/DDTree. The runner is parametrized
+by `--target/--draft/--budget`, so the same tool extends to Qwen3.6-27B, the MoE target,
+and the pflash / kvflash paths by changing flags. Per-PR runs can be gated to only the
+path the PR touches.

--- a/docs/specs/speed-profile.md
+++ b/docs/specs/speed-profile.md
@@ -86,3 +86,4 @@ python3 scripts/profile.py \
   --nsys --check-lossless \
   --baseline scripts/speed-baseline.json --regress-pct 0.10 \
   --out-json profile.json --out-md profile.md
+```

--- a/server/scripts/profile.py
+++ b/server/scripts/profile.py
@@ -36,7 +36,7 @@ Usage
       --out-json profile.json --out-md profile.md
 """
 from __future__ import annotations
-import argparse, csv, datetime, json, os, re, shutil, statistics, struct, subprocess, sys, tempfile
+import argparse, atexit, csv, datetime, json, os, re, shutil, statistics, struct, subprocess, sys, tempfile
 from pathlib import Path
 
 # --------------------------------------------------------------------------------------
@@ -400,6 +400,7 @@ def main():
         prompts = [json.loads(l) for l in Path(cfg.prompts).read_text().splitlines() if l.strip()]
 
     tmp = Path(tempfile.mkdtemp(prefix="lucebox_profile_"))  # unique per run (no concurrent-run collisions)
+    atexit.register(shutil.rmtree, tmp, ignore_errors=True)  # clean up on exit (success or crash) -> no /tmp growth
     runs = []
     for p in prompts:
         pbin = tmp / f"{p['name']}.bin"

--- a/server/scripts/profile.py
+++ b/server/scripts/profile.py
@@ -585,6 +585,30 @@ def rel_stddev(mean_value: float, stddev_value: float) -> float:
     return abs(stddev_value / mean_value) if mean_value else 0.0
 
 
+def pooled_within_stddev(runs, key):
+    """Run-to-run (within-prompt) stddev, pooled across prompts.
+
+    The headline ± must reflect measurement *noise* — how much a single prompt's
+    number wobbles between identical reps — NOT how much different prompts differ
+    from each other. Pooling every raw sample across prompts would fold the
+    (large, real, repeatable) prompt-to-prompt spread into the stddev and badly
+    overstate the noise. We instead pool only the per-prompt deviations:
+
+        sqrt( Σ_prompt Σ_rep (x - prompt_mean)^2 / Σ_prompt (n_rep - 1) )
+
+    i.e. the standard pooled within-group standard deviation. Prompt-to-prompt
+    spread stays visible via the min–max line and the per-prompt table.
+    """
+    num, den = 0.0, 0
+    for r in runs:
+        s = [x for x in r.get("samples", {}).get(key, []) if x is not None]
+        if len(s) > 1:
+            m = statistics.mean(s)
+            num += sum((x - m) ** 2 for x in s)
+            den += len(s) - 1
+    return (num / den) ** 0.5 if den > 0 else 0.0
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--target", required=True)
@@ -688,23 +712,34 @@ def main():
 
     # ---- aggregate summary across prompts ----
     def col(k): return [r[k] for r in runs if k in r]
+    # Headline ± is the run-to-run (within-prompt) stddev, pooled across prompts.
+    # Prompt-to-prompt spread is reported separately (min–max + per-prompt table)
+    # so it never masquerades as measurement noise. See pooled_within_stddev().
+    decode_mean = statistics.mean(col("decode_tok_s"))
+    decode_sd = pooled_within_stddev(runs, "decode_tok_s")
+    mspt_mean = statistics.mean(col("ms_per_token"))
+    mspt_sd = pooled_within_stddev(runs, "ms_per_token")
+    al_mean = statistics.mean(col("al"))
+    al_sd = pooled_within_stddev(runs, "al")
+    ttft_mean = statistics.mean(col("ttft_est_ms")) if col("ttft_est_ms") else 0.0
+    ttft_sd = pooled_within_stddev(runs, "ttft_est_ms")
     summary = {
-        "decode_tok_s_mean": statistics.mean(col("decode_tok_s")),
+        "decode_tok_s_mean": decode_mean,
         "decode_tok_s_min": min(col("decode_tok_s")),
         "decode_tok_s_max": max(col("decode_tok_s")),
-        "decode_tok_s_stddev": stddev([x for r in runs for x in r.get("samples", {}).get("decode_tok_s", [])]),
-        "decode_tok_s_rsd": rel_stddev(statistics.mean(col("decode_tok_s")), stddev([x for r in runs for x in r.get("samples", {}).get("decode_tok_s", [])])),
-        "ms_per_token_mean": statistics.mean(col("ms_per_token")),
-        "ms_per_token_stddev": stddev([x for r in runs for x in r.get("samples", {}).get("ms_per_token", [])]),
-        "ms_per_token_rsd": rel_stddev(statistics.mean(col("ms_per_token")), stddev([x for r in runs for x in r.get("samples", {}).get("ms_per_token", [])])),
-        "al_mean": statistics.mean(col("al")),
-        "al_stddev": stddev([x for r in runs for x in r.get("samples", {}).get("al", [])]),
-        "al_rsd": rel_stddev(statistics.mean(col("al")), stddev([x for r in runs for x in r.get("samples", {}).get("al", [])])),
+        "decode_tok_s_stddev": decode_sd,
+        "decode_tok_s_rsd": rel_stddev(decode_mean, decode_sd),
+        "ms_per_token_mean": mspt_mean,
+        "ms_per_token_stddev": mspt_sd,
+        "ms_per_token_rsd": rel_stddev(mspt_mean, mspt_sd),
+        "al_mean": al_mean,
+        "al_stddev": al_sd,
+        "al_rsd": rel_stddev(al_mean, al_sd),
         "accept_pct_mean": statistics.mean(col("accept_pct")) if col("accept_pct") else 0.0,
         "prefill_ms_mean": statistics.mean([x * 1000 for x in col("prefill_s")]) if col("prefill_s") else 0.0,
-        "ttft_est_ms_mean": statistics.mean(col("ttft_est_ms")) if col("ttft_est_ms") else 0.0,
-        "ttft_est_ms_stddev": stddev([x for r in runs for x in r.get("samples", {}).get("ttft_est_ms", [])]),
-        "ttft_est_ms_rsd": rel_stddev(statistics.mean(col("ttft_est_ms")) if col("ttft_est_ms") else 0.0, stddev([x for r in runs for x in r.get("samples", {}).get("ttft_est_ms", [])])),
+        "ttft_est_ms_mean": ttft_mean,
+        "ttft_est_ms_stddev": ttft_sd,
+        "ttft_est_ms_rsd": rel_stddev(ttft_mean, ttft_sd),
         "phase_sum_ms_mean": statistics.mean(col("phase_sum_ms")) if col("phase_sum_ms") else 0.0,
     }
     if col("ar_tok_s"):

--- a/server/scripts/profile.py
+++ b/server/scripts/profile.py
@@ -260,11 +260,25 @@ def summarize_nsys(rep: Path, tokens: int) -> dict:
         "memcpy_breakdown": mem_breakdown,
         "sync_apis": sorted(api_rows, key=lambda x: x["total_ms"], reverse=True)[:8],
     }
-    # If the trace was captured but no report parsed, record WHY + the nsys
-    # version. Without this the section silently reads 0.0 everywhere and there
-    # is no way to tell a real "no kernels" from a stats-parsing failure.
-    if not kern and not mem and not api:
-        out["error"] = "; ".join(d for d in (dk, dm, da) if d) or "nsys stats produced no rows"
+    diagnostics = {
+        "kern": dk if not kern and dk else "",
+        "mem": dm if not mem and dm else "",
+        "api": da if not api and da else "",
+    }
+    missing = {section: diag for section, diag in diagnostics.items() if diag}
+
+    # If the critical kernel report failed to parse, the launch/fusion metrics are
+    # not measurements. Treat that as an nsys error even when secondary reports
+    # (memcpy/API) produced rows, instead of rendering zero kernel metrics as real.
+    if diagnostics["kern"]:
+        out["error"] = f"kernel report unavailable: {diagnostics['kern']}"
+        if any((dm, da)):
+            out["warnings"] = [f"{section}: {diag}" for section, diag in missing.items()]
+        out["nsys_version"] = nsys_version()
+    elif missing:
+        # Non-kernel sections are useful but not required for the fusion signal.
+        # Surface their diagnostics while still rendering the valid kernel data.
+        out["warnings"] = [f"{section}: {diag}" for section, diag in missing.items()]
         out["nsys_version"] = nsys_version()
     return out
 
@@ -429,6 +443,10 @@ def render_md(doc: dict) -> str:
             L.append("- The `.nsys-rep` is uploaded as an artifact — open it in Nsight Systems, or "
                      "check which report names this nsys exposes with `nsys stats --help-reports`.\n")
         else:
+            for warning in n.get("warnings", []):
+                L.append(f"- ⚠️ nsys stats warning: `{warning}` (nsys `{n.get('nsys_version','?')}`).")
+            if n.get("warnings"):
+                L.append("")
             L.append(f"- GPU kernel time: `{n['gpu_kernel_total_ms']} ms`  over `{n['tokens_profiled']}` tokens")
             L.append(f"- kernel launches/token: `{n['launches_per_token']}`  (fusion signal)")
             L.append(f"- host<->device copy: `{n['memcpy_total_ms']} ms` total, "

--- a/server/scripts/profile.py
+++ b/server/scripts/profile.py
@@ -29,10 +29,11 @@ Design choices
 Usage
 -----
   python3 profile.py \
-      --target /opt/models/Qwen3.5-27B-Q4_K_M.gguf \
-      --draft  /opt/models/draft/qwen35_dflash/model.safetensors \
+      --target /opt/models/Qwen3.6-27B-Q4_K_M.gguf \
+      --draft  /opt/models/draft/dflash-draft-3.6-q4_k_m.gguf \
       --n-gen 48 --budget 22 --reps 3 --nsys \
       --check-lossless \
+      --baseline scripts/speed-baseline.json --regress-pct 0.10 \
       --out-json profile.json --out-md profile.md
 """
 from __future__ import annotations
@@ -172,25 +173,61 @@ def _str(row: dict, *names) -> str:
     return ""
 
 
-def nsys_report(rep: Path, report: str) -> list[dict]:
+# nsys renamed its canned reports across versions (e.g. modern `cuda_gpu_kern_sum`
+# vs legacy `gpukernsum`). Trying both is what keeps the kernel layer working
+# whatever nsys ships on the runner — a name mismatch is the usual reason the nsys
+# section comes out all-zero with an empty table.
+NSYS_REPORTS = {
+    "kern": ["cuda_gpu_kern_sum", "gpukernsum"],
+    "mem":  ["cuda_gpu_mem_time_sum", "gpumemtimesum"],
+    "api":  ["cuda_api_sum", "cudaapisum"],
+}
+
+
+def nsys_version() -> str:
     try:
-        r = subprocess.run(["nsys", "stats", "--report", report, "--format", "csv",
-                            "--force-export=true", str(rep)],
-                           capture_output=True, text=True, timeout=600)
+        out = subprocess.run(["nsys", "--version"], capture_output=True, text=True, timeout=30).stdout.strip()
+        return out.splitlines()[0] if out else "?"
     except Exception:
-        return []
-    lines = r.stdout.splitlines()
-    start = next((i for i, l in enumerate(lines)
-                  if "Total Time (ns)" in l or "Time (%)" in l), None)
-    if start is None:
-        return []
-    return list(csv.DictReader(lines[start:]))
+        return "?"
+
+
+def _looks_like_header(line: str) -> bool:
+    # nsys CSV section header, tolerant to per-version column naming.
+    return "," in line and ("Total Time (ns)" in line or "Total Time" in line
+                            or ("Time (%)" in line and "Name" in line))
+
+
+def nsys_report(rep: Path, names: list[str]) -> tuple[list[dict], str]:
+    """Run `nsys stats` for the first report-name alias that yields a table.
+
+    Returns (rows, diag). diag is "" on success, else a one-line reason the
+    section is empty so the report can say WHY the kernel layer is missing
+    instead of silently printing zeros."""
+    diag = ""
+    for name in names:
+        try:
+            r = subprocess.run(["nsys", "stats", "--report", name, "--format", "csv",
+                                "--force-export=true", str(rep)],
+                               capture_output=True, text=True, timeout=600)
+        except Exception as e:  # noqa
+            diag = f"{name}: {e}"
+            continue
+        lines = r.stdout.splitlines()
+        start = next((i for i, l in enumerate(lines) if _looks_like_header(l)), None)
+        if start is not None:
+            rows = list(csv.DictReader(lines[start:]))
+            if rows:
+                return rows, ""
+        err = (r.stderr or r.stdout).strip()
+        diag = f"{name}: {err.splitlines()[-1] if err else 'no table in output'}"
+    return [], diag
 
 
 def summarize_nsys(rep: Path, tokens: int) -> dict:
-    kern = nsys_report(rep, "cuda_gpu_kern_sum")
-    mem  = nsys_report(rep, "cuda_gpu_mem_time_sum")
-    api  = nsys_report(rep, "cuda_api_sum")
+    kern, dk = nsys_report(rep, NSYS_REPORTS["kern"])
+    mem,  dm = nsys_report(rep, NSYS_REPORTS["mem"])
+    api,  da = nsys_report(rep, NSYS_REPORTS["api"])
 
     total_kern_ns = sum(_num(r, "Total Time (ns)") for r in kern)
     total_insts   = sum(_num(r, "Instances", "Count") for r in kern)
@@ -212,7 +249,7 @@ def summarize_nsys(rep: Path, tokens: int) -> dict:
                  "calls": int(_num(r, "Num Calls", "Count"))} for r in sync_apis]
 
     tk = max(1, tokens)
-    return {
+    out = {
         "tokens_profiled": tokens,
         "gpu_kernel_total_ms": round(total_kern_ns / 1e6, 2),
         "kernel_launches": int(total_insts),
@@ -223,6 +260,13 @@ def summarize_nsys(rep: Path, tokens: int) -> dict:
         "memcpy_breakdown": mem_breakdown,
         "sync_apis": sorted(api_rows, key=lambda x: x["total_ms"], reverse=True)[:8],
     }
+    # If the trace was captured but no report parsed, record WHY + the nsys
+    # version. Without this the section silently reads 0.0 everywhere and there
+    # is no way to tell a real "no kernels" from a stats-parsing failure.
+    if not kern and not mem and not api:
+        out["error"] = "; ".join(d for d in (dk, dm, da) if d) or "nsys stats produced no rows"
+        out["nsys_version"] = nsys_version()
+    return out
 
 
 # --------------------------------------------------------------------------------------
@@ -233,15 +277,68 @@ def read_i32(p: Path) -> list[int]:
     return list(struct.unpack(f"<{len(b)//4}i", b))
 
 
-def check_lossless(prompt_len: int, ar_bin: Path, df_bin: Path) -> dict:
+def _first_divergence(a: list[int], b: list[int]) -> tuple[int | None, int]:
+    n = min(len(a), len(b))
+    return next((i for i in range(n) if a[i] != b[i]), None), n
+
+
+def check_lossless(prompt_len: int, ar_bin: Path, df_bin: Path,
+                   ar_ctrl_bin: Path | None = None) -> dict:
+    """Compare greedy spec-decode (df) against greedy autoregressive (ar).
+
+    A raw bit-exact compare is too strict on its own: the target sees draft
+    tokens as a *batch* in the verify step but one-at-a-time in AR decode, and
+    different GEMM shapes reduce in a different order. IEEE FP is non-associative,
+    so when the top-2 logits are within epsilon the argmax tie can flip — one
+    token diverges and everything after it follows. The engine itself documents
+    this (qwen35_backend.cpp: "different GPU batch sizes -> FP-nondeterministic
+    state divergence -> different greedy output").
+
+    To tell that intrinsic noise apart from a real spec-decode bug we run a
+    second, identical-config AR pass as a determinism control (same idea as the
+    eval harness's baseline_2). If AR disagrees with itself on a prompt, that
+    prompt is intrinsically nondeterministic on this engine and a df-vs-ar
+    mismatch there proves nothing — so we mark it inconclusive rather than FAIL."""
     ar = read_i32(ar_bin)[prompt_len:]
     df = read_i32(df_bin)[prompt_len:]
-    n = min(len(ar), len(df))
-    first = next((i for i in range(n) if ar[i] != df[i]), None)
-    return {"lossless": first is None,
-            "compared_tokens": n,
-            "first_divergence": first,
-            "ar_len": len(ar), "df_len": len(df)}
+    first, n = _first_divergence(ar, df)
+    out = {"lossless": first is None,
+           "compared_tokens": n,
+           "first_divergence": first,
+           "ar_len": len(ar), "df_len": len(df)}
+    if ar_ctrl_bin is not None:
+        ar2 = read_i32(ar_ctrl_bin)[prompt_len:]
+        ar_div, _ = _first_divergence(ar, ar2)
+        out["ar_deterministic"] = ar_div is None   # control: AR == AR on rerun?
+        out["ar_self_divergence"] = ar_div
+    return out
+
+
+# --------------------------------------------------------------------------------------
+# baseline regression check
+# --------------------------------------------------------------------------------------
+# Which way is "better" for each headline metric: +1 = higher is better (throughput),
+# -1 = lower is better (latency). A regression is a move the WRONG way by more than the
+# threshold; a move the right way is just an improvement, never flagged.
+REGRESS_DIRECTION = {
+    "decode_tok_s_mean": +1,
+    "al_mean":           +1,
+    "ttft_est_ms_mean":  -1,
+    "ms_per_token_mean": -1,
+}
+
+
+def regression_delta(base: dict, now: dict, thr: float) -> dict:
+    """Per-metric (baseline, now, delta, pct, regressed?) + an overall verdict."""
+    rows = {}
+    for k, direction in REGRESS_DIRECTION.items():
+        if k not in base or k not in now:
+            continue
+        b, n = base[k], now[k]
+        pct = (n - b) / b if b else 0.0
+        regressed = (direction > 0 and pct < -thr) or (direction < 0 and pct > thr)
+        rows[k] = {"baseline": b, "now": n, "delta": n - b, "pct": pct, "regressed": regressed}
+    return rows
 
 
 # --------------------------------------------------------------------------------------
@@ -255,11 +352,11 @@ def optimization_flags(summary: dict) -> list[str]:
         if ms / step > 0.30:
             flags.append(f"`{name}` is {ms/step*100:.0f}% of the step ({ms:.1f} ms) — primary target.")
     n = summary.get("nsys")
-    if n:
-        if n["launches_per_token"] > 50:
+    if n and not n.get("error"):   # don't reason from a failed/zeroed nsys pass
+        if n.get("launches_per_token", 0) > 50:
             flags.append(f"{n['launches_per_token']} kernel launches/token — kernel-fusion candidate "
                          f"(launch overhead dominates many tiny kernels).")
-        if n["memcpy_ms_per_token"] > 0.5:
+        if n.get("memcpy_ms_per_token", 0) > 0.5:
             flags.append(f"{n['memcpy_ms_per_token']:.2f} ms/token in host<->device copies — "
                          f"CPU/GPU-overlap candidate (data shuttling off the critical path).")
     return flags
@@ -293,13 +390,25 @@ def render_md(doc: dict) -> str:
 
     if "lossless" in doc:
         ll = doc["lossless"]
-        if ll["lossless"]:
-            verdict = f"PASS — all {ll['prompts_checked']} prompts bit-identical to greedy AR"
+        checked = ll["prompts_checked"]
+        inconc = ll.get("prompts_inconclusive", [])
+        if not ll["lossless"]:
+            verdict = (f"FAIL — spec-decode output differs from greedy AR on {len(ll['prompts_failed'])}/{checked} "
+                       f"prompts ({', '.join(ll['prompts_failed'])}), first at token #{ll['first_divergence']}. "
+                       f"AR is self-deterministic, so this is NOT run-to-run noise — but not proven a logic bug "
+                       f"either: it can be batched-verify FP (verify scores draft tokens as a batch vs AR "
+                       f"one-at-a-time). Classify via the logit gap at the divergence: near-tie = FP, clear gap = bug.")
+        elif inconc:
+            verdict = (f"PASS — {len(ll['prompts_passed'])}/{checked} bit-identical to greedy AR; "
+                       f"{len(inconc)} inconclusive ({', '.join(inconc)}) — the engine is intrinsically "
+                       f"nondeterministic on those (AR disagreed with itself), so spec-decode can't be judged.")
         else:
-            verdict = (f"FAIL — {len(ll['prompts_failed'])}/{ll['prompts_checked']} prompts diverge "
-                       f"({', '.join(ll['prompts_failed'])}); first at token #{ll['first_divergence']}")
+            verdict = f"PASS — all {checked} prompts bit-identical to greedy AR"
         L.append("## Correctness (losslessness gate)\n")
-        L.append(f"- **{verdict}**\n")
+        L.append(f"- **{verdict}**")
+        L.append("- FAIL = output changed and it is not run-to-run noise (AR agreed with itself); "
+                 "inconclusive prompts (AR non-deterministic) are excluded. FP-vs-bug needs the logit "
+                 "gap at the first mismatch (a follow-up the binaries don't emit yet).\n")
 
     L.append("## Per-step phase breakdown (engine timers, ms/step)\n")
     L.append("| phase | ms/step | % of step |")
@@ -312,23 +421,31 @@ def render_md(doc: dict) -> str:
     if s.get("nsys"):
         n = s["nsys"]
         L.append("## Kernel-level (nsys)\n")
-        L.append(f"- GPU kernel time: `{n['gpu_kernel_total_ms']} ms`  over `{n['tokens_profiled']}` tokens")
-        L.append(f"- kernel launches/token: `{n['launches_per_token']}`  (fusion signal)")
-        L.append(f"- host<->device copy: `{n['memcpy_total_ms']} ms` total, "
-                 f"`{n['memcpy_ms_per_token']} ms/token` (overlap signal)\n")
-        L.append("**Top kernels by GPU time**\n")
-        L.append("| kernel | total ms | launches | avg µs |")
-        L.append("|---|---:|---:|---:|")
-        for k in n["top_kernels"]:
-            L.append(f"| `{k['name']}` | {k['total_ms']} | {k['instances']} | {k['avg_us']} |")
-        L.append("")
-        if n["sync_apis"]:
-            L.append("**Sync / launch / copy CUDA APIs** (CPU-stall signal)\n")
-            L.append("| api | total ms | calls |")
-            L.append("|---|---:|---:|")
-            for a in n["sync_apis"]:
-                L.append(f"| `{a['name']}` | {a['total_ms']} | {a['calls']} |")
+        if n.get("error"):
+            # Trace was captured but stats wouldn't parse — say why instead of
+            # printing 0.0 everywhere with an empty table.
+            L.append(f"- ⚠️ nsys trace captured but kernel stats could not be parsed: "
+                     f"`{n['error']}` (nsys `{n.get('nsys_version','?')}`).")
+            L.append("- The `.nsys-rep` is uploaded as an artifact — open it in Nsight Systems, or "
+                     "check which report names this nsys exposes with `nsys stats --help-reports`.\n")
+        else:
+            L.append(f"- GPU kernel time: `{n['gpu_kernel_total_ms']} ms`  over `{n['tokens_profiled']}` tokens")
+            L.append(f"- kernel launches/token: `{n['launches_per_token']}`  (fusion signal)")
+            L.append(f"- host<->device copy: `{n['memcpy_total_ms']} ms` total, "
+                     f"`{n['memcpy_ms_per_token']} ms/token` (overlap signal)\n")
+            L.append("**Top kernels by GPU time**\n")
+            L.append("| kernel | total ms | launches | avg µs |")
+            L.append("|---|---:|---:|---:|")
+            for k in n["top_kernels"]:
+                L.append(f"| `{k['name']}` | {k['total_ms']} | {k['instances']} | {k['avg_us']} |")
             L.append("")
+            if n["sync_apis"]:
+                L.append("**Sync / launch / copy CUDA APIs** (CPU-stall signal)\n")
+                L.append("| api | total ms | calls |")
+                L.append("|---|---:|---:|")
+                for a in n["sync_apis"]:
+                    L.append(f"| `{a['name']}` | {a['total_ms']} | {a['calls']} |")
+                L.append("")
 
     flags = optimization_flags(s)
     if flags:
@@ -338,11 +455,18 @@ def render_md(doc: dict) -> str:
         L.append("")
 
     if doc.get("baseline_delta"):
+        reg = doc.get("regression", {})
+        thr = reg.get("threshold_pct", 0.0)
+        verdict = "⚠️ REGRESSION" if reg.get("regressed") else "✅ within threshold"
         L.append("## Delta vs baseline\n")
-        L.append("| metric | baseline | now | Δ |")
-        L.append("|---|---:|---:|---:|")
-        for k, (b, now, d) in doc["baseline_delta"].items():
-            L.append(f"| {k} | {b:.2f} | {now:.2f} | {d:+.2f} |")
+        L.append(f"- baseline commit: `{reg.get('baseline_commit','?')}`  "
+                 f"threshold: `±{thr*100:.0f}%`  verdict: **{verdict}**\n")
+        L.append("| metric | baseline | now | Δ | Δ% | |")
+        L.append("|---|---:|---:|---:|---:|:--|")
+        for k, r in doc["baseline_delta"].items():
+            mark = "⚠️" if r["regressed"] else ""
+            L.append(f"| {k} | {r['baseline']:.2f} | {r['now']:.2f} | {r['delta']:+.2f} | "
+                     f"{r['pct']*100:+.1f}% | {mark} |")
         L.append("")
     return "\n".join(L)
 
@@ -380,7 +504,7 @@ def main():
     ap.add_argument("--draft", required=True)
     ap.add_argument("--df-bin", default=os.environ.get("DFLASH_BIN", "build/test_dflash"))
     ap.add_argument("--ar-bin", default=os.environ.get("DFLASH_BIN_AR", "build/test_generate"))
-    ap.add_argument("--tokenizer", default=os.environ.get("DFLASH_TOKENIZER", "Qwen/Qwen3.5-27B"))
+    ap.add_argument("--tokenizer", default=os.environ.get("DFLASH_TOKENIZER", "Qwen/Qwen3.6-27B"))
     ap.add_argument("--n-gen", type=int, default=48)
     ap.add_argument("--budget", type=int, default=22)
     ap.add_argument("--reps", type=int, default=3)
@@ -388,6 +512,9 @@ def main():
     ap.add_argument("--check-lossless", action="store_true")
     ap.add_argument("--prompts", default=None, help="optional .jsonl of {name,text}")
     ap.add_argument("--baseline", default=None, help="optional baseline profile.json for delta")
+    ap.add_argument("--regress-pct", type=float, default=0.10,
+                    help="fractional move that counts as a regression vs --baseline "
+                         "(0.10 = 10%%; wide enough to absorb run-to-run GPU variance)")
     ap.add_argument("--out-json", default="profile.json")
     ap.add_argument("--out-md", default="profile.md")
     cfg = ap.parse_args()
@@ -420,11 +547,15 @@ def main():
         ar_txt = run(ar_cmd(cfg, pbin, tmp / "ar.bin", cfg.n_gen))
         agg.update(parse_ar(ar_txt))
 
-        # losslessness (uses the AR + a fresh greedy DFlash output we just wrote)
+        # losslessness: greedy spec-decode vs greedy AR, with a second identical
+        # AR pass as a determinism control. ar.bin (the baseline AR run above) is
+        # reused as that control, so the gate costs one extra df + ar pass, same
+        # as before — no extra GPU time for the control.
         if cfg.check_lossless:
             run(dflash_cmd(cfg, pbin, tmp / "df_ll.bin", cfg.n_gen))
             run(ar_cmd(cfg, pbin, tmp / "ar_ll.bin", cfg.n_gen))
-            agg["lossless"] = check_lossless(plen, tmp / "ar_ll.bin", tmp / "df_ll.bin")
+            agg["lossless"] = check_lossless(plen, tmp / "ar_ll.bin", tmp / "df_ll.bin",
+                                             ar_ctrl_bin=tmp / "ar.bin")
 
         runs.append(agg)
 
@@ -481,21 +612,41 @@ def main():
     if cfg.check_lossless:
         ll_runs = [(r["prompt"], r["lossless"]) for r in runs if "lossless" in r]
         if ll_runs:
-            failed = [(name, ll) for name, ll in ll_runs if not ll["lossless"]]
+            # A prompt is a REAL losslessness failure only if AR is self-deterministic
+            # (control passed) AND spec-decode still diverges from it. If AR already
+            # disagrees with itself, the prompt is intrinsically nondeterministic on
+            # this engine -> inconclusive, not a spec-decode bug.
+            passed, real_fail, inconclusive = [], [], []
+            for name, ll in ll_runs:
+                if ll["lossless"]:
+                    passed.append(name)
+                elif ll.get("ar_deterministic", True):
+                    real_fail.append((name, ll))
+                else:
+                    inconclusive.append(name)
             doc["lossless"] = {
-                "lossless": not failed,                       # FAIL if ANY prompt diverges
+                "lossless": not real_fail,                    # FAIL only on a REAL divergence
                 "prompts_checked": len(ll_runs),
-                "prompts_failed": [name for name, _ in failed],
-                "first_divergence": failed[0][1]["first_divergence"] if failed else None,
+                "prompts_passed": passed,
+                "prompts_failed": [name for name, _ in real_fail],
+                "prompts_inconclusive": inconclusive,
+                "first_divergence": real_fail[0][1]["first_divergence"] if real_fail else None,
                 "per_prompt": {name: ll for name, ll in ll_runs},
             }
 
-    # baseline delta
+    # baseline delta + regression verdict
     if cfg.baseline and Path(cfg.baseline).exists():
-        base = json.loads(Path(cfg.baseline).read_text())["summary"]
-        keys = ["decode_tok_s_mean", "al_mean", "ttft_est_ms_mean", "ms_per_token_mean"]
-        doc["baseline_delta"] = {k: (base[k], summary[k], summary[k] - base[k])
-                                 for k in keys if k in base and k in summary}
+        base_doc = json.loads(Path(cfg.baseline).read_text())
+        rows = regression_delta(base_doc["summary"], summary, cfg.regress_pct)
+        if rows:
+            doc["baseline_delta"] = rows
+            regressed = [k for k, r in rows.items() if r["regressed"]]
+            doc["regression"] = {
+                "threshold_pct": cfg.regress_pct,
+                "regressed": bool(regressed),
+                "metrics": regressed,
+                "baseline_commit": base_doc.get("commit", "?"),
+            }
 
     Path(cfg.out_json).write_text(json.dumps(doc, indent=2))
     Path(cfg.out_md).write_text(render_md(doc))

--- a/server/scripts/profile.py
+++ b/server/scripts/profile.py
@@ -17,6 +17,7 @@ What it captures
         - host<->device memcpy time per token   -> CPU/GPU-OVERLAP signal
         - sync-heavy CUDA APIs                   -> CPU-stall signal
   * optional losslessness gate: greedy spec-decode must equal greedy AR token-for-token
+  * repeated-run mean/stddev and report-only noise warnings
   * optional delta vs a stored baseline (regression view)
 
 Design choices
@@ -24,14 +25,15 @@ Design choices
   * Wraps the binaries directly (no HTTP) so the numbers reflect compute, not server noise.
   * The nsys pass is SEPARATE from the timing pass: nsys adds overhead, so tok/s is
     measured on a clean pass and the kernel breakdown on its own short pass.
-  * Built to run on the self-hosted RTX 3090 CI runner; keep --n-gen small in CI.
+  * Built to run on the self-hosted RTX 3090 CI runner; --n-gen controls the
+    requested generated tokens per prompt, so keep it representative but bounded.
 
 Usage
 -----
   python3 profile.py \
       --target /opt/models/Qwen3.6-27B-Q4_K_M.gguf \
       --draft  /opt/models/draft/dflash-draft-3.6-q4_k_m.gguf \
-      --n-gen 48 --budget 22 --reps 3 --nsys \
+      --n-gen 128 --budget 22 --reps 5 --nsys \
       --check-lossless \
       --baseline scripts/speed-baseline.json --regress-pct 0.10 \
       --out-json profile.json --out-md profile.md
@@ -341,6 +343,17 @@ REGRESS_DIRECTION = {
     "ms_per_token_mean": -1,
 }
 
+REGRESS_STD_KEYS = {
+    "decode_tok_s_mean": "decode_tok_s_stddev",
+    "al_mean": "al_stddev",
+    "ttft_est_ms_mean": "ttft_est_ms_stddev",
+    "ms_per_token_mean": "ms_per_token_stddev",
+}
+
+
+def _overlap_1sigma(base_mean: float, base_std: float, now_mean: float, now_std: float) -> bool:
+    return max(base_mean - base_std, now_mean - now_std) <= min(base_mean + base_std, now_mean + now_std)
+
 
 def regression_delta(base: dict, now: dict, thr: float) -> dict:
     """Per-metric (baseline, now, delta, pct, regressed?) + an overall verdict."""
@@ -351,7 +364,16 @@ def regression_delta(base: dict, now: dict, thr: float) -> dict:
         b, n = base[k], now[k]
         pct = (n - b) / b if b else 0.0
         regressed = (direction > 0 and pct < -thr) or (direction < 0 and pct > thr)
-        rows[k] = {"baseline": b, "now": n, "delta": n - b, "pct": pct, "regressed": regressed}
+        std_key = REGRESS_STD_KEYS.get(k)
+        base_std = float(base.get(std_key, 0.0)) if std_key else 0.0
+        now_std = float(now.get(std_key, 0.0)) if std_key else 0.0
+        overlap = _overlap_1sigma(b, base_std, n, now_std) if (base_std or now_std) else False
+        below_detection = overlap and abs(pct) < thr
+        rows[k] = {
+            "baseline": b, "now": n, "delta": n - b, "pct": pct, "regressed": regressed,
+            "baseline_stddev": base_std, "now_stddev": now_std,
+            "overlap_1sigma": overlap, "below_detection_threshold": below_detection,
+        }
     return rows
 
 
@@ -393,14 +415,39 @@ def render_md(doc: dict) -> str:
     L.append("| metric | value |")
     L.append("|---|---:|")
     if "ar_tok_s_mean" in s:    L.append(f"| AR decode (tok/s) | {s['ar_tok_s_mean']:.2f} |")
-    L.append(f"| DFlash decode (tok/s) | {s['decode_tok_s_mean']:.2f} |")
+    L.append(f"| DFlash decode (tok/s) | {s['decode_tok_s_mean']:.2f} ± {s.get('decode_tok_s_stddev', 0.0):.2f} |")
     if "speedup" in s:          L.append(f"| speedup vs AR | {s['speedup']:.2f}x |")
-    L.append(f"| ms / token | {s['ms_per_token_mean']:.2f} |")
-    L.append(f"| TTFT estimate (ms) | {s['ttft_est_ms_mean']:.1f} |")
+    L.append(f"| ms / token | {s['ms_per_token_mean']:.2f} ± {s.get('ms_per_token_stddev', 0.0):.2f} |")
+    L.append(f"| TTFT estimate (ms) | {s['ttft_est_ms_mean']:.1f} ± {s.get('ttft_est_ms_stddev', 0.0):.1f} |")
     L.append(f"| prefill (ms) | {s['prefill_ms_mean']:.1f} |")
-    L.append(f"| acceptance length (AL) | {s['al_mean']:.2f} |")
+    L.append(f"| acceptance length (AL) | {s['al_mean']:.2f} ± {s.get('al_stddev', 0.0):.2f} |")
     L.append(f"| accept % / step | {s['accept_pct_mean']:.1f} |")
     L.append(f"| decode tok/s spread (min–max) | {s['decode_tok_s_min']:.1f}–{s['decode_tok_s_max']:.1f} |\n")
+
+    noise = s.get("noise", {})
+    if noise:
+        threshold = noise.get("threshold_rsd", 0.0)
+        if noise.get("noisy"):
+            L.append("## Noise / detection threshold\n")
+            L.append(f"- ⚠️ **NOISY** — relative stddev exceeded `{threshold*100:.1f}%` for "
+                     f"{', '.join(noise.get('metrics', []))}. Treat small deltas as below detection threshold.")
+            L.append("- This profiler remains report-only: noise warnings do not fail the run.\n")
+        else:
+            L.append("## Noise / detection threshold\n")
+            L.append(f"- ✅ **stable** — all tracked relative stddevs are at or below `{threshold*100:.1f}%`.\n")
+
+
+    if doc.get("runs"):
+        L.append("## Repeated-run samples by prompt\n")
+        L.append("| prompt | decode tok/s | ms/token | AL | TTFT ms |")
+        L.append("|---|---:|---:|---:|---:|")
+        for r in doc["runs"]:
+            L.append(f"| `{r.get('prompt', '?')}` | "
+                     f"{r.get('decode_tok_s', 0.0):.2f} ± {r.get('decode_tok_s_stddev', 0.0):.2f} | "
+                     f"{r.get('ms_per_token', 0.0):.2f} ± {r.get('ms_per_token_stddev', 0.0):.2f} | "
+                     f"{r.get('al', 0.0):.2f} ± {r.get('al_stddev', 0.0):.2f} | "
+                     f"{r.get('ttft_est_ms', 0.0):.1f} ± {r.get('ttft_est_ms_stddev', 0.0):.1f} |")
+        L.append("")
 
     if "lossless" in doc:
         ll = doc["lossless"]
@@ -486,8 +533,12 @@ def render_md(doc: dict) -> str:
         L.append("| metric | baseline | now | Δ | Δ% | |")
         L.append("|---|---:|---:|---:|---:|:--|")
         for k, r in doc["baseline_delta"].items():
-            mark = "⚠️" if r["regressed"] else ""
-            L.append(f"| {k} | {r['baseline']:.2f} | {r['now']:.2f} | {r['delta']:+.2f} | "
+            if r.get("below_detection_threshold"):
+                mark = "⚠️ noisy / overlap"
+            else:
+                mark = "⚠️" if r["regressed"] else ""
+            L.append(f"| {k} | {r['baseline']:.2f} ± {r.get('baseline_stddev', 0.0):.2f} | "
+                     f"{r['now']:.2f} ± {r.get('now_stddev', 0.0):.2f} | {r['delta']:+.2f} | "
                      f"{r['pct']*100:+.1f}% | {mark} |")
         L.append("")
     return "\n".join(L)
@@ -520,6 +571,20 @@ def median(xs):  # tolerant
     return statistics.median(xs) if xs else 0.0
 
 
+def mean(xs):
+    xs = [x for x in xs if x is not None]
+    return statistics.mean(xs) if xs else 0.0
+
+
+def stddev(xs):
+    xs = [x for x in xs if x is not None]
+    return statistics.stdev(xs) if len(xs) > 1 else 0.0
+
+
+def rel_stddev(mean_value: float, stddev_value: float) -> float:
+    return abs(stddev_value / mean_value) if mean_value else 0.0
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--target", required=True)
@@ -527,9 +592,13 @@ def main():
     ap.add_argument("--df-bin", default=os.environ.get("DFLASH_BIN", "build/test_dflash"))
     ap.add_argument("--ar-bin", default=os.environ.get("DFLASH_BIN_AR", "build/test_generate"))
     ap.add_argument("--tokenizer", default=os.environ.get("DFLASH_TOKENIZER", "Qwen/Qwen3.6-27B"))
-    ap.add_argument("--n-gen", type=int, default=48)
+    ap.add_argument("--n-gen", type=int, default=128,
+                    help="requested generated tokens per benchmark prompt")
     ap.add_argument("--budget", type=int, default=22)
-    ap.add_argument("--reps", type=int, default=3)
+    ap.add_argument("--reps", type=int, default=5,
+                    help="timing repetitions per prompt; use 3-5+ to expose run-to-run jitter")
+    ap.add_argument("--noise-rsd-pct", type=float, default=0.05,
+                    help="report-only noisy-run threshold as relative stddev (0.05 = 5%%)")
     ap.add_argument("--nsys", action="store_true")
     ap.add_argument("--check-lossless", action="store_true")
     ap.add_argument("--prompts", default=None, help="optional .jsonl of {name,text}")
@@ -555,14 +624,30 @@ def main():
         pbin = tmp / f"{p['name']}.bin"
         plen = tokenize(p["text"], tok, pbin)
 
-        # clean timing passes (median over reps)
+        # clean timing passes (mean/stddev over reps)
         reps = []
         for _ in range(cfg.reps):
             txt = run(dflash_cmd(cfg, pbin, tmp / "df.bin", cfg.n_gen))
             reps.append(parse_dflash(txt))
         agg = dict(reps[-1])  # keep phases from last
-        agg["decode_tok_s"] = median([r.get("decode_tok_s") for r in reps])
-        agg["al"]           = median([r.get("al") for r in reps])
+        decode_samples = [r.get("decode_tok_s") for r in reps if r.get("decode_tok_s") is not None]
+        al_samples = [r.get("al") for r in reps if r.get("al") is not None]
+        mspt_samples = [1000.0 / x for x in decode_samples if x]
+        ttft_samples = [r.get("ttft_est_ms") for r in reps if r.get("ttft_est_ms") is not None]
+        agg["samples"] = {
+            "decode_tok_s": decode_samples,
+            "ms_per_token": mspt_samples,
+            "al": al_samples,
+            "ttft_est_ms": ttft_samples,
+        }
+        agg["decode_tok_s"] = mean(decode_samples)
+        agg["decode_tok_s_stddev"] = stddev(decode_samples)
+        agg["ms_per_token"] = mean(mspt_samples)
+        agg["ms_per_token_stddev"] = stddev(mspt_samples)
+        agg["al"] = mean(al_samples)
+        agg["al_stddev"] = stddev(al_samples)
+        agg["ttft_est_ms"] = mean(ttft_samples)
+        agg["ttft_est_ms_stddev"] = stddev(ttft_samples)
         agg["prompt"] = p["name"]; agg["prompt_len"] = plen
 
         # AR baseline (single pass — it is deterministic)
@@ -607,11 +692,19 @@ def main():
         "decode_tok_s_mean": statistics.mean(col("decode_tok_s")),
         "decode_tok_s_min": min(col("decode_tok_s")),
         "decode_tok_s_max": max(col("decode_tok_s")),
-        "ms_per_token_mean": statistics.mean([1000.0 / x for x in col("decode_tok_s")]),
+        "decode_tok_s_stddev": stddev([x for r in runs for x in r.get("samples", {}).get("decode_tok_s", [])]),
+        "decode_tok_s_rsd": rel_stddev(statistics.mean(col("decode_tok_s")), stddev([x for r in runs for x in r.get("samples", {}).get("decode_tok_s", [])])),
+        "ms_per_token_mean": statistics.mean(col("ms_per_token")),
+        "ms_per_token_stddev": stddev([x for r in runs for x in r.get("samples", {}).get("ms_per_token", [])]),
+        "ms_per_token_rsd": rel_stddev(statistics.mean(col("ms_per_token")), stddev([x for r in runs for x in r.get("samples", {}).get("ms_per_token", [])])),
         "al_mean": statistics.mean(col("al")),
+        "al_stddev": stddev([x for r in runs for x in r.get("samples", {}).get("al", [])]),
+        "al_rsd": rel_stddev(statistics.mean(col("al")), stddev([x for r in runs for x in r.get("samples", {}).get("al", [])])),
         "accept_pct_mean": statistics.mean(col("accept_pct")) if col("accept_pct") else 0.0,
         "prefill_ms_mean": statistics.mean([x * 1000 for x in col("prefill_s")]) if col("prefill_s") else 0.0,
         "ttft_est_ms_mean": statistics.mean(col("ttft_est_ms")) if col("ttft_est_ms") else 0.0,
+        "ttft_est_ms_stddev": stddev([x for r in runs for x in r.get("samples", {}).get("ttft_est_ms", [])]),
+        "ttft_est_ms_rsd": rel_stddev(statistics.mean(col("ttft_est_ms")) if col("ttft_est_ms") else 0.0, stddev([x for r in runs for x in r.get("samples", {}).get("ttft_est_ms", [])])),
         "phase_sum_ms_mean": statistics.mean(col("phase_sum_ms")) if col("phase_sum_ms") else 0.0,
     }
     if col("ar_tok_s"):
@@ -621,6 +714,20 @@ def main():
     pkeys = set().union(*[set(r.get("phases", {})) for r in runs]) if runs else set()
     summary["phases_mean"] = {k: statistics.mean([r["phases"][k] for r in runs if k in r.get("phases", {})])
                               for k in pkeys}
+    per_prompt_rsd = {}
+    for k in ("decode_tok_s", "ms_per_token", "al", "ttft_est_ms"):
+        values = []
+        for r in runs:
+            values.append(rel_stddev(r.get(k, 0.0), r.get(f"{k}_stddev", 0.0)))
+        per_prompt_rsd[k] = max(values) if values else 0.0
+    noisy_metrics = [k for k, rsd in per_prompt_rsd.items() if rsd > cfg.noise_rsd_pct]
+    summary["noise"] = {
+        "threshold_rsd": cfg.noise_rsd_pct,
+        "noisy": bool(noisy_metrics),
+        "metrics": noisy_metrics,
+        "per_prompt_max_rsd": per_prompt_rsd,
+        "status": "noisy" if noisy_metrics else "stable",
+    }
     if nsys:
         summary["nsys"] = nsys
 

--- a/server/scripts/profile.py
+++ b/server/scripts/profile.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python3
+"""
+Lucebox speed profiler (MVP)
+============================
+Measures forward-pass speed of the Lucebox inference binaries on one GPU and emits
+a machine-readable profile.json + a human-readable profile.md (the report a reviewer
+reads on a PR).
+
+What it captures
+----------------
+  * prefill time, model-side TTFT estimate, decode tok/s, ms/token
+  * speculative-decoding acceptance length (AL) and accept %
+  * per-step phase breakdown (draft_* / verify_* ...) from the engine's own timers
+  * fine-grained kernel view via Nsight Systems (nsys):
+        - top CUDA kernels by GPU time
+        - kernel launches per generated token   -> kernel-FUSION signal
+        - host<->device memcpy time per token   -> CPU/GPU-OVERLAP signal
+        - sync-heavy CUDA APIs                   -> CPU-stall signal
+  * optional losslessness gate: greedy spec-decode must equal greedy AR token-for-token
+  * optional delta vs a stored baseline (regression view)
+
+Design choices
+--------------
+  * Wraps the binaries directly (no HTTP) so the numbers reflect compute, not server noise.
+  * The nsys pass is SEPARATE from the timing pass: nsys adds overhead, so tok/s is
+    measured on a clean pass and the kernel breakdown on its own short pass.
+  * Built to run on the self-hosted RTX 3090 CI runner; keep --n-gen small in CI.
+
+Usage
+-----
+  python3 profile.py \
+      --target /opt/models/Qwen3.5-27B-Q4_K_M.gguf \
+      --draft  /opt/models/draft/qwen35_dflash/model.safetensors \
+      --n-gen 48 --budget 22 --reps 3 --nsys \
+      --check-lossless \
+      --out-json profile.json --out-md profile.md
+"""
+from __future__ import annotations
+import argparse, csv, datetime, json, os, re, statistics, struct, subprocess, sys
+from pathlib import Path
+
+# --------------------------------------------------------------------------------------
+# Canonical prompts (HumanEval-style completion). Override with --prompts <file.jsonl>
+# where each line is {"name": "...", "text": "..."}.
+# --------------------------------------------------------------------------------------
+DEFAULT_PROMPTS = [
+    {"name": "has_close_elements",
+     "text": ("from typing import List\n\n"
+              "def has_close_elements(numbers: List[float], threshold: float) -> bool:\n"
+              '    """Check if any two numbers are closer than the threshold.\n'
+              "    >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n    False\n"
+              '    """\n    for')},
+    {"name": "rolling_max",
+     "text": ("from typing import List\n\n"
+              "def rolling_max(numbers: List[int]) -> List[int]:\n"
+              '    """Generate a list of rolling maximum elements seen so far.\n'
+              "    >>> rolling_max([1, 2, 3, 2, 3, 4, 2])\n    [1, 2, 3, 3, 3, 4, 4]\n"
+              '    """\n    result = []\n    running_max = None\n    for n in numbers:\n        if running_max is')},
+    {"name": "sum_product",
+     "text": ("from typing import List, Tuple\n\n"
+              "def sum_product(numbers: List[int]) -> Tuple[int, int]:\n"
+              '    """Return a tuple of (sum, product) of all integers. Empty -> (0, 1).\n'
+              "    >>> sum_product([1, 2, 3, 4])\n    (10, 24)\n"
+              '    """\n    s = 0\n    p = 1\n    for n in')},
+]
+
+# --------------------------------------------------------------------------------------
+# stdout parsers (matched to the exact print formats in test_dflash.cpp / test_generate.cpp)
+# --------------------------------------------------------------------------------------
+RE_PREFILL      = re.compile(r"\[prefill\]\s+(\d+)\s+tokens?\s+in\s+([\d.]+)\s*s")
+RE_DECODE       = re.compile(r"\[dflash\]\s+generated\s+(\d+)\s+tokens\s+in\s+([\d.]+)\s*s\s*->\s*([\d.]+)\s*tok/s")
+RE_STEPS        = re.compile(r"\[dflash\]\s+(\d+)\s+draft steps,\s+accepted=(\d+)/(\d+)\s+\(([\d.]+)%[^)]*\),\s+avg commit/step=([\d.]+)")
+RE_AR           = re.compile(r"\[gen\]\s+(\d+)\s+new tokens in\s+([\d.]+)\s*s\s*->\s*([\d.]+)\s*tok/s")
+RE_PHASE_LINE   = re.compile(r"^\s+([a-z_]+)\s+([\d.]+)\s*$")
+RE_PHASE_SUM    = re.compile(r"-----\s+sum\s+([\d.]+)")
+RE_TIMING_START = re.compile(r"\[timing\] per-step averages")
+
+
+def parse_dflash(text: str) -> dict:
+    out: dict = {"phases": {}}
+    if m := RE_PREFILL.search(text):
+        out["prefill_s"] = float(m.group(2)); out["prompt_tokens"] = int(m.group(1))
+    if m := RE_DECODE.search(text):
+        out["decode_tokens"] = int(m.group(1)); out["decode_s"] = float(m.group(2)); out["decode_tok_s"] = float(m.group(3))
+    if m := RE_STEPS.search(text):
+        out["steps"] = int(m.group(1)); out["accepted"] = int(m.group(2))
+        out["draft_positions"] = int(m.group(3)); out["accept_pct"] = float(m.group(4)); out["al"] = float(m.group(5))
+    # phase block
+    in_block = False
+    for line in text.splitlines():
+        if RE_TIMING_START.search(line):
+            in_block = True; continue
+        if in_block:
+            if m := RE_PHASE_SUM.search(line):
+                out["phase_sum_ms"] = float(m.group(1)); in_block = False; continue
+            if m := RE_PHASE_LINE.match(line):
+                out["phases"][m.group(1)] = float(m.group(2))
+    # derived
+    if out.get("decode_tok_s"):
+        out["ms_per_token"] = 1000.0 / out["decode_tok_s"]
+    if "prefill_s" in out and "phase_sum_ms" in out:
+        out["ttft_est_ms"] = out["prefill_s"] * 1000.0 + out["phase_sum_ms"]
+    return out
+
+
+def parse_ar(text: str) -> dict:
+    if m := RE_AR.search(text):
+        return {"ar_tokens": int(m.group(1)), "ar_s": float(m.group(2)), "ar_tok_s": float(m.group(3))}
+    return {}
+
+
+# --------------------------------------------------------------------------------------
+# binary runners
+# --------------------------------------------------------------------------------------
+def tokenize(prompt: str, tok, out_path: Path) -> int:
+    ids = tok.encode(prompt, add_special_tokens=False)
+    out_path.write_bytes(struct.pack(f"<{len(ids)}i", *ids))
+    return len(ids)
+
+
+def run(cmd: list[str], timeout: int = 1200) -> str:
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    if r.returncode != 0:
+        sys.stderr.write(f"\n[profile] command failed ({r.returncode}): {' '.join(cmd)}\n")
+        sys.stderr.write((r.stderr or r.stdout)[-2000:] + "\n")
+        raise RuntimeError("binary failed")
+    return r.stdout
+
+
+def dflash_cmd(cfg, prompt_bin: Path, out_bin: Path, n_gen: int) -> list[str]:
+    return [cfg.df_bin, cfg.target, cfg.draft, str(prompt_bin), str(n_gen), str(out_bin),
+            "--fast-rollback", "--ddtree", f"--ddtree-budget={cfg.budget}"]
+
+
+def ar_cmd(cfg, prompt_bin: Path, out_bin: Path, n_gen: int) -> list[str]:
+    return [cfg.ar_bin, cfg.target, str(prompt_bin), str(n_gen), str(out_bin)]
+
+
+# --------------------------------------------------------------------------------------
+# nsys (Nsight Systems) — the fine-grained kernel layer
+# --------------------------------------------------------------------------------------
+def have_nsys() -> bool:
+    from shutil import which
+    return which("nsys") is not None
+
+
+def nsys_profile(cmd: list[str], rep_out: Path) -> bool:
+    full = ["nsys", "profile", "-t", "cuda", "--force-overwrite", "true",
+            "-o", str(rep_out.with_suffix("")), *cmd]
+    try:
+        subprocess.run(full, capture_output=True, text=True, timeout=1800, check=True)
+        return True
+    except Exception as e:  # noqa
+        sys.stderr.write(f"[profile] nsys profile failed: {e}\n")
+        return False
+
+
+def _num(row: dict, *names) -> float:
+    for n in names:
+        if n in row and str(row[n]).strip() not in ("", "-"):
+            try:
+                return float(str(row[n]).replace(",", ""))
+            except ValueError:
+                pass
+    return 0.0
+
+
+def _str(row: dict, *names) -> str:
+    for n in names:
+        if n in row and row[n]:
+            return str(row[n])
+    return ""
+
+
+def nsys_report(rep: Path, report: str) -> list[dict]:
+    try:
+        r = subprocess.run(["nsys", "stats", "--report", report, "--format", "csv",
+                            "--force-export=true", str(rep)],
+                           capture_output=True, text=True, timeout=600)
+    except Exception:
+        return []
+    lines = r.stdout.splitlines()
+    start = next((i for i, l in enumerate(lines)
+                  if "Total Time (ns)" in l or "Time (%)" in l), None)
+    if start is None:
+        return []
+    return list(csv.DictReader(lines[start:]))
+
+
+def summarize_nsys(rep: Path, tokens: int) -> dict:
+    kern = nsys_report(rep, "cuda_gpu_kern_sum")
+    mem  = nsys_report(rep, "cuda_gpu_mem_time_sum")
+    api  = nsys_report(rep, "cuda_api_sum")
+
+    total_kern_ns = sum(_num(r, "Total Time (ns)") for r in kern)
+    total_insts   = sum(_num(r, "Instances", "Count") for r in kern)
+    top = sorted(kern, key=lambda r: _num(r, "Total Time (ns)"), reverse=True)[:8]
+    top_kernels = [{"name": _str(r, "Name")[:70],
+                    "total_ms": round(_num(r, "Total Time (ns)") / 1e6, 2),
+                    "instances": int(_num(r, "Instances", "Count")),
+                    "avg_us": round(_num(r, "Avg (ns)") / 1e3, 2)} for r in top]
+
+    mem_ns = sum(_num(r, "Total Time (ns)") for r in mem)
+    mem_breakdown = [{"op": _str(r, "Operation", "Name"),
+                      "total_ms": round(_num(r, "Total Time (ns)") / 1e6, 2),
+                      "count": int(_num(r, "Count", "Instances"))} for r in mem]
+
+    sync_apis = [r for r in api if any(k in _str(r, "Name")
+                 for k in ("Synchronize", "cudaMemcpy", "cudaLaunchKernel", "cudaStreamSync"))]
+    api_rows = [{"name": _str(r, "Name"),
+                 "total_ms": round(_num(r, "Total Time (ns)") / 1e6, 2),
+                 "calls": int(_num(r, "Num Calls", "Count"))} for r in sync_apis]
+
+    tk = max(1, tokens)
+    return {
+        "tokens_profiled": tokens,
+        "gpu_kernel_total_ms": round(total_kern_ns / 1e6, 2),
+        "kernel_launches": int(total_insts),
+        "launches_per_token": round(total_insts / tk, 1),
+        "memcpy_total_ms": round(mem_ns / 1e6, 2),
+        "memcpy_ms_per_token": round(mem_ns / 1e6 / tk, 3),
+        "top_kernels": top_kernels,
+        "memcpy_breakdown": mem_breakdown,
+        "sync_apis": sorted(api_rows, key=lambda x: x["total_ms"], reverse=True)[:8],
+    }
+
+
+# --------------------------------------------------------------------------------------
+# losslessness gate
+# --------------------------------------------------------------------------------------
+def read_i32(p: Path) -> list[int]:
+    b = p.read_bytes()
+    return list(struct.unpack(f"<{len(b)//4}i", b))
+
+
+def check_lossless(prompt_len: int, ar_bin: Path, df_bin: Path) -> dict:
+    ar = read_i32(ar_bin)[prompt_len:]
+    df = read_i32(df_bin)[prompt_len:]
+    n = min(len(ar), len(df))
+    first = next((i for i in range(n) if ar[i] != df[i]), None)
+    return {"lossless": first is None,
+            "compared_tokens": n,
+            "first_divergence": first,
+            "ar_len": len(ar), "df_len": len(df)}
+
+
+# --------------------------------------------------------------------------------------
+# heuristic flags — turn raw numbers into "where is the margin"
+# --------------------------------------------------------------------------------------
+def optimization_flags(summary: dict) -> list[str]:
+    flags = []
+    phases = summary.get("phases_mean", {})
+    step = summary.get("phase_sum_ms_mean", 0) or 1
+    for name, ms in sorted(phases.items(), key=lambda kv: kv[1], reverse=True)[:2]:
+        if ms / step > 0.30:
+            flags.append(f"`{name}` is {ms/step*100:.0f}% of the step ({ms:.1f} ms) — primary target.")
+    n = summary.get("nsys")
+    if n:
+        if n["launches_per_token"] > 50:
+            flags.append(f"{n['launches_per_token']} kernel launches/token — kernel-fusion candidate "
+                         f"(launch overhead dominates many tiny kernels).")
+        if n["memcpy_ms_per_token"] > 0.5:
+            flags.append(f"{n['memcpy_ms_per_token']:.2f} ms/token in host<->device copies — "
+                         f"CPU/GPU-overlap candidate (data shuttling off the critical path).")
+    return flags
+
+
+# --------------------------------------------------------------------------------------
+# markdown report
+# --------------------------------------------------------------------------------------
+def render_md(doc: dict) -> str:
+    c, s = doc["config"], doc["summary"]
+    L = []
+    L.append("# Lucebox speed profile\n")
+    L.append(f"- created: `{doc['created']}`")
+    L.append(f"- commit: `{doc.get('commit','?')}`")
+    L.append(f"- gpu: `{c.get('gpu','?')}`  driver: `{c.get('driver','?')}`  power: `{c.get('power','?')}`")
+    L.append(f"- target: `{Path(c['target']).name}`  draft: `{Path(c['draft']).name}`")
+    L.append(f"- n_gen: `{c['n_gen']}`  budget: `{c['budget']}`  reps: `{c['reps']}`  nsys: `{c['nsys']}`\n")
+
+    L.append("## Headline\n")
+    L.append("| metric | value |")
+    L.append("|---|---:|")
+    if "ar_tok_s_mean" in s:    L.append(f"| AR decode (tok/s) | {s['ar_tok_s_mean']:.2f} |")
+    L.append(f"| DFlash decode (tok/s) | {s['decode_tok_s_mean']:.2f} |")
+    if "speedup" in s:          L.append(f"| speedup vs AR | {s['speedup']:.2f}x |")
+    L.append(f"| ms / token | {s['ms_per_token_mean']:.2f} |")
+    L.append(f"| TTFT estimate (ms) | {s['ttft_est_ms_mean']:.1f} |")
+    L.append(f"| prefill (ms) | {s['prefill_ms_mean']:.1f} |")
+    L.append(f"| acceptance length (AL) | {s['al_mean']:.2f} |")
+    L.append(f"| accept % / step | {s['accept_pct_mean']:.1f} |")
+    L.append(f"| decode tok/s spread (min–max) | {s['decode_tok_s_min']:.1f}–{s['decode_tok_s_max']:.1f} |\n")
+
+    if "lossless" in doc:
+        ll = doc["lossless"]
+        verdict = "PASS — bit-identical to greedy AR" if ll["lossless"] else \
+                  f"FAIL — diverges at generated token #{ll['first_divergence']}"
+        L.append("## Correctness (losslessness gate)\n")
+        L.append(f"- **{verdict}** (compared {ll['compared_tokens']} tokens)\n")
+
+    L.append("## Per-step phase breakdown (engine timers, ms/step)\n")
+    L.append("| phase | ms/step | % of step |")
+    L.append("|---|---:|---:|")
+    step = s.get("phase_sum_ms_mean", 0) or 1
+    for name, ms in sorted(s.get("phases_mean", {}).items(), key=lambda kv: kv[1], reverse=True):
+        L.append(f"| `{name}` | {ms:.2f} | {ms/step*100:.0f}% |")
+    L.append(f"| **sum** | **{step:.2f}** | 100% |\n")
+
+    if s.get("nsys"):
+        n = s["nsys"]
+        L.append("## Kernel-level (nsys)\n")
+        L.append(f"- GPU kernel time: `{n['gpu_kernel_total_ms']} ms`  over `{n['tokens_profiled']}` tokens")
+        L.append(f"- kernel launches/token: `{n['launches_per_token']}`  (fusion signal)")
+        L.append(f"- host<->device copy: `{n['memcpy_total_ms']} ms` total, "
+                 f"`{n['memcpy_ms_per_token']} ms/token` (overlap signal)\n")
+        L.append("**Top kernels by GPU time**\n")
+        L.append("| kernel | total ms | launches | avg µs |")
+        L.append("|---|---:|---:|---:|")
+        for k in n["top_kernels"]:
+            L.append(f"| `{k['name']}` | {k['total_ms']} | {k['instances']} | {k['avg_us']} |")
+        L.append("")
+        if n["sync_apis"]:
+            L.append("**Sync / launch / copy CUDA APIs** (CPU-stall signal)\n")
+            L.append("| api | total ms | calls |")
+            L.append("|---|---:|---:|")
+            for a in n["sync_apis"]:
+                L.append(f"| `{a['name']}` | {a['total_ms']} | {a['calls']} |")
+            L.append("")
+
+    flags = optimization_flags(s)
+    if flags:
+        L.append("## Where the margin is\n")
+        for f in flags:
+            L.append(f"- {f}")
+        L.append("")
+
+    if doc.get("baseline_delta"):
+        L.append("## Delta vs baseline\n")
+        L.append("| metric | baseline | now | Δ |")
+        L.append("|---|---:|---:|---:|")
+        for k, (b, now, d) in doc["baseline_delta"].items():
+            L.append(f"| {k} | {b:.2f} | {now:.2f} | {d:+.2f} |")
+        L.append("")
+    return "\n".join(L)
+
+
+# --------------------------------------------------------------------------------------
+# main
+# --------------------------------------------------------------------------------------
+def gpu_info() -> dict:
+    try:
+        out = subprocess.run(["nvidia-smi",
+                              "--query-gpu=name,driver_version,power.limit",
+                              "--format=csv,noheader"], capture_output=True, text=True, timeout=30).stdout.strip()
+        name, driver, power = (x.strip() for x in out.split(",")[:3])
+        return {"gpu": name, "driver": driver, "power": power}
+    except Exception:
+        return {}
+
+
+def git_commit() -> str:
+    try:
+        return subprocess.run(["git", "rev-parse", "--short", "HEAD"],
+                              capture_output=True, text=True, timeout=10).stdout.strip()
+    except Exception:
+        return "?"
+
+
+def median(xs):  # tolerant
+    xs = [x for x in xs if x is not None]
+    return statistics.median(xs) if xs else 0.0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--target", required=True)
+    ap.add_argument("--draft", required=True)
+    ap.add_argument("--df-bin", default=os.environ.get("DFLASH_BIN", "build/test_dflash"))
+    ap.add_argument("--ar-bin", default=os.environ.get("DFLASH_BIN_AR", "build/test_generate"))
+    ap.add_argument("--tokenizer", default=os.environ.get("DFLASH_TOKENIZER", "Qwen/Qwen3.5-27B"))
+    ap.add_argument("--n-gen", type=int, default=48)
+    ap.add_argument("--budget", type=int, default=22)
+    ap.add_argument("--reps", type=int, default=3)
+    ap.add_argument("--nsys", action="store_true")
+    ap.add_argument("--check-lossless", action="store_true")
+    ap.add_argument("--prompts", default=None, help="optional .jsonl of {name,text}")
+    ap.add_argument("--baseline", default=None, help="optional baseline profile.json for delta")
+    ap.add_argument("--out-json", default="profile.json")
+    ap.add_argument("--out-md", default="profile.md")
+    cfg = ap.parse_args()
+
+    from transformers import AutoTokenizer
+    tok = AutoTokenizer.from_pretrained(cfg.tokenizer, trust_remote_code=True)
+
+    prompts = DEFAULT_PROMPTS
+    if cfg.prompts:
+        prompts = [json.loads(l) for l in Path(cfg.prompts).read_text().splitlines() if l.strip()]
+
+    tmp = Path("/tmp/lucebox_profile"); tmp.mkdir(exist_ok=True)
+    runs = []
+    for p in prompts:
+        pbin = tmp / f"{p['name']}.bin"
+        plen = tokenize(p["text"], tok, pbin)
+
+        # clean timing passes (median over reps)
+        reps = []
+        for _ in range(cfg.reps):
+            txt = run(dflash_cmd(cfg, pbin, tmp / "df.bin", cfg.n_gen))
+            reps.append(parse_dflash(txt))
+        agg = dict(reps[-1])  # keep phases from last
+        agg["decode_tok_s"] = median([r.get("decode_tok_s") for r in reps])
+        agg["al"]           = median([r.get("al") for r in reps])
+        agg["prompt"] = p["name"]; agg["prompt_len"] = plen
+
+        # AR baseline (single pass — it is deterministic)
+        ar_txt = run(ar_cmd(cfg, pbin, tmp / "ar.bin", cfg.n_gen))
+        agg.update(parse_ar(ar_txt))
+
+        # losslessness (uses the AR + a fresh greedy DFlash output we just wrote)
+        if cfg.check_lossless:
+            run(dflash_cmd(cfg, pbin, tmp / "df_ll.bin", cfg.n_gen))
+            run(ar_cmd(cfg, pbin, tmp / "ar_ll.bin", cfg.n_gen))
+            agg["lossless"] = check_lossless(plen, tmp / "ar_ll.bin", tmp / "df_ll.bin")
+
+        runs.append(agg)
+
+    # nsys on the first prompt only (one short profiled pass)
+    nsys = None
+    if cfg.nsys:
+        if not have_nsys():
+            sys.stderr.write("[profile] nsys not found on PATH — skipping kernel layer.\n")
+        else:
+            pbin = tmp / f"{prompts[0]['name']}.bin"
+            rep = tmp / "profile.nsys-rep"
+            if nsys_profile(dflash_cmd(cfg, pbin, tmp / "df_nsys.bin", cfg.n_gen), rep):
+                nsys = summarize_nsys(rep, cfg.n_gen)
+
+    # ---- aggregate summary across prompts ----
+    def col(k): return [r[k] for r in runs if k in r]
+    summary = {
+        "decode_tok_s_mean": statistics.mean(col("decode_tok_s")),
+        "decode_tok_s_min": min(col("decode_tok_s")),
+        "decode_tok_s_max": max(col("decode_tok_s")),
+        "ms_per_token_mean": statistics.mean([1000.0 / x for x in col("decode_tok_s")]),
+        "al_mean": statistics.mean(col("al")),
+        "accept_pct_mean": statistics.mean(col("accept_pct")) if col("accept_pct") else 0.0,
+        "prefill_ms_mean": statistics.mean([x * 1000 for x in col("prefill_s")]) if col("prefill_s") else 0.0,
+        "ttft_est_ms_mean": statistics.mean(col("ttft_est_ms")) if col("ttft_est_ms") else 0.0,
+        "phase_sum_ms_mean": statistics.mean(col("phase_sum_ms")) if col("phase_sum_ms") else 0.0,
+    }
+    if col("ar_tok_s"):
+        summary["ar_tok_s_mean"] = statistics.mean(col("ar_tok_s"))
+        summary["speedup"] = summary["decode_tok_s_mean"] / summary["ar_tok_s_mean"]
+    # phase means
+    pkeys = set().union(*[set(r.get("phases", {})) for r in runs]) if runs else set()
+    summary["phases_mean"] = {k: statistics.mean([r["phases"][k] for r in runs if k in r.get("phases", {})])
+                              for k in pkeys}
+    if nsys:
+        summary["nsys"] = nsys
+
+    doc = {
+        "created": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "commit": git_commit(),
+        "config": {**vars(cfg), **gpu_info()},
+        "runs": runs,
+        "summary": summary,
+    }
+    if cfg.check_lossless and runs and "lossless" in runs[0]:
+        doc["lossless"] = runs[0]["lossless"]  # representative
+
+    # baseline delta
+    if cfg.baseline and Path(cfg.baseline).exists():
+        base = json.loads(Path(cfg.baseline).read_text())["summary"]
+        keys = ["decode_tok_s_mean", "al_mean", "ttft_est_ms_mean", "ms_per_token_mean"]
+        doc["baseline_delta"] = {k: (base[k], summary[k], summary[k] - base[k])
+                                 for k in keys if k in base and k in summary}
+
+    Path(cfg.out_json).write_text(json.dumps(doc, indent=2))
+    Path(cfg.out_md).write_text(render_md(doc))
+    print(render_md(doc))
+    print(f"\n[profile] wrote {cfg.out_json} and {cfg.out_md}")
+
+
+if __name__ == "__main__":
+    main()

--- a/server/scripts/profile.py
+++ b/server/scripts/profile.py
@@ -36,7 +36,7 @@ Usage
       --out-json profile.json --out-md profile.md
 """
 from __future__ import annotations
-import argparse, csv, datetime, json, os, re, statistics, struct, subprocess, sys
+import argparse, csv, datetime, json, os, re, shutil, statistics, struct, subprocess, sys, tempfile
 from pathlib import Path
 
 # --------------------------------------------------------------------------------------
@@ -293,10 +293,13 @@ def render_md(doc: dict) -> str:
 
     if "lossless" in doc:
         ll = doc["lossless"]
-        verdict = "PASS — bit-identical to greedy AR" if ll["lossless"] else \
-                  f"FAIL — diverges at generated token #{ll['first_divergence']}"
+        if ll["lossless"]:
+            verdict = f"PASS — all {ll['prompts_checked']} prompts bit-identical to greedy AR"
+        else:
+            verdict = (f"FAIL — {len(ll['prompts_failed'])}/{ll['prompts_checked']} prompts diverge "
+                       f"({', '.join(ll['prompts_failed'])}); first at token #{ll['first_divergence']}")
         L.append("## Correctness (losslessness gate)\n")
-        L.append(f"- **{verdict}** (compared {ll['compared_tokens']} tokens)\n")
+        L.append(f"- **{verdict}**\n")
 
     L.append("## Per-step phase breakdown (engine timers, ms/step)\n")
     L.append("| phase | ms/step | % of step |")
@@ -396,7 +399,7 @@ def main():
     if cfg.prompts:
         prompts = [json.loads(l) for l in Path(cfg.prompts).read_text().splitlines() if l.strip()]
 
-    tmp = Path("/tmp/lucebox_profile"); tmp.mkdir(exist_ok=True)
+    tmp = Path(tempfile.mkdtemp(prefix="lucebox_profile_"))  # unique per run (no concurrent-run collisions)
     runs = []
     for p in prompts:
         pbin = tmp / f"{p['name']}.bin"
@@ -432,8 +435,17 @@ def main():
         else:
             pbin = tmp / f"{prompts[0]['name']}.bin"
             rep = tmp / "profile.nsys-rep"
-            if nsys_profile(dflash_cmd(cfg, pbin, tmp / "df_nsys.bin", cfg.n_gen), rep):
-                nsys = summarize_nsys(rep, cfg.n_gen)
+            nbin = tmp / "df_nsys.bin"
+            if nsys_profile(dflash_cmd(cfg, pbin, nbin, cfg.n_gen), rep):
+                # normalize per-token metrics by ACTUAL generated tokens, not requested
+                # n_gen (generation can stop early at EOS), then summarize.
+                actual_gen = max(1, len(read_i32(nbin)) - len(read_i32(pbin)))
+                nsys = summarize_nsys(rep, actual_gen)
+                # copy the trace next to the JSON report so CI can upload a deterministic path
+                try:
+                    shutil.copy(rep, Path(cfg.out_json).with_suffix(".nsys-rep"))
+                except Exception:
+                    pass
 
     # ---- aggregate summary across prompts ----
     def col(k): return [r[k] for r in runs if k in r]
@@ -465,8 +477,17 @@ def main():
         "runs": runs,
         "summary": summary,
     }
-    if cfg.check_lossless and runs and "lossless" in runs[0]:
-        doc["lossless"] = runs[0]["lossless"]  # representative
+    if cfg.check_lossless:
+        ll_runs = [(r["prompt"], r["lossless"]) for r in runs if "lossless" in r]
+        if ll_runs:
+            failed = [(name, ll) for name, ll in ll_runs if not ll["lossless"]]
+            doc["lossless"] = {
+                "lossless": not failed,                       # FAIL if ANY prompt diverges
+                "prompts_checked": len(ll_runs),
+                "prompts_failed": [name for name, _ in failed],
+                "first_divergence": failed[0][1]["first_divergence"] if failed else None,
+                "per_prompt": {name: ll for name, ll in ll_runs},
+            }
 
     # baseline delta
     if cfg.baseline and Path(cfg.baseline).exists():

--- a/server/scripts/profile.py
+++ b/server/scripts/profile.py
@@ -260,11 +260,25 @@ def summarize_nsys(rep: Path, tokens: int) -> dict:
         "memcpy_breakdown": mem_breakdown,
         "sync_apis": sorted(api_rows, key=lambda x: x["total_ms"], reverse=True)[:8],
     }
-    # If the trace was captured but no report parsed, record WHY + the nsys
-    # version. Without this the section silently reads 0.0 everywhere and there
-    # is no way to tell a real "no kernels" from a stats-parsing failure.
-    if not kern and not mem and not api:
-        out["error"] = "; ".join(d for d in (dk, dm, da) if d) or "nsys stats produced no rows"
+    diagnostics = {
+        "kern": dk if not kern and dk else "",
+        "mem": dm if not mem and dm else "",
+        "api": da if not api and da else "",
+    }
+    missing = {section: diag for section, diag in diagnostics.items() if diag}
+
+    # If the critical kernel report failed to parse, the launch/fusion metrics are
+    # not measurements. Treat that as an nsys error even when secondary reports
+    # (memcpy/API) produced rows, instead of rendering zero kernel metrics as real.
+    if diagnostics["kern"]:
+        out["error"] = f"kernel report unavailable: {diagnostics['kern']}"
+        if any((dm, da)):
+            out["warnings"] = [f"{section}: {diag}" for section, diag in missing.items()]
+        out["nsys_version"] = nsys_version()
+    elif missing:
+        # Non-kernel sections are useful but not required for the fusion signal.
+        # Surface their diagnostics while still rendering the valid kernel data.
+        out["warnings"] = [f"{section}: {diag}" for section, diag in missing.items()]
         out["nsys_version"] = nsys_version()
     return out
 
@@ -421,6 +435,10 @@ def render_md(doc: dict) -> str:
     if s.get("nsys"):
         n = s["nsys"]
         L.append("## Kernel-level (nsys)\n")
+        for warning in n.get("warnings", []):
+            L.append(f"- ⚠️ nsys stats warning: `{warning}` (nsys `{n.get('nsys_version','?')}`).")
+        if n.get("warnings"):
+            L.append("")
         if n.get("error"):
             # Trace was captured but stats wouldn't parse — say why instead of
             # printing 0.0 everywhere with an empty table.


### PR DESCRIPTION
## Summary
Adds a report-only speed profiling workflow for Lucebox inference changes.

## Changes
- Adds `server/scripts/profile.py`
- Adds `.github/workflows/speed-profile.yml`
- Adds profiler documentation at `server/docs/speed-profile.md`

## Notes
- Workflow is report-only / non-blocking.
- Intended for the self-hosted RTX 3090 GPU runner.
- Produces `profile.json`, `profile.md`, and nsys artifacts when available.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

