### PR TITLE
fix(qwen35moe): contiguous top_k router ids when host-read (hybrid spark crash)

### DIFF
--- a/server/src/qwen35/qwen35_target_graph.cpp
+++ b/server/src/qwen35/qwen35_target_graph.cpp
@@ -1417,7 +1417,13 @@ QwenLayerPrefnOutputs build_qwen35_layer_prefn(
     out.residual = cur;
     out.post = rms_norm_mul(ctx, cur, L.attn_post_norm, eps);
     if (w.is_moe) {
-        Qwen35MoeRouterOutputs router = build_qwen35moe_router(ctx, out.post, w, L);
+        // selected/weights are read back by the host (hybrid hot/cold expert
+        // compute), not consumed in-graph. argsort_top_k yields a strided view
+        // whose raw packed readback returns garbage ids for tokens > 0 (crash
+        // in expert dispatch on the first multi-token prefill); top_k is
+        // contiguous, and cheaper than a full argsort here.
+        Qwen35MoeRouterOutputs router = build_qwen35moe_router(
+            ctx, out.post, w, L, /*allow_fused_router=*/false);
         out.moe_selected = router.selected;
         out.moe_weights = router.weights;
     }

--- a/server/src/qwen35moe/qwen35moe_ffn.cpp
+++ b/server/src/qwen35moe/qwen35moe_ffn.cpp
@@ -11,7 +11,8 @@ Qwen35MoeRouterOutputs build_qwen35moe_router(
     ggml_context *        ctx,
     ggml_tensor *         cur,
     const TargetWeights & w,
-    const TargetLayer &   L) {
+    const TargetLayer &   L,
+    bool                  allow_fused_router) {
     const int n_tokens = (int)cur->ne[1];
     const int n_expert = w.n_expert;
     const int n_used   = w.n_expert_used;
@@ -35,7 +36,7 @@ Qwen35MoeRouterOutputs build_qwen35moe_router(
     // x30 MoE layers (the launch-bound decode gap vs llama, which uses argsort_top_k).
     // Same top-k selection -> bit-identical. DFLASH_NO_MOE_ROUTER_FUSE=1 = old path.
     static const bool router_fuse = (std::getenv("DFLASH_NO_MOE_ROUTER_FUSE") == nullptr);
-    ggml_tensor * selected = router_fuse
+    ggml_tensor * selected = (router_fuse && allow_fused_router)
         ? ggml_argsort_top_k(ctx, probs, n_used)
         : ggml_top_k(ctx, probs, n_used);
 

--- a/server/src/qwen35moe/qwen35moe_ffn.h
+++ b/server/src/qwen35moe/qwen35moe_ffn.h
@@ -15,7 +15,16 @@ Qwen35MoeRouterOutputs build_qwen35moe_router(
     ggml_context *        ctx,
     ggml_tensor *         cur,   // [hidden, n_tokens], post-attention normed
     const TargetWeights & w,
-    const TargetLayer &   L);
+    const TargetLayer &   L,
+    // Pass false when selected/weights are read back by the host instead of
+    // feeding an in-graph mul_mat_id: ggml_argsort_top_k returns a strided
+    // VIEW into the full [n_expert, n_tokens] argsort, and the hybrid raw
+    // readback (ggml_backend_tensor_get, packed [n_used x n_tokens]) then
+    // yields garbage expert ids for every token after the first (decode
+    // reads one row and is unaffected). ggml_top_k is contiguous by
+    // construction, and cheaper than a full argsort where the fusion
+    // cannot apply anyway.
+    bool                  allow_fused_router = true);
 
 ggml_tensor * build_qwen35moe_ffn(
     ggml_context *        ctx,


### PR DESCRIPTION
## Summary

Fixes a **main regression introduced by #472**: `--spark` hybrid on CUDA crashes with a CUDA illegal memory access on the first multi-token prefill.

## Root cause

`ggml_argsort_top_k` returns a **strided view** into the full `[n_expert, n_tokens]` argsort. The hybrid hot/cold path reads the router outputs back with a raw packed `ggml_backend_tensor_get` (prefill chunk readback in `qwen35moe_backend.cpp`), which silently yields **garbage expert ids for every token after the first** → corrupted hot/cold dispatch → illegal access inside expert compute, surfacing ~30 ops later in `mul_mat_q`.

Decode reads a single row (correct even on the view) and all-hot consumes `selected` in-graph via `mul_mat_id` (stride-aware), which is why #472's validation (all-hot + decode, byte-identical) passed. The CUDA topk-moe **fusion is innocent**: the crash reproduces with `GGML_CUDA_DISABLE_FUSION=1`.

## Fix (scoped, 16 lines)

`build_qwen35moe_router(allow_fused_router=false)` at the hybrid export site emits contiguous `ggml_top_k` ids. The in-graph FFN path keeps `argsort_top_k` and its topk-moe fusion. Unfused `top_k` is also cheaper than a full argsort where the fusion cannot apply anyway.

Companion hardening: Luce-Org/lucebox-ggml#29 makes `ggml_backend_tensor_get/set` abort loudly at the call site when a raw span crosses a stride gap — with that patch, unfixed main fails with a clear assert instead of the mystery CUDA fault; this class of bug can't hide again.

## Validation (lucebox2, RTX 3090, boot profile)

| Check | Result |
|---|---|
| Bisect | f7fc9448 OK, #479 OK, main (13ac2092) crash; env pinpoint: `DFLASH_NO_MOE_ROUTER_FUSE=1` fixes, `DFLASH_NO_MOE_SWIGLU_FUSE=1` does not |
| Spark repro (was 100% crash) | 2x clean + coherent output, ~11-12 tok/s decode |
| All-hot long prefill (4316 tok) | byte-identical, hash `8cda68b0ca5eb797`, fusion still active |
| Dense spec-decode sweep | 3/3 hashes byte-identical to baseline, accept 326/1440 avg_commit 4.27 exactly equal |
| Unit suite | 2050 assertions, 0 failures |

Note: this also unblocks #388 on CUDA mains (its expert-compute IPC path goes through the same hybrid router export).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NGcrzzuJsdxU5tLgztaQnK

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

