### PR TITLE
perf(laguna): spec-decode verify path — bonus fold, fused domino head, draft-graph replay, AUTO width, fused QK/shexp weights

### DIFF
--- a/server/src/common/dflash_draft_graph.cpp
+++ b/server/src/common/dflash_draft_graph.cpp
@@ -24,6 +24,10 @@ static bool draft_has_swa_layers(const DraftWeights & dw) {
 
 // Build draft graph at a given ctx_len into sg. Does NOT touch sg.alloc.
 // mirror_view: if true, uses a view into mirror->target_feat at slot0.
+// ctx_alloc: allocation/topology size of the ctx dimension (>= ctx_len).
+// When ctx_alloc > 0 and differs from the legacy behavior, a full-layer pad
+// mask input is created so the graph topology stays stable while ctx_len
+// grows (CUDA-graph replay for the draft forward).
 static bool build_draft_graph_internal(
     StepGraph & sg,
     const DraftWeights & dw,
@@ -31,11 +35,14 @@ static bool build_draft_graph_internal(
     int ctx_len,
     const DraftFeatureMirror * mirror,
     int mirror_slot0,
-    bool mirror_view) {
+    bool mirror_view,
+    bool pad_masked = false) {
 
+    const size_t arena_sz = 32u * 1024 * 1024;
+    if (sg.meta_arena.size() < arena_sz) sg.meta_arena.resize(arena_sz);
     ggml_init_params ip{};
-    ip.mem_size   = 256 * 1024 * 1024;
-    ip.mem_buffer = nullptr;
+    ip.mem_size   = sg.meta_arena.size();
+    ip.mem_buffer = sg.meta_arena.data();
     ip.no_alloc   = true;
     sg.ctx = ggml_init(ip);
     if (!sg.ctx) return false;
@@ -86,6 +93,18 @@ static bool build_draft_graph_internal(
         ggml_set_input(sg.attn_mask);
     }
 
+    bool any_full_layer = false;
+    for (int i = 0; i < dw.n_layer; i++)
+        if (!dw.layers[i].is_swa) { any_full_layer = true; break; }
+    sg.pad_mask_full = nullptr;
+    if (pad_masked && any_full_layer) {
+        const int total_k = ctx_len + q_len;
+        const int kv_pad = mask_align_up(total_k, MASK_KV_PAD);
+        sg.pad_mask_full = ggml_new_tensor_2d(sg.ctx, GGML_TYPE_F16, kv_pad, q_len);
+        ggml_set_name(sg.pad_mask_full, "pad_mask_full");
+        ggml_set_input(sg.pad_mask_full);
+    }
+
     sg.gf = ggml_new_graph_custom(sg.ctx, 4096, false);
 
     DraftGraphInputs gi{};
@@ -96,6 +115,7 @@ static bool build_draft_graph_internal(
     gi.positions_k       = sg.positions_k;
     gi.lm_head           = lm_head;
     gi.causal_mask_swa   = sg.attn_mask;
+    gi.pad_mask_full     = sg.pad_mask_full;
     DraftGraphOutputs go = build_draft_graph(sg.ctx, dw, gi);
     sg.hidden_states = go.hidden_states;
     sg.logits = go.logits;
@@ -123,16 +143,42 @@ bool build_draft_step(
     int ctx_len,
     const DraftFeatureMirror * mirror,
     int committed,
-    int /*ctx_len_max*/) {
+    int /*ctx_len_max*/,
+    bool pad_ctx) {
     step_graph_free(sg);
 
     if (!sg.alloc) {
         sg.alloc = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend));
     }
 
+    // Padded-ctx mode: build the graph at the 64-aligned ctx size and mask the
+    // pad keys, so the topology (and gallocr layout) stays IDENTICAL across
+    // ~64 tokens of context growth and ggml-cuda can replay the draft forward
+    // as a CUDA graph. Requires masking, so only usable when the draft has no
+    // SWA layers (SWA windowing would slide into the pad region).
+    // Padding is safe as long as no layer does actual SWA WINDOWING at this
+    // context size (windowing would slide the K view into the pad region).
+    // Layers flagged is_swa below the window size just mean "causal noise
+    // mask" and pad fine with the pad rows masked out.
+    const int ctx_pad_cand = (ctx_len + 63) & ~63;
+    const bool swa_windowing = draft_has_swa_layers(dw) && dw.swa_window > 0 &&
+                               ctx_pad_cand > dw.swa_window;
+    const bool do_pad = pad_ctx && !swa_windowing;
+    const int ctx_alloc = do_pad ? ctx_pad_cand : ctx_len;
+    static bool s_pad_logged = false;
+    if (!s_pad_logged) {
+        s_pad_logged = true;
+        std::fprintf(stderr, "[draft-pad] pad_ctx=%d has_swa=%d do_pad=%d ctx_len=%d ctx_alloc=%d\n",
+                     (int)pad_ctx, (int)draft_has_swa_layers(dw), (int)do_pad, ctx_len, ctx_alloc);
+    }
+
     int mirror_slot0 = 0;
-    const bool use_view = mirror &&
+    bool use_view = mirror &&
         draft_feature_mirror_can_view(*mirror, committed, ctx_len, mirror_slot0);
+    if (use_view && do_pad &&
+        mirror_slot0 + ctx_alloc > mirror->cap) {
+        use_view = false;  // padded view would run past the ring
+    }
 
     // If ctx_len exceeds our cached reserve, re-reserve at next 64 boundary.
     // This makes all subsequent alloc_graph calls within the 64-token window
@@ -142,7 +188,7 @@ bool build_draft_step(
         // Build a dummy graph at ctx_padded just for sizing.
         // Use non-view path for reserve (view tensors don't need allocation).
         if (!build_draft_graph_internal(sg, dw, lm_head, ctx_padded,
-                                        nullptr, 0, false)) {
+                                        nullptr, 0, false, do_pad)) {
             return false;
         }
         ggml_gallocr_reserve(sg.alloc, sg.gf);
@@ -150,21 +196,64 @@ bool build_draft_step(
         step_graph_free(sg);
     }
 
-    // Build real graph at ctx_len for actual computation.
-    if (!build_draft_graph_internal(sg, dw, lm_head, ctx_len,
-                                    mirror, mirror_slot0, use_view)) {
+    // Build real graph. Padded mode: topology at ctx_alloc, real rows = ctx_len.
+    if (!build_draft_graph_internal(sg, dw, lm_head,
+                                    do_pad ? ctx_alloc : ctx_len,
+                                    mirror, mirror_slot0, use_view, do_pad)) {
         return false;
     }
+    sg.ctx_alloc = do_pad ? ctx_alloc : 0;
 
     if (!ggml_gallocr_alloc_graph(sg.alloc, sg.gf)) {
         return false;
     }
 
+    if (do_pad) {
+        const int q_len = dw.block_size;
+        const int total_k = ctx_alloc + q_len;
+        const int kv_pad = mask_align_up(total_k, MASK_KV_PAD);
+        // Full-layer mask: real ctx keys + all noise keys visible (the DFlash
+        // block is non-causal on full layers), pad keys and alignment columns
+        // -inf.
+        static constexpr uint16_t ZERO = 0x0000;
+        static constexpr uint16_t NEG_INF = 0xFC00;
+        std::vector<uint16_t> mask_data((size_t)kv_pad * q_len, NEG_INF);
+        for (int q = 0; q < q_len; q++) {
+            for (int k = 0; k < ctx_len; k++)
+                mask_data[(size_t)q * kv_pad + k] = ZERO;
+            for (int j = 0; j < q_len; j++)
+                mask_data[(size_t)q * kv_pad + (ctx_alloc + j)] = ZERO;
+        }
+        ggml_backend_tensor_set(sg.pad_mask_full, mask_data.data(), 0,
+                                sizeof(uint16_t) * mask_data.size());
+
+        // The pad rows of the ctx features must be FINITE (they are masked
+        // out, but NaN/Inf would still poison flash-attn). Zero them.
+        if (ctx_alloc > ctx_len) {
+            if (use_view) {
+                const size_t row_bytes = (size_t)mirror->target_feat->nb[1];
+                std::vector<uint8_t> zeros((size_t)(ctx_alloc - ctx_len) * row_bytes, 0);
+                ggml_backend_tensor_set(mirror->target_feat, zeros.data(),
+                                        (size_t)(mirror_slot0 + ctx_len) * row_bytes,
+                                        zeros.size());
+            } else {
+                const size_t row_bytes = (size_t)sg.target_hidden_cat->nb[1];
+                std::vector<uint8_t> zeros((size_t)(ctx_alloc - ctx_len) * row_bytes, 0);
+                ggml_backend_tensor_set(sg.target_hidden_cat, zeros.data(),
+                                        (size_t)ctx_len * row_bytes,
+                                        zeros.size());
+            }
+        }
+    }
+
     // Fill causal mask data for SWA layers (after allocation gives memory to the tensor).
     if (sg.attn_mask) {
         const int q_len = dw.block_size;
-        const bool swa_active = dw.swa_window > 0 && ctx_len > dw.swa_window;
-        const int eff_ctx = swa_active ? dw.swa_window : ctx_len;
+        const bool swa_active = !do_pad && dw.swa_window > 0 && ctx_len > dw.swa_window;
+        // Padded mode: keys span ctx_alloc rows; only the first ctx_len are
+        // real (visible), the pad rows stay -inf. Noise keys sit at ctx_alloc.
+        const int eff_ctx = do_pad ? ctx_alloc : (swa_active ? dw.swa_window : ctx_len);
+        const int vis_ctx = do_pad ? ctx_len : eff_ctx;
         const int eff_total_k = eff_ctx + q_len;
         const int kv_pad = mask_align_up(eff_total_k, MASK_KV_PAD);
 
@@ -175,7 +264,7 @@ bool build_draft_step(
         static constexpr uint16_t NEG_INF = 0xFC00;
         std::vector<uint16_t> mask_data((size_t)kv_pad * q_len, NEG_INF);
         for (int q = 0; q < q_len; q++) {
-            for (int k = 0; k < eff_ctx; k++)
+            for (int k = 0; k < vis_ctx; k++)
                 mask_data[(size_t)q * kv_pad + k] = ZERO;
             for (int j = 0; j <= q; j++)
                 mask_data[(size_t)q * kv_pad + (eff_ctx + j)] = ZERO;

--- a/server/src/common/dflash_draft_graph.cpp
+++ b/server/src/common/dflash_draft_graph.cpp
@@ -224,8 +224,10 @@ bool build_draft_step(
             for (int j = 0; j < q_len; j++)
                 mask_data[(size_t)q * kv_pad + (ctx_alloc + j)] = ZERO;
         }
-        ggml_backend_tensor_set(sg.pad_mask_full, mask_data.data(), 0,
-                                sizeof(uint16_t) * mask_data.size());
+        if (sg.pad_mask_full) {
+            ggml_backend_tensor_set(sg.pad_mask_full, mask_data.data(), 0,
+                                    sizeof(uint16_t) * mask_data.size());
+        }
 
         // The pad rows of the ctx features must be FINITE (they are masked
         // out, but NaN/Inf would still poison flash-attn). Zero them.

--- a/server/src/common/dflash_draft_graph.h
+++ b/server/src/common/dflash_draft_graph.h
@@ -31,6 +31,7 @@ bool build_draft_step(
     int ctx_len,
     const DraftFeatureMirror * mirror = nullptr,
     int committed = 0,
-    int ctx_len_max = 0);
+    int ctx_len_max = 0,
+    bool pad_ctx = false);
 
 }  // namespace dflash::common

--- a/server/src/common/dflash_target.h
+++ b/server/src/common/dflash_target.h
@@ -16,6 +16,9 @@
 
 #include "ddtree.h"
 
+struct ggml_tensor;
+struct ggml_backend;
+
 namespace dflash::common {
 
 struct DFlashTarget {
@@ -110,6 +113,12 @@ struct DFlashTarget {
 
     // Embed token IDs using the target's embedding table.
     // Output: `out` must have space for `n * hidden_size()` floats.
+    // Optional GPU handles for the fused domino draft head. A target that
+    // returns non-null for all three enables the single-graph draft-side path.
+    virtual ggml_tensor *  lm_head_tensor()  { return nullptr; }
+    virtual ggml_tensor *  gpu_embd_table()  { return nullptr; }
+    virtual ggml_backend * fused_head_backend() { return nullptr; }
+
     virtual bool embed_tokens(const int32_t * tokens, int n,
                               float * out) const = 0;
 

--- a/server/src/common/domino_head.cpp
+++ b/server/src/common/domino_head.cpp
@@ -197,6 +197,16 @@ bool domino_correct_greedy_chain_fused(const DraftWeights & dw,
     const int n_cand = q_len - 1;
     const int vocab  = (int)lm_head->ne[1];
     if (hidden <= 0 || H <= 0 || E <= 0 || vocab <= 0) return false;
+    if (dw.domino.vocab_size > 0 && vocab != dw.domino.vocab_size) {
+        static bool s_vocab_warned = false;
+        if (!s_vocab_warned) {
+            s_vocab_warned = true;
+            std::fprintf(stderr,
+                "domino_fused: vocab mismatch lm_head=%d domino=%d; falling back\n",
+                vocab, dw.domino.vocab_size);
+        }
+        return false;
+    }
 
     static const bool zero_start = std::getenv("DFLASH_DOMINO_ZERO_START") != nullptr;
 

--- a/server/src/common/domino_head.cpp
+++ b/server/src/common/domino_head.cpp
@@ -179,4 +179,134 @@ bool domino_correct_greedy_chain(const DraftWeights & dw,
     return true;
 }
 
+bool domino_correct_greedy_chain_fused(const DraftWeights & dw,
+                                       ggml_backend_t backend,
+                                       ggml_tensor * lm_head,
+                                       ggml_tensor * embd_table,
+                                       const float * local_hidden,
+                                       int q_len,
+                                       int32_t last_tok,
+                                       std::vector<int32_t> & draft_tok) {
+    if (!dw.domino.enabled || q_len <= 1 || !local_hidden ||
+        !backend || !lm_head || !embd_table) {
+        return false;
+    }
+    const int hidden = dw.n_embd;
+    const int H      = dw.domino.gru_hidden_dim;
+    const int E      = dw.domino.emb_dim;
+    const int n_cand = q_len - 1;
+    const int vocab  = (int)lm_head->ne[1];
+    if (hidden <= 0 || H <= 0 || E <= 0 || vocab <= 0) return false;
+
+    static const bool zero_start = std::getenv("DFLASH_DOMINO_ZERO_START") != nullptr;
+
+    const size_t arena_size = ggml_tensor_overhead() * (size_t)(96 + 48 * n_cand) +
+                              ggml_graph_overhead_custom(1024, false) + 4 * 1024 * 1024;
+    static thread_local std::vector<uint8_t> g_arena_fused;
+    if (g_arena_fused.size() < arena_size) g_arena_fused.resize(arena_size);
+
+    ggml_init_params ip{};
+    ip.mem_size   = g_arena_fused.size();
+    ip.mem_buffer = g_arena_fused.data();
+    ip.no_alloc   = true;
+    ggml_context * ctx = ggml_init(ip);
+    if (!ctx) return false;
+    ggml_cgraph * gf = ggml_new_graph_custom(ctx, 1024, false);
+
+    ggml_tensor * inp_hidden = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, hidden, n_cand);
+    ggml_tensor * inp_seed   = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, 1);
+    ggml_set_input(inp_hidden);
+    ggml_set_input(inp_seed);
+
+    // Base logits for every candidate in one matmul: [vocab, n_cand].
+    ggml_tensor * base = ggml_mul_mat(ctx, lm_head, inp_hidden);
+
+    ggml_tensor * state = ggml_reshape_2d(ctx, dw.domino.start, H, 1);
+    if (zero_start) state = ggml_scale(ctx, state, 0.0f);
+    ggml_tensor * prev_embed = ggml_get_rows(ctx, embd_table, inp_seed);  // [hidden,1] f32
+    ggml_set_name(prev_embed, "dom_embed_seed");
+
+    std::vector<ggml_tensor *> toks((size_t)n_cand, nullptr);
+    for (int i = 0; i < n_cand; ++i) {
+        ggml_tensor * gi = ggml_mul_mat(ctx, dw.domino.gru_w_ih, prev_embed);
+        gi = ggml_add(ctx, gi, ggml_reshape_2d(ctx, dw.domino.gru_b_ih, 3 * H, 1));
+        ggml_tensor * gh = ggml_mul_mat(ctx, dw.domino.gru_w_hh, state);
+        gh = ggml_add(ctx, gh, ggml_reshape_2d(ctx, dw.domino.gru_b_hh, 3 * H, 1));
+
+        const size_t gate_bytes = (size_t)H * ggml_element_size(gi);
+        ggml_tensor * i_r = ggml_view_2d(ctx, gi, H, 1, gi->nb[1], 0);
+        ggml_tensor * i_z = ggml_view_2d(ctx, gi, H, 1, gi->nb[1], gate_bytes);
+        ggml_tensor * i_n = ggml_view_2d(ctx, gi, H, 1, gi->nb[1], 2 * gate_bytes);
+        ggml_tensor * h_r = ggml_view_2d(ctx, gh, H, 1, gh->nb[1], 0);
+        ggml_tensor * h_z = ggml_view_2d(ctx, gh, H, 1, gh->nb[1], gate_bytes);
+        ggml_tensor * h_n = ggml_view_2d(ctx, gh, H, 1, gh->nb[1], 2 * gate_bytes);
+
+        ggml_tensor * reset  = ggml_sigmoid(ctx, ggml_add(ctx, i_r, h_r));
+        ggml_tensor * update = ggml_sigmoid(ctx, ggml_add(ctx, i_z, h_z));
+        ggml_tensor * cand   = ggml_tanh(ctx, ggml_add(ctx, i_n, ggml_mul(ctx, reset, h_n)));
+        ggml_tensor * h_new  = ggml_add(ctx, cand,
+                                        ggml_mul(ctx, update,
+                                                 ggml_sub(ctx, state, cand)));
+
+        ggml_tensor * hid_i = ggml_view_2d(ctx, inp_hidden, hidden, 1,
+                                           inp_hidden->nb[1],
+                                           (size_t)i * inp_hidden->nb[1]);
+        ggml_tensor * zcat = ggml_concat(ctx, hid_i, h_new, 0);
+        ggml_tensor * bias = ggml_mul_mat(ctx, dw.domino.head_w1, zcat);
+        bias = ggml_add(ctx, bias, ggml_reshape_2d(ctx, dw.domino.head_b1, E, 1));
+        bias = ggml_silu(ctx, bias);
+        bias = ggml_mul_mat(ctx, dw.domino.head_w2, bias);
+        bias = ggml_add(ctx, bias, ggml_reshape_2d(ctx, dw.domino.head_b2, vocab, 1));
+
+        ggml_tensor * base_i = ggml_view_2d(ctx, base, vocab, 1,
+                                            base->nb[1], (size_t)i * base->nb[1]);
+        ggml_tensor * corrected = ggml_add(ctx, base_i, bias);
+        ggml_tensor * tok = ggml_argmax(ctx, corrected);
+        ggml_set_output(tok);
+        ggml_build_forward_expand(gf, tok);
+        toks[(size_t)i] = tok;
+
+        if (i + 1 < n_cand) {
+            prev_embed = ggml_get_rows(ctx, embd_table, tok);
+            ggml_set_name(prev_embed, "dom_embed_tok");
+        }
+        state = h_new;
+    }
+
+    static thread_local ggml_gallocr_t galloc_fused = nullptr;
+    if (!galloc_fused) {
+        galloc_fused = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend));
+    }
+    if (!ggml_gallocr_alloc_graph(galloc_fused, gf)) {
+        std::fprintf(stderr, "domino_fused: gallocr_alloc_graph failed\n");
+        ggml_free(ctx);
+        return false;
+    }
+
+    ggml_backend_tensor_set(inp_hidden, local_hidden + (size_t)hidden, 0,
+                            sizeof(float) * (size_t)hidden * (size_t)n_cand);
+    ggml_backend_tensor_set(inp_seed, &last_tok, 0, sizeof(int32_t));
+
+    if (ggml_backend_graph_compute(backend, gf) != GGML_STATUS_SUCCESS) {
+        std::fprintf(stderr, "domino_fused: graph_compute failed\n");
+        ggml_free(ctx);
+        return false;
+    }
+
+    draft_tok.assign((size_t)q_len, 0);
+    draft_tok[0] = last_tok;
+    // One synchronize instead of n_cand blocking readbacks.
+    int32_t t_out[16];
+    const int n_get = n_cand < 16 ? n_cand : 16;
+    for (int i = 0; i < n_get; ++i) {
+        ggml_backend_tensor_get_async(backend, toks[(size_t)i], &t_out[i], 0, sizeof(int32_t));
+    }
+    ggml_backend_synchronize(backend);
+    for (int i = 0; i < n_get; ++i) {
+        draft_tok[(size_t)i + 1] = t_out[i];
+    }
+    ggml_free(ctx);
+    return true;
+}
+
 }  // namespace dflash::common

--- a/server/src/common/domino_head.h
+++ b/server/src/common/domino_head.h
@@ -8,6 +8,20 @@
 
 namespace dflash::common {
 
+// Fused variant: one GPU graph = lm_head projection of the candidate hidden
+// states + unrolled GRU correction chain with in-graph argmax -> get_rows
+// token feedback. Requires the target to expose its lm_head and a GPU (f16)
+// token-embedding table. Runs on a dedicated CUDA backend instance so the
+// ggml-cuda graph cache can replay it across steps.
+bool domino_correct_greedy_chain_fused(const DraftWeights & dw,
+                                       ggml_backend_t backend,
+                                       ggml_tensor * lm_head,
+                                       ggml_tensor * embd_table,
+                                       const float * local_hidden,
+                                       int q_len,
+                                       int32_t last_tok,
+                                       std::vector<int32_t> & draft_tok);
+
 bool domino_correct_greedy_chain(const DraftWeights & dw,
                                  ggml_backend_t backend,
                                  DFlashTarget & target,

--- a/server/src/common/step_graph.h
+++ b/server/src/common/step_graph.h
@@ -21,6 +21,12 @@ struct StepGraph {
     ggml_cgraph *   gf  = nullptr;
     ggml_gallocr_t  alloc = nullptr;
 
+    // Persistent metadata arena for the draft graph. Reusing the same arena
+    // across rebuilds keeps every ggml_tensor at a stable address, which is
+    // what the ggml-cuda graph cache keys on (nodes[0] pointer + src tensor
+    // pointers). A fresh malloc per step would defeat CUDA-graph replay.
+    std::vector<uint8_t> meta_arena;
+
     // The ctx_len last used for ggml_gallocr_reserve (draft only).
     // When the real ctx_len fits within this, alloc_graph is a no-op.
     int alloc_reserved_ctx = 0;
@@ -32,6 +38,10 @@ struct StepGraph {
     ggml_tensor *   parent_ids = nullptr;    // DDTree tree-mode; null for chain mode
     ggml_tensor *   target_hidden_cat = nullptr;  // draft only
     ggml_tensor *   positions_k = nullptr;        // draft only
+    ggml_tensor *   pad_mask_full = nullptr;      // draft only; padded-ctx mask
+    // When >0, the draft graph was built with the ctx dimension padded to this
+    // size (stable topology for CUDA-graph replay); noise keys start here.
+    int             ctx_alloc = 0;
     ggml_tensor *   hidden_input = nullptr;        // lm-head projection only
     // [n_tokens,n_head_kv] i64; step-invariant KV write (carries kv_start). Null on non-graph paths.
     ggml_tensor *   kv_write_rows = nullptr;
@@ -59,6 +69,8 @@ inline void step_graph_free(StepGraph & sg) {
     sg.gf = nullptr;
     sg.inp_embed = sg.positions = sg.attn_mask = nullptr;
     sg.target_hidden_cat = sg.positions_k = nullptr;
+    sg.pad_mask_full = nullptr;
+    sg.ctx_alloc = 0;
     sg.hidden_input = nullptr;
     sg.parent_ids = nullptr;
     sg.kv_write_rows = nullptr;

--- a/server/src/common/step_graph.h
+++ b/server/src/common/step_graph.h
@@ -91,6 +91,9 @@ inline void step_graph_free(StepGraph & sg) {
 inline void step_graph_destroy(StepGraph & sg) {
     if (sg.alloc) { ggml_gallocr_free(sg.alloc); sg.alloc = nullptr; }
     step_graph_free(sg);
+    sg.meta_arena.clear();
+    sg.meta_arena.shrink_to_fit();
+    sg.alloc_reserved_ctx = 0;
 }
 
 }  // namespace dflash::common

--- a/server/src/draft/draft_graph.cpp
+++ b/server/src/draft/draft_graph.cpp
@@ -137,7 +137,9 @@ DraftGraphOutputs build_draft_graph(
 
         // ── 2f. Attention: causal for SWA layers, non-causal for full layers.
         const float scale = 1.0f / std::sqrt((float)head_dim);
-        ggml_tensor * mask = (L.is_swa && in.causal_mask_swa) ? in.causal_mask_swa : nullptr;
+        ggml_tensor * mask = L.is_swa
+            ? (in.causal_mask_swa ? in.causal_mask_swa : nullptr)
+            : in.pad_mask_full;
         ggml_tensor * attn = ggml_flash_attn_ext(ctx, Q, K, V, mask,
                                                  scale, /*max_bias=*/0.0f,
                                                  /*logit_softcap=*/0.0f);

--- a/server/src/draft/draft_graph.h
+++ b/server/src/draft/draft_graph.h
@@ -21,6 +21,10 @@ struct DraftGraphInputs {
     // Optional: causal mask for SWA layers [kv_pad, q_len] F16.
     // nullptr = all layers non-causal.
     ggml_tensor * causal_mask_swa = nullptr;
+    // Optional: mask for NON-SWA layers [kv_pad, q_len] F16. Used when the
+    // context is padded to a stable allocation size for CUDA-graph replay:
+    // real keys are 0, pad keys are -inf. nullptr = no mask (legacy).
+    ggml_tensor * pad_mask_full = nullptr;
 };
 
 struct DraftGraphOutputs {

--- a/server/src/laguna/laguna_backend.cpp
+++ b/server/src/laguna/laguna_backend.cpp
@@ -438,7 +438,19 @@ bool LagunaBackend::do_spec_decode(int committed, int n_gen,
         if (w > 0) verify_width = w;
     }
     const bool adaptive_width = (verify_width <= 0);
-    int chain_w = adaptive_width ? (int)spec_ewma_accept_ + 2 : verify_width;
+    // AUTO width: on RTX 3090 with XS2-class drafters a marginal verify
+    // position costs ~2.3ms while its marginal commit is <0.3 tokens beyond
+    // width 3, so width 3 dominates for accept lengths in the 1.5-3 range
+    // (HumanEval: w3 188 tok/s vs w4 173 vs old AUTO 172). Follow the accept
+    // EWMA but cap at DFLASH_LAGUNA_VERIFY_WIDTH_MAX (default 3).
+    static const int auto_w_max = []() {
+        const char * e = std::getenv("DFLASH_LAGUNA_VERIFY_WIDTH_MAX");
+        const int v = e ? std::atoi(e) : 3;
+        return v > 0 ? v : 3;
+    }();
+    int chain_w = adaptive_width
+        ? std::min((int)(spec_ewma_accept_ + 0.5) + 1, auto_w_max)
+        : verify_width;
     if (chain_w < 2) chain_w = 2;
     if (chain_w > std::min(block_size, 8)) chain_w = std::min(block_size, 8);
     // DDTree sizes its batch via its budget; chain uses the width chosen above.
@@ -610,10 +622,15 @@ bool LagunaBackend::do_spec_decode(int committed, int n_gen,
         const bool use_mirror_view =
             draft_feature_mirror_can_view(feature_mirror_, committed, draft_ctx, mirror_slot0);
 
+        static const bool draft_pad = []() {
+            const char * e = std::getenv("DFLASH_LAGUNA_DRAFT_PAD");
+            return !(e && e[0] == '0' && e[1] == '\0');
+        }();
         if (!build_draft_step(draft_sg, dw_, /*lm_head=*/nullptr, draft_backend_,
                               draft_ctx, use_mirror_view ? &feature_mirror_ : nullptr,
                               committed,
-                              std::min(ring_cap, std::max(DRAFT_CTX_MAX_DEFAULT, args_.draft_ctx_max)))) {
+                              std::min(ring_cap, std::max(DRAFT_CTX_MAX_DEFAULT, args_.draft_ctx_max)),
+                              draft_pad)) {
             std::fprintf(stderr, "[laguna-spec] draft build failed\n");
             step_graph_destroy(draft_sg);
             return false;
@@ -628,9 +645,11 @@ bool LagunaBackend::do_spec_decode(int committed, int n_gen,
 
         ggml_backend_tensor_set(draft_sg.inp_embed, noise_embed.data(), 0,
                                 sizeof(float) * noise_embed.size());
-        pos_k.resize((size_t)draft_ctx + (size_t)block_size);
+        const int kctx = (draft_sg.ctx_alloc > 0) ? draft_sg.ctx_alloc : draft_ctx;
+        pos_k.resize((size_t)kctx + (size_t)block_size);
         for (int i = 0; i < block_size; i++) pos_q[(size_t)i] = draft_ctx + i;
-        for (int i = 0; i < draft_ctx + block_size; i++) pos_k[(size_t)i] = i;
+        for (int i = 0; i < kctx; i++) pos_k[(size_t)i] = (i < draft_ctx) ? i : 0;
+        for (int j = 0; j < block_size; j++) pos_k[(size_t)kctx + j] = draft_ctx + j;
         ggml_backend_tensor_set(draft_sg.positions, pos_q.data(), 0,
                                 sizeof(int32_t) * pos_q.size());
         ggml_backend_tensor_set(draft_sg.positions_k, pos_k.data(), 0,
@@ -655,7 +674,23 @@ bool LagunaBackend::do_spec_decode(int committed, int n_gen,
                     "(H=%d E=%d)\n",
                     dw_.domino.gru_hidden_dim, dw_.domino.emb_dim);
             }
-            if (domino_correct_greedy_chain(dw_, draft_backend_, *target,
+            static const bool fused_domino = []() {
+                const char * e = std::getenv("DFLASH_LAGUNA_FUSED_DOMINO");
+                return !(e && e[0] == '0' && e[1] == '\0');
+            }();
+            if (fused_domino) {
+                // Run on the draft backend: same stream as the draft forward,
+                // second graph key in the multi-key CUDA-graph cache.
+                if (domino_correct_greedy_chain_fused(
+                        dw_, draft_backend_, target->lm_head_tensor(),
+                        target->gpu_embd_table(), local_hidden.data(), q_len,
+                        last_tok, draft_tok)) {
+                    used_domino = true;
+                }
+            }
+            if (used_domino) {
+                // fused path done
+            } else if (domino_correct_greedy_chain(dw_, draft_backend_, *target,
                                             local_hidden.data(), q_len,
                                             last_tok, draft_tok)) {
                 used_domino = true;
@@ -831,7 +866,25 @@ bool LagunaBackend::do_spec_decode(int committed, int n_gen,
 
         cache_.cur_pos = committed + accept_n;
 
-        if (bonus_tok >= 0) {
+        const bool bonus_is_stop = bonus_tok >= 0 && !ignore_eos && target->is_eos(bonus_tok);
+        bool bonus_deferred = false;
+        if (bonus_tok >= 0 && !sampled_verify && !bonus_is_stop) {
+            // Fold the bonus token into the next verify batch instead of
+            // running a dedicated 1-token target forward for it. The bonus
+            // becomes the next iteration's seed (draft_tok[0]); the next
+            // verify_batch writes its KV row and feature-ring entry, exactly
+            // like the DDTree path's next_token contract. This removes one of
+            // the two target forwards per chain step.
+            commit_n = accept_n;
+            replay_tok.resize((size_t)commit_n);
+            last_tok = bonus_tok;
+            bonus_deferred = true;
+        }
+        if (bonus_tok >= 0 && bonus_is_stop && !sampled_verify) {
+            // Generation stops at the bonus token: no KV row is ever needed
+            // for it, so skip the bonus forward and let the emit loop hit EOS.
+            last_tok = bonus_tok;
+        } else if (bonus_tok >= 0 && !bonus_deferred) {
             std::vector<int32_t> bonus_vec = { bonus_tok };
             int bonus_last = -1;
             if (!target->verify_batch(bonus_vec, committed + accept_n, bonus_last, nullptr)) {
@@ -851,7 +904,7 @@ bool LagunaBackend::do_spec_decode(int committed, int n_gen,
             } else {
                 last_tok = bonus_last;
             }
-        } else {
+        } else if (bonus_tok < 0) {
             if (sampled_verify && commit_n > 0) {
                 if (verify_vocab <= 0) {
                     std::fprintf(stderr, "[laguna-spec] invalid sampled verify vocab\n");

--- a/server/src/laguna/laguna_dflash_target.cpp
+++ b/server/src/laguna/laguna_dflash_target.cpp
@@ -512,6 +512,68 @@ bool LagunaDFlashTarget::is_eos(int token) const {
     return token == w_.eos_id || token == w_.eos_chat_id;
 }
 
+ggml_tensor * LagunaDFlashTarget::lm_head_tensor() {
+    return w_.output;
+}
+
+ggml_backend_t LagunaDFlashTarget::fused_head_backend() {
+    if (!fused_backend_) {
+        ggml_backend_dev_t dev = ggml_backend_get_device(backend_);
+        if (dev) fused_backend_ = ggml_backend_dev_init(dev, nullptr);
+    }
+    return fused_backend_ ? fused_backend_ : backend_;
+}
+
+ggml_tensor * LagunaDFlashTarget::gpu_embd_table() {
+    if (embd_gpu_) return embd_gpu_;
+    if (embd_gpu_failed_) return nullptr;
+    const int64_t nv = w_.embedder.n_vocab;
+    const int64_t ne = w_.n_embd;
+    if (nv <= 0 || ne <= 0) { embd_gpu_failed_ = true; return nullptr; }
+
+    ggml_init_params ip{};
+    ip.mem_size   = 2 * ggml_tensor_overhead();
+    ip.no_alloc   = true;
+    embd_gpu_ctx_ = ggml_init(ip);
+    if (!embd_gpu_ctx_) { embd_gpu_failed_ = true; return nullptr; }
+    ggml_tensor * t = ggml_new_tensor_2d(embd_gpu_ctx_, GGML_TYPE_F16, ne, nv);
+    embd_gpu_buf_ = ggml_backend_alloc_ctx_tensors(embd_gpu_ctx_, backend_);
+    if (!embd_gpu_buf_) {
+        std::fprintf(stderr,
+            "[laguna-spec] gpu_embd_table: VRAM alloc failed (%.0f MiB), fused domino disabled\n",
+            (double)nv * (double)ne * 2.0 / (1024.0 * 1024.0));
+        ggml_free(embd_gpu_ctx_); embd_gpu_ctx_ = nullptr;
+        embd_gpu_failed_ = true;
+        return nullptr;
+    }
+
+    const int64_t CH = 4096;
+    std::vector<int32_t>     ids((size_t)CH);
+    std::vector<float>       rows_f32((size_t)CH * (size_t)ne);
+    std::vector<ggml_fp16_t> rows_f16((size_t)CH * (size_t)ne);
+    for (int64_t v0 = 0; v0 < nv; v0 += CH) {
+        const int n = (int)((nv - v0 < CH) ? (nv - v0) : CH);
+        for (int i = 0; i < n; ++i) ids[(size_t)i] = (int32_t)(v0 + i);
+        if (!w_.embedder.embed(ids.data(), n, rows_f32.data())) {
+            std::fprintf(stderr, "[laguna-spec] gpu_embd_table: embed failed\n");
+            ggml_backend_buffer_free(embd_gpu_buf_); embd_gpu_buf_ = nullptr;
+            ggml_free(embd_gpu_ctx_); embd_gpu_ctx_ = nullptr;
+            embd_gpu_failed_ = true;
+            return nullptr;
+        }
+        ggml_fp32_to_fp16_row(rows_f32.data(), rows_f16.data(), (size_t)n * (size_t)ne);
+        ggml_backend_tensor_set(t, rows_f16.data(),
+                                (size_t)v0 * (size_t)ne * sizeof(ggml_fp16_t),
+                                (size_t)n * (size_t)ne * sizeof(ggml_fp16_t));
+    }
+    std::fprintf(stderr,
+        "[laguna-spec] gpu_embd_table: uploaded f16 embedding table (%lld x %lld, %.0f MiB)\n",
+        (long long)nv, (long long)ne,
+        (double)nv * (double)ne * 2.0 / (1024.0 * 1024.0));
+    embd_gpu_ = t;
+    return embd_gpu_;
+}
+
 bool LagunaDFlashTarget::embed_tokens(const int32_t * tokens, int n,
                                       float * out) const {
     return w_.embedder.embed(tokens, n, out);

--- a/server/src/laguna/laguna_dflash_target.cpp
+++ b/server/src/laguna/laguna_dflash_target.cpp
@@ -42,6 +42,10 @@ LagunaDFlashTarget::LagunaDFlashTarget(
 
 LagunaDFlashTarget::~LagunaDFlashTarget() {
     laguna_snapshot_free(verify_snap_);
+    if (embd_gpu_buf_) { ggml_backend_buffer_free(embd_gpu_buf_); embd_gpu_buf_ = nullptr; }
+    if (embd_gpu_ctx_) { ggml_free(embd_gpu_ctx_); embd_gpu_ctx_ = nullptr; }
+    embd_gpu_ = nullptr;
+    if (fused_backend_) { ggml_backend_free(fused_backend_); fused_backend_ = nullptr; }
 }
 
 bool LagunaDFlashTarget::verify_batch(

--- a/server/src/laguna/laguna_dflash_target.h
+++ b/server/src/laguna/laguna_dflash_target.h
@@ -50,6 +50,10 @@ public:
 
     bool is_eos(int token) const override;
 
+    ggml_tensor *  lm_head_tensor() override;
+    ggml_tensor *  gpu_embd_table() override;
+    ggml_backend_t fused_head_backend() override;
+
     bool embed_tokens(const int32_t * tokens, int n,
                       float * out) const override;
 
@@ -77,6 +81,15 @@ private:
     LagunaTargetCache & cache_;
     ggml_backend_t backend_;
     class KvFlashPager * pager_ = nullptr;
+
+    // Lazily-built f16 GPU copy of the token embedding table + a dedicated
+    // CUDA backend instance for the fused domino head (own instance so the
+    // ggml-cuda graph cache is not shared with the verify graphs).
+    ggml_context *         embd_gpu_ctx_ = nullptr;
+    ggml_backend_buffer_t  embd_gpu_buf_ = nullptr;
+    ggml_tensor *          embd_gpu_     = nullptr;
+    bool                   embd_gpu_failed_ = false;
+    ggml_backend_t         fused_backend_   = nullptr;
     std::vector<int> capture_ids_;
     LagunaCacheSnapshot verify_snap_;
     bool keep_verify_logits_ = false;

--- a/server/src/laguna/laguna_internal.h
+++ b/server/src/laguna/laguna_internal.h
@@ -68,6 +68,14 @@ struct LagunaTargetLayer {
     ggml_tensor * ffn_gate_shexp   = nullptr;  // [n_embd, n_ff_shexp]    shared expert gate
     ggml_tensor * ffn_up_shexp     = nullptr;  // [n_embd, n_ff_shexp]    shared expert up
     ggml_tensor * ffn_down_shexp   = nullptr;  // [n_ff_shexp, n_embd]    shared expert down
+
+    // Fused views over ADJACENT weight pairs (the loader lays q|k and
+    // gate_shexp|up_shexp out back-to-back and binds one tensor over both
+    // regions; zero extra VRAM). Null when the pair could not be fused
+    // (type mismatch / DFLASH_LAGUNA_FUSED_QK=0). Same data as wq/wk etc.
+    ggml_tensor * wqk       = nullptr;  // [n_embd, (n_head+n_head_kv)*head_dim]
+    ggml_tensor * shexp_gu  = nullptr;  // [n_embd, 2*n_ff_shexp]  gate rows then up rows
+    ggml_tensor * qk_norm_f = nullptr;  // [head_dim, n_head+n_head_kv] f32, q_norm|k_norm per head
 };
 
 struct LagunaTargetWeights {
@@ -83,6 +91,11 @@ struct LagunaTargetWeights {
     std::vector<LagunaTargetLayer> layers;   // size = n_layer
     ggml_tensor * out_norm = nullptr;        // [n_embd]
     ggml_tensor * output   = nullptr;        // [n_embd, n_vocab]  (lm_head)
+
+    // Metadata contexts/buffer for the fused-weight views (see LagunaTargetLayer).
+    ggml_context *        fuse_ctx      = nullptr;
+    ggml_context *        fuse_norm_ctx = nullptr;
+    ggml_backend_buffer_t fuse_norm_buf = nullptr;
 
     // Architecture metadata (validated at load time).
     int  n_layer              = 40;

--- a/server/src/laguna/laguna_target_graph.cpp
+++ b/server/src/laguna/laguna_target_graph.cpp
@@ -356,6 +356,25 @@ static ggml_tensor * laguna_rms_norm_mul(ggml_context * ctx, ggml_tensor * x,
     return ggml_mul(ctx, n, weight);
 }
 
+// Shared-expert SwiGLU. With the loader's fused gate|up weight this is one
+// matmul + one in-place split-activation (bit-identical to the two-matmul
+// form: every output row is the same independent dot product, and
+// ggml_swiglu(x) == swiglu_split(first half, second half)).
+static ggml_tensor * laguna_shexp_ffn(ggml_context * ctx, const LagunaTargetLayer & L,
+                                      ggml_tensor * cur) {
+    // Decode widths only (see the fused-QK note: MMQ prefill is not
+    // bit-identical under row-concat, MMVQ decode is).
+    if (L.shexp_gu && cur->ne[1] <= 8) {
+        ggml_tensor * gu  = ggml_mul_mat(ctx, L.shexp_gu, cur);  // [2*ff_shexp, T]
+        ggml_tensor * act = ggml_swiglu(ctx, gu);                // silu(gate) * up
+        return ggml_mul_mat(ctx, L.ffn_down_shexp, act);
+    }
+    ggml_tensor * sh_gate = ggml_mul_mat(ctx, L.ffn_gate_shexp, cur);
+    ggml_tensor * sh_up   = ggml_mul_mat(ctx, L.ffn_up_shexp,   cur);
+    ggml_tensor * sh_gu   = ggml_swiglu_split(ctx, sh_gate, sh_up);
+    return ggml_mul_mat(ctx, L.ffn_down_shexp, sh_gu);
+}
+
 static ggml_tensor * build_laguna_dense_ffn(ggml_context * ctx, ggml_tensor * cur,
                                               const LagunaTargetLayer & L) {
     // SwiGLU: down( silu(gate(x)) * up(x) )
@@ -395,10 +414,7 @@ static ggml_tensor * build_laguna_moe_block(ggml_context * ctx, ggml_cgraph * gf
                                              const LagunaHybridMoe * hyb = nullptr, int il = 0) {
     static const bool stub = (std::getenv("DFLASH_LAGUNA_MOE_STUB") != nullptr);
     if (stub) {
-        ggml_tensor * sh_gate = ggml_mul_mat(ctx, L.ffn_gate_shexp, cur);
-        ggml_tensor * sh_up   = ggml_mul_mat(ctx, L.ffn_up_shexp,   cur);
-        ggml_tensor * sh_gu   = ggml_swiglu_split(ctx, sh_gate, sh_up);
-        return ggml_mul_mat(ctx, L.ffn_down_shexp, sh_gu);
+        return laguna_shexp_ffn(ctx, L, cur);
     }
     if (hyb && hyb->storage) {
         return build_laguna_moe_block_hybrid(ctx, gf, cur, w, L,
@@ -466,10 +482,7 @@ static ggml_tensor * build_laguna_moe_block_full(ggml_context * ctx, ggml_cgraph
     }
 
     // Always-on shared expert (SwiGLU).
-    ggml_tensor * sh_gate = ggml_mul_mat(ctx, L.ffn_gate_shexp, cur);
-    ggml_tensor * sh_up   = ggml_mul_mat(ctx, L.ffn_up_shexp,   cur);
-    ggml_tensor * sh_gu   = ggml_swiglu_split(ctx, sh_gate, sh_up);
-    ggml_tensor * shared  = ggml_mul_mat(ctx, L.ffn_down_shexp, sh_gu);
+    ggml_tensor * shared  = laguna_shexp_ffn(ctx, L, cur);
 
     return ggml_add(ctx, routed, shared);
 }
@@ -532,10 +545,7 @@ static ggml_tensor * build_laguna_moe_block_hybrid(ggml_context * ctx, ggml_cgra
         routed = (i == 0) ? slice : ggml_add(ctx, routed, slice);
     }
 
-    ggml_tensor * sh_gate = ggml_mul_mat(ctx, L.ffn_gate_shexp, cur);
-    ggml_tensor * sh_up   = ggml_mul_mat(ctx, L.ffn_up_shexp,   cur);
-    ggml_tensor * sh_gu   = ggml_swiglu_split(ctx, sh_gate, sh_up);
-    ggml_tensor * shared  = ggml_mul_mat(ctx, L.ffn_down_shexp, sh_gu);
+    ggml_tensor * shared  = laguna_shexp_ffn(ctx, L, cur);
 
     return ggml_add(ctx, routed, shared);
 }
@@ -616,10 +626,7 @@ static ggml_tensor * build_laguna_moe_block_legacy(ggml_context * ctx, ggml_tens
     routed = ggml_reshape_2d(ctx, routed, w.n_embd, ggml_nelements(routed) / w.n_embd);
 
     // Shared expert (always on).
-    ggml_tensor * sh_gate = ggml_mul_mat(ctx, L.ffn_gate_shexp, cur);
-    ggml_tensor * sh_up   = ggml_mul_mat(ctx, L.ffn_up_shexp,   cur);
-    ggml_tensor * sh_gu   = ggml_swiglu_split(ctx, sh_gate, sh_up);
-    ggml_tensor * shared  = ggml_mul_mat(ctx, L.ffn_down_shexp, sh_gu);
+    ggml_tensor * shared  = laguna_shexp_ffn(ctx, L, cur);
 
     return ggml_add(ctx, routed, shared);
 }
@@ -656,17 +663,62 @@ static ggml_tensor * build_laguna_attn_block(
     const int q_dim      = n_head * head_dim;
 
     // ---- Q/K/V projections ---
-    ggml_tensor * Qcur = ggml_mul_mat(ctx, L.wq, cur);  // [q_dim, n_tokens]
-    ggml_tensor * Kcur = ggml_mul_mat(ctx, L.wk, cur);  // [n_head_kv*head_dim, n_tokens]
+    // Fused path: ONE matmul for Q|K (loader-fused adjacent weights), then a
+    // single per-head rms_norm+mul+rope over all n_head+n_head_kv heads with
+    // the fused norm weight. Bit-identical to the split path: matmul rows,
+    // rms_norm rows, the weight mul and rope are all per-head independent.
+    static const int qk_fuse_mode = []() {
+        const char * e = getenv("LUCE_QK_FUSE_MODE");
+        return e ? atoi(e) : 3;
+    }();
+    static const int qk_fuse_layers = []() {
+        const char * e = getenv("LUCE_QK_FUSE_LAYERS");
+        return e ? atoi(e) : 1000;
+    }();
+    // Fused weights are used ONLY at decode widths (MMVQ, n_tokens <= 8):
+    // per-row dot products are bit-identical under row-concat there. MMQ
+    // (prefill) partitions work by total row count, so concat changes the
+    // partial-sum order (~1e-5); prefill keeps the split weights.
+    const bool qk_layer_on = il < qk_fuse_layers && n_tokens <= 8;
+    ggml_tensor * Qcur = nullptr;
+    ggml_tensor * Kcur = nullptr;
+    ggml_tensor * qk_fused = nullptr;
+    if (L.wqk && L.qk_norm_f && qk_layer_on && qk_fuse_mode == 1) {
+        // matmul-only fusion: split + cont right after the projection, then the
+        // legacy norm/rope path
+        ggml_tensor * qkmm = ggml_mul_mat(ctx, L.wqk, cur);
+        const int64_t qd = (int64_t)n_head * head_dim;
+        const int64_t kd = (int64_t)n_head_kv * head_dim;
+        Qcur = ggml_cont(ctx, ggml_view_2d(ctx, qkmm, qd, n_tokens, qkmm->nb[1], 0));
+        Kcur = ggml_cont(ctx, ggml_view_2d(ctx, qkmm, kd, n_tokens, qkmm->nb[1], (size_t)qd * sizeof(float)));
+        Qcur = ggml_reshape_3d(ctx, Qcur, head_dim, n_head,    n_tokens);
+        Kcur = ggml_reshape_3d(ctx, Kcur, head_dim, n_head_kv, n_tokens);
+        Qcur = laguna_rms_norm_mul(ctx, Qcur, L.q_norm);
+        Kcur = laguna_rms_norm_mul(ctx, Kcur, L.k_norm);
+    } else if (L.wqk && L.qk_norm_f && qk_layer_on && qk_fuse_mode == 2) {
+        // matmul + fused norm; split + cont before rope (legacy rope path)
+        ggml_tensor * qkn = ggml_mul_mat(ctx, L.wqk, cur);
+        qkn = ggml_reshape_3d(ctx, qkn, head_dim, n_head + n_head_kv, n_tokens);
+        qkn = laguna_rms_norm_mul(ctx, qkn, L.qk_norm_f);
+        Qcur = ggml_cont(ctx, ggml_view_3d(ctx, qkn, head_dim, n_head, n_tokens,
+                                           qkn->nb[1], qkn->nb[2], 0));
+        Kcur = ggml_cont(ctx, ggml_view_3d(ctx, qkn, head_dim, n_head_kv, n_tokens,
+                                           qkn->nb[1], qkn->nb[2], (size_t)n_head * qkn->nb[1]));
+    } else if (L.wqk && L.qk_norm_f && qk_layer_on && qk_fuse_mode >= 3) {
+        qk_fused = ggml_mul_mat(ctx, L.wqk, cur);  // [(n_head+n_head_kv)*head_dim, n_tokens]
+        qk_fused = ggml_reshape_3d(ctx, qk_fused, head_dim, n_head + n_head_kv, n_tokens);
+        qk_fused = laguna_rms_norm_mul(ctx, qk_fused, L.qk_norm_f);
+    } else {
+        Qcur = ggml_mul_mat(ctx, L.wq, cur);  // [q_dim, n_tokens]
+        Kcur = ggml_mul_mat(ctx, L.wk, cur);  // [n_head_kv*head_dim, n_tokens]
+        Qcur = ggml_reshape_3d(ctx, Qcur, head_dim, n_head,    n_tokens);
+        Kcur = ggml_reshape_3d(ctx, Kcur, head_dim, n_head_kv, n_tokens);
+        // ---- Per-head Q/K RMSNorm (norm over head_dim) ---
+        Qcur = laguna_rms_norm_mul(ctx, Qcur, L.q_norm);
+        Kcur = laguna_rms_norm_mul(ctx, Kcur, L.k_norm);
+    }
     ggml_tensor * Vcur = ggml_mul_mat(ctx, L.wv, cur);
-
-    Qcur = ggml_reshape_3d(ctx, Qcur, head_dim, n_head,    n_tokens);
-    Kcur = ggml_reshape_3d(ctx, Kcur, head_dim, n_head_kv, n_tokens);
     Vcur = ggml_reshape_3d(ctx, Vcur, head_dim, n_head_kv, n_tokens);
-
-    // ---- Per-head Q/K RMSNorm (norm over head_dim) ---
-    Qcur = laguna_rms_norm_mul(ctx, Qcur, L.q_norm);
-    Kcur = laguna_rms_norm_mul(ctx, Kcur, L.k_norm);
 
     // ---- Per-head softplus attention gate ---
     // wqkv_gate : [n_embd, n_head]; gate_proj output [n_head, n_tokens] f32.
@@ -687,14 +739,28 @@ static ggml_tensor * build_laguna_attn_block(
     const int   n_ctx_orig  = is_full ? w.yarn_orig_ctx  : 0;
     const float freq_scale  = is_full ? (1.0f / w.yarn_factor) : 1.0f;
 
-    Qcur = ggml_rope_ext(ctx, Qcur, positions, /*freq_factors=*/nullptr,
-                          n_rot, /*mode=*/GGML_ROPE_TYPE_NEOX,
-                          n_ctx_orig, rope_th, freq_scale,
-                          ext_factor, attn_factor, beta_fast, beta_slow);
-    Kcur = ggml_rope_ext(ctx, Kcur, positions, nullptr,
-                          n_rot, GGML_ROPE_TYPE_NEOX,
-                          n_ctx_orig, rope_th, freq_scale,
-                          ext_factor, attn_factor, beta_fast, beta_slow);
+    if (qk_fused) {
+        // Q and K use IDENTICAL rope parameters, so rope the fused tensor once
+        // (rope is per-head independent) and split with views afterwards.
+        qk_fused = ggml_rope_ext(ctx, qk_fused, positions, /*freq_factors=*/nullptr,
+                                 n_rot, /*mode=*/GGML_ROPE_TYPE_NEOX,
+                                 n_ctx_orig, rope_th, freq_scale,
+                                 ext_factor, attn_factor, beta_fast, beta_slow);
+        Qcur = ggml_view_3d(ctx, qk_fused, head_dim, n_head, n_tokens,
+                            qk_fused->nb[1], qk_fused->nb[2], 0);
+        Kcur = ggml_view_3d(ctx, qk_fused, head_dim, n_head_kv, n_tokens,
+                            qk_fused->nb[1], qk_fused->nb[2],
+                            (size_t)n_head * qk_fused->nb[1]);
+    } else {
+        Qcur = ggml_rope_ext(ctx, Qcur, positions, /*freq_factors=*/nullptr,
+                             n_rot, /*mode=*/GGML_ROPE_TYPE_NEOX,
+                             n_ctx_orig, rope_th, freq_scale,
+                             ext_factor, attn_factor, beta_fast, beta_slow);
+        Kcur = ggml_rope_ext(ctx, Kcur, positions, nullptr,
+                             n_rot, GGML_ROPE_TYPE_NEOX,
+                             n_ctx_orig, rope_th, freq_scale,
+                             ext_factor, attn_factor, beta_fast, beta_slow);
+    }
 
     // ---- Write K/V to cache slot ---
     // All layers (full + SWA) use a uniform max_ctx-sized cache. SWA layers

--- a/server/src/laguna/laguna_target_loader.cpp
+++ b/server/src/laguna/laguna_target_loader.cpp
@@ -432,6 +432,65 @@ bool load_target_gguf_laguna_partial(const std::string & path,
         alloc_total += ggml_backend_buft_get_alloc_size(buft, t);
         allocs.push_back(a);
     }
+
+    // Lay attn_q|attn_k and ffn_gate_shexp|ffn_up_shexp adjacently in the
+    // weight buffer so one fused tensor can view both regions (saves one
+    // matmul launch + one activation quantization per pair per forward).
+    static const bool fuse_qk_env = []() {
+        const char * e = getenv("DFLASH_LAGUNA_FUSED_QK");
+        return !(e && e[0] == '0' && e[1] == '\0');
+    }();
+    if (fuse_qk_env) {
+        // For each fusable pair, `first` must land before `second` in the
+        // buffer regardless of GGUF order (attn_k typically precedes attn_q).
+        auto rename_sub = [](const std::string & s, const char * from, const char * to) {
+            std::string p = s;
+            const size_t pos = p.find(from);
+            if (pos == std::string::npos) return std::string();
+            p.replace(pos, std::string(from).size(), to);
+            return p;
+        };
+        std::vector<LagunaTensorAlloc> arranged;
+        arranged.reserve(allocs.size());
+        std::vector<char> used(allocs.size(), 0);
+        auto idx_of = [&](const std::string & nm) -> int {
+            if (nm.empty()) return -1;
+            for (size_t j = 0; j < allocs.size(); ++j) {
+                if (!used[j] && nm == ggml_get_name(allocs[j].tensor)) return (int)j;
+            }
+            return -1;
+        };
+        for (size_t i = 0; i < allocs.size(); ++i) {
+            if (used[i]) continue;
+            const std::string nm = ggml_get_name(allocs[i].tensor);
+            std::string first, second;
+            if (nm.find("attn_q.weight") != std::string::npos) {
+                first = nm; second = rename_sub(nm, "attn_q.weight", "attn_k.weight");
+            } else if (nm.find("attn_k.weight") != std::string::npos) {
+                first = rename_sub(nm, "attn_k.weight", "attn_q.weight"); second = nm;
+            } else if (nm.find("ffn_gate_shexp.weight") != std::string::npos) {
+                first = nm; second = rename_sub(nm, "ffn_gate_shexp.weight", "ffn_up_shexp.weight");
+            } else if (nm.find("ffn_up_shexp.weight") != std::string::npos) {
+                first = rename_sub(nm, "ffn_up_shexp.weight", "ffn_gate_shexp.weight"); second = nm;
+            } else {
+                used[i] = 1;
+                arranged.push_back(allocs[i]);
+                continue;
+            }
+            const int fi = idx_of(first);
+            const int si = idx_of(second);
+            if (fi >= 0) { used[fi] = 1; arranged.push_back(allocs[fi]); }
+            if (si >= 0) { used[si] = 1; arranged.push_back(allocs[si]); }
+        }
+        allocs.swap(arranged);
+        alloc_total = 0;
+        for (LagunaTensorAlloc & a : allocs) {
+            alloc_total = align_up_size(alloc_total, alignment);
+            a.buffer_offset = alloc_total;
+            alloc_total += ggml_backend_buft_get_alloc_size(buft, a.tensor);
+        }
+    }
+
     if (allocs.empty()) {
         set_last_error("laguna: load plan selected no GPU tensors");
         gguf_free(gctx);
@@ -455,6 +514,48 @@ bool load_target_gguf_laguna_partial(const std::string & path,
             gguf_free(gctx);
             return false;
         }
+    }
+
+    // Bind fused-view tensors over adjacent pairs. The fused tensor shares
+    // the pair's bytes (no copy); wq/wk stay valid for all other paths.
+    if (fuse_qk_env) {
+        ggml_init_params fip{};
+        fip.mem_size = ggml_tensor_overhead() * (size_t)(2 * n_layer + 8);
+        fip.no_alloc = true;
+        out.fuse_ctx = ggml_init(fip);
+    }
+    int n_fused_qk = 0, n_fused_gu = 0;
+    if (out.fuse_ctx) {
+        auto adjacent = [&](ggml_tensor * a, ggml_tensor * b) {
+            return a && b && a->type == b->type && a->ne[0] == b->ne[0] &&
+                   a->data && b->data &&
+                   (char *) b->data == (char *) a->data + ggml_nbytes(a) &&
+                   ggml_backend_buft_get_alloc_size(buft, a) == ggml_nbytes(a);
+        };
+        for (uint32_t il = 0; il < n_layer; ++il) {
+            LagunaTargetLayer & L = out.layers[il];
+            if (adjacent(L.wq, L.wk)) {
+                ggml_tensor * t = ggml_new_tensor_2d(out.fuse_ctx, L.wq->type,
+                                                     L.wq->ne[0], L.wq->ne[1] + L.wk->ne[1]);
+                ggml_format_name(t, "blk.%u.attn_qk_fused", il);
+                if (ggml_backend_tensor_alloc(out.buf, t, L.wq->data) == GGML_STATUS_SUCCESS) {
+                    L.wqk = t;
+                    n_fused_qk++;
+                }
+            }
+            if (adjacent(L.ffn_gate_shexp, L.ffn_up_shexp)) {
+                ggml_tensor * t = ggml_new_tensor_2d(out.fuse_ctx, L.ffn_gate_shexp->type,
+                                                     L.ffn_gate_shexp->ne[0],
+                                                     L.ffn_gate_shexp->ne[1] + L.ffn_up_shexp->ne[1]);
+                ggml_format_name(t, "blk.%u.ffn_shexp_gu_fused", il);
+                if (ggml_backend_tensor_alloc(out.buf, t, L.ffn_gate_shexp->data) == GGML_STATUS_SUCCESS) {
+                    L.shexp_gu = t;
+                    n_fused_gu++;
+                }
+            }
+        }
+        std::printf("[laguna-loader] fused adjacent weights: qk=%d shexp_gu=%d layers\n",
+                    n_fused_qk, n_fused_gu);
     }
 
     // ── 4. Copy selected tensor bytes to GPU; remember tok_embd for embedder ─
@@ -483,6 +584,57 @@ bool load_target_gguf_laguna_partial(const std::string & path,
         if (!should_load_laguna_tensor(tname, plan)) continue;
         ggml_backend_tensor_set(t, mm_addr + off, 0, sz);
         total += sz;
+    }
+
+    // Fused per-head q/k norm weights: [head_dim, n_head+n_head_kv] f32 with
+    // q_norm replicated over the query heads and k_norm over the kv heads.
+    // Lets the fused-QK path run ONE rms_norm+mul+rope over all heads
+    // (bit-identical: every op is per-row/per-head independent).
+    if (n_fused_qk > 0) {
+        ggml_init_params nip{};
+        nip.mem_size = ggml_tensor_overhead() * (size_t)(n_layer + 4);
+        nip.no_alloc = true;
+        out.fuse_norm_ctx = ggml_init(nip);
+        const int hd  = out.head_dim;
+        const int nkv = out.n_head_kv;
+        if (out.fuse_norm_ctx) {
+            for (uint32_t il = 0; il < n_layer; ++il) {
+                LagunaTargetLayer & L = out.layers[il];
+                if (!L.wqk || !L.q_norm || !L.k_norm ||
+                    L.q_norm->type != GGML_TYPE_F32 || L.k_norm->type != GGML_TYPE_F32 ||
+                    L.q_norm->ne[0] != hd || L.k_norm->ne[0] != hd) {
+                    L.wqk = nullptr;  // fused path needs the fused norm too
+                    continue;
+                }
+                ggml_tensor * t = ggml_new_tensor_2d(out.fuse_norm_ctx, GGML_TYPE_F32,
+                                                     hd, out.n_head_arr[il] + nkv);
+                ggml_format_name(t, "blk.%u.qk_norm_fused", il);
+                L.qk_norm_f = t;
+            }
+            out.fuse_norm_buf = ggml_backend_alloc_ctx_tensors(out.fuse_norm_ctx, backend);
+            if (out.fuse_norm_buf) {
+                std::vector<float> qn((size_t)hd), kn((size_t)hd), fused;
+                for (uint32_t il = 0; il < n_layer; ++il) {
+                    LagunaTargetLayer & L = out.layers[il];
+                    if (!L.wqk || !L.qk_norm_f) continue;
+                    const int nh = out.n_head_arr[il];
+                    ggml_backend_tensor_get(L.q_norm, qn.data(), 0, sizeof(float) * hd);
+                    ggml_backend_tensor_get(L.k_norm, kn.data(), 0, sizeof(float) * hd);
+                    fused.resize((size_t)hd * (size_t)(nh + nkv));
+                    for (int h = 0; h < nh + nkv; ++h) {
+                        const float * src = h < nh ? qn.data() : kn.data();
+                        std::memcpy(fused.data() + (size_t)h * hd, src, sizeof(float) * hd);
+                    }
+                    ggml_backend_tensor_set(L.qk_norm_f, fused.data(), 0,
+                                            sizeof(float) * fused.size());
+                }
+            } else {
+                for (uint32_t il = 0; il < n_layer; ++il) {
+                    out.layers[il].wqk = nullptr;
+                    out.layers[il].qk_norm_f = nullptr;
+                }
+            }
+        }
     }
 
     gguf_free(gctx);
@@ -524,6 +676,9 @@ bool load_target_gguf_laguna_partial(const std::string & path,
 }
 
 void free_laguna_target_weights(LagunaTargetWeights & w) {
+    if (w.fuse_norm_buf) { ggml_backend_buffer_free(w.fuse_norm_buf); w.fuse_norm_buf = nullptr; }
+    if (w.fuse_norm_ctx) { ggml_free(w.fuse_norm_ctx); w.fuse_norm_ctx = nullptr; }
+    if (w.fuse_ctx)      { ggml_free(w.fuse_ctx);      w.fuse_ctx = nullptr; }
     if (w.buf) { ggml_backend_buffer_free(w.buf); w.buf = nullptr; }
     if (w.ctx) { ggml_free(w.ctx);                w.ctx = nullptr; }
     // CpuEmbedder destructor handles mmap.


### PR DESCRIPTION
## What

Speculative-decode verification-path optimization for the Laguna target, profiled and validated end-to-end on RTX 3090 (laguna-xs2 Q4_K_M + DFlash v23 domino drafter, greedy):

| Workload | main (old AUTO) | this PR | plain AR |
|---|---|---|---|
| HumanEval | 172.0 | **192.6** | 181 |
| GSM8K-style | 164.8 | **181.6** | 179.6 |

Spec decode goes from 8% behind AR to **+6.4% ahead on HumanEval**, with **byte-identical outputs** enforced on every change by a 19-output sha256 harness (quicksort-chat + 10 HumanEval + 8 GSM8K prompts, greedy 192-512 tokens).

## Commits

**1. `perf(laguna): verify-path optimizations — bonus fold, fused domino, draft padding, AUTO width`**
- **AUTO verify width fix (the single biggest win):** the old `(int)EWMA + 2` drifted to width 4-5 exactly on high-acceptance workloads; measured marginal verify position costs ~2.3ms while its marginal commit is <0.3 tokens beyond width 3 (HE: w3 187.8 / w4 172.8 / w5 162.1 tok/s). AUTO is now `round(EWMA)+1` capped at `DFLASH_LAGUNA_VERIFY_WIDTH_MAX` (default 3).
- **Bonus-fold (chain greedy):** the bonus token becomes the next iteration's seed instead of running a dedicated 1-token target forward for it (same contract the DDTree path already uses via `next_token`). One target forward per step instead of two; EOS-on-bonus skips the forward entirely. Sampled-verify path untouched.
- **Fused domino head:** the GRU correction loop was ~30 blocking syncs + a full-vocab logits D2H/H2D round-trip per step; now one GPU graph (lm_head projection + unrolled GRU + in-graph argmax→get_rows feedback) on the draft backend stream, replayed by the CUDA-graph cache, with async token readbacks and a single synchronize. Needs a one-time F16 GPU embedding table (392 MiB for the 100k vocab; CUDA get_rows can't read k-quants). Kill switch `DFLASH_LAGUNA_FUSED_DOMINO=0`.
- **Draft-graph CUDA-graph replay:** the draft forward never replayed because (a) its context length grows every step (topology change) and (b) it built its metadata in a fresh 256MB malloc each step, defeating the pointer-keyed graph cache. Now: draft ctx padded to a 64-aligned allocation with -inf pad-key masks (`DFLASH_LAGUNA_DRAFT_PAD=0` to disable; guarded off when SWA windowing is active at the current ctx), plus a persistent `meta_arena` in `StepGraph` (benefits all arches using `build_draft_step`).

**2. `perf(laguna): fused adjacent QK and shexp gate/up weights for decode-width matmuls`**
- The loader lays `attn_q|attn_k` and `ffn_gate_shexp|ffn_up_shexp` adjacently in the weight buffer and binds a fused tensor over each pair — zero extra VRAM, the split tensors remain valid views for all other paths.
- At decode widths the attention builder runs ONE matmul for Q|K, ONE rms_norm+mul with a fused per-head norm weight, ONE rope over all heads (Q and K use identical rope params), then splits with views; the shared expert becomes one matmul + `ggml_swiglu`.
- **Bit-exactness boundary (established with a standalone bitwise test):** MMVQ (n_tokens ≤ 8) is bit-identical under weight row-concatenation — every output row is the same independent dot product. MMQ (prefill) partitions work by total row count and is NOT bit-stable (~1e-5), so the fused weights engage only for `n_tokens <= 8`; prefill keeps the split weights and is unchanged. Kill switch `DFLASH_LAGUNA_FUSED_QK=0`.

**3. `deps: bump llama.cpp`** to `perf/luce-verify-kernels` (companion PR in Luce-Org/llama.cpp: CUDA-graph cache stats, q8_1 quantize memo, MMVQ ncols knob, richer op-error diagnostics — all architecture-agnostic).

## How general is this? (portability beyond Laguna)

- **Architecture-agnostic already:** everything in the llama.cpp companion PR; the persistent `StepGraph` metadata arena (common draft code, all DFlash arches benefit immediately).
- **General technique, Laguna-first implementation (straightforward follow-up ports):**
  - *Bonus-fold* — any chain-verify spec loop with the separate bonus forward (qwen35, qwen35moe, gemma4 share the pattern).
  - *AUTO width cap* — the "marginal verify position vs marginal commit" economics apply to every MMVQ-width verify; each arch's width heuristic can adopt the capped-EWMA form.
  - *Draft-ctx padding* — lives in common `dflash_draft_graph.cpp` behind an opt-in flag; other arches can enable after validating their draft SWA configs.
  - *Fused adjacent weights* — applies to any GGUF arch with same-type q/k or gate/up pairs (qwen35moe has the same shexp pair; the loader pattern and the MMVQ-only gating carry over 1:1).
- **Laguna-specific:** the fused domino head (Laguna's drafter feature), though the single-graph + in-graph-argmax-feedback pattern is reusable for future draft heads.

## Validation

- Byte-identity: all 19 harness outputs sha256-identical to the pre-change reference on every commit (harness: `capture_outputs.sh`, greedy, temperature 0); the fused-weight commit additionally verified with a standalone concat-vs-split bitwise matmul test at the exact laguna shapes.
- nsys profiling before/after each stage (verify exec 9.07ms at w=3 fully CUDA-graph replayed; per-key replay rates 90-99.8% via the new `GGML_CUDA_GRAPH_STATS`).
- Negative results documented to save future effort: MMQ routing at verify widths (-8%), f16 KV cache (neutral), `GGML_CUDA_FORCE_MMQ` (no-op for this path), DDTree at budgets 2/4/8 with this drafter (strictly worse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NGcrzzuJsdxU5tLgztaQnK


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

