### PR TITLE
feat(laguna): add Domino GRU draft head

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -253,6 +253,7 @@ add_library(dflash_common STATIC
     src/laguna/laguna_layer_split_adapter.cpp
     src/laguna/laguna_dflash_target.cpp
     src/common/backend_ipc.cpp
+    src/common/domino_head.cpp
     src/common/target_shard_ipc.cpp
     src/common/target_shard_ipc_daemon.cpp
     src/common/dflash_feature_ring.cpp

--- a/server/scripts/convert_dflash_to_gguf.py
+++ b/server/scripts/convert_dflash_to_gguf.py
@@ -231,6 +231,69 @@ SAFETENSORS_DTYPE_TO_GGUF = {
 }
 
 
+DOMINO_TENSOR_MAP = {
+    "domino_start":               ("dflash.domino.start",         gguf.GGMLQuantizationType.F32),
+    "domino_gru.weight_ih_l0":    ("dflash.domino.gru.weight_ih", gguf.GGMLQuantizationType.F16),
+    "domino_gru.weight_hh_l0":    ("dflash.domino.gru.weight_hh", gguf.GGMLQuantizationType.F16),
+    "domino_gru.bias_ih_l0":      ("dflash.domino.gru.bias_ih",   gguf.GGMLQuantizationType.F32),
+    "domino_gru.bias_hh_l0":      ("dflash.domino.gru.bias_hh",   gguf.GGMLQuantizationType.F32),
+    "domino_head.W1.weight":      ("dflash.domino.head.w1",       gguf.GGMLQuantizationType.F16),
+    "domino_head.W1.bias":        ("dflash.domino.head.b1",       gguf.GGMLQuantizationType.F32),
+    "domino_head.W2.weight":      ("dflash.domino.head.w2",       gguf.GGMLQuantizationType.F16),
+    "domino_head.W2.bias":        ("dflash.domino.head.b2",       gguf.GGMLQuantizationType.F32),
+}
+
+
+def add_domino_aux_heads(writer, arch: str, aux_path: Path | None):
+    if aux_path is None:
+        return
+    if not aux_path.exists():
+        print(f"[warn] Domino aux heads not found: {aux_path}")
+        return
+
+    try:
+        import torch
+    except ImportError as exc:
+        print(f"[error] --aux-heads requires torch: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"[info] reading Domino aux heads from {aux_path}")
+    state = torch.load(aux_path, map_location="cpu")
+    if isinstance(state, dict) and "state_dict" in state and isinstance(state["state_dict"], dict):
+        state = state["state_dict"]
+    if not isinstance(state, dict):
+        print(f"[error] Domino aux heads file is not a tensor dict: {aux_path}", file=sys.stderr)
+        sys.exit(1)
+
+    missing = [k for k in DOMINO_TENSOR_MAP if k not in state]
+    if missing:
+        print(f"[warn] incomplete Domino aux heads; missing {missing}; skipping Domino tensors")
+        return
+
+    w_hh = state["domino_gru.weight_hh_l0"]
+    w1 = state["domino_head.W1.weight"]
+    w2 = state["domino_head.W2.weight"]
+    gru_hidden_dim = int(w_hh.shape[1])
+    emb_dim = int(w1.shape[0])
+    vocab = int(w2.shape[0])
+    writer.add_uint32(f"{arch}.dflash.domino.enabled", 1)
+    writer.add_uint32(f"{arch}.dflash.domino.gru_hidden_dim", gru_hidden_dim)
+    writer.add_uint32(f"{arch}.dflash.domino.emb_dim", emb_dim)
+    writer.add_uint32(f"{arch}.dflash.domino.vocab_size", vocab)
+
+    for st_name, (gguf_name, raw_dtype) in DOMINO_TENSOR_MAP.items():
+        t = state[st_name]
+        if hasattr(t, "detach"):
+            t = t.detach().cpu()
+        arr = t.float().numpy()
+        if raw_dtype == gguf.GGMLQuantizationType.F16:
+            arr = arr.astype("<f2")
+        else:
+            arr = arr.astype("<f4")
+        writer.add_tensor(gguf_name, arr, raw_dtype=raw_dtype)
+        print(f"[tensor] {gguf_name:50s} aux ->{raw_dtype.name:4s} {tuple(arr.shape)}")
+
+
 # ──────────────────────────────────────────────────────────────────────
 # Main
 # ──────────────────────────────────────────────────────────────────────
@@ -239,6 +302,10 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("safetensors", type=Path)
     ap.add_argument("out_gguf",     type=Path)
+    ap.add_argument("--aux-heads", type=Path, default=None,
+                    help="optional Domino aux-head .pt file; defaults to dflash_aux_heads.pt next to the safetensors")
+    ap.add_argument("--no-aux-heads", action="store_true",
+                    help="do not auto-embed Domino aux-head tensors")
     args = ap.parse_args()
 
     if not args.safetensors.exists():
@@ -328,6 +395,11 @@ def main():
             raw_dtype = gguf.GGMLQuantizationType.F32
         writer.add_tensor(gguf_name, arr, raw_dtype=raw_dtype)
         print(f"[tensor] {gguf_name:50s} {st_dtype:4s}->{raw_dtype.name:4s} {tuple(shape)}")
+
+    aux_path = None
+    if not args.no_aux_heads:
+        aux_path = args.aux_heads if args.aux_heads is not None else args.safetensors.parent / "dflash_aux_heads.pt"
+    add_domino_aux_heads(writer, ARCH, aux_path)
 
     print(f"[info] writing {args.out_gguf}")
     writer.write_header_to_file()

--- a/server/src/common/dflash_target.h
+++ b/server/src/common/dflash_target.h
@@ -122,6 +122,16 @@ struct DFlashTarget {
                                           int n_tokens,
                                           std::vector<int32_t> & tokens_out) = 0;
 
+    // Project draft hidden states through the target lm_head and return full
+    // f32 logits with vocab as the fastest-changing dimension.
+    // Default false (unsupported); Domino-capable targets override.
+    virtual bool project_hidden_to_logits(const float * hidden,
+                                          int n_tokens,
+                                          std::vector<float> & logits_out) {
+        (void)hidden; (void)n_tokens; (void)logits_out;
+        return false;
+    }
+
     // Project draft hidden states through the target lm_head and return the
     // per-position top-K log-probabilities + token ids (for DDTree building).
     // Default false (unsupported); tree-verify targets override.

--- a/server/src/common/domino_head.cpp
+++ b/server/src/common/domino_head.cpp
@@ -1,0 +1,182 @@
+#include "domino_head.h"
+
+#include "ggml-alloc.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+namespace dflash::common {
+
+namespace {
+
+bool domino_step(const DraftWeights & dw,
+                 ggml_backend_t backend,
+                 const float * prev_embed,
+                 const float * prev_state,
+                 const float * draft_hidden,
+                 const float * base_logits,
+                 int vocab,
+                 int32_t & out_token,
+                 std::vector<float> & out_state) {
+    const int hidden = dw.n_embd;
+    const int H = dw.domino.gru_hidden_dim;
+    const int E = dw.domino.emb_dim;
+    if (hidden <= 0 || H <= 0 || E <= 0 || vocab <= 0) return false;
+
+    const size_t arena_size =
+        ggml_tensor_overhead() * 256 + ggml_graph_overhead() + 2 * 1024 * 1024;
+    static thread_local std::vector<uint8_t> g_arena;
+    if (g_arena.size() < arena_size) g_arena.resize(arena_size);
+
+    ggml_init_params ip{};
+    ip.mem_size = arena_size;
+    ip.mem_buffer = g_arena.data();
+    ip.no_alloc = true;
+    ggml_context * ctx = ggml_init(ip);
+    if (!ctx) return false;
+    ggml_cgraph * gf = ggml_new_graph_custom(ctx, 256, false);
+
+    ggml_tensor * inp_embed = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, hidden, 1);
+    ggml_tensor * inp_state = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, H, 1);
+    ggml_tensor * inp_hidden = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, hidden, 1);
+    ggml_tensor * inp_base = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, vocab, 1);
+    ggml_set_input(inp_embed);
+    ggml_set_input(inp_state);
+    ggml_set_input(inp_hidden);
+    ggml_set_input(inp_base);
+
+    ggml_tensor * gi = ggml_mul_mat(ctx, dw.domino.gru_w_ih, inp_embed);
+    gi = ggml_add(ctx, gi, ggml_reshape_2d(ctx, dw.domino.gru_b_ih, 3 * H, 1));
+    ggml_tensor * gh = ggml_mul_mat(ctx, dw.domino.gru_w_hh, inp_state);
+    gh = ggml_add(ctx, gh, ggml_reshape_2d(ctx, dw.domino.gru_b_hh, 3 * H, 1));
+
+    const size_t gate_bytes = (size_t)H * ggml_element_size(gi);
+    ggml_tensor * i_r = ggml_view_2d(ctx, gi, H, 1, gi->nb[1], 0);
+    ggml_tensor * i_z = ggml_view_2d(ctx, gi, H, 1, gi->nb[1], gate_bytes);
+    ggml_tensor * i_n = ggml_view_2d(ctx, gi, H, 1, gi->nb[1], 2 * gate_bytes);
+    ggml_tensor * h_r = ggml_view_2d(ctx, gh, H, 1, gh->nb[1], 0);
+    ggml_tensor * h_z = ggml_view_2d(ctx, gh, H, 1, gh->nb[1], gate_bytes);
+    ggml_tensor * h_n = ggml_view_2d(ctx, gh, H, 1, gh->nb[1], 2 * gate_bytes);
+
+    ggml_tensor * reset = ggml_sigmoid(ctx, ggml_add(ctx, i_r, h_r));
+    ggml_tensor * update = ggml_sigmoid(ctx, ggml_add(ctx, i_z, h_z));
+    ggml_tensor * cand = ggml_tanh(ctx, ggml_add(ctx, i_n, ggml_mul(ctx, reset, h_n)));
+    ggml_tensor * h_new = ggml_add(ctx, cand,
+                                   ggml_mul(ctx, update,
+                                            ggml_sub(ctx, inp_state, cand)));
+
+    ggml_tensor * zcat = ggml_concat(ctx, inp_hidden, h_new, 0);
+    ggml_tensor * bias = ggml_mul_mat(ctx, dw.domino.head_w1, zcat);
+    bias = ggml_add(ctx, bias, ggml_reshape_2d(ctx, dw.domino.head_b1, E, 1));
+    bias = ggml_silu(ctx, bias);
+    bias = ggml_mul_mat(ctx, dw.domino.head_w2, bias);
+    bias = ggml_add(ctx, bias, ggml_reshape_2d(ctx, dw.domino.head_b2, vocab, 1));
+
+    ggml_tensor * corrected = ggml_add(ctx, inp_base, bias);
+    ggml_tensor * tok = ggml_argmax(ctx, corrected);
+    ggml_set_output(tok);
+    ggml_set_output(h_new);
+    ggml_build_forward_expand(gf, tok);
+    ggml_build_forward_expand(gf, h_new);
+
+    static thread_local ggml_gallocr_t galloc = nullptr;
+    if (!galloc) {
+        galloc = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend));
+    }
+    if (!ggml_gallocr_alloc_graph(galloc, gf)) {
+        std::fprintf(stderr, "domino_step: gallocr_alloc_graph failed\n");
+        ggml_free(ctx);
+        return false;
+    }
+
+    ggml_backend_tensor_set(inp_embed, prev_embed, 0, sizeof(float) * (size_t)hidden);
+    ggml_backend_tensor_set(inp_state, prev_state, 0, sizeof(float) * (size_t)H);
+    ggml_backend_tensor_set(inp_hidden, draft_hidden, 0, sizeof(float) * (size_t)hidden);
+    ggml_backend_tensor_set(inp_base, base_logits, 0, sizeof(float) * (size_t)vocab);
+
+    if (ggml_backend_graph_compute(backend, gf) != GGML_STATUS_SUCCESS) {
+        std::fprintf(stderr, "domino_step: graph_compute failed\n");
+        ggml_free(ctx);
+        return false;
+    }
+
+    ggml_backend_tensor_get(tok, &out_token, 0, sizeof(out_token));
+    out_state.resize((size_t)H);
+    ggml_backend_tensor_get(h_new, out_state.data(), 0, sizeof(float) * (size_t)H);
+    ggml_free(ctx);
+    return true;
+}
+
+}  // namespace
+
+bool domino_correct_greedy_chain(const DraftWeights & dw,
+                                 ggml_backend_t backend,
+                                 DFlashTarget & target,
+                                 const float * local_hidden,
+                                 int q_len,
+                                 int32_t last_tok,
+                                 std::vector<int32_t> & draft_tok) {
+    if (!dw.domino.enabled || q_len <= 1 || !local_hidden) return false;
+    const int hidden = dw.n_embd;
+    const int H = dw.domino.gru_hidden_dim;
+    const int n_candidates = q_len - 1;
+    if (hidden <= 0 || H <= 0 || n_candidates <= 0) return false;
+
+    std::vector<float> candidate_hidden((size_t)n_candidates * (size_t)hidden);
+    for (int i = 0; i < n_candidates; ++i) {
+        const float * src = local_hidden + (size_t)(i + 1) * (size_t)hidden;
+        std::memcpy(candidate_hidden.data() + (size_t)i * (size_t)hidden,
+                    src, sizeof(float) * (size_t)hidden);
+    }
+
+    std::vector<float> base_logits;
+    if (!target.project_hidden_to_logits(candidate_hidden.data(), n_candidates, base_logits)) {
+        return false;
+    }
+    if (base_logits.size() % (size_t)n_candidates != 0) return false;
+    const int vocab = (int)(base_logits.size() / (size_t)n_candidates);
+    if (dw.domino.vocab_size > 0 && vocab != dw.domino.vocab_size) {
+        std::fprintf(stderr, "domino_correct_greedy_chain: vocab mismatch target=%d domino=%d\n",
+                     vocab, dw.domino.vocab_size);
+        return false;
+    }
+
+    std::vector<float> state((size_t)H, 0.0f);
+    if (std::getenv("DFLASH_DOMINO_ZERO_START") == nullptr) {
+        ggml_backend_tensor_get(dw.domino.start, state.data(), 0,
+                                sizeof(float) * (size_t)H);
+    }
+
+    std::vector<float> prev_embed((size_t)hidden);
+    int32_t prefix_tok = last_tok;
+    if (!target.embed_tokens(&prefix_tok, 1, prev_embed.data())) {
+        return false;
+    }
+
+    draft_tok.assign((size_t)q_len, 0);
+    draft_tok[0] = last_tok;
+    std::vector<float> next_state;
+    for (int i = 0; i < n_candidates; ++i) {
+        int32_t tok = -1;
+        if (!domino_step(dw, backend,
+                         prev_embed.data(),
+                         state.data(),
+                         candidate_hidden.data() + (size_t)i * (size_t)hidden,
+                         base_logits.data() + (size_t)i * (size_t)vocab,
+                         vocab,
+                         tok,
+                         next_state)) {
+            return false;
+        }
+        draft_tok[(size_t)i + 1] = tok;
+        state.swap(next_state);
+        if (!target.embed_tokens(&tok, 1, prev_embed.data())) {
+            return false;
+        }
+    }
+    return true;
+}
+
+}  // namespace dflash::common

--- a/server/src/common/domino_head.h
+++ b/server/src/common/domino_head.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "dflash_target.h"
+#include "internal.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace dflash::common {
+
+bool domino_correct_greedy_chain(const DraftWeights & dw,
+                                 ggml_backend_t backend,
+                                 DFlashTarget & target,
+                                 const float * local_hidden,
+                                 int q_len,
+                                 int32_t last_tok,
+                                 std::vector<int32_t> & draft_tok);
+
+}  // namespace dflash::common

--- a/server/src/draft/draft_gguf_loader.cpp
+++ b/server/src/draft/draft_gguf_loader.cpp
@@ -115,6 +115,29 @@ int count_swa_layers(const DraftWeights & w) {
     return n_swa;
 }
 
+bool check_shape_1d(const ggml_tensor * t, int64_t ne0, const char * name, char * buf, size_t buf_sz) {
+    if (!t || t->ne[0] != ne0) {
+        std::snprintf(buf, buf_sz, "draft GGUF: Domino tensor %s shape mismatch: got [%lld], expected [%lld]",
+                      name, t ? (long long)t->ne[0] : -1LL, (long long)ne0);
+        return false;
+    }
+    return true;
+}
+
+bool check_shape_2d(const ggml_tensor * t, int64_t ne0, int64_t ne1,
+                    const char * name, char * buf, size_t buf_sz) {
+    if (!t || t->ne[0] != ne0 || t->ne[1] != ne1) {
+        std::snprintf(buf, buf_sz,
+                      "draft GGUF: Domino tensor %s shape mismatch: got [%lld,%lld], expected [%lld,%lld]",
+                      name,
+                      t ? (long long)t->ne[0] : -1LL,
+                      t ? (long long)t->ne[1] : -1LL,
+                      (long long)ne0, (long long)ne1);
+        return false;
+    }
+    return true;
+}
+
 } // namespace
 
 bool load_draft_gguf(const std::string & path,
@@ -177,6 +200,10 @@ bool load_draft_gguf(const std::string & path,
     const uint32_t head_dim  = read_u32("attention.key_length",    0);
     const uint32_t block_sz  = read_u32("dflash.block_size",       0);
     uint32_t n_tgt_lay       = read_u32("dflash.n_target_layers",  0);
+    const uint32_t domino_meta_enabled = read_u32("dflash.domino.enabled", 0);
+    const uint32_t domino_meta_gru     = read_u32("dflash.domino.gru_hidden_dim", 0);
+    const uint32_t domino_meta_emb     = read_u32("dflash.domino.emb_dim", 0);
+    const uint32_t domino_meta_vocab   = read_u32("dflash.domino.vocab_size", 0);
     // Explicit captured target-layer ids (data-driven). Lets any DFlash drafter
     // load without a hardcoded per-arch set; the array length also backstops
     // n_target_layers when the scalar KV is absent.
@@ -303,6 +330,64 @@ bool load_draft_gguf(const std::string & path,
             gguf_free(gctx);
             return false;
         }
+    }
+
+    out.domino = DraftDominoWeights{};
+    out.domino.start    = g("dflash.domino.start");
+    out.domino.gru_w_ih = g("dflash.domino.gru.weight_ih");
+    out.domino.gru_w_hh = g("dflash.domino.gru.weight_hh");
+    out.domino.gru_b_ih = g("dflash.domino.gru.bias_ih");
+    out.domino.gru_b_hh = g("dflash.domino.gru.bias_hh");
+    out.domino.head_w1  = g("dflash.domino.head.w1");
+    out.domino.head_b1  = g("dflash.domino.head.b1");
+    out.domino.head_w2  = g("dflash.domino.head.w2");
+    out.domino.head_b2  = g("dflash.domino.head.b2");
+
+    const bool domino_any =
+        out.domino.start || out.domino.gru_w_ih || out.domino.gru_w_hh ||
+        out.domino.gru_b_ih || out.domino.gru_b_hh || out.domino.head_w1 ||
+        out.domino.head_b1 || out.domino.head_w2 || out.domino.head_b2 ||
+        domino_meta_enabled != 0;
+    if (domino_any) {
+        const bool domino_all =
+            out.domino.start && out.domino.gru_w_ih && out.domino.gru_w_hh &&
+            out.domino.gru_b_ih && out.domino.gru_b_hh && out.domino.head_w1 &&
+            out.domino.head_b1 && out.domino.head_w2 && out.domino.head_b2;
+        if (!domino_all) {
+            set_last_error("draft GGUF: incomplete Domino aux-head tensors");
+            gguf_free(gctx);
+            return false;
+        }
+
+        out.domino.gru_hidden_dim =
+            domino_meta_gru != 0 ? (int)domino_meta_gru : (int)out.domino.gru_w_hh->ne[0];
+        out.domino.emb_dim =
+            domino_meta_emb != 0 ? (int)domino_meta_emb : (int)out.domino.head_w1->ne[1];
+        out.domino.vocab_size =
+            domino_meta_vocab != 0 ? (int)domino_meta_vocab : (int)out.domino.head_w2->ne[1];
+
+        const int64_t H = out.domino.gru_hidden_dim;
+        const int64_t E = out.domino.emb_dim;
+        const int64_t V = out.domino.vocab_size;
+        char shape_err[320];
+        if (!check_shape_1d(out.domino.start, H, "start", shape_err, sizeof(shape_err)) ||
+            !check_shape_2d(out.domino.gru_w_ih, out.n_embd, 3 * H, "gru.weight_ih", shape_err, sizeof(shape_err)) ||
+            !check_shape_2d(out.domino.gru_w_hh, H, 3 * H, "gru.weight_hh", shape_err, sizeof(shape_err)) ||
+            !check_shape_1d(out.domino.gru_b_ih, 3 * H, "gru.bias_ih", shape_err, sizeof(shape_err)) ||
+            !check_shape_1d(out.domino.gru_b_hh, 3 * H, "gru.bias_hh", shape_err, sizeof(shape_err)) ||
+            !check_shape_2d(out.domino.head_w1, out.n_embd + H, E, "head.w1", shape_err, sizeof(shape_err)) ||
+            !check_shape_1d(out.domino.head_b1, E, "head.b1", shape_err, sizeof(shape_err)) ||
+            !check_shape_2d(out.domino.head_w2, E, V, "head.w2", shape_err, sizeof(shape_err)) ||
+            !check_shape_1d(out.domino.head_b2, V, "head.b2", shape_err, sizeof(shape_err))) {
+            set_last_error(shape_err);
+            gguf_free(gctx);
+            return false;
+        }
+
+        out.domino.enabled = true;
+        std::fprintf(stderr, "[draft GGUF] Domino GRU head enabled: H=%d E=%d vocab=%d\n",
+                     out.domino.gru_hidden_dim, out.domino.emb_dim,
+                     out.domino.vocab_size);
     }
 
     // GGUF Qwen3.6 drafters carry SWA metadata emitted by the converter:

--- a/server/src/draft/draft_safetensors_loader.cpp
+++ b/server/src/draft/draft_safetensors_loader.cpp
@@ -698,6 +698,7 @@ void free_draft_weights(DraftWeights & w) {
     w.fc = nullptr;
     w.hidden_norm = nullptr;
     w.out_norm = nullptr;
+    w.domino = DraftDominoWeights{};
 }
 
 } // namespace dflash::common

--- a/server/src/internal.h
+++ b/server/src/internal.h
@@ -246,6 +246,23 @@ struct DraftLayer {
     bool is_swa = false;  // true for SWA layers (Qwen3.6 pattern)
 };
 
+struct DraftDominoWeights {
+    bool enabled = false;
+    int  gru_hidden_dim = 0;
+    int  emb_dim = 0;
+    int  vocab_size = 0;
+
+    ggml_tensor * start       = nullptr;  // [gru_hidden_dim] f32
+    ggml_tensor * gru_w_ih    = nullptr;  // [n_embd, 3*gru_hidden_dim]
+    ggml_tensor * gru_w_hh    = nullptr;  // [gru_hidden_dim, 3*gru_hidden_dim]
+    ggml_tensor * gru_b_ih    = nullptr;  // [3*gru_hidden_dim] f32
+    ggml_tensor * gru_b_hh    = nullptr;  // [3*gru_hidden_dim] f32
+    ggml_tensor * head_w1     = nullptr;  // [n_embd+gru_hidden_dim, emb_dim]
+    ggml_tensor * head_b1     = nullptr;  // [emb_dim] f32
+    ggml_tensor * head_w2     = nullptr;  // [emb_dim, vocab_size]
+    ggml_tensor * head_b2     = nullptr;  // [vocab_size] f32
+};
+
 struct DraftWeights {
     ggml_context *    ctx = nullptr;
     ggml_backend_t    backend = nullptr;
@@ -279,6 +296,11 @@ struct DraftWeights {
     int n_target_layers = DFLASH27B_DRAFT_N_TARGET_LAYERS;  // captured target layers (5)
     std::vector<int> capture_layer_ids;                     // explicit captured target-layer ids (GGUF dflash.target_layer_ids); empty = derive from count
     int mask_token_id   = DFLASH27B_DRAFT_MASK_TOKEN_ID;    // noise mask token
+
+    // Optional Domino causal correction head. When present, greedy chain
+    // speculative decode corrects each draft token with a lightweight GRU
+    // conditioned on the realized prefix before target verification.
+    DraftDominoWeights domino;
 };
 
 bool load_draft_safetensors(const std::string & path,

--- a/server/src/laguna/laguna_backend.cpp
+++ b/server/src/laguna/laguna_backend.cpp
@@ -11,6 +11,7 @@
 #include "qwen3/qwen3_kvflash_scorer.h"
 #include "dflash27b.h"
 #include "common/ddtree.h"
+#include "common/domino_head.h"
 #include "common/dflash_feature_ring.h"
 #include "common/dflash_draft_graph.h"
 
@@ -30,6 +31,7 @@
 #include "common/snapshot_backend.h"
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
@@ -572,12 +574,36 @@ bool LagunaBackend::do_spec_decode(int committed, int n_gen,
         ggml_backend_tensor_get(draft_sg.hidden_states, local_hidden.data(), 0,
                                 sizeof(float) * local_hidden.size());
 
-        if (!target->project_hidden_to_tokens(local_hidden.data(), q_len, draft_tok)) {
-            std::fprintf(stderr, "[laguna-spec] projection failed\n");
-            step_graph_destroy(draft_sg);
-            return false;
+        bool used_domino = false;
+        if (dw_.domino.enabled && q_len > 1 && !sampled_verify && !args_.ddtree_mode) {
+            static std::atomic<bool> s_domino_logged{false};
+            if (!s_domino_logged.exchange(true)) {
+                std::fprintf(stderr,
+                    "[laguna-spec] Domino GRU head active for greedy chain decode "
+                    "(H=%d E=%d)\n",
+                    dw_.domino.gru_hidden_dim, dw_.domino.emb_dim);
+            }
+            if (domino_correct_greedy_chain(dw_, draft_backend_, *target,
+                                            local_hidden.data(), q_len,
+                                            last_tok, draft_tok)) {
+                used_domino = true;
+            } else {
+                static std::atomic<bool> s_domino_warned{false};
+                if (!s_domino_warned.exchange(true)) {
+                    std::fprintf(stderr,
+                        "[laguna-spec] Domino GRU head failed; falling back to base "
+                        "DFlash projection\n");
+                }
+            }
         }
-        draft_tok[0] = last_tok;
+        if (!used_domino) {
+            if (!target->project_hidden_to_tokens(local_hidden.data(), q_len, draft_tok)) {
+                std::fprintf(stderr, "[laguna-spec] projection failed\n");
+                step_graph_destroy(draft_sg);
+                return false;
+            }
+            draft_tok[0] = last_tok;
+        }
 
         const bool tree_special_inactive =
             !(budget_hook && !budget_hook->close_token_ids.empty());

--- a/server/src/laguna/laguna_dflash_target.cpp
+++ b/server/src/laguna/laguna_dflash_target.cpp
@@ -523,6 +523,51 @@ bool LagunaDFlashTarget::project_hidden_to_tokens(
     return laguna_project_hidden(backend_, w_, hidden, n_tokens, tokens_out);
 }
 
+bool LagunaDFlashTarget::project_hidden_to_logits(
+        const float * hidden,
+        int n_tokens,
+        std::vector<float> & logits_out) {
+    if (n_tokens <= 0) return false;
+
+    ggml_init_params ip{};
+    ip.mem_size = ggml_tensor_overhead() * 64 + ggml_graph_overhead() + 1024 * 1024;
+    ip.no_alloc = true;
+    ggml_context * ctx = ggml_init(ip);
+    if (!ctx) return false;
+    ggml_cgraph * gf = ggml_new_graph(ctx);
+
+    ggml_tensor * inp = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, w_.n_embd, n_tokens);
+    ggml_set_input(inp);
+    ggml_tensor * logits = ggml_mul_mat(ctx, w_.output, inp);
+    ggml_set_output(logits);
+    ggml_build_forward_expand(gf, logits);
+
+    static ggml_gallocr_t galloc_logits = nullptr;
+    if (!galloc_logits) {
+        galloc_logits = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend_));
+    }
+    if (!ggml_gallocr_alloc_graph(galloc_logits, gf)) {
+        std::fprintf(stderr, "laguna_project_hidden_to_logits: gallocr_alloc_graph failed\n");
+        ggml_free(ctx);
+        return false;
+    }
+
+    ggml_backend_tensor_set(inp, hidden, 0,
+                            sizeof(float) * (size_t)n_tokens * (size_t)w_.n_embd);
+    if (ggml_backend_graph_compute(backend_, gf) != GGML_STATUS_SUCCESS) {
+        std::fprintf(stderr, "laguna_project_hidden_to_logits: graph_compute failed\n");
+        ggml_free(ctx);
+        return false;
+    }
+
+    const int vocab = (int)w_.embedder.n_vocab;
+    logits_out.resize((size_t)n_tokens * (size_t)vocab);
+    ggml_backend_tensor_get(logits, logits_out.data(), 0,
+                            sizeof(float) * logits_out.size());
+    ggml_free(ctx);
+    return true;
+}
+
 bool LagunaDFlashTarget::project_hidden_to_topk(
         const float * hidden,
         int n_tokens,

--- a/server/src/laguna/laguna_dflash_target.h
+++ b/server/src/laguna/laguna_dflash_target.h
@@ -57,6 +57,10 @@ public:
                                   int n_tokens,
                                   std::vector<int32_t> & tokens_out) override;
 
+    bool project_hidden_to_logits(const float * hidden,
+                                  int n_tokens,
+                                  std::vector<float> & logits_out) override;
+
     bool project_hidden_to_topk(const float * hidden,
                                 int n_tokens,
                                 int K,


### PR DESCRIPTION
## Summary
- embed optional Domino GRU/head aux tensors into DFlash draft GGUFs via convert_dflash_to_gguf.py
- load and validate dflash.domino.* tensors in the draft GGUF loader
- add a Laguna target full-logits projection hook and greedy-chain Domino correction path
- keep DDTree and sampled verify on the existing base projection path for now

## Bench notes
Ran the 30-case he,gsm,math harness on lucebox-ts RTX 3090 with Laguna-XS.2 target, max_ctx 4096, default cache, no DDTree.

v13-final+Domino:
- HumanEval: 10/10, 172.94 tok/s
- GSM8K: 7/10, 155.27 tok/s
- MATH: 8/10, 149.53 tok/s
- server aggregate: 151.56 weighted tok/s, 60.3% accept, 3.03 avg commit

Compared with v12, v13-final+Domino is slower but improves GSM by one case. This PR is the runtime/model-loading support, not a claim that v13 is the best drafter.

## Checks
- python3 -m py_compile server/scripts/convert_dflash_to_gguf.py
- git diff --check
- cmake --build server/build -j -t dflash_server on lucebox-ts existing CUDA build

Note: a fresh clean-worktree CUDA rebuild on the 3090 was attempted, but the full llama.cpp CUDA dependency compile was killed with Error 137 under memory pressure before reaching the project-only compile.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

