### PR TITLE
fix(hip): generalize RMSNorm reduction to wavefront width, guard wave32 kernels

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -648,6 +648,20 @@ if(DFLASH27B_TESTS)
             ${CMAKE_CURRENT_SOURCE_DIR}/hip_compat)
         target_link_libraries(test_flashprefill_kernels PRIVATE dflash_common ${DFLASH27B_GGML_BACKEND_TARGET})
     endif()
+    # RMSNorm HIP kernel vs CPU reference. HIP only, and on ANY HIP build:
+    # rms_norm_hip.cu is compiled into dflash_common regardless of SM80_EQUIV
+    # (it feeds the HIP chunk-B graph path). Validates the wavefront-generalized
+    # reduction against the device's actual wave width.
+    if(DFLASH27B_GPU_BACKEND STREQUAL "hip" AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_rms_norm_hip.cpp")
+        add_executable(test_rms_norm_hip test/test_rms_norm_hip.cpp)
+        set_source_files_properties(test/test_rms_norm_hip.cpp PROPERTIES LANGUAGE HIP)
+        set_target_properties(test_rms_norm_hip PROPERTIES HIP_ARCHITECTURES "${_dflash_archs}")
+        target_include_directories(test_rms_norm_hip PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src
+            ${CMAKE_CURRENT_SOURCE_DIR}/hip_compat)
+        target_link_libraries(test_rms_norm_hip PRIVATE dflash_common ${DFLASH27B_GGML_BACKEND_TARGET})
+        add_test(NAME rms_norm_hip COMMAND test_rms_norm_hip)
+    endif()
     # GPU draft top-K kernel vs CPU reference (extract_draft_topk). CUDA only:
     # geometric_draft_topk_cuda.cu is compiled into dflash_common solely on the cuda backend.
     if(DFLASH27B_GPU_BACKEND STREQUAL "cuda" AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_draft_topk_cuda.cpp")

--- a/server/src/device_runtime.h
+++ b/server/src/device_runtime.h
@@ -10,8 +10,21 @@ using __nv_bfloat16 = __hip_bfloat16;
 #ifndef cudaEventElapsedTime
 #define cudaEventElapsedTime hipEventElapsedTime
 #endif
+// HIP has no masked ballot. __ballot(p) ballots every active lane of the
+// wavefront and returns a 64-bit mask (wavefronts are 64 lanes wide on
+// GCN/CDNA), whereas CUDA's __ballot_sync(mask, p) returns a 32-bit mask over
+// only the lanes in `mask`. Two porting hazards follow:
+//   1. Width: the result must be stored in a 64-bit sink on wave64 archs, or
+//      lanes 32..63 are truncated away. We cast to unsigned long long so the
+//      full width is explicit at the shim boundary; call sites that assign to a
+//      32-bit type still truncate and are only correct on wave32 (e.g. the
+//      rocWMMA flashprefill kernel, which is gated wave32-only).
+//   2. Mask: the CUDA active-lane mask is dropped. That is only equivalent when
+//      every lane in `mask` is active, which holds at all current call sites
+//      (they pass a full 0xffffffff mask).
 #ifndef __ballot_sync
-#define __ballot_sync(mask, predicate) __ballot(predicate)
+#define __ballot_sync(mask, predicate) \
+    (static_cast<unsigned long long>(__ballot(predicate)))
 #endif
 #else
 #include <hip/hip_runtime.h>

--- a/server/src/flashprefill_kernels.hip.cu
+++ b/server/src/flashprefill_kernels.hip.cu
@@ -23,6 +23,20 @@
 #include <hip/hip_bfloat16.h>
 #include <rocwmma/rocwmma.hpp>
 
+// These kernels are WAVE32-ONLY BY DESIGN, not merely wave32-tuned. Kernel 4's
+// accumulator handling assumes the RDNA3 v_wmma_f32_16x16x16 fragment layout
+// (lane t, elem i -> row = t%16, col = (t/16)*8 + i; see the header note above),
+// which is a 32-lane instruction. A wave64 target would need a different WMMA
+// instruction and fragment layout, not a warp-width tweak, so we fail the build
+// loudly rather than emit silently-wrong results. All currently declared AMD
+// targets (gfx1100 / gfx1151, RDNA3) are wave32. __AMDGCN_WAVEFRONT_SIZE(__) is
+// defined only in the device compile pass.
+#if defined(__AMDGCN_WAVEFRONT_SIZE__) && (__AMDGCN_WAVEFRONT_SIZE__ != 32)
+#  error "flashprefill_kernels.hip.cu requires a 32-lane wavefront (RDNA v_wmma_f32_16x16x16 fragment layout). Build for a wave32 target (gfx10/gfx11) or provide a wave64 WMMA rewrite."
+#elif !defined(__AMDGCN_WAVEFRONT_SIZE__) && defined(__AMDGCN_WAVEFRONT_SIZE) && (__AMDGCN_WAVEFRONT_SIZE != 32)
+#  error "flashprefill_kernels.hip.cu requires a 32-lane wavefront (RDNA v_wmma_f32_16x16x16 fragment layout). Build for a wave32 target (gfx10/gfx11) or provide a wave64 WMMA rewrite."
+#endif
+
 namespace dflash::common {
 namespace flashprefill {
 

--- a/server/src/rms_norm_hip.cu
+++ b/server/src/rms_norm_hip.cu
@@ -4,12 +4,32 @@
 
 #include <hip/hip_runtime.h>
 
+// Wavefront width of the target arch: 32 on RDNA (gfx10/gfx11), 64 on GCN/CDNA.
+// The reduction below must span exactly one wavefront, so hardcoding 32 leaves
+// lanes 32..63 out of the reduce on wave64 archs. __AMDGCN_WAVEFRONT_SIZE(__) is
+// a compile-time builtin defined only in the device pass. The 64 fallback is
+// host-only (WAVE is never used off-device); a device pass without the builtin
+// is a hard error rather than a silent wrong-width guess.
+#ifndef DFLASH_WAVE_SIZE
+#  if defined(__AMDGCN_WAVEFRONT_SIZE__)
+#    define DFLASH_WAVE_SIZE __AMDGCN_WAVEFRONT_SIZE__
+#  elif defined(__AMDGCN_WAVEFRONT_SIZE)
+#    define DFLASH_WAVE_SIZE __AMDGCN_WAVEFRONT_SIZE
+#  elif !defined(__HIP_DEVICE_COMPILE__)
+#    define DFLASH_WAVE_SIZE 64  // host pass only; WAVE is unused off-device
+#  else
+#    error "rms_norm_hip: missing wavefront-size builtin in device pass; set DFLASH_WAVE_SIZE"
+#  endif
+#endif
+
 __global__ void rms_norm_mul_w_f32_kernel(
     const float * __restrict__ src,
     const float * __restrict__ w,
     float       * __restrict__ dst,
     int hidden, float eps)
 {
+    constexpr int WAVE = DFLASH_WAVE_SIZE;
+
     const int tok = blockIdx.x;
     const float * row = src + (size_t)tok * hidden;
     float       * out = dst + (size_t)tok * hidden;
@@ -22,17 +42,22 @@ __global__ void rms_norm_mul_w_f32_kernel(
         sumsq += v * v;
     }
 
-    for (int off = 16; off > 0; off >>= 1)
+    #pragma unroll
+    for (int off = WAVE / 2; off > 0; off >>= 1)
         sumsq += __shfl_xor(sumsq, off);
 
-    if ((threadIdx.x & 31) == 0)
-        smem[threadIdx.x >> 5] = sumsq;
+    if ((threadIdx.x & (WAVE - 1)) == 0)
+        smem[threadIdx.x / WAVE] = sumsq;
     __syncthreads();
 
-    const int n_warps = blockDim.x >> 5;
-    if (threadIdx.x < 32) {
+    // Final reduce across per-wavefront partials in a single wavefront. Valid
+    // while n_warps <= WAVE, which holds for the fixed block=256 launch below
+    // (8 warps on wave32, 4 on wave64).
+    const int n_warps = blockDim.x / WAVE;
+    if (threadIdx.x < WAVE) {
         sumsq = (threadIdx.x < n_warps) ? smem[threadIdx.x] : 0.0f;
-        for (int off = 16; off > 0; off >>= 1)
+        #pragma unroll
+        for (int off = WAVE / 2; off > 0; off >>= 1)
             sumsq += __shfl_xor(sumsq, off);
         if (threadIdx.x == 0)
             smem[0] = sumsq;
@@ -51,6 +76,9 @@ extern "C" void launch_rms_norm_mul_w_f32(
     hipStream_t stream)
 {
     const int block = 256;
+    // One float per wavefront partial. Host code can't see __AMDGCN_WAVEFRONT_SIZE,
+    // so size for the wave32 (max-warp) case: block/32 floats is a safe upper
+    // bound that also covers wave64 (block/64 partials).
     const size_t smem = (size_t)(block >> 5) * sizeof(float);
     rms_norm_mul_w_f32_kernel<<<n_tokens, block, smem, stream>>>(
         src, w, dst, hidden, eps);

--- a/server/test/test_rms_norm_hip.cpp
+++ b/server/test/test_rms_norm_hip.cpp
@@ -1,0 +1,96 @@
+// CPU-parity test for the HIP per-token RMSNorm kernel (rms_norm_hip.cu).
+//
+// rms_norm_mul_w_f32_kernel reduces sum-of-squares across one wavefront, then
+// across per-wavefront partials. That reduction was hardcoded to a 32-lane
+// wavefront; AMD-2 generalized it to __AMDGCN_WAVEFRONT_SIZE so wave64 archs
+// reduce all lanes. This test compares the GPU kernel against a CPU reference
+// on the device's actual wavefront width, so it validates whichever mode the
+// runner's card uses (gfx1100 / gfx1151 are wave32; a wave64 card exercises the
+// generalized path). Written in CUDA spellings; the hip_compat/ shim maps them
+// onto HIP exactly as the kernel and the flashprefill test do.
+//
+// Pass criterion: max |gpu - cpu| within a tight fp32 tolerance (the kernel
+// accumulates in fp32, so the only slack is reduction ordering).
+
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
+#include <vector>
+#include <random>
+#include <cuda_runtime.h>
+
+extern "C" void launch_rms_norm_mul_w_f32(
+    const float * src, const float * w, float * dst,
+    int n_tokens, int hidden, float eps,
+    cudaStream_t stream);
+
+#define CK(call) do { \
+    cudaError_t e = (call); \
+    if (e != cudaSuccess) { \
+        std::fprintf(stderr, "HIP error %s at %s:%d: %s\n", #call, __FILE__, __LINE__, cudaGetErrorString(e)); \
+        return 1; \
+    } \
+} while (0)
+
+int main() {
+    constexpr int N_TOK  = 64;
+    constexpr int HIDDEN = 2048;   // > block(256): forces the strided load loop
+    constexpr float EPS  = 1e-5f;
+
+    cudaDeviceProp prop;
+    CK(cudaGetDeviceProperties(&prop, 0));
+    std::printf("[rmsnorm-test] device=%s warpSize=%d hidden=%d n_tok=%d\n",
+                prop.name, prop.warpSize, HIDDEN, N_TOK);
+
+    std::mt19937 rng(1234);
+    std::uniform_real_distribution<float> xdist(-1.0f, 1.0f);
+    std::uniform_real_distribution<float> wdist(0.5f, 1.5f);
+
+    std::vector<float> src((size_t)N_TOK * HIDDEN);
+    std::vector<float> w(HIDDEN);
+    for (auto & v : src) v = xdist(rng);
+    for (auto & v : w)   v = wdist(rng);
+
+    float *d_src, *d_w, *d_dst;
+    CK(cudaMalloc(&d_src, src.size() * sizeof(float)));
+    CK(cudaMalloc(&d_w,   w.size()   * sizeof(float)));
+    CK(cudaMalloc(&d_dst, src.size() * sizeof(float)));
+    CK(cudaMemcpy(d_src, src.data(), src.size() * sizeof(float), cudaMemcpyHostToDevice));
+    CK(cudaMemcpy(d_w,   w.data(),   w.size()   * sizeof(float), cudaMemcpyHostToDevice));
+
+    launch_rms_norm_mul_w_f32(d_src, d_w, d_dst, N_TOK, HIDDEN, EPS, 0);
+    CK(cudaDeviceSynchronize());
+    CK(cudaGetLastError());
+
+    std::vector<float> gpu(src.size());
+    CK(cudaMemcpy(gpu.data(), d_dst, gpu.size() * sizeof(float), cudaMemcpyDeviceToHost));
+
+    // CPU reference: inv = rsqrt(mean(x^2) + eps); out = x * inv * w.
+    float max_abs = 0.0f, max_rel = 0.0f;
+    for (int t = 0; t < N_TOK; ++t) {
+        const float * row = src.data() + (size_t)t * HIDDEN;
+        double sumsq = 0.0;
+        for (int i = 0; i < HIDDEN; ++i) sumsq += (double)row[i] * row[i];
+        const float inv = 1.0f / std::sqrt((float)(sumsq / HIDDEN) + EPS);
+        for (int i = 0; i < HIDDEN; ++i) {
+            const float ref = row[i] * inv * w[i];
+            const float got = gpu[(size_t)t * HIDDEN + i];
+            const float ad  = std::fabs(got - ref);
+            max_abs = std::fmax(max_abs, ad);
+            max_rel = std::fmax(max_rel, ad / (std::fabs(ref) + 1e-6f));
+        }
+    }
+
+    cudaFree(d_src); cudaFree(d_w); cudaFree(d_dst);
+
+    std::printf("[rmsnorm-test] max_abs_diff=%.3e max_rel_diff=%.3e\n", max_abs, max_rel);
+
+    // fp32 accumulation on both sides; allow only reduction-ordering slack.
+    const float TOL = 1e-4f;
+    if (max_abs > TOL) {
+        std::fprintf(stderr, "[rmsnorm-test] FAIL: max_abs_diff %.3e exceeds tol %.3e\n", max_abs, TOL);
+        return 1;
+    }
+    std::printf("[rmsnorm-test] PASS\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

The HIP kernels bake in a wave32 assumption. On a wave64 arch the RMSNorm block reduction leaves the upper 32 lanes out of the reduction, and the `__ballot_sync` shim truncates its result. This PR generalizes the RMSNorm reduction to the compile-time wavefront width, hardens the ballot shim, and guards the kernels that are wave32-only by design so a wave64 build fails loud at compile time instead of silently producing wrong numbers. No behavior change on the declared AMD targets (gfx1100 / gfx1151), which are all wave32.

## Changes

- `server/src/rms_norm_hip.cu`: reduction generalized off a compile-time `WAVE = __AMDGCN_WAVEFRONT_SIZE(__)` (host pass falls back to 64). Replaced the hardcoded `off=16` -> `WAVE/2`, `&31` -> `&(WAVE-1)`, `>>5` -> `/WAVE`, `<32` -> `<WAVE` in both reduce loops. The final single-wave reduce stays valid while `n_warps <= WAVE` (holds for block=256: 8 warps on wave32, 4 on wave64). Launcher smem stays at the `block>>5` max-warp upper bound (the host cannot see the device wave macro), with a comment.
- `server/src/device_runtime.h`: the `__ballot_sync(mask, p)` -> `__ballot(p)` shim now casts to `unsigned long long` (explicit 64-bit width) and documents the dropped-mask and wave64-truncation hazards.
- `server/src/flashprefill_kernels.hip.cu`: added a compile-time `#error` gate on `__AMDGCN_WAVEFRONT_SIZE(__) != 32`. This kernel's rocWMMA `v_wmma_f32_16x16x16` fragment layout is a 32-lane instruction, not a width knob, so making it wave64-correct is a different WMMA instruction rather than a width tweak. All declared AMD targets are wave32, so this is a no-op on supported hardware and fails loud on wave64.
- `server/test/test_rms_norm_hip.cpp` (new) + CMake wiring: a HIP-backend CPU-parity test (GPU RMSNorm vs an fp32 CPU reference, tol 1e-4), built on any HIP build since `rms_norm_hip.cu` compiles regardless of `SM80_EQUIV`. It prints the device `warpSize` so the log records which wave mode was exercised. Registered via `add_test(NAME rms_norm_hip)`.

## Performance

None. This is a correctness fix; on wave32 hardware the generated reduction is equivalent to the previous hardcoded path.

## Limitations / Known follow-up

- This does not by itself fix #367. That card (gfx1102) is wave32, where 32 is already correct; the reported bug's root cause is the vendored ggml predating gfx1102 arch support.
- The wave64 correctness path is not validated: no wave64 AMD hardware was available. The guard makes a wave64 build fail loud rather than run silently wrong; it does not prove the reduction on wave64.
- The `flashprefill_kernels.hip.cu` `#error` guard only compiles under `SM80_EQUIV=ON` (the rocWMMA path), which was not exercised in this run. It is a no-op on wave32.

## Verification

- Hardware: AMD Radeon 8060S (gfx1151, wave32), ROCm 6.4.4, hipcc 6.4.43484.
- Built `test_rms_norm_hip` with `LANGUAGE HIP`, `HIP_ARCHITECTURES=gfx1151`, `CMAKE_BUILD_TYPE=Release`, and ran it on the GPU:

```
[rmsnorm-test] device=Radeon 8060S Graphics warpSize=32 hidden=2048 n_tok=64
[rmsnorm-test] max_abs_diff=4.768e-07 max_rel_diff=3.196e-07
[rmsnorm-test] PASS
```

```
ctest -R rms_norm_hip
1/1 Test #1: rms_norm_hip .....................   Passed    2.16 sec
100% tests passed, 0 tests failed out of 1
```

GPU vs CPU RMSNorm parity holds on wave32 (`max_abs_diff 4.77e-07`, well under the 1e-4 tolerance), and the log records `warpSize=32`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

