### PR TITLE
fix: gate json fetch timestamp option

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -19,11 +19,15 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 find_package(nlohmann_json CONFIG QUIET)
 if(NOT nlohmann_json_FOUND)
     include(FetchContent)
-    FetchContent_Declare(json
+    set(_dflash_json_fetch_args
         URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
-        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
         URL_HASH SHA256=d6c65aca6b1ed68e7a182f4757257b107ae403032760ed6ef121c9d55e81757d
     )
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")
+        list(APPEND _dflash_json_fetch_args DOWNLOAD_EXTRACT_TIMESTAMP TRUE)
+    endif()
+    FetchContent_Declare(json ${_dflash_json_fetch_args})
+    unset(_dflash_json_fetch_args)
     FetchContent_MakeAvailable(json)
 endif()
 


### PR DESCRIPTION
## What

Fix the Docker prebuild configure failure by only passing
`DOWNLOAD_EXTRACT_TIMESTAMP` to `FetchContent_Declare()` when the active CMake
version supports it.

The Docker images install Ubuntu 22.04's CMake 3.22.1, while
`DOWNLOAD_EXTRACT_TIMESTAMP` was added in CMake 3.24. CMake 3.22 interprets the
unknown keyword incorrectly and fails while configuring the `json` FetchContent
subbuild.

## Validation

- `git diff --check`
- Ubuntu 22.04 / CMake 3.22.1 focused FetchContent configure: passed
- macOS / CMake 4.3.1 focused FetchContent configure: passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

