### PR TITLE
feat(ipc): optional GPU isolation for target-shard daemon (same-backend splits)

### DIFF
--- a/server/src/common/backend_ipc.cpp
+++ b/server/src/common/backend_ipc.cpp
@@ -179,6 +179,13 @@ bool BackendIpcProcess::start(const BackendIpcLaunchConfig & cfg) {
         }
         argv_storage.emplace_back("--stream-fd=" + std::to_string(stream_pipe[1]));
 
+        // Apply any per-daemon environment overrides (e.g. GPU visibility
+        // pinning) in the child before exec, so the parent's own environment is
+        // untouched.
+        for (const auto & kv : cfg.child_env) {
+            ::setenv(kv.first.c_str(), kv.second.c_str(), 1);
+        }
+
         std::vector<char *> argv;
         argv.reserve(argv_storage.size() + 1);
         for (std::string & arg : argv_storage) argv.push_back(arg.data());

--- a/server/src/common/backend_ipc.h
+++ b/server/src/common/backend_ipc.h
@@ -12,6 +12,7 @@
 #include <cstdio>
 #include <limits>
 #include <string>
+#include <utility>
 #include <vector>
 
 #if !defined(_WIN32)
@@ -81,6 +82,10 @@ struct BackendIpcLaunchConfig {
     std::string work_dir;
     BackendIpcPayloadTransport payload_transport = BackendIpcPayloadTransport::Auto;
     size_t shared_payload_bytes = 0;
+    // Extra environment variables to set in the child *before* exec (e.g. to pin
+    // the daemon to a subset of GPUs via ROCR_VISIBLE_DEVICES/CUDA_VISIBLE_DEVICES).
+    // Empty by default: the child inherits the parent environment unchanged.
+    std::vector<std::pair<std::string, std::string>> child_env;
 };
 
 struct BackendIpcPayloadSegment {

--- a/server/src/common/target_shard_ipc.cpp
+++ b/server/src/common/target_shard_ipc.cpp
@@ -171,7 +171,26 @@ bool TargetShardIpcSession::start(const TargetShardIpcLaunchConfig & cfg) {
         layer_begin_list += std::to_string(cfg.layer_begins[i]);
         layer_end_list += std::to_string(cfg.layer_ends[i]);
     }
-    launch.args.push_back("--target-gpus=" + gpu_list);
+    // Optional GPU isolation for the target-shard daemon. By default the main
+    // process and the daemon both enumerate every GPU; for a cross-backend split
+    // (CUDA main + HIP daemon) that is harmless, but for a same-backend split
+    // (e.g. HIP main + HIP daemon across two AMD GPUs) two ROCr runtimes each
+    // initializing the *other* process's device can hard-fault the machine.
+    // When DFLASH_TARGET_SHARD_ISOLATE_GPUS is set, pin the daemon to see only
+    // its assigned GPUs via {CUDA,ROCR}_VISIBLE_DEVICES; under that pinned view
+    // the visible GPUs re-index from 0, so remap --target-gpus to match.
+    std::string target_gpu_list = gpu_list;
+    if (std::getenv("DFLASH_TARGET_SHARD_ISOLATE_GPUS") != nullptr) {
+        launch.child_env.emplace_back("ROCR_VISIBLE_DEVICES", gpu_list);
+        launch.child_env.emplace_back("CUDA_VISIBLE_DEVICES", gpu_list);
+        std::string remapped;
+        for (size_t i = 0; i < cfg.gpus.size(); ++i) {
+            if (i > 0) remapped += ",";
+            remapped += std::to_string(i);
+        }
+        target_gpu_list = remapped;
+    }
+    launch.args.push_back("--target-gpus=" + target_gpu_list);
     launch.args.push_back("--layer-begins=" + layer_begin_list);
     launch.args.push_back("--layer-ends=" + layer_end_list);
     launch.args.push_back("--max-ctx=" + std::to_string(cfg.max_ctx));


### PR DESCRIPTION
## Summary

The target-shard IPC daemon is `fork()`+`execv()`'d and **inherits the parent's environment with no GPU-visibility pinning** (`backend_ipc.cpp` builds argv and execs; the daemon uses the raw `--target-gpus` indices). So the main process and the daemon both enumerate *every* GPU.

- **Cross-backend split** (CUDA main + HIP daemon) — harmless: the two runtimes see disjoint device sets.
- **Same-backend split** (e.g. **HIP main + HIP daemon across two AMD GPUs**) — two ROCr runtimes each initialize the *other* process's device at startup, which on some ROCm/gfx setups **hard-faults the host**.

This blocks same-backend multi-GPU target-shard splits for *any* model that uses the IPC path (qwen35 / gemma4 / laguna / deepseek4).

## Change

Opt-in, backward-compatible:

- `BackendIpcLaunchConfig` gains `child_env` — extra env vars `setenv`'d in the child **before exec** (parent env untouched).
- When **`DFLASH_TARGET_SHARD_ISOLATE_GPUS`** is set, `TargetShardIpcSession` pins the daemon to only its assigned GPUs via `{CUDA,ROCR}_VISIBLE_DEVICES` and remaps `--target-gpus` to the 0-based pinned view.

**Default (env unset) is byte-identical to today** — `child_env` stays empty, the gpu list is unchanged. So existing CUDA+HIP splits are unaffected; there's no behavior change unless you opt in.

## Why both `CUDA_VISIBLE_DEVICES` and `ROCR_VISIBLE_DEVICES`

Set both so the isolation is backend-agnostic: a HIP daemon honors `ROCR_VISIBLE_DEVICES`, a CUDA daemon honors `CUDA_VISIBLE_DEVICES`, and each ignores the other's var.

## Validation

Validated **in concept** on a Strix Halo (gfx1151, iGPU) + external Radeon AI PRO R9700 (gfx1201, dGPU) HIP+HIP split. Applying the exact same pinning via an `exec` wrapper (`ROCR_VISIBLE_DEVICES=<gpu>; exec backend_ipc_daemon`) took the dual-GPU DeepSeek V4 Flash split from an **instant host hard-fault** to a **stable, coherent generation across both GPUs** (~8.4 tok/s, both GPUs computing). This PR moves that proven workaround into the launch mechanism.

## Draft — testing checklist before merge

- [ ] Build (Linux HIP + Linux CUDA).
- [ ] In-code path on the HIP+HIP box (replace the exec wrapper with `DFLASH_TARGET_SHARD_ISOLATE_GPUS=1`).
- [ ] Regression: a CUDA+HIP split with the env **unset** (expect no change) and **set** (expect equivalent behavior + the daemon pinned to its GPU).
- [ ] Multi-GPU remote daemon (>1 remote GPU) index remap.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

