### PR TITLE
fix(gguf): overflow-safe diagnostic tensor bounds check across loaders

### DIFF
--- a/server/src/common/gguf_bounds.h
+++ b/server/src/common/gguf_bounds.h
@@ -1,0 +1,71 @@
+// common/gguf_bounds.h — overflow-safe tensor bounds check for GGUF loaders.
+//
+// Every loader that copies tensor bytes out of an mmap'd GGUF must verify that a
+// tensor's [data_off + tensor_off, + tensor_sz) region lies within the file
+// before the copy. Otherwise a truncated or corrupt file makes the copy read
+// past the end of the mapping and fault inside the device copy (bug #438). A
+// naive `data_off + tensor_off + tensor_sz > file_size` test can itself wrap on
+// malformed offsets/sizes and silently pass, so gguf_tensor_in_file() avoids any
+// addition that can overflow size_t.
+//
+// When a *valid* file is wrongly rejected (bug #318), gguf_bounds_error() emits
+// every operand (data offset, tensor offset, size, file size, type) so the
+// mismatch is diagnosable instead of an opaque "overflows file".
+//
+// Include convention: #include "common/gguf_bounds.h"
+// Never: ../common/gguf_bounds.h or absolute paths.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace dflash::common {
+
+// True iff the tensor's data region lies fully within the mapped file.
+//   data_off:   byte offset of the GGUF data section (gguf_get_data_offset)
+//   tensor_off: tensor offset relative to the data section (gguf_get_tensor_offset)
+//   tensor_sz:  tensor byte size (gguf_get_tensor_size)
+//   file_size:  mapped file size in bytes
+// Overflow-safe: never forms data_off + tensor_off + tensor_sz directly.
+inline bool gguf_tensor_in_file(size_t data_off, size_t tensor_off,
+                                size_t tensor_sz, size_t file_size) {
+    if (data_off > file_size) return false;
+    const size_t data_avail = file_size - data_off;   // bytes from data section start to EOF
+    if (tensor_off > data_avail) return false;
+    return tensor_sz <= data_avail - tensor_off;
+}
+
+// Build a diagnostic error for a tensor that failed gguf_tensor_in_file().
+// Reports every operand so a false rejection on a genuinely valid file (#318)
+// can be traced to a data-section offset/alignment or size mismatch rather than
+// guessed at. `what` is the loader-specific prefix (e.g. "draft GGUF").
+inline std::string gguf_bounds_error(const std::string & what,
+                                     const char * tensor_name,
+                                     const char * type_name,
+                                     size_t data_off, size_t tensor_off,
+                                     size_t tensor_sz, size_t file_size) {
+    const std::string name = tensor_name ? tensor_name : "(null)";
+    const std::string type = type_name   ? type_name   : "(unknown)";
+
+    // end = data_off + tensor_off + tensor_sz, reported only when it does not
+    // overflow size_t (it never does for a genuinely valid file; an overflow
+    // here is itself the diagnosis).
+    std::string end_str;
+    if (data_off <= SIZE_MAX - tensor_off &&
+        data_off + tensor_off <= SIZE_MAX - tensor_sz) {
+        end_str = std::to_string(data_off + tensor_off + tensor_sz);
+    } else {
+        end_str = "overflow";
+    }
+
+    return what + ": tensor '" + name + "' (" + type + ") data region [data_off="
+        + std::to_string(data_off) + " + tensor_off=" + std::to_string(tensor_off)
+        + " + size=" + std::to_string(tensor_sz) + " = " + end_str
+        + "] exceeds file size " + std::to_string(file_size)
+        + ". The GGUF is truncated or corrupt, or its data-section offset/alignment "
+          "does not match the writer.";
+}
+
+} // namespace dflash::common

--- a/server/src/draft/draft_gguf_loader.cpp
+++ b/server/src/draft/draft_gguf_loader.cpp
@@ -25,6 +25,8 @@
 
 #include "internal.h"
 #include "common/derived_scalars.h"
+#include "common/gguf_mmap.h"
+#include "common/gguf_bounds.h"
 
 #include <cinttypes>
 #include <cstdint>
@@ -43,63 +45,6 @@
 namespace dflash::common {
 
 namespace {
-
-struct Mmap {
-    void *  addr = nullptr;
-    size_t  len  = 0;
-#if defined(_WIN32)
-    HANDLE  hFile = INVALID_HANDLE_VALUE;
-    HANDLE  hMap  = nullptr;
-#else
-    int     fd   = -1;
-#endif
-
-    bool open_ro(const std::string & path, std::string & err) {
-#if defined(_WIN32)
-        hFile = CreateFileA(path.c_str(), GENERIC_READ, FILE_SHARE_READ,
-                            nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
-        if (hFile == INVALID_HANDLE_VALUE) {
-            err = "CreateFileA: " + path + ": error " + std::to_string(GetLastError());
-            return false;
-        }
-        LARGE_INTEGER sz;
-        if (!GetFileSizeEx(hFile, &sz)) {
-            err = "GetFileSizeEx: error " + std::to_string(GetLastError());
-            return false;
-        }
-        len = (size_t)sz.QuadPart;
-        hMap = CreateFileMappingA(hFile, nullptr, PAGE_READONLY, 0, 0, nullptr);
-        if (!hMap) {
-            err = "CreateFileMappingA: error " + std::to_string(GetLastError());
-            return false;
-        }
-        addr = MapViewOfFile(hMap, FILE_MAP_READ, 0, 0, 0);
-        if (!addr) {
-            err = "MapViewOfFile: error " + std::to_string(GetLastError());
-            return false;
-        }
-#else
-        fd = ::open(path.c_str(), O_RDONLY);
-        if (fd < 0) { err = "open: " + path + ": " + std::strerror(errno); return false; }
-        struct stat st;
-        if (::fstat(fd, &st) < 0) { err = "fstat: " + std::string(std::strerror(errno)); return false; }
-        len = (size_t)st.st_size;
-        addr = ::mmap(nullptr, len, PROT_READ, MAP_PRIVATE, fd, 0);
-        if (addr == MAP_FAILED) { err = "mmap: " + std::string(std::strerror(errno)); addr = nullptr; return false; }
-#endif
-        return true;
-    }
-    ~Mmap() {
-#if defined(_WIN32)
-        if (addr)                        UnmapViewOfFile(addr);
-        if (hMap)                        CloseHandle(hMap);
-        if (hFile != INVALID_HANDLE_VALUE) CloseHandle(hFile);
-#else
-        if (addr) ::munmap(addr, len);
-        if (fd >= 0) ::close(fd);
-#endif
-    }
-};
 
 uint32_t get_u32_or(const gguf_context * g, const char * key, uint32_t fallback) {
     int64_t id = gguf_find_key(g, key);
@@ -420,8 +365,10 @@ bool load_draft_gguf(const std::string & path,
 
     // ── 4. mmap file and copy tensor bytes to CUDA ───────────────────────
     std::string err;
-    Mmap mm;
-    if (!mm.open_ro(path, err)) { set_last_error(err); gguf_free(gctx); return false; }
+    GgufMmap mm;
+    if (!mm.open(path, err)) { set_last_error(err); gguf_free(gctx); return false; }
+    const uint8_t * mm_addr = (const uint8_t *)mm.data();
+    const size_t    mm_len  = mm.size();
     const size_t data_start = gguf_get_data_offset(gctx);
     const int64_t n_tensors = gguf_get_n_tensors(gctx);
 
@@ -430,14 +377,16 @@ bool load_draft_gguf(const std::string & path,
         const char * tname = gguf_get_tensor_name(gctx, tid);
         ggml_tensor * t = ggml_get_tensor(meta_ctx, tname);
         if (!t) continue;
-        const size_t off = data_start + gguf_get_tensor_offset(gctx, tid);
-        const size_t sz  = gguf_get_tensor_size(gctx, tid);
-        if (off + sz > mm.len) {
-            set_last_error(std::string("draft GGUF: tensor '") + tname + "' overflows file");
+        const size_t rel_off = gguf_get_tensor_offset(gctx, tid);
+        const size_t sz      = gguf_get_tensor_size(gctx, tid);
+        if (!gguf_tensor_in_file(data_start, rel_off, sz, mm_len)) {
+            set_last_error(gguf_bounds_error("draft GGUF", tname,
+                ggml_type_name(gguf_get_tensor_type(gctx, tid)),
+                data_start, rel_off, sz, mm_len));
             gguf_free(gctx);
             return false;
         }
-        ggml_backend_tensor_set(t, (const uint8_t *)mm.addr + off, 0, sz);
+        ggml_backend_tensor_set(t, mm_addr + data_start + rel_off, 0, sz);
         total += sz;
     }
 

--- a/server/src/laguna/laguna_target_loader.cpp
+++ b/server/src/laguna/laguna_target_loader.cpp
@@ -40,6 +40,8 @@
 #include "laguna_internal.h"
 #include "internal.h"
 #include "dflash27b.h"
+#include "common/gguf_mmap.h"
+#include "common/gguf_bounds.h"
 
 #include <cinttypes>
 #include <climits>
@@ -65,63 +67,6 @@ namespace dflash::common {
 static bool is_laguna_expert_tensor(const char * name);
 
 namespace {
-
-// Same Mmap shape as gguf_target_loader.cpp's local helper. Duplicated locally
-// to keep the loader self-contained without exporting internals.
-struct LagunaMmap {
-    void *  addr = nullptr;
-    size_t  len  = 0;
-#if defined(_WIN32)
-    HANDLE  hFile = INVALID_HANDLE_VALUE;
-    HANDLE  hMap  = nullptr;
-#else
-    int     fd   = -1;
-#endif
-
-    bool open_ro(const std::string & path, std::string & err) {
-#if defined(_WIN32)
-        hFile = CreateFileA(path.c_str(), GENERIC_READ, FILE_SHARE_READ,
-                            nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
-        if (hFile == INVALID_HANDLE_VALUE) {
-            err = "CreateFileA: " + path; return false;
-        }
-        LARGE_INTEGER sz;
-        if (!GetFileSizeEx(hFile, &sz)) { err = "GetFileSizeEx"; return false; }
-        len = (size_t)sz.QuadPart;
-        hMap = CreateFileMappingA(hFile, nullptr, PAGE_READONLY, 0, 0, nullptr);
-        if (!hMap) { err = "CreateFileMappingA"; return false; }
-        addr = MapViewOfFile(hMap, FILE_MAP_READ, 0, 0, 0);
-        if (!addr) { err = "MapViewOfFile"; return false; }
-#else
-        fd = ::open(path.c_str(), O_RDONLY);
-        if (fd < 0) { err = "open: " + path + ": " + std::strerror(errno); return false; }
-        struct stat st;
-        if (::fstat(fd, &st) < 0) { err = "fstat: " + std::string(std::strerror(errno)); return false; }
-        len = (size_t)st.st_size;
-        addr = ::mmap(nullptr, len, PROT_READ, MAP_PRIVATE, fd, 0);
-        if (addr == MAP_FAILED) { err = "mmap: " + std::string(std::strerror(errno)); addr = nullptr; return false; }
-#endif
-        return true;
-    }
-    void release() {
-        addr = nullptr; len = 0;
-#if defined(_WIN32)
-        hFile = INVALID_HANDLE_VALUE; hMap = nullptr;
-#else
-        fd = -1;
-#endif
-    }
-    ~LagunaMmap() {
-#if defined(_WIN32)
-        if (addr)                          UnmapViewOfFile(addr);
-        if (hMap)                          CloseHandle(hMap);
-        if (hFile != INVALID_HANDLE_VALUE) CloseHandle(hFile);
-#else
-        if (addr) ::munmap(addr, len);
-        if (fd >= 0) ::close(fd);
-#endif
-    }
-};
 
 int32_t  get_i32_or(const gguf_context * g, const char * key, int32_t fallback) {
     int64_t id = gguf_find_key(g, key); return (id < 0) ? fallback : gguf_get_val_i32(g, id);
@@ -463,9 +408,11 @@ bool load_target_gguf_laguna_partial(const std::string & path,
 
     // ── 3. Allocate backend buffer only for selected tensors. Token embedding
     //       stays CPU-only and is owned by the CpuEmbedder mmap.
-    LagunaMmap mm;
+    GgufMmap mm;
     std::string err;
-    if (!mm.open_ro(path, err)) { set_last_error(err); gguf_free(gctx); return false; }
+    if (!mm.open(path, err)) { set_last_error(err); gguf_free(gctx); return false; }
+    const uint8_t * mm_addr = (const uint8_t *)mm.data();
+    const size_t    mm_len  = mm.size();
     const size_t data_start = gguf_get_data_offset(gctx);
     const int64_t n_tensors  = gguf_get_n_tensors(gctx);
     ggml_backend_buffer_type_t buft = ggml_backend_get_default_buffer_type(backend);
@@ -518,10 +465,13 @@ bool load_target_gguf_laguna_partial(const std::string & path,
         const char * tname = gguf_get_tensor_name(gctx, tid);
         ggml_tensor * t = ggml_get_tensor(meta_ctx, tname);
         if (!t) continue;
-        const size_t off = data_start + gguf_get_tensor_offset(gctx, tid);
+        const size_t rel_off = gguf_get_tensor_offset(gctx, tid);
+        const size_t off = data_start + rel_off;
         const size_t sz  = gguf_get_tensor_size(gctx, tid);
-        if (off + sz > mm.len) {
-            set_last_error(std::string("tensor '") + tname + "' overflows file");
+        if (!gguf_tensor_in_file(data_start, rel_off, sz, mm_len)) {
+            set_last_error(gguf_bounds_error("laguna target GGUF", tname,
+                ggml_type_name(gguf_get_tensor_type(gctx, tid)),
+                data_start, rel_off, sz, mm_len));
             gguf_free(gctx); return false;
         }
         if (std::string(tname) == "token_embd.weight") {
@@ -531,7 +481,7 @@ bool load_target_gguf_laguna_partial(const std::string & path,
             continue;
         }
         if (!should_load_laguna_tensor(tname, plan)) continue;
-        ggml_backend_tensor_set(t, (const uint8_t *)mm.addr + off, 0, sz);
+        ggml_backend_tensor_set(t, mm_addr + off, 0, sz);
         total += sz;
     }
 
@@ -543,20 +493,24 @@ bool load_target_gguf_laguna_partial(const std::string & path,
     }
 
     // ── 5. Hand mmap to CpuEmbedder ──────────────────────────────────────
-    out.embedder.mmap_addr      = mm.addr;
-    out.embedder.mmap_len       = mm.len;
+    // Transfer ownership of the mapping out of the RAII wrapper; the embedder's
+    // destructor unmaps it. On Windows GgufMmap::release() has already closed the
+    // mapping handle (the view stays valid until UnmapViewOfFile), and the file
+    // handle was closed at open() time, so the embedder only needs the address.
+    GgufMmap::OwnedRegion region = mm.release();
+    out.embedder.mmap_addr      = const_cast<void *>(region.data);
+    out.embedder.mmap_len       = region.size;
 #if defined(_WIN32)
-    out.embedder.mmap_hfile     = mm.hFile;
-    out.embedder.mmap_hmap      = mm.hMap;
+    out.embedder.mmap_hfile     = INVALID_HANDLE_VALUE;
+    out.embedder.mmap_hmap      = nullptr;
 #else
-    out.embedder.mmap_fd        = mm.fd;
+    out.embedder.mmap_fd        = region.fd;
 #endif
-    out.embedder.tok_embd_bytes = (const uint8_t *)mm.addr + tok_embd_off;
+    out.embedder.tok_embd_bytes = (const uint8_t *)region.data + tok_embd_off;
     out.embedder.tok_embd_type  = tok_embd_type;
     out.embedder.n_embd         = out.n_embd;
     out.embedder.n_vocab        = (int64_t)n_vocab;
     out.embedder.row_bytes      = tok_embd_sz / (size_t)n_vocab;
-    mm.release();
 
     char summary[224];
     std::snprintf(summary, sizeof(summary),

--- a/server/src/qwen35/gguf_target_loader.cpp
+++ b/server/src/qwen35/gguf_target_loader.cpp
@@ -46,6 +46,8 @@
 #include "internal.h"
 #include "common/derived_scalars.h"
 #include "common/layer_split_utils.h"
+#include "common/gguf_mmap.h"
+#include "common/gguf_bounds.h"
 
 #include <cinttypes>
 #include <cstdint>
@@ -91,77 +93,6 @@ bool CpuEmbedder::embed(const int32_t * ids, int n, float * out_f32) const {
 }
 
 namespace {
-
-// Local Mmap used only during load (separate from the one kept alive inside
-// TargetWeights::embedder). We don't call munmap on this one when we want
-// to hand ownership to the CpuEmbedder — see end of load_target_gguf.
-struct Mmap {
-    void *  addr = nullptr;
-    size_t  len  = 0;
-#if defined(_WIN32)
-    HANDLE  hFile = INVALID_HANDLE_VALUE;
-    HANDLE  hMap  = nullptr;
-#else
-    int     fd   = -1;
-#endif
-
-    bool open_ro(const std::string & path, std::string & err) {
-#if defined(_WIN32)
-        hFile = CreateFileA(path.c_str(), GENERIC_READ, FILE_SHARE_READ,
-                            nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
-        if (hFile == INVALID_HANDLE_VALUE) {
-            err = "CreateFileA: " + path + ": error " + std::to_string(GetLastError());
-            return false;
-        }
-        LARGE_INTEGER sz;
-        if (!GetFileSizeEx(hFile, &sz)) {
-            err = "GetFileSizeEx: error " + std::to_string(GetLastError());
-            return false;
-        }
-        len = (size_t)sz.QuadPart;
-        hMap = CreateFileMappingA(hFile, nullptr, PAGE_READONLY, 0, 0, nullptr);
-        if (!hMap) {
-            err = "CreateFileMappingA: error " + std::to_string(GetLastError());
-            return false;
-        }
-        addr = MapViewOfFile(hMap, FILE_MAP_READ, 0, 0, 0);
-        if (!addr) {
-            err = "MapViewOfFile: error " + std::to_string(GetLastError());
-            return false;
-        }
-#else
-        fd = ::open(path.c_str(), O_RDONLY);
-        if (fd < 0) { err = "open: " + path + ": " + std::strerror(errno); return false; }
-        struct stat st;
-        if (::fstat(fd, &st) < 0) { err = "fstat: " + std::string(std::strerror(errno)); return false; }
-        len = (size_t)st.st_size;
-        addr = ::mmap(nullptr, len, PROT_READ, MAP_PRIVATE, fd, 0);
-        if (addr == MAP_FAILED) { err = "mmap: " + std::string(std::strerror(errno)); addr = nullptr; return false; }
-#endif
-        return true;
-    }
-    // Ownership transfer: release handles without unmapping.
-    void release() {
-        addr = nullptr;
-        len  = 0;
-#if defined(_WIN32)
-        hFile = INVALID_HANDLE_VALUE;
-        hMap  = nullptr;
-#else
-        fd = -1;
-#endif
-    }
-    ~Mmap() {
-#if defined(_WIN32)
-        if (addr)                        UnmapViewOfFile(addr);
-        if (hMap)                        CloseHandle(hMap);
-        if (hFile != INVALID_HANDLE_VALUE) CloseHandle(hFile);
-#else
-        if (addr) ::munmap(addr, len);
-        if (fd >= 0) ::close(fd);
-#endif
-    }
-};
 
 // Required uint32 metadata key → bound check. Aborts load on mismatch.
 bool expect_u32(const gguf_context * g, const char * key, uint32_t expected, std::string & err) {
@@ -633,10 +564,13 @@ bool load_target_gguf_partial(const std::string & path,
     // ── 4. mmap the file and copy tensor bytes to CUDA ────────────────
     //
     // SKIP uploading token_embd.weight — it stays on CPU for embedding
-    // lookup (CUDA get_rows doesn't support k-quants). We hand the mmap
-    // ownership to TargetWeights::embedder at the end.
-    Mmap mm;
-    if (!mm.open_ro(path, err)) { set_last_error(err); gguf_free(gctx); return false; }
+    // lookup (CUDA get_rows doesn't support k-quants). Its bytes are copied
+    // into owned host memory below (step 5), so the mmap is released when this
+    // local goes out of scope.
+    GgufMmap mm;
+    if (!mm.open(path, err)) { set_last_error(err); gguf_free(gctx); return false; }
+    const uint8_t * mm_addr = (const uint8_t *)mm.data();
+    const size_t    mm_len  = mm.size();
     const size_t data_start = gguf_get_data_offset(gctx);
 
     size_t total = 0;
@@ -646,10 +580,13 @@ bool load_target_gguf_partial(const std::string & path,
         const char * tname = gguf_get_tensor_name(gctx, tid);
         ggml_tensor * t = ggml_get_tensor(meta_ctx, tname);
         if (!t) continue;
-        const size_t off = data_start + gguf_get_tensor_offset(gctx, tid);
+        const size_t rel_off = gguf_get_tensor_offset(gctx, tid);
+        const size_t off = data_start + rel_off;
         const size_t sz  = gguf_get_tensor_size(gctx, tid);
-        if (off + sz > mm.len) {
-            set_last_error(std::string("tensor '") + tname + "' overflows file");
+        if (!gguf_tensor_in_file(data_start, rel_off, sz, mm_len)) {
+            set_last_error(gguf_bounds_error("target GGUF", tname,
+                ggml_type_name(gguf_get_tensor_type(gctx, tid)),
+                data_start, rel_off, sz, mm_len));
             gguf_free(gctx);
             return false;
         }
@@ -663,7 +600,7 @@ bool load_target_gguf_partial(const std::string & path,
         if (!should_load_target_tensor(tname, plan.layer_begin, plan.layer_end, plan.load_output, plan.skip_expert_tensors)) {
             continue;
         }
-        ggml_backend_tensor_set(t, (const uint8_t *)mm.addr + off, 0, sz);
+        ggml_backend_tensor_set(t, mm_addr + off, 0, sz);
         total += sz;
     }
 
@@ -689,10 +626,10 @@ bool load_target_gguf_partial(const std::string & path,
                 stid = gguf_find_tensor(gctx, sname);
             }
             if (stid < 0) return 1.0f;
-            const size_t soff = data_start + gguf_get_tensor_offset(gctx, stid);
-            if (soff + sizeof(float) > mm.len) return 1.0f;
+            const size_t srel = gguf_get_tensor_offset(gctx, stid);
+            if (!gguf_tensor_in_file(data_start, srel, sizeof(float), mm_len)) return 1.0f;
             float val;
-            std::memcpy(&val, (const uint8_t *)mm.addr + soff, sizeof(float));
+            std::memcpy(&val, mm_addr + data_start + srel, sizeof(float));
             return val;
         };
 
@@ -777,7 +714,7 @@ bool load_target_gguf_partial(const std::string & path,
     }
     out.embedder.tok_embd_owned.resize(tok_embd_sz);
     std::memcpy(out.embedder.tok_embd_owned.data(),
-                (const uint8_t *)mm.addr + tok_embd_off,
+                mm_addr + tok_embd_off,
                 tok_embd_sz);
     out.embedder.tok_embd_bytes = out.embedder.tok_embd_owned.data();
     out.embedder.tok_embd_type  = tok_embd_type;

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -28,6 +28,7 @@
 #include "common/layer_split_utils.h"
 #include "common/kvflash_pager.h"
 #include "placement/draft_residency.h"
+#include "common/gguf_bounds.h"
 #include "ggml-cpu.h"
 #include "server/prompt_normalize.h"
 #include "qwen3_drafter_model.h"
@@ -4108,6 +4109,75 @@ static void test_qwen3_drafter_rejects_truncated_gguf() {
     unlink(path.c_str());
 }
 
+// ─── GGUF tensor bounds (gguf_tensor_in_file / gguf_bounds_error) ───────
+//
+// The shared overflow-safe bounds check used by every GGUF loader
+// (draft/target/laguna) to reject truncated/corrupt files before a copy reads
+// past the mapping (#438), without wrongly rejecting valid files (#318). These
+// tests pin the boundary and, critically, the size_t overflow behaviour that a
+// naive `data_off + tensor_off + tensor_sz > file_size` test gets wrong.
+static void test_gguf_tensor_in_file_bounds() {
+    // Typical layout: 100-byte header/kv, 900-byte data section, 1000-byte file.
+    const size_t data_off = 100;
+    const size_t file     = 1000;
+
+    // Fully inside, including the exact end-of-file boundary.
+    TEST_ASSERT(gguf_tensor_in_file(data_off, 0,   900, file));   // fills the data section
+    TEST_ASSERT(gguf_tensor_in_file(data_off, 0,   0,   file));   // zero-size tensor
+    TEST_ASSERT(gguf_tensor_in_file(data_off, 899, 1,   file));   // last byte
+    TEST_ASSERT(gguf_tensor_in_file(data_off, 900, 0,   file));   // zero-size at EOF
+
+    // One byte past EOF must be rejected.
+    TEST_ASSERT(!gguf_tensor_in_file(data_off, 0,   901, file));
+    TEST_ASSERT(!gguf_tensor_in_file(data_off, 900, 1,   file));
+
+    // Data section offset itself past EOF (corrupt header).
+    TEST_ASSERT(!gguf_tensor_in_file(2000, 0, 0, file));
+    // data_off == file: only a zero-size tensor at offset 0 fits.
+    TEST_ASSERT(gguf_tensor_in_file(file, 0, 0, file));
+    TEST_ASSERT(!gguf_tensor_in_file(file, 0, 1, file));
+
+    // Whole-file data section (data_off == 0), valid full read.
+    TEST_ASSERT(gguf_tensor_in_file(0, 0, file, file));
+    TEST_ASSERT(!gguf_tensor_in_file(0, 0, file + 1, file));
+
+    // Overflow safety: a malformed offset/size must not wrap and slip through.
+    const size_t kMax = std::numeric_limits<size_t>::max();
+    TEST_ASSERT(!gguf_tensor_in_file(data_off, kMax, 10, file));   // huge tensor_off
+    TEST_ASSERT(!gguf_tensor_in_file(data_off, 0, kMax, file));    // huge tensor_sz
+    // The case a naive `off + sz > file` check fails: off + sz wraps below file.
+    // off = kMax - 10, sz = 20  →  off + sz == 9 (< file) would FALSE-PASS.
+    TEST_ASSERT(!gguf_tensor_in_file(0, kMax - 10, 20, file));
+    TEST_ASSERT(!gguf_tensor_in_file(kMax, 10, 10, file));         // huge data_off
+}
+
+static void test_gguf_bounds_error_reports_operands() {
+    // A normal (non-overflowing) rejection: the message must surface every
+    // operand so a false positive on a valid file (#318) is diagnosable.
+    const std::string e = gguf_bounds_error("target GGUF", "blk.56.ssm_out.weight",
+                                            "q5_K", 100, 5000, 200, 1000);
+    TEST_ASSERT(e.find("blk.56.ssm_out.weight") != std::string::npos);
+    TEST_ASSERT(e.find("q5_K") != std::string::npos);
+    TEST_ASSERT(e.find("data_off=100") != std::string::npos);
+    TEST_ASSERT(e.find("tensor_off=5000") != std::string::npos);
+    TEST_ASSERT(e.find("size=200") != std::string::npos);
+    TEST_ASSERT(e.find("5300") != std::string::npos);      // 100 + 5000 + 200
+    TEST_ASSERT(e.find("1000") != std::string::npos);      // file size
+
+    // Null name/type must not crash and must produce placeholders.
+    const std::string n = gguf_bounds_error("draft GGUF", nullptr, nullptr,
+                                            0, 0, 1, 0);
+    TEST_ASSERT(n.find("(null)") != std::string::npos);
+    TEST_ASSERT(n.find("(unknown)") != std::string::npos);
+
+    // When the end offset itself overflows size_t, report "overflow" rather
+    // than a wrapped number.
+    const size_t kMax = std::numeric_limits<size_t>::max();
+    const std::string o = gguf_bounds_error("target GGUF", "t", "f32",
+                                            kMax, 10, 10, 100);
+    TEST_ASSERT(o.find("overflow") != std::string::npos);
+}
+
 int main() {
     std::fprintf(stderr, "══════════════════════════════════════════\n");
     std::fprintf(stderr, " Server Unit Tests\n");
@@ -4373,6 +4443,10 @@ int main() {
 
     std::fprintf(stderr, "\n── Qwen3-0.6B drafter loader (bug #438) ──\n");
     RUN_TEST(test_qwen3_drafter_rejects_truncated_gguf);
+
+    std::fprintf(stderr, "\n── GGUF tensor bounds ──\n");
+    RUN_TEST(test_gguf_tensor_in_file_bounds);
+    RUN_TEST(test_gguf_bounds_error_reports_operands);
 
     std::fprintf(stderr, "\n══════════════════════════════════════════\n");
     std::fprintf(stderr, " Results: %d assertions, %d failures\n",


### PR DESCRIPTION
## Summary
The draft, qwen35 target, and laguna target GGUF loaders each duplicated a hand-rolled mmap and a `data_off + tensor_off + tensor_sz > file_size` bounds check. That sum can wrap on a malformed offset or size and silently pass, letting a truncated or corrupt GGUF read past the mapping and fault inside the device copy (#438). On a valid file the same check rejects with an opaque `"overflows file"` that gives no way to diagnose a false positive (#318).

## Changes
- New `common/gguf_bounds.h`: `gguf_tensor_in_file()` (overflow-safe) and `gguf_bounds_error()` (diagnostic message builder).
- Migrate `draft_gguf_loader.cpp`, `gguf_target_loader.cpp`, and `laguna_target_loader.cpp` onto the shared `common/gguf_mmap.h` RAII wrapper plus the helper, removing the three duplicated `struct Mmap` definitions (net -86 lines).
- Unit tests for the boundary, the `size_t` overflow cases, and the error text.

## How it works
`gguf_tensor_in_file` computes `data_avail = file_size - data_off` and checks `tensor_off <= data_avail` and `tensor_sz <= data_avail - tensor_off`, never forming a sum that can overflow `size_t`. On failure `gguf_bounds_error` reports data offset, tensor offset, size, computed end, file size, tensor name, and type. Laguna keeps its token-embedding mmap resident via `GgufMmap::release()`/`OwnedRegion`.

## Performance
None intended. Load-time correctness only.

## Limitations
- The #318 reporter file (aarch64, 16.82 GB unsloth GGUF) is not reproducible on the hardware here, so this makes a recurrence diagnosable rather than fixing an unknown root cause.
- The laguna loader is compile-verified only; no laguna model was available to load.

## Verification (RTX 3090)
- Build of all smoke loaders and `dflash_server` is clean.
- `test_server_unit`: 2015 assertions, 0 failures.
- Real Qwen3.6-27B Q4_K_M loads (850 tensors on GPU).
- A truncated copy of the 27B is rejected with the full diagnostic and a clean exit, no SIGSEGV: `target GGUF: tensor 'output.weight' (q6_K) data region [data_off=10993888 + tensor_off=0 + size=1042944000 = 1053937888] exceeds file size 104857600. ...`
- `dflash_server` loads the real draft GGUF alongside the target and reaches `listening`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

