### PR TITLE
fix(server): align Qwen target-split prefill ubatch default

### DIFF
--- a/server/src/qwen35/qwen35_layer_split_adapter.cpp
+++ b/server/src/qwen35/qwen35_layer_split_adapter.cpp
@@ -530,7 +530,7 @@ bool Qwen35LayerSplitAdapter::prefill(const std::vector<int32_t> & prompt,
             base_pos, (size_t)base_pos + prompt.size(), cfg_.device.max_ctx);
         return false;
     }
-    int ubatch = prompt.size() > 2048 ? 384 : 16;
+    int ubatch = cfg_.chunk > 0 ? cfg_.chunk : 512;
     if (const char * s = std::getenv("DFLASH27B_PREFILL_UBATCH")) {
         ubatch = std::max(1, std::atoi(s));
     }


### PR DESCRIPTION
## Summary

This PR fixes a Qwen target layer-split default that can make mixed-backend prefill much slower when the caller does not explicitly set `DFLASH27B_PREFILL_UBATCH`.

The non-layer-split Qwen path defaults to a fixed prefill ubatch of `512`. The target layer-split adapter currently uses a separate prompt-size-based default, derived from the per-dispatch prompt chunk. With the common `--chunk 512` target-split path, the adapter sees each prefill dispatch as a 512-token chunk and falls back to `ubatch=16`, even for a multi-thousand-token request. This PR makes the Qwen35/Qwen3.6 target layer-split default follow the same `cfg_.chunk > 0 ? cfg_.chunk : 512` policy used by the Gemma4/Laguna layer-split adapters, while keeping `DFLASH27B_PREFILL_UBATCH` as the explicit override.

On a current-main mixed-backend Qwen3.6-27B 4096/128 check, this reduces prefill time from about `24.12s` to `9.95s` and improves prefill throughput from `148.49 tok/s` to `359.98 tok/s`, with decode unchanged.

## Changes

- Change the Qwen35/Qwen3.6 target layer-split prefill default ubatch from prompt-size-dependent `384/16` to `cfg_.chunk > 0 ? cfg_.chunk : 512`.
- Keep the existing `DFLASH27B_PREFILL_UBATCH` environment override unchanged.
- Leave placement, IPC transport, DFlash/PFlash behavior, sampling, and precision policy unchanged.

## Validation

Runtime A/B was run on current main versus the same source with only this one-line default change.

Environment:

- Host: `3090 + Strix Halo`
- Model: `Qwen3.6-27B-Q4_K_M.gguf`
- Request: 3581 prompt tokens, 128 output tokens
- Mode: mixed target layer split, `cuda:0,hip:0`, split `1,1`, `--chunk 512`

| Build | Default ubatch source | Prefill time | Prefill throughput | Decode throughput |
| --- | ---: | ---: | ---: | ---: |
| Current main | `prompt.size() > 2048 ? 384 : 16` | 24.12s | 148.49 tok/s | 14.2 tok/s |
| This PR | `cfg_.chunk > 0 ? cfg_.chunk : 512` | 9.95s | 359.98 tok/s | 14.3 tok/s |

Two-run details:

| Run | Prefill time | Prefill throughput | Decode throughput |
| --- | ---: | ---: | ---: |
| Current main 1 | 24.095s | 148.62 tok/s | 14.2 tok/s |
| Current main 2 | 24.138s | 148.36 tok/s | 14.2 tok/s |
| This PR 1 | 9.929s | 360.68 tok/s | 14.3 tok/s |
| This PR 2 | 9.967s | 359.28 tok/s | 14.3 tok/s |


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

