### PR TITLE
deps: bump llama.cpp for RDNA3.5 MMQ override

### DIFF
--- a/server/docs/HIP_PERF_PLAN.md
+++ b/server/docs/HIP_PERF_PLAN.md
@@ -3,11 +3,12 @@
 > **Update 2026-06-23 — RDNA MMQ tile override shipped (via submodule bump).**
 > A `48×64`/4-warp MMQ tile for the small DFlash verify batches (vs the stock
 > `128×128`/8) lands in the `luce-dflash` llama.cpp submodule
-> (Luce-Org/llama.cpp-dflash-ggml#18). Measured on Qwen3.6-27B Q4_K_M,
-> `--ddtree-budget=22`, 10-prompt HE mean, output bit-identical:
+> (Luce-Org/llama.cpp-dflash-ggml#18 and #20). Measured on Qwen3.6-27B Q4_K_M,
+> `--ddtree-budget=22`, output bit-identical:
 > **gfx1201 (R9700) 54.65 → 59.37 tok/s (+8.3%)**, **gfx1100 (RX 7900 XTX)
-> 56.78 → 60.18 tok/s (+6.0%)**. This is the cycle-9 idea generalized to
-> budget=22 and to RDNA4; gfx1151/RDNA3.5 stays on the default (untested).
+> 56.78 → 60.18 tok/s (+6.0%)** on the 10-prompt HE mean; **gfx1151
+> (Strix Halo) 11.53 → 12.00 tok/s (+4.1%)** on the 256-token smoke bench.
+> This is the cycle-9 idea generalized to budget=22, RDNA4, and RDNA3.5.
 
 _Drafted 2026-05-11 against `Luce-Org/lucebox-hub` post-#122 with HIP/ROCm
 support landing in the upcoming PR. Numbers below are from the canonical


### PR DESCRIPTION
Follow-up to #439 after Luce-Org/llama.cpp-dflash-ggml#20 merged.

This repoints `server/deps/llama.cpp` from the PR #18 head commit to the
current merged `luce-dflash` head:

- old: `01545515c8ec61878295336f0023f0aa2d50fa16`
- new: `6fd3d84e2168476d5e199a2fa1221d82ba883c21`

That merged llama.cpp SHA includes the RDNA3.5 / gfx1151 gate change for the
48x64 / 4-warp MMQ tile override.

Measured on lucebox2 / Strix Halo (`gfx1151`), Qwen3.6-27B Q4_K_M, DFlash
draft, `--ddtree-budget=22`:

| workload | #439 submodule | RDNA3.5 submodule | delta |
|---|---:|---:|---:|
| 256-token low-acceptance prompt, 3-run mean excluding warmup | 11.53 tok/s | 12.00 tok/s | +4.1% |
| 64-token higher-acceptance prompt | 30.01 tok/s single run | 30.27 tok/s 3-run mean | ~+0.9% |

The 256-token run kept the same speculative-decode shape:
`accepted=138/1040`, `target_forwards=119`, accept rate 13.3%.

Also updates `server/docs/HIP_PERF_PLAN.md` so it no longer says gfx1151 stays
on the default path.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

