### PR TITLE
fix(laguna): honor explicit verify width

### DIFF
--- a/server/src/laguna/laguna_backend.cpp
+++ b/server/src/laguna/laguna_backend.cpp
@@ -490,7 +490,11 @@ bool LagunaBackend::do_spec_decode(int committed, int n_gen,
         ? std::min((int)(spec_ewma_accept_ + 0.5) + 1, auto_w_max)
         : verify_width;
     if (chain_w < 2) chain_w = 2;
-    if (chain_w > std::min(block_size, 8)) chain_w = std::min(block_size, 8);
+    // Explicit --verify-width / DFLASH_LAGUNA_VERIFY_WIDTH may use the full
+    // drafted block; AUTO keeps the narrow cap because it is optimized for
+    // throughput when the accepted length is low.
+    const int chain_w_max = adaptive_width ? std::min(block_size, 8) : block_size;
+    if (chain_w > chain_w_max) chain_w = chain_w_max;
     // DDTree sizes its batch via its budget; chain uses the width chosen above.
     const int base_q_len = args_.ddtree_mode ? block_size : chain_w;
 


### PR DESCRIPTION
## Summary

- allow explicit Laguna chain verify widths to use the full drafted block
- keep AUTO verify width capped at 8, preserving the current throughput-oriented behavior
- fixes the issue where `--verify-width 15/16` and `DFLASH_LAGUNA_VERIFY_WIDTH` were silently clamped back to 8

## Verification

- Built `dflash_server` from a clean lucebox worktree:
  `cmake --build build-sm86 --target dflash_server -j 4`
- Measured on lucebox with the Poolside BF16 Laguna XS 2.1 drafter:
  - width 8: ~211 tok/s, avg commit 3.876
  - width 15: ~158 tok/s, avg commit 4.042

The width-15 run is slower on the current kernels, but this confirms explicit wider verification is now actually exercised instead of being hard-capped at 8.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

