### PR TITLE
fix(server): handle UMA memory accounting for MoE placement

### DIFF
--- a/server/src/common/moe_hybrid_placement.h
+++ b/server/src/common/moe_hybrid_placement.h
@@ -4,13 +4,30 @@
 
 #include "moe_hybrid_types.h"
 
+#include <cstddef>
 #include <cstdint>
+#include <cstdio>
 #include <string>
 #include <vector>
 
 namespace dflash::common {
 
 struct MoeHybridRoutingStats;  // forward decl
+
+inline uint64_t moe_hybrid_core_bytes_from_memory(const char * log_prefix,
+                                                  size_t gpu_free,
+                                                  size_t gpu_total) {
+    if (gpu_total >= gpu_free) {
+        return (uint64_t) gpu_total - (uint64_t) gpu_free;
+    }
+
+    std::printf("[%s] dynamic placement: free memory exceeds reported GPU total "
+                "(free=%.2f GiB, total=%.2f GiB), using core=0 for UMA budget accounting\n",
+                log_prefix ? log_prefix : "moe-hybrid",
+                gpu_free / 1024.0 / 1024.0 / 1024.0,
+                gpu_total / 1024.0 / 1024.0 / 1024.0);
+    return 0;
+}
 
 struct MoeHybridPlacement {
     int n_layer       = 0;

--- a/server/src/laguna/laguna_backend.cpp
+++ b/server/src/laguna/laguna_backend.cpp
@@ -1432,7 +1432,8 @@ bool LagunaBackend::init_hybrid_mode() {
 
     const uint64_t warm_cache_bytes = 200ULL * 1024 * 1024;
     const uint64_t safety_bytes = 512ULL * 1024 * 1024;
-    const uint64_t core_bytes = gpu_total - gpu_free;
+    const uint64_t core_bytes =
+        moe_hybrid_core_bytes_from_memory("laguna", gpu_free, gpu_total);
 
     uint64_t expert_budget = 0;
     if (gpu_total > core_bytes + kv_total + warm_cache_bytes + safety_bytes) {

--- a/server/src/qwen35moe/qwen35moe_backend.cpp
+++ b/server/src/qwen35moe/qwen35moe_backend.cpp
@@ -2145,8 +2145,9 @@ bool Qwen35MoeBackend::load_dynamic_placement(const char * hotness_path,
         safety_bytes = 256ULL * 1024 * 1024;  // can reduce safety when draft accounts for it
     }
 
-    // Core model bytes = what's already used on GPU (non-expert tensors)
-    const uint64_t core_bytes = gpu_total - gpu_free;
+    // Core model bytes = what's already used on GPU (non-expert tensors).
+    const uint64_t core_bytes =
+        moe_hybrid_core_bytes_from_memory("qwen35moe", gpu_free, gpu_total);
 
     uint64_t expert_budget = 0;
     if (gpu_total > core_bytes + kv_total + warm_cache_bytes + safety_bytes + draft_reserve_bytes) {


### PR DESCRIPTION
## Summary

Fix MoE dynamic placement on UMA HIP backends where `ggml_backend_dev_memory()` can report available UMA memory larger than the fixed GPU total. The previous `gpu_total - gpu_free` core-memory estimate could unsigned-underflow, making the expert budget collapse to zero and preventing MoE backends from starting.

This adds a shared MoE placement helper that keeps the existing dGPU accounting unchanged, while saturating the UMA `free > total` case to `core=0`.

## Changes

- Add shared MoE hybrid placement memory accounting for UMA `gpu_free > gpu_total`.
- Use the shared helper in Qwen35MoE dynamic expert placement.
- Use the same helper in Laguna hybrid expert placement.

## Notes

- This is a narrow placement-accounting fix. It does not change expert routing, IPC, layer split, GDN, or scheduling policy.
- On normal dGPU memory reports where `gpu_total >= gpu_free`, the original used-memory calculation is preserved.
- Remote Strix Halo/gfx1151 HIP validation:
  - Qwen35MoE pure HIP now starts and serves. It logs `core=0.00 GiB`, `expert_budget=11.25 GiB`, and all `10240` experts resident; smoke result: `3092` prompt tokens, prefill `702.71 tok/s`, decode `53.8 tok/s`.
  - Laguna pure HIP now starts and serves. It logs `core=0.00 GiB`, `expert_budget=17.68 GiB`, and all `9984` experts resident; smoke result: `1250` prompt tokens, prefill `790.64 tok/s`, decode `46.2 tok/s`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

