### PR TITLE
perf(qwen/qwen35moe): speed up prefill by skipping unused GDN writes

### DIFF
--- a/server/src/internal.h
+++ b/server/src/internal.h
@@ -665,7 +665,8 @@ QwenLayerPrefnOutputs build_qwen35_layer_prefn(
     int                   kv_start,
     int                   n_tokens,
     int                   fa_window = 0,
-    ggml_tensor *         kv_write_rows = nullptr);
+    ggml_tensor *         kv_write_rows = nullptr,
+    bool                  skip_gdn_intermediate = true);
 
 } // namespace dflash::common
 

--- a/server/src/qwen35/graph_builders.cpp
+++ b/server/src/qwen35/graph_builders.cpp
@@ -155,7 +155,8 @@ bool build_layer_prefn_step(
         sg.ctx, sg.gf, w, cache, layer_idx,
         sg.inp_embed, sg.positions, sg.attn_mask,
         kv_start, n_tokens, fa_window,
-        sg.kv_write_rows);
+        sg.kv_write_rows,
+        /*skip_gdn_intermediate=*/true);
     if (!go.residual || !go.post) return false;
     sg.ffn_residual = go.residual;
     sg.ffn_post = go.post;

--- a/server/src/qwen35/qwen35_target_graph.cpp
+++ b/server/src/qwen35/qwen35_target_graph.cpp
@@ -747,7 +747,8 @@ static ggml_tensor * build_delta_net_block(
     ggml_tensor * ssm_state,      // [head_v_dim, head_v_dim, num_v_heads] persistent
     int n_tokens,
     DeltaNetCapture * cap,        // optional: populated on capture_delta_intermediate
-    ggml_tensor * parent_ids      // optional [n_tokens] i32; tree mode when non-null
+    ggml_tensor * parent_ids,     // optional [n_tokens] i32; tree mode when non-null
+    bool skip_gdn_intermediate
 ) {
     const int head_k_dim   = w.ssm_d_state;
     const int num_k_heads  = w.ssm_n_group;
@@ -756,6 +757,7 @@ static ggml_tensor * build_delta_net_block(
     const int conv_channels = w.ssm_d_inner + 2 * w.ssm_n_group * w.ssm_d_state;
     const int n_seqs       = 1;
     const int n_seq_tokens = n_tokens;
+    const bool can_skip_gdn_intermediate = skip_gdn_intermediate && !parent_ids && !cap;
 
     // ── qkv_mixed = wqkv @ cur         [10240, n_tokens]
     ggml_tensor * qkv_mixed = apply_scale2(ctx, ggml_mul_mat(ctx, L.wqkv, cur), L.wqkv_s);
@@ -899,7 +901,7 @@ static ggml_tensor * build_delta_net_block(
     // causing AL degradation and loopy output. Set DFLASH27B_CHUNKED=1 to
     // opt in for A/B testing while debugging.
     bool use_chunked = false;
-    if (!parent_ids && !cap && n_seq_tokens > 1) {
+    if (can_skip_gdn_intermediate && n_seq_tokens > 1) {
         if (const char * s_env = std::getenv("DFLASH27B_CHUNKED")) {
             use_chunked = (std::atoi(s_env) != 0);
         }
@@ -922,7 +924,7 @@ static ggml_tensor * build_delta_net_block(
             : (parent_ids
                 ? ggml_gated_delta_net_tree(ctx, q_c, k_c, v_c, g_tensor, beta, s, parent_ids)
                 : ggml_gated_delta_net     (ctx, q_c, k_c, v_c, g_tensor, beta, s));
-    if (!parent_ids && !cap) {
+    if (can_skip_gdn_intermediate) {
         ggml_gated_delta_net_set_skip_intermediate(result, true);
     }
 
@@ -1077,7 +1079,8 @@ static ggml_tensor * build_single_layer(
         }
         cur = build_delta_net_block(ctx, gf, w, L, cur,
                                     cache.conv_state[dn_idx], cache.ssm_state[dn_idx],
-                                    n_tokens, nullptr, nullptr);
+                                    n_tokens, nullptr, nullptr,
+                                    /*skip_gdn_intermediate=*/true);
     }
 
     cur = ggml_add(ctx, cur, inpSA);
@@ -1220,7 +1223,8 @@ QwenGraphOutputs build_qwen35_graph(
             }
             cur = build_delta_net_block(ctx, gf, w, L, cur,
                                         cache.conv_state[dn_idx], cache.ssm_state[dn_idx],
-                                        n_tokens, cap_ptr, in.parent_ids);
+                                        n_tokens, cap_ptr, in.parent_ids,
+                                        /*skip_gdn_intermediate=*/true);
             dn_idx++;
         }
 
@@ -1375,7 +1379,8 @@ QwenLayerPrefnOutputs build_qwen35_layer_prefn(
     int                   kv_start,
     int                   n_tokens,
     int                   fa_window,
-    ggml_tensor *         kv_write_rows) {
+    ggml_tensor *         kv_write_rows,
+    bool                  skip_gdn_intermediate) {
     QwenLayerPrefnOutputs out{};
     const float eps = w.rms_eps;
     const TargetLayer & L = w.layers[layer_idx];
@@ -1405,7 +1410,8 @@ QwenLayerPrefnOutputs build_qwen35_layer_prefn(
         }
         cur = build_delta_net_block(ctx, gf, w, L, cur,
                                     cache.conv_state[dn_idx], cache.ssm_state[dn_idx],
-                                    n_tokens, nullptr, nullptr);
+                                    n_tokens, nullptr, nullptr,
+                                    skip_gdn_intermediate);
     }
 
     cur = ggml_add(ctx, cur, inpSA);

--- a/server/src/qwen35/qwen35_target_graph.cpp
+++ b/server/src/qwen35/qwen35_target_graph.cpp
@@ -922,6 +922,9 @@ static ggml_tensor * build_delta_net_block(
             : (parent_ids
                 ? ggml_gated_delta_net_tree(ctx, q_c, k_c, v_c, g_tensor, beta, s, parent_ids)
                 : ggml_gated_delta_net     (ctx, q_c, k_c, v_c, g_tensor, beta, s));
+    if (!parent_ids && !cap) {
+        ggml_gated_delta_net_set_skip_intermediate(result, true);
+    }
 
     // Slice output and new_state out of the packed result
     {

--- a/server/src/qwen35moe/qwen35moe_pipelined_decode.cpp
+++ b/server/src/qwen35moe/qwen35moe_pipelined_decode.cpp
@@ -68,7 +68,9 @@ static bool build_cached_deltanet_prefn(
     QwenLayerPrefnOutputs go = build_qwen35_layer_prefn(
         out.ctx, out.gf, w, cache, layer_idx,
         out.inp_embed, /*positions=*/nullptr, /*attn_mask=*/nullptr,
-        kv_start, /*n_tokens=*/1, /*fa_window=*/0);
+        kv_start, /*n_tokens=*/1, /*fa_window=*/0,
+        /*kv_write_rows=*/nullptr,
+        /*skip_gdn_intermediate=*/true);
     if (!go.residual || !go.post) { out.free(); return false; }
 
     out.ffn_residual = go.residual;
@@ -144,7 +146,8 @@ static bool build_cached_attn_prefn(
         out.ctx, out.gf, w, cache, layer_idx,
         out.inp_embed, out.positions, /*attn_mask=*/nullptr,
         /*kv_start=*/kv_win - 1, /*n_tokens=*/1, /*fa_window=*/0,
-        out.kv_write_rows);
+        out.kv_write_rows,
+        /*skip_gdn_intermediate=*/true);
     if (!go.residual || !go.post) { out.free(); return false; }
 
     out.ffn_residual = go.residual;


### PR DESCRIPTION
## Summary

This PR reduces Qwen35/Qwen3.6 Gated DeltaNet prefill memory traffic by skipping per-token intermediate-state writes when the graph is running the plain chain path and no consumer needs those intermediates.

The same shared Qwen35-family pre-FFN graph is used by both dense Qwen35/Qwen3.6 and qwen35moe. In qwen35moe hybrid prefill and batched verify, `build_layer_prefn_step()` routes through `build_qwen35_layer_prefn()`, so the GDN skip flag is active before the MoE router/FFN stage. The MoE expert FFN/offload path is otherwise unchanged.

Tree/DDTree, capture, and persistent-intermediate paths keep the existing intermediate layout, so DFlash speculative decode remains available while the unused plain-chain writes are avoided.

On Qwen3.6-27B default-ubatch runtime checks, this improves prefill across pure CUDA, pure HIP, and mixed CUDA/HIP target-split paths while decode stays in the same range. DFlash A/B also shows unchanged acceptance rate. On qwen35moe hybrid prefill, the same change is a larger win because the shared DeltaNet pre-FFN graph was writing unused GDN intermediates for every MoE layer chunk.

## Changes

- Add `ggml_gated_delta_net_set_skip_intermediate()` to mark a GDN op as not needing embedded per-token intermediate states.
- Compact the packed GDN result shape only for the plain chain path; tree and persistent-intermediate variants keep the existing layout.
- Thread the flag through the CUDA/HIP GDN kernels and skip the intermediate-state global writes when safe.
- Enable the optimization in the shared Qwen35-family graph for non-tree, non-capture GDN prefill, covering dense Qwen35/Qwen3.6 and qwen35moe paths that use `build_qwen35_layer_prefn()`.

## Validation

Runtime A/B was run on the same remote host and model with baseline `current main + #464` versus candidate `current main + #464 + this PR`.

Environment:

- Host: `3090 + Strix Halo`
- Model: `Qwen3.6-27B-Q4_K_M.gguf`
- Request: 3581 prompt tokens, 128 output tokens
- Default-ubatch condition: `DFLASH27B_PREFILL_UBATCH` unset; target-split uses `--chunk 512`, so after #464 the Qwen target-split default follows the chunk value.
- Pure HIP and pure CUDA checks used no target split.
- Mixed target-split checks used `cuda:0,hip:0`, split `1,1`.

| Path | Prefill before | Prefill after | Prefill delta | Decode before | Decode after |
| --- | ---: | ---: | ---: | ---: | ---: |
| Pure CUDA | 631.50 tok/s | 718.86 tok/s | +13.8% | 21.5 tok/s | 21.1 tok/s |
| Pure HIP | 252.28 tok/s | 302.02 tok/s | +19.7% | 10.7 tok/s | 10.8 tok/s |
| Mixed CUDA/HIP target split | 361.90 tok/s | 431.92 tok/s | +19.3% | 14.3 tok/s | 14.4 tok/s |

DFlash compatibility check used the same target model plus `dflash-draft-3.6-q4_k_m.gguf`, 3581 prompt tokens, and 64 output tokens.

| DFlash path | Acceptance before | Acceptance after | Prefill before | Prefill after | Decode before | Decode after |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| CUDA target + CUDA draft | 65.6% | 65.6% | 626.5 tok/s | 718.0 tok/s | 81.3 tok/s | 80.7 tok/s |
| Mixed CUDA/HIP target split + CUDA draft | 51.8% | 51.8% | 354.3 tok/s | 421.1 tok/s | 29.3 tok/s | 30.5 tok/s |

### qwen35moe hybrid prefill

Additional A/B was run on `lucebox` over Tailscale, with prefix-cache restore disabled by graph behavior (`prefix_len=0` in both logs).

Environment:

- Host: `lucebox`, RTX 3090
- Baseline: hub `cbaf5486`, ggml `0aaf1dee`
- Candidate: hub `53fadf8d`, ggml PR26 `a317b0ea`
- Model: `Qwen3.6-35B-A3B-UD-Q4_K_M.gguf`
- Mode: `--spark`, `DFLASH_EXPERT_BUDGET_PCT=60`
- Benchmark: `bench_moe_prefill_streaming.py --prompt-lengths 128,256,512,1024,2048 --n-warmup 1 --n-iter 3`

| Prompt tokens | Base prefill | PR prefill | Speedup |
| ---: | ---: | ---: | ---: |
| 120 | 453.4 ms | 222.2 ms | 2.04x |
| 229 | 942.3 ms | 347.9 ms | 2.71x |
| 448 | 1891.3 ms | 693.0 ms | 2.73x |
| 886 | 3912.6 ms | 1369.6 ms | 2.86x |
| 1762 | 8154.0 ms | 2857.4 ms | 2.85x |

## Dependency

This PR updates the `server/deps/llama.cpp` submodule pointer and should be merged after the ggml-side companion PR: Luce-Org/lucebox-ggml#26.

## Notes

- This targets Qwen-style GDN prefill, including qwen35moe paths that use the shared Qwen35-family DeltaNet graph. It does not change MoE expert placement policy, expert FFN/offload evaluation, tree/DDTree rollback, capture, IPC transport, DFlash/PFlash scheduling, or sampling behavior.
- The optimization is enabled by graph structure, not by a user-facing environment variable.
