### PR TITLE
fix(server): grow prefix-cache snapshot chains

### DIFF
--- a/server/src/server/prefix_cache.cpp
+++ b/server/src/server/prefix_cache.cpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 #include <cstring>
 #include <chrono>
+#include <utility>
 
 namespace dflash::common {
 
@@ -115,7 +116,10 @@ std::vector<int> find_all_boundaries(const std::vector<int32_t> & ids,
             }
         }
         found:
-        if (next_match < 0) break;
+        if (next_match < 0) {
+            cursor = end_idx + 1;
+            continue;
+        }
         int boundary = next_match + next_len;
         out.push_back(boundary);
         cursor = boundary;
@@ -192,6 +196,17 @@ PrefixCache::PrefixCache(int cap, const Tokenizer & tokenizer)
     std::fprintf(stderr, "[pc] enabled: cap=%d family=%s\n", cap_, markers_.family.c_str());
 }
 
+PrefixCache::PrefixCache(int cap, ChatMarkers markers)
+    : cap_(std::min(cap, MAX_SLOTS)), markers_(std::move(markers))
+{
+    if (cap_ <= 0) {
+        disabled_ = true;
+        cap_ = 0;
+        return;
+    }
+    disabled_ = false;
+}
+
 // ── LRU helpers ─────────────────────────────────────────────────────────
 
 int PrefixCache::find_entry(const PrefixHash & h) const {
@@ -257,10 +272,9 @@ std::pair<int, int> PrefixCache::prepare_inline_snap(
     auto candidates = find_all_boundaries(prompt_ids, markers_);
     if (candidates.empty()) return {-1, 0};
 
-    // Best cache point: second-to-last boundary (last completed assistant turn).
-    int target_cut = candidates.size() >= 2
-        ? candidates[candidates.size() - 2]
-        : candidates.back();
+    // Snapshot the newest completed boundary so replay-style conversations keep
+    // growing the cached prefix instead of reusing a stale ancestor forever.
+    int target_cut = candidates.back();
 
     auto key = hash_prefix(prompt_ids.data(), target_cut);
     if (find_entry(key) >= 0) return {-1, 0};  // already cached

--- a/server/src/server/prefix_cache.h
+++ b/server/src/server/prefix_cache.h
@@ -76,6 +76,7 @@ public:
 
     // cap = number of prefix-cache slots (0 disables).
     PrefixCache(int cap, const Tokenizer & tokenizer);
+    PrefixCache(int cap, ChatMarkers markers);
 
     bool disabled() const { return disabled_; }
 

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -1246,6 +1246,61 @@ static void test_find_boundaries_empty() {
     TEST_ASSERT(bounds.empty());
 }
 
+static ChatMarkers synthetic_chat_markers() {
+    ChatMarkers markers;
+    markers.family = "synthetic";
+    markers.sys_role_prefix = {1};
+    markers.end_msg_seqs = {{2}};
+    markers.next_role_starts = {{3}};
+    return markers;
+}
+
+static void test_find_boundaries_skips_unmatched_content_markers() {
+    auto markers = synthetic_chat_markers();
+    std::vector<int32_t> ids = {
+        1, 100, 2, 3,
+        200, 2, 901, 902, 903, 904, 905, 201, 2, 3, 202
+    };
+
+    auto bounds = find_all_boundaries(ids, markers);
+    TEST_ASSERT(bounds.size() == 2);
+    TEST_ASSERT(bounds[0] == 4);
+    TEST_ASSERT(bounds[1] == 14);
+}
+
+static void test_prefix_cache_prepares_newest_boundary() {
+    auto markers = synthetic_chat_markers();
+    PrefixCache cache(2, markers);
+    std::vector<int32_t> ids = {1, 100, 2, 3, 200, 2, 3, 300};
+
+    auto prep = cache.prepare_inline_snap(ids);
+    TEST_ASSERT(prep.first == 0);
+    TEST_ASSERT(prep.second == 7);
+}
+
+static void test_prefix_cache_lookup_grows_chain_from_exact_prefix() {
+    auto markers = synthetic_chat_markers();
+    PrefixCache cache(2, markers);
+    std::vector<int32_t> ids = {1, 100, 2, 3, 200, 2, 3, 300};
+
+    auto prep = cache.prepare_inline_snap(ids);
+    cache.confirm_inline_snap(prep.first, prep.second, ids);
+
+    std::vector<int32_t> appended = {
+        1, 100, 2, 3, 200, 2, 3, 300, 2, 3, 400
+    };
+    auto hit = cache.lookup(appended);
+    TEST_ASSERT(hit.first == prep.first);
+    TEST_ASSERT(hit.second == 7);
+
+    std::vector<int32_t> sibling = {
+        1, 100, 2, 3, 201, 2, 3, 300, 2, 3, 400
+    };
+    auto miss = cache.lookup(sibling);
+    TEST_ASSERT(miss.first == -1);
+    TEST_ASSERT(miss.second == 0);
+}
+
 // ── Prefix-aware eviction policy (model-free) ───────────────────────────
 
 static void test_evict_empty_is_zero() {
@@ -4276,6 +4331,9 @@ int main() {
     RUN_TEST(test_hash_prefix_different_lengths);
     RUN_TEST(test_hash_prefix_empty);
     RUN_TEST(test_find_boundaries_empty);
+    RUN_TEST(test_find_boundaries_skips_unmatched_content_markers);
+    RUN_TEST(test_prefix_cache_prepares_newest_boundary);
+    RUN_TEST(test_prefix_cache_lookup_grows_chain_from_exact_prefix);
     RUN_TEST(test_evict_empty_is_zero);
     RUN_TEST(test_evict_single_is_zero);
     RUN_TEST(test_evict_chain_keeps_ancestors);


### PR DESCRIPTION
## What changed

This fixes inline prefix-cache chaining for replay-style agentic conversations:

- keep scanning chat boundaries after an unmatched end-marker-looking token appears in content
- snapshot the newest completed boundary instead of the previous boundary
- add model-free unit coverage for boundary recovery and exact-prefix chain growth

## Why

The agentic replay failure mode was repeated re-prefill from a stale ancestor snapshot. The cache could stop discovering later boundaries after marker-like content, and even when later boundaries existed `prepare_inline_snap()` selected the second-to-last cut. That prevented the snapshot chain from advancing turn by turn.

## Validation

Red before fix:

- `server/build-pr-cuda126-sm86/test_server_unit` failed with `2031 assertions, 6 failures`, all in the new prefix-cache cases

Green after fix:

- `cmake --build server/build-pr-cuda126-sm86 --target test_server_unit -j 8`
- `server/build-pr-cuda126-sm86/test_server_unit` -> `2031 assertions, 0 failures`

The wider 35B replay validation was performed on the integration branch before extracting this focused upstream patch; this PR intentionally keeps the backend-specific MoE resnapshot work out of scope.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

