### PR TITLE
fix(dflash): name the failing cuda/hip call in feature ring errors

### DIFF
--- a/server/src/common/dflash_feature_ring.cpp
+++ b/server/src/common/dflash_feature_ring.cpp
@@ -23,18 +23,32 @@ namespace dflash::common {
 
 // ── internal helpers ────────────────────────────────────────────
 
+// Log a failed CUDA/HIP runtime call with its error string and return true.
+// The backends surface only a generic "feature mirror init failed" /
+// "feature_sync" when any of these helpers returns false, so on HIP there is no
+// way to tell an OOM from a bad device id from a peer-copy failure. Naming the
+// call + printing cudaGetErrorString (mapped to hipGetErrorString on HIP builds)
+// turns that into a per-call diagnostic. Needed for the #457 DDTree-never-engages
+// triage: a mirror-init or feature-sync failure silently drops spec decode to AR.
+static bool feature_cuda_failed(const char * call, cudaError_t err) {
+    if (err == cudaSuccess) return false;
+    std::fprintf(stderr, "[dflash-feature] %s failed: %s\n",
+                 call, cudaGetErrorString(err));
+    return true;
+}
+
 static bool ensure_staging(DraftFeatureMirror & mirror, size_t bytes) {
     if (bytes <= mirror.staging_bytes) return true;
     cudaError_t err = cudaSetDevice(mirror.device);
-    if (err != cudaSuccess) return false;
+    if (feature_cuda_failed("cudaSetDevice", err)) return false;
     if (mirror.staging) {
         err = cudaFree(mirror.staging);
-        if (err != cudaSuccess) return false;
+        if (feature_cuda_failed("cudaFree", err)) return false;
         mirror.staging = nullptr;
         mirror.staging_bytes = 0;
     }
     err = cudaMalloc(&mirror.staging, bytes);
-    if (err != cudaSuccess) return false;
+    if (feature_cuda_failed("cudaMalloc", err)) return false;
     mirror.staging_bytes = bytes;
     return true;
 }
@@ -135,10 +149,10 @@ static bool convert_device_f32_to_feature_type(DraftFeatureMirror & mirror,
 
     std::vector<float> host(elems);
     cudaError_t err = cudaSetDevice(src_device);
-    if (err != cudaSuccess) return false;
+    if (feature_cuda_failed("cudaSetDevice", err)) return false;
     err = cudaMemcpy(host.data(), src, elems * sizeof(float),
                      cudaMemcpyDeviceToHost);
-    if (err != cudaSuccess) return false;
+    if (feature_cuda_failed("cudaMemcpy", err)) return false;
 
     const size_t row_bytes = ggml_row_size(mirror.storage_type, (int64_t)elems);
     std::vector<uint8_t> tmp(row_bytes);
@@ -170,7 +184,7 @@ static bool convert_bf16_feature_to_storage(DraftFeatureMirror & mirror,
     const size_t dst_offset = (size_t)((char *)dst - (char *)mirror.target_feat->data);
 
     cudaError_t err = cudaSetDevice(src_device);
-    if (err != cudaSuccess) return false;
+    if (feature_cuda_failed("cudaSetDevice", err)) return false;
 
     size_t done = 0;
     size_t dst_bytes_done = 0;
@@ -184,7 +198,7 @@ static bool convert_bf16_feature_to_storage(DraftFeatureMirror & mirror,
                          (const char *)src + done * sizeof(ggml_bf16_t),
                          chunk * sizeof(ggml_bf16_t),
                          cudaMemcpyDeviceToHost);
-        if (err != cudaSuccess) return false;
+        if (feature_cuda_failed("cudaMemcpy", err)) return false;
 
         std::vector<float> host(chunk);
         ggml_bf16_to_fp32_row(bf16_host.data(), host.data(), (int64_t)chunk);
@@ -223,9 +237,11 @@ static bool copy_feature_to_f32(DraftFeatureMirror & mirror,
         src = mirror.staging;
     }
     cudaError_t err = cudaSetDevice(mirror.device);
-    if (err != cudaSuccess) return false;
+    if (feature_cuda_failed("cudaSetDevice", err)) return false;
     to_f32(src, dst, (int64_t)elems, nullptr);
-    return cudaGetLastError() == cudaSuccess;
+    err = cudaGetLastError();
+    if (feature_cuda_failed("to_fp32_cuda", err)) return false;
+    return true;
 }
 
 // ── public API ──────────────────────────────────────────────────
@@ -291,12 +307,12 @@ bool draft_feature_mirror_init(DraftFeatureMirror & mirror,
     }
     const size_t bytes = ggml_nbytes(mirror.target_feat);
     cudaError_t err = cudaSetDevice(device);
-    if (err != cudaSuccess) {
+    if (feature_cuda_failed("cudaSetDevice", err)) {
         draft_feature_mirror_free(mirror);
         return false;
     }
     err = cudaMemset(mirror.target_feat->data, 0, bytes);
-    if (err != cudaSuccess) {
+    if (feature_cuda_failed("cudaMemset", err)) {
         draft_feature_mirror_free(mirror);
         return false;
     }
@@ -346,10 +362,12 @@ bool draft_feature_mirror_sync_range(const ggml_tensor * src_target_feat,
             return false;
         }
         cudaError_t err = cudaGetLastError();
-        if (err != cudaSuccess) return false;
+        if (feature_cuda_failed("cudaGetLastError", err)) return false;
         done += run;
     }
-    return cudaDeviceSynchronize() == cudaSuccess;
+    cudaError_t err = cudaDeviceSynchronize();
+    if (feature_cuda_failed("cudaDeviceSynchronize", err)) return false;
+    return true;
 }
 
 bool draft_feature_mirror_sync_tail(const ggml_tensor * src_target_feat,
@@ -393,7 +411,9 @@ bool copy_capture_slice_to_draft_ring(
             return false;
         }
     }
-    return cudaDeviceSynchronize() == cudaSuccess;
+    cudaError_t err = cudaDeviceSynchronize();
+    if (feature_cuda_failed("cudaDeviceSynchronize", err)) return false;
+    return true;
 }
 
 bool copy_host_capture_slice_to_draft_ring(
@@ -465,7 +485,9 @@ bool copy_feature_ring_range_to_tensor(
         }
         done += run;
     }
-    return cudaDeviceSynchronize() == cudaSuccess;
+    cudaError_t err = cudaDeviceSynchronize();
+    if (feature_cuda_failed("cudaDeviceSynchronize", err)) return false;
+    return true;
 }
 
 bool copy_feature_ring_range_to_host_f32(


### PR DESCRIPTION
## Summary

Route every `cuda*` call in `dflash_feature_ring.cpp` through a helper that prints the call name and `cudaGetErrorString`/`hipGetErrorString` on failure. This turns the generic "feature mirror init failed" (#457) into an actionable diagnostic that names the exact failing call.

## Changes

- Added `feature_cuda_failed(const char* call, cudaError_t err)` helper in `dflash_feature_ring.cpp` that returns `false` on `cudaSuccess` and prints `[dflash-feature] <call> failed: <error string>` otherwise.
- Replaced all `if (err != cudaSuccess) return false;` sites with `if (feature_cuda_failed("call", err)) return false;` (13 call sites across `ensure_staging`, `convert_device_f32_to_feature_type`, `convert_bf16_feature_to_storage`, `copy_feature_to_f32`, `draft_feature_mirror_init`, and three trailing `cudaDeviceSynchronize` functions).
- No control flow change. Success-path behavior is identical.

## How it works

On HIP, `cudaGetErrorString` resolves to `hipGetErrorString` via the existing `hip_compat/cuda_runtime.h` shim (line 74). On CUDA it maps to the native `cudaGetErrorString`. The helper is called only on the failure branch; the success path is unchanged.

## Limitations

- Logging only. This does not fix the underlying #457 performance or SIGSEGV issues. It provides the diagnostic information needed to triage them.
- No behavior change on either CUDA or HIP.

## Verification

- Host-side syntax check passes clean (`g++ -std=c++17 -fsyntax-only -Wall -Wextra`) with no diagnostics.
- No hardware needed. No runtime behavior change.
- Related issue: #457 (gfx1100 2x-slow / DDTree-never-engages / long-ctx SIGSEGV).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

