### PR TITLE
fix(qwen3): guard drafter loader against truncated GGUF (bug #438)

### DIFF
--- a/server/src/qwen3/qwen3_loader.cpp
+++ b/server/src/qwen3/qwen3_loader.cpp
@@ -228,13 +228,16 @@ bool load_qwen3_drafter_model(const std::string & path,
     // Validate that every tensor's data region lies within the mapped file
     // before any H2D copy. A truncated or corrupt GGUF would otherwise make
     // copy_tensor_from_file read past the end of the mapping and fault inside
-    // the device copy (bug #438).
+    // the device copy (bug #438). The comparisons are written to avoid size_t
+    // overflow on malformed offsets/sizes: a wrapped data_off + off + sz could
+    // otherwise slip past a naive "off + sz > file_size" test.
+    const size_t data_avail = data_off <= file_size ? file_size - data_off : 0;
     for (int64_t i = 0; i < gguf_get_n_tensors(gctx); ++i) {
-        const size_t off = data_off + gguf_get_tensor_offset(gctx, i);
+        const size_t off = gguf_get_tensor_offset(gctx, i);  // relative to data_off
         const size_t sz  = gguf_get_tensor_size(gctx, i);
-        if (off + sz > file_size) {
+        if (data_off > file_size || off > data_avail || sz > data_avail - off) {
             set_last_error(std::string("Qwen3-0.6B drafter GGUF is truncated or corrupt: tensor '")
-                + gguf_get_tensor_name(gctx, i) + "' data ends at " + std::to_string(off + sz)
+                + gguf_get_tensor_name(gctx, i) + "' data ends at " + std::to_string(data_off + off + sz)
                 + " but file is only " + std::to_string(file_size)
                 + " bytes. Re-download the drafter model (" + path + ").");
             gguf_free(gctx);

--- a/server/src/qwen3/qwen3_loader.cpp
+++ b/server/src/qwen3/qwen3_loader.cpp
@@ -24,6 +24,7 @@
 
 #include "qwen3_drafter_model.h"
 #include "common/backend_precision.h"
+#include "common/gguf_mmap.h"
 #include "internal.h"
 
 #include <cstdio>
@@ -211,51 +212,39 @@ bool load_qwen3_drafter_model(const std::string & path,
         precision.reason.c_str());
     std::fflush(stderr);
 
-    // mmap the GGUF data section.
+    // mmap the GGUF data section via the shared RAII wrapper (checks
+    // open/fstat, reports errors, and unmaps in its destructor).
     const size_t data_off = gguf_get_data_offset(gctx);
-#if defined(_WIN32)
-    std::wstring wpath;
-    {
-        const int wlen = MultiByteToWideChar(CP_UTF8, 0, path.c_str(), -1, nullptr, 0);
-        if (wlen <= 0) {
-            set_last_error("MultiByteToWideChar failed for " + path);
+    GgufMmap mmap;
+    std::string mmap_err;
+    if (!mmap.open(path, mmap_err)) {
+        set_last_error(mmap_err);
+        gguf_free(gctx);
+        return false;
+    }
+    const void * mm        = mmap.data();
+    const size_t file_size = mmap.size();
+
+    // Validate that every tensor's data region lies within the mapped file
+    // before any H2D copy. A truncated or corrupt GGUF would otherwise make
+    // copy_tensor_from_file read past the end of the mapping and fault inside
+    // the device copy (bug #438).
+    for (int64_t i = 0; i < gguf_get_n_tensors(gctx); ++i) {
+        const size_t off = data_off + gguf_get_tensor_offset(gctx, i);
+        const size_t sz  = gguf_get_tensor_size(gctx, i);
+        if (off + sz > file_size) {
+            set_last_error(std::string("Qwen3-0.6B drafter GGUF is truncated or corrupt: tensor '")
+                + gguf_get_tensor_name(gctx, i) + "' data ends at " + std::to_string(off + sz)
+                + " but file is only " + std::to_string(file_size)
+                + " bytes. Re-download the drafter model (" + path + ").");
             gguf_free(gctx);
+            ggml_backend_buffer_free(out.buf);
+            ggml_free(out.ctx);
+            out.buf = nullptr;
+            out.ctx = nullptr;
             return false;
         }
-        wpath.resize(wlen - 1);
-        MultiByteToWideChar(CP_UTF8, 0, path.c_str(), -1, wpath.data(), wlen);
     }
-    HANDLE hFile = CreateFileW(wpath.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
-    if (hFile == INVALID_HANDLE_VALUE) {
-        set_last_error("CreateFileW failed for " + path);
-        gguf_free(gctx);
-        return false;
-    }
-    HANDLE hMapping = CreateFileMappingA(hFile, nullptr, PAGE_READONLY, 0, 0, nullptr);
-    CloseHandle(hFile);
-    if (!hMapping) {
-        set_last_error("CreateFileMappingA failed for " + path);
-        gguf_free(gctx);
-        return false;
-    }
-    void * mm = MapViewOfFile(hMapping, FILE_MAP_READ, 0, 0, 0);
-    CloseHandle(hMapping);
-    if (!mm) {
-        set_last_error("MapViewOfFile failed for " + path);
-        gguf_free(gctx);
-        return false;
-    }
-#else
-    int fd = ::open(path.c_str(), O_RDONLY);
-    struct stat st; ::fstat(fd, &st);
-    void * mm = ::mmap(nullptr, st.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
-    ::close(fd);
-    if (mm == MAP_FAILED) {
-        set_last_error("mmap failed for " + path);
-        gguf_free(gctx);
-        return false;
-    }
-#endif
 
     bool ok = true;
     ok &= copy_tensor_from_file(gctx, "token_embd.weight", mm, data_off, out.tok_embd);
@@ -285,11 +274,6 @@ bool load_qwen3_drafter_model(const std::string & path,
         std::snprintf(nm, sizeof(nm), "blk.%d.ffn_up.weight",      il); ok &= copy_tensor_from_file(gctx, nm, mm, data_off, L.ffn_up);
         std::snprintf(nm, sizeof(nm), "blk.%d.ffn_down.weight",    il); ok &= copy_tensor_from_file(gctx, nm, mm, data_off, L.ffn_down);
     }
-#if defined(_WIN32)
-    UnmapViewOfFile(mm);
-#else
-    ::munmap(mm, st.st_size);
-#endif
     gguf_free(gctx);
 
     if (!ok) {

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -30,6 +30,9 @@
 #include "placement/draft_residency.h"
 #include "ggml-cpu.h"
 #include "server/prompt_normalize.h"
+#include "qwen3_drafter_model.h"
+#include "dflash27b.h"
+#include "gguf.h"
 #include <nlohmann/json.hpp>
 
 #include <cmath>
@@ -3990,6 +3993,121 @@ static void test_flowkv_T5_inert_guard_token_count() {
     TEST_ASSERT(1024 >= kFkvInertMinTokens);
 }
 
+// ═══════════════════════════════════════════════════════════════════════
+// Qwen3-0.6B drafter loader: truncated GGUF guard (bug #438)
+// ═══════════════════════════════════════════════════════════════════════
+//
+// Builds a minimal but structurally valid Qwen3-0.6B-style GGUF on disk, then
+// verifies that load_qwen3_drafter_model:
+//   (1) loads the full, untruncated file successfully (positive control), and
+//   (2) fails cleanly with a "truncated or corrupt" error when the tensor-data
+//       section is truncated — instead of letting the H2D copy read past the
+//       end of the mmap and SIGSEGV inside the device copy.
+
+// Write a tiny valid drafter GGUF and return its path. The loader fixes
+// n_vocab at 151936 (Qwen3DrafterWeights default), so token_embd stays the
+// largest tensor (~2.4 MB BF16) while every other tensor is minimal.
+static std::string write_qwen3_drafter_fixture_gguf() {
+    const int n_embd    = 8;
+    const int n_head    = 2;
+    const int head_dim  = 4;
+    const int n_head_kv = 1;
+    const int n_ff      = 16;
+    const int n_layer   = 1;
+    const int n_vocab   = 151936;                // must match the loader default
+    const int q_dim     = n_head * head_dim;     // 8
+    const int kv_dim    = n_head_kv * head_dim;  // 4
+
+    ggml_init_params ip{};
+    ip.mem_size   = (size_t)16 * 1024 * 1024;    // headroom for token_embd + 13 tensors
+    ip.mem_buffer = nullptr;
+    ip.no_alloc   = false;
+    ggml_context * ctx = ggml_init(ip);
+
+    gguf_context * g = gguf_init_empty();
+    gguf_set_val_u32(g, "qwen3.embedding_length",        (uint32_t)n_embd);
+    gguf_set_val_u32(g, "qwen3.feed_forward_length",     (uint32_t)n_ff);
+    gguf_set_val_u32(g, "qwen3.attention.head_count",    (uint32_t)n_head);
+    gguf_set_val_u32(g, "qwen3.attention.head_count_kv", (uint32_t)n_head_kv);
+    gguf_set_val_u32(g, "qwen3.block_count",             (uint32_t)n_layer);
+    gguf_set_val_u32(g, "qwen3.context_length",          (uint32_t)64);
+    gguf_set_val_u32(g, "qwen3.attention.key_length",    (uint32_t)head_dim);
+    gguf_set_val_f32(g, "qwen3.rope.freq_base",          1000000.0f);
+
+    auto add_tensor = [&](const char * name, ggml_type t, int n_dims,
+                          int64_t ne0, int64_t ne1) {
+        ggml_tensor * w = (n_dims == 1)
+            ? ggml_new_tensor_1d(ctx, t, ne0)
+            : ggml_new_tensor_2d(ctx, t, ne0, ne1);
+        ggml_set_name(w, name);
+        std::memset(w->data, 0, ggml_nbytes(w));
+        gguf_add_tensor(g, w);
+    };
+
+    // Top-level tensors. output.weight is intentionally omitted so the loader
+    // exercises its tied-weights path (and the fixture stays small).
+    add_tensor("token_embd.weight",  GGML_TYPE_BF16, 2, n_embd, n_vocab);
+    add_tensor("output_norm.weight", GGML_TYPE_F32,  1, n_embd, 0);
+
+    // The single transformer block: the 11 per-layer tensors the loader copies.
+    add_tensor("blk.0.attn_norm.weight",   GGML_TYPE_F32,  1, n_embd,   0);
+    add_tensor("blk.0.attn_q.weight",      GGML_TYPE_BF16, 2, n_embd,   q_dim);
+    add_tensor("blk.0.attn_k.weight",      GGML_TYPE_BF16, 2, n_embd,   kv_dim);
+    add_tensor("blk.0.attn_v.weight",      GGML_TYPE_BF16, 2, n_embd,   kv_dim);
+    add_tensor("blk.0.attn_output.weight", GGML_TYPE_BF16, 2, q_dim,    n_embd);
+    add_tensor("blk.0.attn_q_norm.weight", GGML_TYPE_F32,  1, head_dim, 0);
+    add_tensor("blk.0.attn_k_norm.weight", GGML_TYPE_F32,  1, head_dim, 0);
+    add_tensor("blk.0.ffn_norm.weight",    GGML_TYPE_F32,  1, n_embd,   0);
+    add_tensor("blk.0.ffn_gate.weight",    GGML_TYPE_BF16, 2, n_embd,   n_ff);
+    add_tensor("blk.0.ffn_up.weight",      GGML_TYPE_BF16, 2, n_embd,   n_ff);
+    add_tensor("blk.0.ffn_down.weight",    GGML_TYPE_BF16, 2, n_ff,     n_embd);
+
+    const std::string path = "/tmp/dflash_test_qwen3_drafter_438.gguf";
+    gguf_write_to_file(g, path.c_str(), /*only_meta=*/false);
+
+    gguf_free(g);
+    ggml_free(ctx);
+    return path;
+}
+
+static void test_qwen3_drafter_rejects_truncated_gguf() {
+    const std::string path = write_qwen3_drafter_fixture_gguf();
+
+    ggml_backend_t backend = ggml_backend_cpu_init();
+    TEST_ASSERT(backend != nullptr);
+
+    // Positive control: the full, untruncated file loads cleanly.
+    {
+        Qwen3DrafterWeights w;
+        bool ok = load_qwen3_drafter_model(path, backend, w);
+        TEST_ASSERT_MSG(ok, dflash27b_last_error());
+        free_qwen3_drafter_model(w);
+    }
+
+    // Truncate inside the tensor-data section. The header, kv block, and tensor
+    // info table all live before the data offset, so gguf_init_from_file still
+    // succeeds and we reach the EOF guard rather than a parse failure.
+    struct stat st{};
+    TEST_ASSERT(stat(path.c_str(), &st) == 0);
+    const off_t truncated_size = (off_t)st.st_size - 4096;
+    TEST_ASSERT(truncated_size > 0);
+    TEST_ASSERT(truncate(path.c_str(), truncated_size) == 0);
+
+    // The loader must fail cleanly (no SIGSEGV) with a descriptive error.
+    {
+        Qwen3DrafterWeights w;
+        bool ok = load_qwen3_drafter_model(path, backend, w);
+        TEST_ASSERT(!ok);
+        const std::string err = dflash27b_last_error();
+        TEST_ASSERT_MSG(err.find("truncated or corrupt") != std::string::npos,
+                        err.c_str());
+        free_qwen3_drafter_model(w);
+    }
+
+    ggml_backend_free(backend);
+    unlink(path.c_str());
+}
+
 int main() {
     std::fprintf(stderr, "══════════════════════════════════════════\n");
     std::fprintf(stderr, " Server Unit Tests\n");
@@ -4252,6 +4370,9 @@ int main() {
     RUN_TEST(test_flowkv_T3_ws1_continuation_json_shape);
     RUN_TEST(test_flowkv_T1_system_end_boundary_first);
     RUN_TEST(test_flowkv_T5_inert_guard_token_count);
+
+    std::fprintf(stderr, "\n── Qwen3-0.6B drafter loader (bug #438) ──\n");
+    RUN_TEST(test_qwen3_drafter_rejects_truncated_gguf);
 
     std::fprintf(stderr, "\n══════════════════════════════════════════\n");
     std::fprintf(stderr, " Results: %d assertions, %d failures\n",


### PR DESCRIPTION
## Summary

Fixes #438. The PFlash prefill drafter loader (`server/src/qwen3/qwen3_loader.cpp`) crashes the whole `dflash_server` process with a SIGSEGV when the Qwen3-0.6B drafter GGUF is truncated or corrupt, instead of failing the load cleanly.

**What:** Replace the loader's hand-rolled mmap with the shared `dflash::common::GgufMmap` wrapper and validate every tensor's data region against the file size before any host-to-device copy.

**Why:** `qwen3_loader.cpp` was the one drafter loader that inlined its own platform-conditional mmap. It ignored the POSIX `::open`/`::fstat` return values and copied each tensor's bytes to the device with no check that the tensor's data region actually lay within the mapped file. For a truncated file the H2D copy reads past the end of the mmap and faults inside the device copy, taking down the process.

## Changes

- `server/src/qwen3/qwen3_loader.cpp`
  - Drop the inline `#if defined(_WIN32) CreateFileMapping/MapViewOfFile #else ::open/::fstat/::mmap #endif` block (and its matching `UnmapViewOfFile`/`::munmap`) in favor of `dflash::common::GgufMmap` from `common/gguf_mmap.h`. The wrapper checks `open`/`fstat`, reports errors, and unmaps via RAII, matching the newer loaders (`laguna_backend.cpp`, `qwen35moe_backend.cpp`).
  - Add a file-level EOF validation loop that checks `data_off + tensor_offset + tensor_size <= file_size` for every tensor before the copy loop, returning a descriptive error and freeing the backend buffer + ggml context on failure.
- `server/test/test_server_unit.cpp`
  - Add `test_qwen3_drafter_rejects_truncated_gguf` (CPU backend, no GPU): builds a minimal valid Qwen3-0.6B-style GGUF, loads it (positive control), truncates the tensor-data section, and asserts the load returns `false` with an error containing `truncated or corrupt`.

## How it works

`gguf_init_from_file` only parses the header, KV block, and tensor-info table; it does not require the tensor data to be fully present, so a truncated file parses successfully and the bug surfaces later in the copy. The new loop runs right after the mmap and before any copy: it walks all tensors reported by the GGUF metadata and fails fast if any tensor's `offset + size` exceeds the actual mapped file size. This fully prevents the out-of-bounds read that caused the SIGSEGV.

## Limitations

- The per-tensor guard inside `copy_tensor_from_file` (the reporter's second suggestion) is intentionally left out. The file-level loop already prevents the SIGSEGV for the reported case; the per-copy guard is a reasonable optional follow-up but is out of scope here to keep the change focused on one concern.
- The other loaders share the same mmap idiom but are not touched in this PR.
- No end-to-end GPU inference repro was run with a real corrupt Qwen3-0.6B model. The new unit test is the regression repro: it drives the real `load_qwen3_drafter_model` against a truncated GGUF and asserts the clean failure. The crash was a host-side out-of-bounds read in the loader before the H2D copy, so it reproduces and is fixed independently of which backend the copy targets.

## Verification

- Added `test_qwen3_drafter_rejects_truncated_gguf` to `test_server_unit.cpp`: builds a minimal valid Qwen3-0.6B GGUF, loads it (positive control returns `true`), truncates the tensor-data section, and asserts the load returns `false` with an error containing `truncated or corrupt`. 7 assertions.
- Built and ran the full `test_server_unit` target (CUDA backend, gcc 13 / CUDA 12.6, ggml at the recorded submodule commit). The test runs on the CPU backend (`ggml_backend_cpu_init()`), so no GPU kernel execution is required for the assertions.

  ```
  ── Qwen3-0.6B drafter loader (bug #438) ──
    test_qwen3_drafter_rejects_truncated_gguf ... ok

   Results: 1997 assertions, 0 failures
  ALL PASSED
  ```

  ```
  100% tests passed, 0 tests failed out of 1
  Test #12: server_unit .......................   Passed    0.66 sec
  ```

- Reproduce:

  ```
  cmake -B server/build -S server -DCMAKE_BUILD_TYPE=Release
  cmake --build server/build --target test_server_unit -j
  cd server/build && ctest --output-on-failure -R server_unit
  ```

Fixes #438.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

