### PR TITLE
deps: bump llama.cpp — RDNA3/RDNA4 MMQ tile override (+6–8% decode)

### DIFF
--- a/server/docs/HIP_PERF_PLAN.md
+++ b/server/docs/HIP_PERF_PLAN.md
@@ -1,5 +1,14 @@
 # HIP perf — diagnosis + kernel-side optimization plan
 
+> **Update 2026-06-23 — RDNA MMQ tile override shipped (via submodule bump).**
+> A `48×64`/4-warp MMQ tile for the small DFlash verify batches (vs the stock
+> `128×128`/8) lands in the `luce-dflash` llama.cpp submodule
+> (Luce-Org/llama.cpp-dflash-ggml#18). Measured on Qwen3.6-27B Q4_K_M,
+> `--ddtree-budget=22`, 10-prompt HE mean, output bit-identical:
+> **gfx1201 (R9700) 54.65 → 59.37 tok/s (+8.3%)**, **gfx1100 (RX 7900 XTX)
+> 56.78 → 60.18 tok/s (+6.0%)**. This is the cycle-9 idea generalized to
+> budget=22 and to RDNA4; gfx1151/RDNA3.5 stays on the default (untested).
+
 _Drafted 2026-05-11 against `Luce-Org/lucebox-hub` post-#122 with HIP/ROCm
 support landing in the upcoming PR. Numbers below are from the canonical
 DFlash bench (Qwen3.6-27B-Q4_K_M + z-lab DFlash drafter,


### PR DESCRIPTION
Bumps the `server/deps/llama.cpp` submodule (`luce-dflash`) to pick up the RDNA3/RDNA4 MMQ tile override — a `48×64`/4-warp tile for DFlash's small spec-decode verify batches in place of the stock `128×128`/8.

### Impact (Qwen3.6-27B Q4_K_M, `--ddtree-budget=22`, 10-prompt HE mean, n_gen=256, output bit-identical)
| GPU | before | after | gain |
|-----|------:|------:|-----:|
| gfx1201 (R9700) | 54.65 | 59.37 | +8.3% |
| gfx1100 (RX 7900 XTX) | 56.78 | 60.18 | +6.0% |

### Dependency / draft status
- **Depends on Luce-Org/llama.cpp-dflash-ggml#18** (the kernel change). This PR currently points the submodule at that PR's head commit; before merging, repoint the SHA to the `luce-dflash` merge commit of #18.
- Draft until #18 merges. CI submodule checkout may not resolve the PR-head SHA until then.
- gfx1151/RDNA3.5 is intentionally left on the default (not benchmarked).

Benchmarks measured on the two GPUs above; AI-assisted (Claude Code).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

