### PR TITLE
fix(server): Accept Top-Level `reasoning_effort` For Chat Completions

### DIFF
--- a/server/scripts/test_server_integration.py
+++ b/server/scripts/test_server_integration.py
@@ -518,6 +518,21 @@ class TestReasoning:
         msg = r.json()["choices"][0]["message"]
         assert msg["content"]
 
+    @pytest.mark.slow
+    def test_thinking_enabled_via_top_level_reasoning_effort(self):
+        """OpenAI Chat Completions-style reasoning_effort field."""
+        r = post_json("/v1/chat/completions", {
+            "model": MODEL_NAME,
+            "messages": [{"role": "user", "content": "What is 15 * 17?"}],
+            "stream": False,
+            "max_tokens": 512,
+            "reasoning_effort": "medium",
+        })
+        assert r.status_code == 200
+        choice = r.json()["choices"][0]
+        assert choice["message"]["content"]
+        assert "finish_details" in choice
+
 
 # ═══════════════════════════════════════════════════════════════════
 # POST /v1/responses — OpenAI Responses API

--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -1569,28 +1569,45 @@ bool HttpServer::route_request(int fd, const HttpRequest & hr) {
         int  effort_phase1_cap       = -1;  // from reasoning.effort lookup
         bool effort_set              = false;
 
+        auto apply_reasoning_effort = [&](const std::string & effort) {
+            if (effort == "none") {
+                enable_thinking = false;
+                return;
+            }
+
+            // Five-tier vocabulary (spec §4.2). Unknown → high.
+            int tier_value = config_.effort_tiers.high;
+            if      (effort == "minimal") tier_value = config_.effort_tiers.low;
+            else if (effort == "low")     tier_value = config_.effort_tiers.low;
+            else if (effort == "medium")  tier_value = config_.effort_tiers.medium;
+            else if (effort == "high")    tier_value = config_.effort_tiers.high;
+            else if (effort == "x-high")  tier_value = config_.effort_tiers.x_high;
+            else if (effort == "max")     tier_value = config_.effort_tiers.max;
+            // else: unknown tier → fall back to high (no error).
+
+            effort_phase1_cap = tier_value;
+            effort_set = true;
+            enable_thinking = true;
+            // Spec §4.2: reasoning effort activates the budget envelope.
+            req.thinking_opt_in = true;
+        };
+
         // OpenAI Responses API: "reasoning" field. Spec §4.2.
         if (body.contains("reasoning")) {
             auto & r = body["reasoning"];
             if (r.contains("effort")) {
-                std::string effort = r.value("effort", "high");
-                // Five-tier vocabulary (spec §4.2). Unknown → high.
-                int tier_value = config_.effort_tiers.high;
-                if      (effort == "low")    tier_value = config_.effort_tiers.low;
-                else if (effort == "medium") tier_value = config_.effort_tiers.medium;
-                else if (effort == "high")   tier_value = config_.effort_tiers.high;
-                else if (effort == "x-high") tier_value = config_.effort_tiers.x_high;
-                else if (effort == "max")    tier_value = config_.effort_tiers.max;
-                // else: unknown tier → fall back to high (no error).
-
-                effort_phase1_cap = tier_value;
-                effort_set = true;
-                enable_thinking = true;
-                // Spec §4.2: reasoning.effort activates the budget envelope.
-                req.thinking_opt_in = true;
+                apply_reasoning_effort(r.value("effort", "high"));
             } else {
                 enable_thinking = true;
             }
+        }
+        // OpenAI Chat Completions compatibility: some clients send a
+        // top-level reasoning_effort instead of Responses-style
+        // reasoning.effort. Treat it as the same tier selector unless the
+        // structured field already provided one.
+        if (!effort_set && body.contains("reasoning_effort") &&
+            body["reasoning_effort"].is_string()) {
+            apply_reasoning_effort(body["reasoning_effort"].get<std::string>());
         }
         // Anthropic-style: "thinking" field. Presence-as-opt-in: any
         // request that sends this field has opted in to the thinking-budget


### PR DESCRIPTION
Adds Chat Completions compatibility for clients that send:

```json
{
  "reasoning_effort": "medium"
}
```

Lucebox already supported the nested Responses-style field:

```json
{
  "reasoning": {
    "effort": "medium"
  }
}
```

but OpenAI-compatible clients such as Open WebUI can send the top-level `reasoning_effort` field instead. Before this change, those requests were accepted but did not enable thinking.

## User-Visible Bug

Open WebUI could be configured with reasoning set to `medium`, while Lucebox logs still showed:

```text
thinking=false
```

That meant the no-thinking chat template was used and no reasoning block was generated for clients to display separately.

## Change

- Reuses the existing effort-tier selection path for both request shapes.
- Supports:

  ```json
  {"reasoning": {"effort": "medium"}}
  ```

  and:

  ```json
  {"reasoning_effort": "medium"}
  ```

- Keeps structured `reasoning.effort` higher priority if both are present.
- Maps `minimal` to the low tier for broader client compatibility.
- Treats `none` as explicit thinking disabled.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

