### PR TITLE
fix(spec-decode): DFlash tree-verify under KVFlash (qwen35 + laguna) + laguna ddtree HIP top_k

### DIFF
--- a/server/src/common/kvflash_pager.h
+++ b/server/src/common/kvflash_pager.h
@@ -323,6 +323,20 @@ public:
         }
         return true;
     }
+
+    // True iff every chunk intersecting [0, n_tok) is resident in its identity
+    // block (block_of(c) == c). Expresses "the logical prefix [0, n_tok) is a
+    // contiguous, identity-mapped, materialized span" — the exact precondition
+    // the non-paged tree-verify graph relies on. Stronger than is_identity(),
+    // which is also true for an empty / not-yet-materialized pager.
+    bool identity_prefix_covers(int n_tok) const {
+        if (n_tok <= 0) return true;
+        const int nc = (n_tok + cfg_.chunk_tokens - 1) / cfg_.chunk_tokens;
+        if (nc > (int)chunks_.size()) return false;
+        for (int c = 0; c < nc; c++)
+            if (chunks_[c].block != c) return false;
+        return true;
+    }
     int block_of(int c) const {
         return c < (int)chunks_.size() ? chunks_[c].block : -1;
     }

--- a/server/src/laguna/laguna_backend.cpp
+++ b/server/src/laguna/laguna_backend.cpp
@@ -484,6 +484,12 @@ bool LagunaBackend::do_spec_decode(int committed, int n_gen,
         return true;
     };
 
+    // kvflash: register the prompt prefix so the pager tracks the tree path's
+    // position-indexed writes consistently (idempotent if prefill already did).
+    if (kvflash_active() && kvflash_pager_.is_identity()) {
+        (void)kvflash_alloc_span(0, committed);
+    }
+
     auto t_dec0 = std::chrono::steady_clock::now();
 
     while (n_generated < n_gen) {
@@ -575,7 +581,14 @@ bool LagunaBackend::do_spec_decode(int committed, int n_gen,
 
         const bool tree_special_inactive =
             !(budget_hook && !budget_hook->close_token_ids.empty());
-        if (args_.ddtree_mode && target->supports_tree_verify() &&
+        // kvflash: the tree graph is position-indexed, so only take it while
+        // the pager is identity and the step fits the resident pool; otherwise
+        // the slot-mapped chain verify below handles it.
+        const bool kvflash_tree_ok =
+            !kvflash_active() ||
+            (kvflash_pager_.is_identity() &&
+             committed + args_.ddtree_budget + 1 <= kvflash_tokens_);
+        if (args_.ddtree_mode && target->supports_tree_verify() && kvflash_tree_ok &&
             q_len > 1 && tree_special_inactive && !sampled_verify) {
             const int L = q_len - 1;
             const int K = (args_.ddtree_budget > L) ? 8 : 1;

--- a/server/src/laguna/laguna_dflash_target.cpp
+++ b/server/src/laguna/laguna_dflash_target.cpp
@@ -2,6 +2,7 @@
 
 #include "laguna_dflash_target.h"
 #include "../common/kvflash_pager.h"
+#include "../common/ddtree.h"
 
 #include "ggml-alloc.h"
 
@@ -154,10 +155,12 @@ bool LagunaDFlashTarget::restore_kv() {
 }
 
 bool LagunaDFlashTarget::supports_tree_verify() const {
-    // Laguna tree verify is a logical-position, non-paged pure-attention graph.
-    // The kvflash pager uses relocated slot-space masks, so keep tree verify
-    // disabled under paging until a slot-space tree mask is implemented.
-    return pager_ == nullptr;
+    // Laguna tree verify is a logical-position, non-paged pure-attention graph
+    // (physical row == logical position). It is bit-correct while the kvflash
+    // pager is identity (slot == position); the call site bounds the step to the
+    // resident pool and verify_tree re-checks the identity prefix defensively.
+    // Past the pool, chain verify takes over.
+    return pager_ == nullptr || pager_->is_identity();
 }
 
 bool LagunaDFlashTarget::verify_tree(
@@ -174,7 +177,14 @@ bool LagunaDFlashTarget::verify_tree(
         tree.visibility.size() < (size_t)N_actual * (size_t)N_actual) {
         return false;
     }
-    if (pager_ != nullptr) return false;
+    // kvflash: this graph is position-indexed (physical row == logical
+    // position), so it is valid only while the pager is identity and the span
+    // fits the pool. do_spec_decode gates on this; bail cleanly otherwise.
+    if (pager_ != nullptr &&
+        (committed + N > pager_->pool_tokens() ||
+         !pager_->identity_prefix_covers(committed))) {
+        return false;
+    }
 
     int kv_cap = 0;
     for (ggml_tensor * k : cache_.attn_k) {
@@ -369,6 +379,7 @@ bool LagunaDFlashTarget::rollback_to_tree(
         }
     }
     if (contiguous_prefix) {
+        if (pager_) (void)pager_->alloc_span(committed, commit_n);
         cache_.cur_pos = committed + commit_n;
         cache_.last_tok = -1;
         return true;
@@ -469,6 +480,10 @@ bool LagunaDFlashTarget::rollback_to_tree(
         return false;
     }
 
+    // kvflash: register the tree-committed (identity) positions so the pager
+    // tracks this path's position-indexed writes (chain/AR self-register via
+    // kvflash_alloc_span; this is the only path that writes KV directly).
+    if (pager_) (void)pager_->alloc_span(committed, commit_n);
     cache_.cur_pos = committed + commit_n;
     cache_.last_tok = -1;
     ggml_free(ctx);
@@ -510,17 +525,8 @@ bool LagunaDFlashTarget::project_hidden_to_topk(
     ggml_tensor * inp = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, w_.n_embd, n_tokens);
     ggml_set_input(inp);
     ggml_tensor * logits = ggml_mul_mat(ctx, w_.output, inp);
-    const float inv_t = 1.0f / std::max(1e-3f, temperature);
-    ggml_tensor * scaled = (inv_t != 1.0f) ? ggml_scale(ctx, logits, inv_t) : logits;
-    ggml_tensor * top_ids = ggml_top_k(ctx, scaled, K);
-    ggml_tensor * probs = ggml_soft_max(ctx, scaled);
-    ggml_tensor * probs_3d = ggml_reshape_3d(ctx, probs, 1, w_.embedder.n_vocab, n_tokens);
-    ggml_tensor * top_probs = ggml_get_rows(ctx, probs_3d, top_ids);
-    top_probs = ggml_cont(ctx, top_probs);
-    ggml_set_output(top_ids);
-    ggml_set_output(top_probs);
-    ggml_build_forward_expand(gf, top_ids);
-    ggml_build_forward_expand(gf, top_probs);
+    ggml_set_output(logits);
+    ggml_build_forward_expand(gf, logits);
 
     static ggml_gallocr_t galloc_topk = nullptr;
     if (!galloc_topk) {
@@ -540,16 +546,19 @@ bool LagunaDFlashTarget::project_hidden_to_topk(
         return false;
     }
 
+    // CPU top-K via extract_draft_topk (shared with qwen35). The GPU ggml_top_k
+    // path bitonic-argsorts the full vocab, whose shared memory exceeds HIP
+    // shared-mem-per-block on gfx1151 (argsort.cu GGML_ASSERT). extract_draft_topk
+    // applies the temperature + log-softmax on host.
+    const int vocab = (int)logits->ne[0];
+    std::vector<float> logits_host((size_t)vocab * (size_t)n_tokens);
+    ggml_backend_tensor_get(logits, logits_host.data(), 0,
+                            sizeof(float) * logits_host.size());
+
     top_log_probs.assign((size_t)n_tokens * (size_t)K, 0.0f);
     top_token_ids.assign((size_t)n_tokens * (size_t)K, 0);
-    std::vector<float> top_probs_host((size_t)n_tokens * (size_t)K);
-    ggml_backend_tensor_get(top_ids, top_token_ids.data(), 0,
-                            sizeof(int32_t) * top_token_ids.size());
-    ggml_backend_tensor_get(top_probs, top_probs_host.data(), 0,
-                            sizeof(float) * top_probs_host.size());
-    for (size_t i = 0; i < top_probs_host.size(); ++i) {
-        top_log_probs[i] = std::log(std::max(top_probs_host[i], 1e-30f));
-    }
+    extract_draft_topk(logits_host.data(), n_tokens, vocab, K,
+                       top_log_probs.data(), top_token_ids.data(), temperature);
 
     ggml_free(ctx);
     return true;

--- a/server/src/laguna/laguna_dflash_target.cpp
+++ b/server/src/laguna/laguna_dflash_target.cpp
@@ -379,7 +379,16 @@ bool LagunaDFlashTarget::rollback_to_tree(
         }
     }
     if (contiguous_prefix) {
-        if (pager_) (void)pager_->alloc_span(committed, commit_n);
+        // A failed alloc must abort: returning true with unmapped slots would
+        // make the next step read stale/unmapped KV (silent corruption). The
+        // call-site guard bounds the span to the resident pool so this never
+        // evicts in practice.
+        if (pager_ && !pager_->alloc_span(committed, commit_n)) {
+            std::fprintf(stderr,
+                "rollback_to_tree: kvflash alloc_span failed (committed=%d commit_n=%d)\n",
+                committed, commit_n);
+            return false;
+        }
         cache_.cur_pos = committed + commit_n;
         cache_.last_tok = -1;
         return true;
@@ -482,8 +491,16 @@ bool LagunaDFlashTarget::rollback_to_tree(
 
     // kvflash: register the tree-committed (identity) positions so the pager
     // tracks this path's position-indexed writes (chain/AR self-register via
-    // kvflash_alloc_span; this is the only path that writes KV directly).
-    if (pager_) (void)pager_->alloc_span(committed, commit_n);
+    // kvflash_alloc_span; this is the only path that writes KV directly). A
+    // failed alloc must abort: returning true with unmapped slots would make the
+    // next step read stale/unmapped KV (silent corruption).
+    if (pager_ && !pager_->alloc_span(committed, commit_n)) {
+        std::fprintf(stderr,
+            "rollback_to_tree: kvflash alloc_span failed (committed=%d commit_n=%d)\n",
+            committed, commit_n);
+        ggml_free(ctx);
+        return false;
+    }
     cache_.cur_pos = committed + commit_n;
     cache_.last_tok = -1;
     ggml_free(ctx);

--- a/server/src/qwen35/qwen35_backend.cpp
+++ b/server/src/qwen35/qwen35_backend.cpp
@@ -1882,6 +1882,15 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
                      n_draft_steps > 0 ? (double)target_forwards / n_draft_steps : 0.0);
     };
 
+    // kvflash: an in-pool prompt prefills contiguously without registering
+    // chunks in the pager. Map the prefix now so the pager stays consistent
+    // with the tree path's direct writes and hands off cleanly to slot-mapped
+    // paging once the context outgrows the pool. (A >pool prompt already paged
+    // during prefill, leaving the pager non-identity, so this is skipped.)
+    if (kvflash_active() && kvflash_pager_.is_identity()) {
+        (void)kvflash_pager_.alloc_span(0, committed);
+    }
+
     auto t_dec0 = std::chrono::steady_clock::now();
 
     while (n_generated < n_gen) {
@@ -2007,7 +2016,17 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
             !(hint_tokens && n_generated < (int)hint_tokens->size()) &&
             stall_tool_prefix_tokens == nullptr &&
             (int)out_tokens.size() >= _min_floor;
-        if (cfg_.ddtree_mode && target->supports_tree_verify() &&
+        // kvflash: only take the non-paged tree path while the read prefix
+        // [0, committed) is identity-resident and the write span (+FA padding)
+        // fits the resident pool. Full-attention only (windowed FA padding could
+        // index past the pool). Otherwise the slot-mapped chain verify handles
+        // it. Non-kvflash is unaffected.
+        const bool kvflash_tree_ok =
+            !kvflash_active() ||
+            (cfg_.fa_window == 0 &&
+             committed + cfg_.ddtree_budget + 1 + cfg_.kq_stride_pad <= kvflash_tokens_ &&
+             kvflash_pager_.identity_prefix_covers(committed));
+        if (cfg_.ddtree_mode && target->supports_tree_verify() && kvflash_tree_ok &&
             !use_remote_draft && q_len > 1 && tree_special_inactive) {
             const int L = q_len - 1;
             const int K = (cfg_.ddtree_budget > L) ? 8 : 1;

--- a/server/src/qwen35/qwen35_dflash_target.cpp
+++ b/server/src/qwen35/qwen35_dflash_target.cpp
@@ -452,8 +452,16 @@ bool Qwen35DFlashTarget::rollback_to_tree(
     // kvflash: the tree graph writes KV directly (not slot-mapped), so this is
     // the single owning point that advances the pager for tree-committed
     // positions. Covers both the greedy and sampled tree fast paths; chain
-    // paths self-register through verify_batch()'s slot_for().
-    if (pager_) (void)pager_->alloc_span(committed, commit_n);
+    // paths self-register through verify_batch()'s slot_for(). The call-site
+    // guard bounds the span to the resident identity pool so this never evicts,
+    // but a failed alloc must abort: returning true with unmapped slots would
+    // make the next step read stale/unmapped KV (silent corruption).
+    if (pager_ && !pager_->alloc_span(committed, commit_n)) {
+        std::fprintf(stderr,
+            "rollback_to_tree: kvflash alloc_span failed (committed=%d commit_n=%d)\n",
+            committed, commit_n);
+        return false;
+    }
     cache_.cur_pos = committed + commit_n;
     return true;
 }

--- a/server/src/qwen35/qwen35_dflash_target.cpp
+++ b/server/src/qwen35/qwen35_dflash_target.cpp
@@ -192,10 +192,11 @@ bool Qwen35DFlashTarget::read_verify_logits(int n_tokens, std::vector<float> & o
 }
 
 bool Qwen35DFlashTarget::supports_tree_verify() const {
-    // Tree verify reuses the fast-rollback SSM-intermediate capture, and builds
-    // the non-paged tree graph + logical attention mask. It is NOT slot-mapped,
-    // so it is incompatible with the kvflash pager — gate it off when paging.
-    return fast_rollback_ && pager_ == nullptr;
+    // Tree verify reuses the fast-rollback SSM-intermediate capture and builds a
+    // non-paged, contiguous tree graph. Pure capability here; the kvflash
+    // identity/pool precondition is enforced at the call site in do_spec_decode
+    // and re-checked defensively in verify_tree() below.
+    return fast_rollback_;
 }
 
 bool Qwen35DFlashTarget::verify_tree(
@@ -209,6 +210,20 @@ bool Qwen35DFlashTarget::verify_tree(
     const int N        = n_alloc;                 // fixed alloc width (budget+1)
     const int N_actual = 1 + tree.n_nodes;        // real tree size incl. root
     if (N_actual <= 0 || N_actual > N || (int)flat_tokens.size() < N) return false;
+    // kvflash: the tree graph reads the prefix [0, committed) contiguously and
+    // writes rows [committed, committed+N). Only valid while that prefix is
+    // identity-resident and the write span fits the pool. do_spec_decode gates
+    // on this; reaching here otherwise is a bug — fail cleanly, never read past
+    // the pool.
+    if (pager_ &&
+        (committed + N > pager_->pool_tokens() ||
+         !pager_->identity_prefix_covers(committed))) {
+        std::fprintf(stderr,
+            "verify_tree: kvflash layout not identity-contiguous "
+            "(committed=%d N=%d pool=%d)\n",
+            committed, N, pager_->pool_tokens());
+        return false;
+    }
     const int hidden = w_.n_embd;
 
     // Tree-verify graph: ancestor-masked batched forward over DFS-ordered nodes.
@@ -434,6 +449,11 @@ bool Qwen35DFlashTarget::rollback_to_tree(
     }
 
     cudaStreamSynchronize(stream);
+    // kvflash: the tree graph writes KV directly (not slot-mapped), so this is
+    // the single owning point that advances the pager for tree-committed
+    // positions. Covers both the greedy and sampled tree fast paths; chain
+    // paths self-register through verify_batch()'s slot_for().
+    if (pager_) (void)pager_->alloc_span(committed, commit_n);
     cache_.cur_pos = committed + commit_n;
     return true;
 }
@@ -449,7 +469,11 @@ bool Qwen35DFlashTarget::restore_kv() {
 }
 
 bool Qwen35DFlashTarget::supports_fast_rollback() const {
-    return fast_rollback_ && pager_ == nullptr;
+    // Pure capability. Fast-rollback only restores recurrent SSM/conv state and
+    // defers the bonus token, so it is pager-safe even while paging: committed
+    // KV rows are written slot-mapped by verify_batch(), and the deferred bonus
+    // is re-fed at the next committed position on the following step.
+    return fast_rollback_;
 }
 
 bool Qwen35DFlashTarget::rollback_to(int base_pos, int commit_n) {


### PR DESCRIPTION
## Problem

`--ddtree` + `--kvflash` collapses throughput. Root cause: `supports_tree_verify()`/`supports_fast_rollback()` were gated `&& pager_ == nullptr`, so attaching a KVFlash pager disabled tree-verify, forcing `--ddtree` onto the slow chain path (which also tripped `invalid draft seed -1 -> AR`).

While the pager is **identity** (context fits the resident pool), the non-paged contiguous tree graph is bit-correct, so tree-verify is safe there.

## Fix (qwen35 27B dense + laguna)

Both targets get the same change:
- `supports_tree_verify()` / `supports_fast_rollback()` → pure capability; the KVFlash precondition moves to the `do_spec_decode` call site, bounded so the tree step never reads past the resident pool.
- New `KvFlashPager::identity_prefix_covers(n)` = the precise invariant (every chunk in `[0,n)` resident at `block==c`), used by the call-site guard and a defensive `verify_tree` check.
- `rollback_to_tree()` advances the pager (`alloc_span`) for tree-committed positions; the prompt prefix is registered before decode, so the identity→paged handoff stays consistent.

**Laguna also needed an independent HIP fix:** `project_hidden_to_topk` used GPU `ggml_top_k`, whose bitonic argsort over the full vocab overflows HIP shared-memory-per-block on gfx1151 (`argsort.cu` GGML_ASSERT) — so laguna `--ddtree` crashed on HIP regardless of kvflash. Switched to the shared CPU `extract_draft_topk` (as qwen35).

Design reviewed with Codex (centralize pager-advance in the state-transition method; pure capabilities + call-site gate; `identity_prefix_covers` as the invariant).

## Verification (Strix Halo gfx1151, ROCm 7.2.2, built against current main)

**qwen35 (27B dense, Qwen3.6-27B-Q4_K_M):**
| config | tok/s | invalid-seed |
|---|---|---|
| `--kvflash --ddtree` before | ~25 (chain) | every prose req |
| **after** | **33.3** | **0** |
| `--ddtree` (no kvflash) | 33.9 | n/a |

- >pool paged path intact: 25,543-token needle → pooled prefill w/ eviction → recalled, no assert.
- `test_kvflash` pager suite green (relocation, page roundtrip, eviction, reselect, KV reduction 99.2%).

**laguna (laguna-xs2-Q4_K_M):**
| config | tok/s | crash |
|---|---|---|
| `--ddtree` before (any) | — | argsort GGML_ASSERT (HIP) |
| `--kvflash --ddtree` after | **30.6** | 0 |
| `--ddtree` (no kvflash) after | 29.7 | 0 |

Parity: kvflash == no-kvflash (tree-verify engages under kvflash), coherent, 0 invalid-seed. Laguna kvflash requires prompt ≤ pool (no pooled chunked prefill; >pool errors are pre-existing and unrelated).

## Not included
- **MoE (qwen35moe)**: has no tree-verify wired (no DFlashTarget / `verify_tree`), so there is nothing to gate — getting the same win there is a separate feature (wire DDTree into MoE), not a port of this fix.

## Test plan
- [x] qwen35 + laguna build (HIP, gfx1151) against current main
- [x] `--kvflash --ddtree` throughput restored, 0 invalid-seed, both models
- [x] laguna `--ddtree` no longer crashes on HIP (top_k fix)
- [x] qwen35 >pool paging + needle recall
- [x] no-kvflash path unchanged / at parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)
