### PR TITLE
fix(ds4): propagate sampler config in layer split

### DIFF
--- a/server/src/deepseek4/deepseek4_layer_split_adapter.cpp
+++ b/server/src/deepseek4/deepseek4_layer_split_adapter.cpp
@@ -405,7 +405,10 @@ bool DeepSeek4LayerSplitAdapter::init_mixed_target_split() {
 }
 
 void DeepSeek4LayerSplitAdapter::begin_request(const GenerateRequest & req) {
-    (void)req;
+    sampler_ = req.sampler;
+    if (req.do_sample && sampler_.seed != 0) {
+        sampler_rng_.seed(sampler_.seed);
+    }
 }
 
 void DeepSeek4LayerSplitAdapter::reset_request_state() {

--- a/server/tests/test_deepseek4_unit.cpp
+++ b/server/tests/test_deepseek4_unit.cpp
@@ -621,6 +621,27 @@ static void test_hc_state_dimensions() {
     std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
 }
 
+static void test_layer_split_request_propagates_sampler() {
+    std::fprintf(stderr, "  test_layer_split_request_propagates_sampler ...");
+
+    DeepSeek4LayerSplitAdapter adapter({});
+    GenerateRequest req;
+    req.do_sample = true;
+    req.sampler.temp = 0.25f;
+    req.sampler.top_p = 0.9f;
+    req.sampler.seed = 42;
+
+    adapter.begin_request(req);
+
+    TEST_ASSERT(adapter.sampler_.temp == req.sampler.temp);
+    TEST_ASSERT(adapter.sampler_.top_p == req.sampler.top_p);
+    TEST_ASSERT(adapter.sampler_.seed == req.sampler.seed);
+    std::mt19937_64 expected(req.sampler.seed);
+    TEST_ASSERT(adapter.sampler_rng_() == expected());
+
+    std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
+}
+
 static void test_loader_rejects_missing_required_metadata(ggml_backend_t backend) {
     std::fprintf(stderr, "  test_loader_rejects_missing_required_metadata ...");
 
@@ -1558,6 +1579,7 @@ int main() {
     test_auto_split_computation();
     test_layer_range_validation();
     test_hc_state_dimensions();
+    test_layer_split_request_propagates_sampler();
     test_loader_rejects_missing_required_metadata(backend);
     test_loader_rejects_invalid_compress_ratio_type(backend);
     test_loader_rejects_zero_vocab_size(backend);


### PR DESCRIPTION
## Summary

- propagate the request sampler configuration into `DeepSeek4LayerSplitAdapter`
- preserve request temperature, top-p, top-k, repetition/frequency/presence penalties, and seed instead of silently retaining the adapter defaults
- reseed the adapter RNG when deterministic sampling is explicitly requested
- add unit coverage for sampler propagation and deterministic reseeding

## Stack

> **Stacked on #503.** Base is `codex/ds4-rocmfpx-server`, so this PR contains only the DeepSeek4 layer-split sampler propagation fix. Retarget to the branch where #503 lands once it is merged.

## Problem

`LayerSplitBackend::run_from_state()` calls `adapter_->begin_request(req)` before prefill and decode. The Qwen35, Gemma4, and Laguna layer-split adapters copy `req.sampler` into their request-local sampler state, but the DeepSeek4 adapter discarded the request:

```cpp
void DeepSeek4LayerSplitAdapter::begin_request(const GenerateRequest & req) {
    (void)req;
}
```

As a result, DeepSeek4 layer-split requests silently retained the default sampler configuration. A request sent with `temperature: 0.01` and `seed: 42` still reached `run_layer_split_ar_decode()` with `sampler.temp == 0` under GDB.

The adapter now follows the same contract as the other layer-split implementations:

```cpp
sampler_ = req.sampler;
if (req.do_sample && sampler_.seed != 0) {
    sampler_rng_.seed(sampler_.seed);
}
```

A non-zero seed explicitly requests reproducible sampling. Seed zero keeps the RNG's existing nondeterministic state and does not disable temperature sampling.

## Validation

- branch rebased directly onto the current #503 head (`6c7ee19`)
- `git diff --check`: passed
- diff is limited to the DeepSeek4 layer-split adapter and its unit test
- pre-fix GDB validation: an HTTP request with `temperature: 0.01` reached `run_layer_split_ar_decode()` with `sampler.temp == 0`
- post-fix Release/RelWithDebInfo CUDA H200 build: passed
- post-fix request with `temperature: 0.01` and `seed: 42` returned the coherent response `The capital of France is Paris.`
- unit coverage verifies temperature/top-p/seed propagation and deterministic RNG reseeding

## Follow-up

**TO INVESTIGATE**: Greedy layer-split decode with `temperature: 0` has a separate common-runtime issue: `run_layer_split_ar_decode()` currently skips logits processing instead of selecting their argmax. That cross-model fix is intentionally kept out of this DeepSeek4-specific change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

