### PR TITLE
Add DFLASH_MODEL_NAME env for --model-name

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ Pages the attention KV cache through a fixed pool of GPU slots; cold 64-token ch
 | `--no-cors` | CORS on | Disable CORS headers |
 | `DFLASH_TARGET_GPU=N` | `0` | Env var equivalent of `--target-gpu` |
 | `DFLASH_DRAFT_GPU=N` | same as target | Env var equivalent of `--draft-gpu` |
+| `DFLASH_MODEL_NAME=<name>` | `dflash` | Env var equivalent of `--model-name`; sets the `/v1/models` id and selects the matching `share/model_cards/<name>.json` |
 
 **MoE expert offload (Spark)**
 

--- a/server/scripts/entrypoint.sh
+++ b/server/scripts/entrypoint.sh
@@ -293,6 +293,10 @@ fi
 # Optional server default for requests that omit max_tokens. When unset,
 # the C++ server uses the model-card default.
 : "${DFLASH_DEFAULT_MAX_TOKENS:=}"
+# Optional advertised model name for /v1/models (also selects the matching
+# share/model_cards/<name>.json). When unset, the C++ server uses its default
+# ("dflash"). Lets an operator surface the real model id without a wrapper.
+: "${DFLASH_MODEL_NAME:=}"
 # Phase-1 (thinking) cap when a request opts into thinking. Default mirrors
 # antirez/ds4 ds4_eval.c: think_max_tokens = max_tokens(16000) - hard_limit
 # reply budget(512) = 15488. The server's own hardcoded default is 10000;
@@ -495,6 +499,7 @@ CMD=("$DFLASH_SERVER_BIN" "$DFLASH_TARGET"
 [ -n "$DRAFT_ARG" ]                && CMD+=(--draft "$DRAFT_ARG")
 [ -n "$DRAFT_ARG" ]                && CMD+=(--ddtree --ddtree-budget "$DFLASH_BUDGET")
 [ -n "$DFLASH_DEFAULT_MAX_TOKENS" ] && CMD+=(--default-max-tokens "$DFLASH_DEFAULT_MAX_TOKENS")
+[ -n "$DFLASH_MODEL_NAME" ]         && CMD+=(--model-name "$DFLASH_MODEL_NAME")
 # `--lazy-draft` is silently dropped by the C++ server unless both
 # `--prefill-drafter` and `--draft` are present (look for the runtime
 # warning `--lazy-draft ignored: requires both --prefill-drafter and


### PR DESCRIPTION
Adds a `DFLASH_MODEL_NAME` env mapping to the server's existing `--model-name` flag, mirroring the `DFLASH_DEFAULT_MAX_TOKENS` pattern. Unset => default (`dflash`); existing deployments unchanged. Lets an operator set the `/v1/models` id (and select the matching model card) without overriding the entrypoint. README env table updated.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

