### PR TITLE
fix(server): recover single-tool JSON argument responses

### DIFF
--- a/server/src/server/sse_emitter.cpp
+++ b/server/src/server/sse_emitter.cpp
@@ -23,6 +23,17 @@ static bool has_request_tools(const json & tools) {
     return tools.is_array() && !tools.empty();
 }
 
+static bool has_single_request_tool(const json & tools) {
+    return tools.is_array() && tools.size() == 1 && tools[0].is_object();
+}
+
+static bool starts_with_potential_bare_json_tool(const std::string & text,
+                                                 const json & tools) {
+    if (!has_single_request_tool(tools)) return false;
+    size_t first = text.find_first_not_of(" \t\n\r");
+    return first != std::string::npos && text[first] == '{';
+}
+
 static bool find_tool_start(const std::string & text, size_t & pos) {
     size_t idx = text.find('<');
     while (idx != std::string::npos) {
@@ -418,6 +429,14 @@ std::vector<std::string> SseEmitter::emit_token(const std::string & raw_piece) {
             continue;
         }
 
+        if (starts_with_potential_bare_json_tool(window_, tools_)) {
+            tool_buffer_ = window_;
+            tool_buffer_fallback_to_content_ = true;
+            window_.clear();
+            mode_ = StreamMode::TOOL_BUFFER;
+            continue;
+        }
+
         // No tags found — emit safe prefix
         if (window_.size() > std::max(BASE_HOLDBACK, stop_holdback_)) {
             size_t cut = utf8_safe_len(window_, window_.size() - std::max(BASE_HOLDBACK, stop_holdback_));
@@ -601,6 +620,9 @@ std::vector<std::string> SseEmitter::emit_finish(int completion_tokens,
                 break;
             default: break;
             }
+        } else if (tool_buffer_fallback_to_content_) {
+            accumulated_content_ += tool_buffer_;
+            emit_content_delta(out, tool_buffer_);
         } else {
             // Tool syntax was detected but no valid call parsed. Do not leak
             // malformed/incomplete XML back to the user as assistant text.

--- a/server/src/server/sse_emitter.cpp
+++ b/server/src/server/sse_emitter.cpp
@@ -429,7 +429,8 @@ std::vector<std::string> SseEmitter::emit_token(const std::string & raw_piece) {
             continue;
         }
 
-        if (starts_with_potential_bare_json_tool(window_, tools_)) {
+        if (accumulated_content_.find_first_not_of(" \t\n\r") == std::string::npos &&
+            starts_with_potential_bare_json_tool(window_, tools_)) {
             tool_buffer_ = window_;
             tool_buffer_fallback_to_content_ = true;
             window_.clear();

--- a/server/src/server/sse_emitter.h
+++ b/server/src/server/sse_emitter.h
@@ -146,6 +146,7 @@ private:
     StreamMode   mode_;
     std::string  window_;           // holdback buffer
     std::string  tool_buffer_;      // accumulated tool text
+    bool         tool_buffer_fallback_to_content_ = false;
     std::string  accumulated_content_;
     std::string  accumulated_raw_;  // all raw text for tool memory
     std::string  reasoning_text_;

--- a/server/src/server/tool_parser.cpp
+++ b/server/src/server/tool_parser.cpp
@@ -1,12 +1,13 @@
 // Tool call parser implementation.
 //
-// Six detection patterns, tried in order:
+// Seven detection patterns, tried in order:
 // 1. <tool_call><function=NAME>...<parameter=K>V</parameter>...</function></tool_call>
 // 2. <function=NAME>...params...</function>  (bare, outside tool_call)
 // 3. <function=NAME(k="v", ...)></function>  (function-signature style)
 // 4. <tool_code>{JSON}</tool_code>
 // 5. call:<ns>?<verb>{relaxed-JSON args}    (gemma plain-text emissions)
 // 6. Bare JSON objects with name+arguments fields
+// 7. Whole-response JSON args for exactly one declared tool
 //
 // Pattern 5 runs *before* pattern 6 so that args like
 //   call:outer{"name": "inner", "arguments": {}}
@@ -381,6 +382,119 @@ static bool parse_json_tool_call(const json & obj, std::string & out_name, json 
     return true;
 }
 
+static bool is_ws(char c) {
+    return c == ' ' || c == '\t' || c == '\n' || c == '\r';
+}
+
+static bool span_covers_non_ws(const std::string & text, size_t start, size_t end) {
+    for (size_t i = 0; i < start; i++) {
+        if (!is_ws(text[i])) return false;
+    }
+    for (size_t i = end; i < text.size(); i++) {
+        if (!is_ws(text[i])) return false;
+    }
+    return true;
+}
+
+static const json * single_tool_function(const json & tools) {
+    if (!tools.is_array() || tools.size() != 1) return nullptr;
+    const auto & t = tools[0];
+    if (!t.is_object()) return nullptr;
+    if (t.contains("function") && t["function"].is_object()) return &t["function"];
+    return &t;
+}
+
+static const json * tool_input_schema(const json & fn) {
+    if (fn.contains("parameters") && fn["parameters"].is_object()) {
+        return &fn["parameters"];
+    }
+    if (fn.contains("input_schema") && fn["input_schema"].is_object()) {
+        return &fn["input_schema"];
+    }
+    return nullptr;
+}
+
+static bool value_matches_type(const json & value, const std::string & type) {
+    if (type == "string" || type == "str") return value.is_string();
+    if (type == "integer" || type == "int") return value.is_number_integer();
+    if (type == "number" || type == "float") return value.is_number();
+    if (type == "boolean" || type == "bool") return value.is_boolean();
+    if (type == "object") return value.is_object();
+    if (type == "array") return value.is_array();
+    if (type == "null") return value.is_null();
+    return true;
+}
+
+static bool value_matches_type_spec(const json & value, const json & spec) {
+    if (spec.is_string()) return value_matches_type(value, spec.get<std::string>());
+    if (spec.is_array()) {
+        for (const auto & t : spec) {
+            if (t.is_string() && value_matches_type(value, t.get<std::string>())) {
+                return true;
+            }
+        }
+        return false;
+    }
+    return true;
+}
+
+static bool object_matches_tool_schema(const json & obj, const json * schema) {
+    if (!obj.is_object()) return false;
+    if (!schema) return !obj.empty();
+    if (schema->contains("type") &&
+        !value_matches_type_spec(obj, (*schema)["type"])) {
+        return false;
+    }
+
+    const json * props = nullptr;
+    if (schema->contains("properties") && (*schema)["properties"].is_object()) {
+        props = &(*schema)["properties"];
+    }
+
+    bool has_required = false;
+    if (schema->contains("required") && (*schema)["required"].is_array()) {
+        for (const auto & key_json : (*schema)["required"]) {
+            if (!key_json.is_string()) continue;
+            has_required = true;
+            std::string key = key_json.get<std::string>();
+            if (!obj.contains(key)) return false;
+        }
+    }
+
+    const bool additional_forbidden =
+        schema->contains("additionalProperties") &&
+        (*schema)["additionalProperties"].is_boolean() &&
+        !(*schema)["additionalProperties"].get<bool>();
+
+    bool saw_declared_key = false;
+    for (auto it = obj.begin(); it != obj.end(); ++it) {
+        const bool declared = props && props->contains(it.key());
+        if (!declared) {
+            if (additional_forbidden) return false;
+            continue;
+        }
+        saw_declared_key = true;
+        const auto & prop_schema = (*props)[it.key()];
+        if (prop_schema.is_object() && prop_schema.contains("type") &&
+            !value_matches_type_spec(it.value(), prop_schema["type"])) {
+            return false;
+        }
+    }
+
+    return has_required || saw_declared_key || props == nullptr || props->empty();
+}
+
+static bool parse_single_tool_arg_object(const json & obj, const json & tools,
+                                         std::string & out_name, json & out_args) {
+    const json * fn = single_tool_function(tools);
+    if (!fn || !fn->contains("name") || !(*fn)["name"].is_string()) return false;
+    const json * schema = tool_input_schema(*fn);
+    if (!object_matches_tool_schema(obj, schema)) return false;
+    out_name = (*fn)["name"].get<std::string>();
+    out_args = obj;
+    return true;
+}
+
 // ─── Function signature parser ──────────────────────────────────────────
 
 // Parse key=value pairs from `<function=name(k="v", k2=123)></function>`.
@@ -627,6 +741,9 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
             std::string name;
             json args;
             if (parse_json_tool_call(obj2, name, args)) {
+                add_call(name, args, start, end_pos);
+            } else if (span_covers_non_ws(text, start, end_pos) &&
+                       parse_single_tool_arg_object(obj2, tools, name, args)) {
                 add_call(name, args, start, end_pos);
             }
             cursor = end_pos;

--- a/server/src/server/tool_parser.cpp
+++ b/server/src/server/tool_parser.cpp
@@ -481,7 +481,8 @@ static bool object_matches_tool_schema(const json & obj, const json * schema) {
         }
     }
 
-    return has_required || saw_declared_key || props == nullptr || props->empty();
+    return has_required || saw_declared_key || obj.empty() ||
+           props == nullptr || props->empty();
 }
 
 static bool parse_single_tool_arg_object(const json & obj, const json & tools,

--- a/server/src/server/tool_parser.h
+++ b/server/src/server/tool_parser.h
@@ -1,12 +1,13 @@
 // Tool call parser — extracts structured tool calls from generated text.
 //
-// Supports 6 detection patterns:
+// Supports 7 detection patterns:
 //   1. <tool_call><function=name>...</function></tool_call>  (Qwen XML)
 //   2. <function=name>...</function>                          (bare function XML)
 //   3. <function=name(k="v")></function>                      (function signature)
 //   4. <tool_code>{...JSON...}</tool_code>                    (tool_code wrapper)
 //   5. call:<ns>?<verb>{relaxed-JSON-args}                    (gemma plain-text)
 //   6. Bare JSON objects  {"name":..., "arguments":...}       (raw JSON)
+//   7. Whole-response JSON args for one declared tool          {"arg":...}
 
 #pragma once
 

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -118,6 +118,26 @@ static json weather_tools() {
     });
 }
 
+static json shell_tools() {
+    return json::array({
+        {
+            {"name", "shell"},
+            {"description", "Run one read-only shell command in the repository."},
+            {"input_schema", {
+                {"type", "object"},
+                {"properties", {
+                    {"command", {
+                        {"type", "string"},
+                        {"description", "The shell command to run."}
+                    }}
+                }},
+                {"required", json::array({"command"})},
+                {"additionalProperties", false}
+            }}
+        }
+    });
+}
+
 static SseEmitter make_emitter(ApiFormat fmt, json tools = json::array(),
                                bool started_in_thinking = false) {
     return SseEmitter(fmt, "test_id_001", "test-model", 10,
@@ -310,6 +330,35 @@ static void test_parse_json_tool_call() {
         auto args = json::parse(result.tool_calls[0].arguments);
         TEST_ASSERT(args["query"] == "hello world");
     }
+}
+
+static void test_parse_single_tool_bare_json_args() {
+    std::string text =
+        "{\n"
+        "  \"command\": \"git branch --show-current\"\n"
+        "}";
+    auto result = parse_tool_calls(text, shell_tools());
+    TEST_ASSERT(result.tool_calls.size() == 1);
+    if (!result.tool_calls.empty()) {
+        TEST_ASSERT(result.tool_calls[0].name == "shell");
+        auto args = json::parse(result.tool_calls[0].arguments);
+        TEST_ASSERT(args["command"] == "git branch --show-current");
+    }
+    TEST_ASSERT(result.cleaned_text.empty());
+}
+
+static void test_parse_single_tool_bare_json_args_rejects_prose() {
+    std::string text = "The command is {\"command\": \"git status\"}.";
+    auto result = parse_tool_calls(text, shell_tools());
+    TEST_ASSERT(result.tool_calls.empty());
+    TEST_ASSERT(result.cleaned_text == text);
+}
+
+static void test_parse_single_tool_bare_json_args_rejects_ambiguous_tools() {
+    std::string text = "{\"command\": \"git status\"}";
+    auto result = parse_tool_calls(text, weather_tools());
+    TEST_ASSERT(result.tool_calls.empty());
+    TEST_ASSERT(result.cleaned_text == text);
 }
 
 static void test_parse_no_tools() {
@@ -886,6 +935,23 @@ static void test_emitter_anthropic_tool_use_blocks() {
         n_stop++; pos++;
     }
     TEST_ASSERT(n_stop >= 2);
+}
+
+static void test_emitter_single_tool_bare_json_args() {
+    auto em = make_emitter(ApiFormat::ANTHROPIC, shell_tools());
+    em.emit_start();
+    em.emit_token("{\n");
+    em.emit_token("  \"command\": \"git branch --show-current\"\n");
+    em.emit_token("}");
+    em.emit_finish(16);
+
+    TEST_ASSERT(em.tool_calls().size() == 1);
+    if (!em.tool_calls().empty()) {
+        TEST_ASSERT(em.tool_calls()[0].name == "shell");
+        auto args = json::parse(em.tool_calls()[0].arguments);
+        TEST_ASSERT(args["command"] == "git branch --show-current");
+    }
+    TEST_ASSERT(em.accumulated_text().empty());
 }
 
 static void test_emitter_bare_function_tool_buffer_detection() {
@@ -4206,6 +4272,9 @@ int main() {
     RUN_TEST(test_parse_tool_call_xml);
     RUN_TEST(test_parse_bare_function_xml);
     RUN_TEST(test_parse_json_tool_call);
+    RUN_TEST(test_parse_single_tool_bare_json_args);
+    RUN_TEST(test_parse_single_tool_bare_json_args_rejects_prose);
+    RUN_TEST(test_parse_single_tool_bare_json_args_rejects_ambiguous_tools);
     RUN_TEST(test_parse_no_tools);
     RUN_TEST(test_parse_tool_code_wrapper);
     RUN_TEST(test_parse_tool_allowed_filter);
@@ -4247,6 +4316,7 @@ int main() {
     RUN_TEST(test_emitter_content_only_no_thinking);
     RUN_TEST(test_emitter_tool_buffer_detection);
     RUN_TEST(test_emitter_anthropic_tool_use_blocks);
+    RUN_TEST(test_emitter_single_tool_bare_json_args);
     RUN_TEST(test_emitter_bare_function_tool_buffer_detection);
     RUN_TEST(test_emitter_does_not_leak_malformed_tool_xml);
     RUN_TEST(test_emitter_parses_tool_call_missing_outer_close);

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -138,6 +138,12 @@ static json shell_tools() {
     });
 }
 
+static json optional_shell_tools() {
+    json tools = shell_tools();
+    tools[0]["input_schema"].erase("required");
+    return tools;
+}
+
 static SseEmitter make_emitter(ApiFormat fmt, json tools = json::array(),
                                bool started_in_thinking = false) {
     return SseEmitter(fmt, "test_id_001", "test-model", 10,
@@ -343,6 +349,18 @@ static void test_parse_single_tool_bare_json_args() {
         TEST_ASSERT(result.tool_calls[0].name == "shell");
         auto args = json::parse(result.tool_calls[0].arguments);
         TEST_ASSERT(args["command"] == "git branch --show-current");
+    }
+    TEST_ASSERT(result.cleaned_text.empty());
+}
+
+static void test_parse_single_tool_bare_json_args_allows_empty_optional_object() {
+    auto result = parse_tool_calls("{}", optional_shell_tools());
+    TEST_ASSERT(result.tool_calls.size() == 1);
+    if (!result.tool_calls.empty()) {
+        TEST_ASSERT(result.tool_calls[0].name == "shell");
+        auto args = json::parse(result.tool_calls[0].arguments);
+        TEST_ASSERT(args.is_object());
+        TEST_ASSERT(args.empty());
     }
     TEST_ASSERT(result.cleaned_text.empty());
 }
@@ -952,6 +970,20 @@ static void test_emitter_single_tool_bare_json_args() {
         TEST_ASSERT(args["command"] == "git branch --show-current");
     }
     TEST_ASSERT(em.accumulated_text().empty());
+}
+
+static void test_emitter_bare_json_args_do_not_trigger_after_content() {
+    auto em = make_emitter(ApiFormat::ANTHROPIC, shell_tools());
+    em.emit_start();
+    em.emit_token("This answer already emitted visible prose before JSON appears.");
+    em.emit_token("                    ");
+    em.emit_token("{\"command\":\"git status\"}");
+    em.emit_finish(16);
+
+    TEST_ASSERT(em.tool_calls().empty());
+    TEST_ASSERT(em.accumulated_text().find("visible prose") != std::string::npos);
+    TEST_ASSERT(em.accumulated_text().find("\"command\":\"git status\"") !=
+                std::string::npos);
 }
 
 static void test_emitter_bare_function_tool_buffer_detection() {
@@ -4273,6 +4305,7 @@ int main() {
     RUN_TEST(test_parse_bare_function_xml);
     RUN_TEST(test_parse_json_tool_call);
     RUN_TEST(test_parse_single_tool_bare_json_args);
+    RUN_TEST(test_parse_single_tool_bare_json_args_allows_empty_optional_object);
     RUN_TEST(test_parse_single_tool_bare_json_args_rejects_prose);
     RUN_TEST(test_parse_single_tool_bare_json_args_rejects_ambiguous_tools);
     RUN_TEST(test_parse_no_tools);
@@ -4317,6 +4350,7 @@ int main() {
     RUN_TEST(test_emitter_tool_buffer_detection);
     RUN_TEST(test_emitter_anthropic_tool_use_blocks);
     RUN_TEST(test_emitter_single_tool_bare_json_args);
+    RUN_TEST(test_emitter_bare_json_args_do_not_trigger_after_content);
     RUN_TEST(test_emitter_bare_function_tool_buffer_detection);
     RUN_TEST(test_emitter_does_not_leak_malformed_tool_xml);
     RUN_TEST(test_emitter_parses_tool_call_missing_outer_close);


### PR DESCRIPTION
## Summary

Recover whole-response bare JSON argument objects as a tool call when exactly one tool is declared.

This is intentionally conservative: standalone JSON object only, exactly one declared tool only, rejects prose-wrapped JSON and multi-tool ambiguity, and routes through the existing parser/emitter path.

## Why

The agentic replay produced valid JSON arguments without an explicit tool wrapper, which caused otherwise valid tool turns to be counted as invalid. This preserves correctness without changing multi-tool or prose parsing behavior.

## Validation

- `env CCACHE_DIR=/tmp/lucebox-ccache CCACHE_TEMPDIR=/tmp/lucebox-ccache-tmp cmake --build server/build-cuda126-sm86 --target test_server_unit -j 8`
- `server/build-cuda126-sm86/test_server_unit`
- Result: `2034 assertions, 0 failures`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

