### PR TITLE
perf(qwen35): accelerate Ampere prefill GDN

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -712,6 +712,18 @@ if(DFLASH27B_TESTS)
         target_link_libraries(test_draft_topk_cuda PRIVATE dflash_common ${DFLASH27B_GGML_BACKEND_TARGET})
         add_test(NAME draft_topk_cuda COMMAND test_draft_topk_cuda)
     endif()
+    # Focused CUDA-vs-CPU oracle for the IQ4_XS MMQ stream-k scheduler. These
+    # shapes cover the no-fixup, partial-row, fixup, two-wave, and deeper-K
+    # transitions validated for the llama.cpp #22298 backport on sm_86.
+    if(DFLASH27B_GPU_BACKEND STREQUAL "cuda")
+        add_executable(test_mmq_streamk_iq4_xs test/test_mmq_streamk_iq4_xs.cpp)
+        target_link_libraries(test_mmq_streamk_iq4_xs PRIVATE
+            ggml
+            ggml-cpu
+            ggml-cuda
+            ggml-base)
+        add_test(NAME mmq_streamk_iq4_xs COMMAND test_mmq_streamk_iq4_xs)
+    endif()
     # GPU port of the sample_logits chain vs the CPU reference. CUDA only:
     # geometric_sampler_cuda.cu is compiled into dflash_common solely on the cuda backend.
     if(DFLASH27B_GPU_BACKEND STREQUAL "cuda" AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_gpu_sampler_cuda.cpp")

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -642,6 +642,18 @@ endif()
 option(DFLASH27B_TESTS "Build numerics tests" ON)
 option(DFLASH27B_SERVER "Build dflash_server + backend_ipc_daemon" ON)
 if(DFLASH27B_TESTS)
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_gdn_grouped_policy.cpp")
+        add_executable(test_gdn_grouped_policy test/test_gdn_grouped_policy.cpp)
+        target_include_directories(test_gdn_grouped_policy PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/deps/llama.cpp/ggml/src/ggml-cuda)
+        add_test(NAME gdn_grouped_policy COMMAND test_gdn_grouped_policy)
+    endif()
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_qwen35_gdn_broadcast.cpp")
+        add_executable(test_qwen35_gdn_broadcast test/test_qwen35_gdn_broadcast.cpp)
+        target_include_directories(test_qwen35_gdn_broadcast PRIVATE ${DFLASH27B_SRC_INCLUDE_DIRS})
+        target_link_libraries(test_qwen35_gdn_broadcast PRIVATE dflash_common)
+        add_test(NAME qwen35_gdn_broadcast COMMAND test_qwen35_gdn_broadcast)
+    endif()
     if(DFLASH27B_GPU_BACKEND STREQUAL "cuda" AND _dflash_cuda_min_sm GREATER_EQUAL 80 AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_flashprefill_kernels.cpp")
         add_executable(test_flashprefill_kernels test/test_flashprefill_kernels.cpp)
         set_target_properties(test_flashprefill_kernels PROPERTIES CUDA_ARCHITECTURES "${_dflash_archs}")
@@ -716,6 +728,13 @@ if(DFLASH27B_TESTS)
     # shapes cover the no-fixup, partial-row, fixup, two-wave, and deeper-K
     # transitions validated for the llama.cpp #22298 backport on sm_86.
     if(DFLASH27B_GPU_BACKEND STREQUAL "cuda")
+        add_executable(test_gdn_grouped_cuda test/test_gdn_grouped_cuda.cpp)
+        target_link_libraries(test_gdn_grouped_cuda PRIVATE
+            ggml
+            ggml-cuda
+            ggml-base)
+        add_test(NAME gdn_grouped_cuda COMMAND test_gdn_grouped_cuda)
+
         add_executable(test_mmq_streamk_iq4_xs test/test_mmq_streamk_iq4_xs.cpp)
         target_link_libraries(test_mmq_streamk_iq4_xs PRIVATE
             ggml

--- a/server/deps/llama.cpp/VENDOR.md
+++ b/server/deps/llama.cpp/VENDOR.md
@@ -7,7 +7,8 @@ This directory contains the ggml-only subset used by Lucebox Hub.
 - Source base commit: `6fbe72d67069136bbd370be703e1d4f441b5e942`
 - Included merged PR: `#35` (`0fe65d9354b7c5da52a7741d2e37ba85f0d0c925`)
 - Included test PR: `#37` (`0699be81480428f01b9b7ac49a09a2d51c77f8df`)
-- Reconstruction: `luce-dflash@6fbe72d67069136bbd370be703e1d4f441b5e942` plus cherry-picked PRs `#35` and `#37`
+- Included upstream backport: `llama.cpp #22298` (`9725a313be0528214c4a02fed906ddaf7b3f712e`)
+- Reconstruction: `luce-dflash@6fbe72d67069136bbd370be703e1d4f441b5e942` plus cherry-picked PRs `#35`, `#37`, and upstream `llama.cpp #22298`
 - Vendored paths: `LICENSE`, `common/jinja`, `common/log.h`, `common/unicode.*`, `ggml`, `gguf-py`
 
 Open ggml feature PRs are intentionally not included until they are merged, except for explicitly listed hub test PRs.

--- a/server/deps/llama.cpp/VENDOR.md
+++ b/server/deps/llama.cpp/VENDOR.md
@@ -12,3 +12,11 @@ This directory contains the ggml-only subset used by Lucebox Hub.
 - Vendored paths: `LICENSE`, `common/jinja`, `common/log.h`, `common/unicode.*`, `ggml`, `gguf-py`
 
 Open ggml feature PRs are intentionally not included until they are merged, except for explicitly listed hub test PRs.
+
+## Hub-local deltas
+
+- `ggml/src/ggml-cuda/gated_delta_net*`: Lucebox selects the existing grouped-column
+  Gated DeltaNet kernel for Ampere prefill launches of at least 512 tokens while
+  retaining the classic kernel for decode and partial chunks. The force/disable
+  environment controls remain available for differential testing. This policy is
+  maintained locally until it is suitable for upstreaming to `lucebox-ggml`.

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/gated_delta_net.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/gated_delta_net.cu
@@ -1,4 +1,5 @@
 #include "gated_delta_net.cuh"
+#include "gated_delta_net_policy.h"
 #ifndef GGML_USE_HIP
 #include <cuda_fp16.h>
 #endif
@@ -471,8 +472,8 @@ static void launch_gated_delta_net(
                             && cc <  GGML_CUDA_CC_ADA_LOVELACE;
     const bool force_grouped_cols = getenv("DFLASH_GDN_FORCE_GROUPED_COLS") != nullptr;
     const bool disable_grouped_cols = getenv("DFLASH_GDN_NO_GROUPED_COLS") != nullptr;
-    const bool use_grouped_cols = force_grouped_cols ||
-        (!disable_grouped_cols && !ampere_nvidia);
+    const bool use_grouped_cols = ggml_cuda_gdn_use_grouped_columns(
+        ampere_nvidia, n_tokens, force_grouped_cols, disable_grouped_cols);
 
     switch (S_v) {
         case 16:

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/gated_delta_net_policy.h
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/gated_delta_net_policy.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdint>
+
+// Grouped columns share each Q/K load across four state columns. On Ampere,
+// that reuse wins for prefill-sized launches but its larger register footprint
+// loses at decode and other short batch sizes. Diagnostic overrides retain the
+// existing force-over-disable precedence.
+inline bool ggml_cuda_gdn_use_grouped_columns(
+        bool ampere_nvidia,
+        int64_t n_tokens,
+        bool force_grouped_columns,
+        bool disable_grouped_columns) {
+    const bool ampere_prefill = ampere_nvidia && n_tokens >= 512;
+    return force_grouped_columns ||
+        (!disable_grouped_columns && (!ampere_nvidia || ampere_prefill));
+}

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/mmq.cuh
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/mmq.cuh
@@ -3638,10 +3638,10 @@ template <ggml_type type, int mmq_x, bool need_check>
 static __global__ void mul_mat_q(
         const char * __restrict__ x, const int * __restrict__ y, const int32_t * __restrict__ ids_dst,
         const int32_t * __restrict__ expert_bounds, float * __restrict__ dst, float * __restrict__ tmp_fixup,
-        const int ncols_x, const int nrows_x, const int ncols_dst, const int stride_row_x, const int ncols_y, const int stride_col_dst,
-        const int channel_ratio, const int nchannels_y, const int stride_channel_x, const int stride_channel_y, const int stride_channel_dst,
-        const int sample_ratio, const int nsamples_y, const int stride_sample_x, const int stride_sample_y, const int stride_sample_dst,
-        const int ncols_max) {
+        const uint3 blocks_per_ne00, const int nrows_x, const int ncols_dst, const int stride_row_x, const int ncols_y, const int stride_col_dst,
+        const uint3 channel_ratio, const uint3 nchannels_y, const int stride_channel_x, const int stride_channel_y, const int stride_channel_dst,
+        const uint3 sample_ratio, const uint3 nsamples_y, const int stride_sample_x, const int stride_sample_y, const int stride_sample_dst,
+        const uint3 ntx) {
 
     // Skip unused template specializations for faster compilation:
     if (mmq_x > get_mmq_x_max_device() || mmq_x % mmq_get_granularity_device(mmq_x) != 0) {
@@ -3655,8 +3655,7 @@ static __global__ void mul_mat_q(
     constexpr int qk    = ggml_cuda_type_traits<type>::qk;
     constexpr int mmq_y = get_mmq_y_device();
 
-    const int ntx = (ncols_max + mmq_x - 1) / mmq_x; // Number of tiles x
-    const int nty = (nrows_x   + mmq_y - 1) / mmq_y; // Number of tiles y
+    const uint32_t nty = (nrows_x + mmq_y - 1) / mmq_y; // Number of tiles y
 
     // Initialize the ids for writing back data with just the index.
     // For regular matrix multiplications this is never changed.
@@ -3677,8 +3676,9 @@ static __global__ void mul_mat_q(
     // On non-CDNA AMD or old CUDA the performance with stream-k was worse, use conventional tiling instead:
 #if (defined(GGML_USE_HIP) && !defined(CDNA)) || __CUDA_ARCH__ < GGML_CUDA_CC_VOLTA
     {
-        const int wt = blockIdx.z / nchannels_y;
-        const int zt = blockIdx.z - wt*nchannels_y;
+        const uint2 tmp2 = fast_div_modulo(blockIdx.z, nchannels_y);
+        const int wt = tmp2.x;
+        const int zt = tmp2.y;
         const int jt = blockIdx.y;
         const int it = blockIdx.x;
 
@@ -3721,40 +3721,40 @@ static __global__ void mul_mat_q(
         const int tile_x_max_i = nrows_x  - it*mmq_y - 1;
         const int tile_y_max_j = col_diff - jt*mmq_x - 1;
 
-        const int offset_x = (wt/sample_ratio)*stride_sample_x + (zt/channel_ratio)*stride_channel_x + it*mmq_y*stride_row_x;
+        const int offset_x = fastdiv(wt, sample_ratio)*stride_sample_x + fastdiv(zt, channel_ratio)*stride_channel_x + it*mmq_y*stride_row_x;
 
         constexpr bool fixup = false;
         mul_mat_q_process_tile<type, mmq_x, need_check, fixup>
             (x, offset_x, y + offset_y, ids_dst_shared, dst + offset_dst, tmp_fixup, stride_row_x, ncols_y, stride_col_dst,
-             tile_x_max_i, tile_y_max_j, 0, ncols_x/qk);
+             tile_x_max_i, tile_y_max_j, 0, blocks_per_ne00.z);
         return;
     }
 #endif // (defined(GGML_USE_HIP) && !defined(CDNA4) && !defined(CDNA3)) || __CUDA_ARCH__ < GGML_CUDA_CC_VOLTA
 
-    constexpr int ITER_K = get_iter_k(type);
-
-    const     int64_t blocks_per_ne00 = ncols_x / qk;
-    constexpr int     blocks_per_iter = ITER_K / qk;
+    constexpr int ITER_K          = get_iter_k(type);
+    constexpr int blocks_per_iter = ITER_K / qk;
 
     // kbc == k block continuous, current index in continuous ijk space.
-    int64_t kbc      = (int64_t) blockIdx.x     *nsamples_y*nchannels_y*ntx*nty*blocks_per_ne00 / gridDim.x;
-    int64_t kbc_stop = (int64_t)(blockIdx.x + 1)*nsamples_y*nchannels_y*ntx*nty*blocks_per_ne00 / gridDim.x;
+    int kbc      = int64_t(blockIdx.x)    *(nsamples_y.z*nchannels_y.z*ntx.z*nty*blocks_per_ne00.z) / gridDim.x;
+    int kbc_stop = int64_t(blockIdx.x + 1)*(nsamples_y.z*nchannels_y.z*ntx.z*nty*blocks_per_ne00.z) / gridDim.x;
 
-    kbc      -= (kbc      % blocks_per_ne00) % blocks_per_iter;
-    kbc_stop -= (kbc_stop % blocks_per_ne00) % blocks_per_iter;
+    kbc      -= fastmodulo(kbc,      blocks_per_ne00) % blocks_per_iter;
+    kbc_stop -= fastmodulo(kbc_stop, blocks_per_ne00) % blocks_per_iter;
 
     // kb0 == k index when doing the matrix multiplication for an output tile.
-    int kb0_start = kbc % blocks_per_ne00;
-    int kb0_stop  = min(blocks_per_ne00, kb0_start + kbc_stop - kbc);
-    while (kbc < kbc_stop && kb0_stop == blocks_per_ne00) {
-        int tmp = kbc;
-        const int it = tmp / (nsamples_y*nchannels_y*ntx*blocks_per_ne00);
-        tmp -= it * (nsamples_y*nchannels_y*ntx*blocks_per_ne00);
-        const int wt = tmp / (nchannels_y*ntx*blocks_per_ne00);
-        tmp -= wt * (nchannels_y*ntx*blocks_per_ne00);
-        const int zt = tmp / (ntx*blocks_per_ne00);
-        tmp -= zt * (ntx*blocks_per_ne00);
-        const int jt = tmp / blocks_per_ne00;
+    int kb0_start = fastmodulo(kbc, blocks_per_ne00);
+    int kb0_stop  = min(blocks_per_ne00.z, uint32_t(kb0_start + kbc_stop - kbc));
+    while (kbc < kbc_stop && kb0_stop == int(blocks_per_ne00.z)) {
+        int tmp = fastdiv(kbc, blocks_per_ne00);
+        uint2 tmp2 = fast_div_modulo(tmp, ntx);
+        const int jt = tmp2.y;
+        tmp = tmp2.x;
+        tmp2 = fast_div_modulo(tmp, nchannels_y);
+        const int zt = tmp2.y;
+        tmp = tmp2.x;
+        tmp2 = fast_div_modulo(tmp, nsamples_y);
+        const int wt = tmp2.y;
+        const int it = tmp2.x;
 
         // Defaults for regular matrix multiplication:
         int col_low    = 0;
@@ -3772,11 +3772,11 @@ static __global__ void mul_mat_q(
             offset_dst = 0;
 
             if (jt*mmq_x >= col_diff) {
-                kbc += blocks_per_ne00;
-                kbc -= kbc % blocks_per_ne00;
+                kbc += blocks_per_ne00.z;
+                kbc -= fastmodulo(kbc, blocks_per_ne00);
 
                 kb0_start = 0;
-                kb0_stop  = min(blocks_per_ne00, kbc_stop - kbc);
+                kb0_stop  = min(blocks_per_ne00.z, uint32_t(kbc_stop - kbc));
 
                 continue;
             }
@@ -3801,32 +3801,34 @@ static __global__ void mul_mat_q(
         const int tile_x_max_i = nrows_x  - it*mmq_y - 1;
         const int tile_y_max_j = col_diff - jt*mmq_x - 1;
 
-        const int offset_x = (wt/sample_ratio)*stride_sample_x + (zt/channel_ratio)*stride_channel_x + it*mmq_y*stride_row_x;
+        const int offset_x = fastdiv(wt, sample_ratio)*stride_sample_x + fastdiv(zt, channel_ratio)*stride_channel_x + it*mmq_y*stride_row_x;
 
         constexpr bool fixup = false; // All but (potentially) the last iterations write their data to dst rather than the fixup buffer.
         mul_mat_q_process_tile<type, mmq_x, need_check, fixup>
             (x, offset_x, y + offset_y, ids_dst_shared, dst + offset_dst, tmp_fixup, stride_row_x, ncols_y, stride_col_dst,
              tile_x_max_i, tile_y_max_j, kb0_start, kb0_stop);
 
-        kbc += blocks_per_ne00;
-        kbc -= kbc % blocks_per_ne00;
+        kbc += blocks_per_ne00.z;
+        kbc -= fastmodulo(kbc, blocks_per_ne00);
 
         kb0_start = 0;
-        kb0_stop  = min(blocks_per_ne00, kbc_stop - kbc);
+        kb0_stop  = min(blocks_per_ne00.z, uint32_t(kbc_stop - kbc));
     }
 
     if (kbc >= kbc_stop) {
         return;
     }
 
-    int tmp = kbc;
-    const int it = tmp / (nsamples_y*nchannels_y*ntx*blocks_per_ne00);
-    tmp -= it * (nsamples_y*nchannels_y*ntx*blocks_per_ne00);
-    const int wt = tmp / (nchannels_y*ntx*blocks_per_ne00);
-    tmp -= wt * (nchannels_y*ntx*blocks_per_ne00);
-    const int zt = tmp / (ntx*blocks_per_ne00);
-    tmp -= zt * (ntx*blocks_per_ne00);
-    const int jt = tmp / blocks_per_ne00;
+    int tmp = fastdiv(kbc, blocks_per_ne00);
+    uint2 tmp2 = fast_div_modulo(tmp, ntx);
+    const int jt = tmp2.y;
+    tmp = tmp2.x;
+    tmp2 = fast_div_modulo(tmp, nchannels_y);
+    const int zt = tmp2.y;
+    tmp = tmp2.x;
+    tmp2 = fast_div_modulo(tmp, nsamples_y);
+    const int wt = tmp2.y;
+    const int it = tmp2.x;
 
     // Defaults for regular matrix multiplication:
     int col_low    = 0;
@@ -3868,7 +3870,7 @@ static __global__ void mul_mat_q(
     const int tile_x_max_i = nrows_x  - it*mmq_y - 1;
     const int tile_y_max_j = col_diff - jt*mmq_x - 1;
 
-    const int offset_x = (wt/sample_ratio)*stride_sample_x + (zt/channel_ratio)*stride_channel_x + it*mmq_y*stride_row_x;
+    const int offset_x = fastdiv(wt, sample_ratio)*stride_sample_x + fastdiv(zt, channel_ratio)*stride_channel_x + it*mmq_y*stride_row_x;
 
     constexpr bool fixup = true; // Last index writes its data to fixup buffer to avoid data races with other blocks.
     mul_mat_q_process_tile<type, mmq_x, need_check, fixup>
@@ -3877,46 +3879,37 @@ static __global__ void mul_mat_q(
 }
 
 template <ggml_type type, int mmq_x, bool need_check>
-static __global__ void mul_mat_q_stream_k_fixup(const int32_t * ids_dst,
-                                                const int32_t * expert_bounds,
-                                                float * __restrict__ dst,
-                                                const float * __restrict__ tmp_last_tile,
-                                                const int    ncols_x,
-                                                const int    nrows_x,
-                                                const int    ncols_dst,
-                                                const size_t stride_col_dst,
-                                                const int    nchannels_y,
-                                                const size_t stride_channel_dst,
-                                                const int    nsamples_y,
-                                                const size_t stride_sample_dst,
-                                                const int    ncols_max) {
-    constexpr int     mmq_y           = get_mmq_y_device();
-    constexpr int     qk              = ggml_cuda_type_traits<type>::qk;
-    constexpr int     ITER_K          = get_iter_k(type);
+__launch_bounds__(ggml_cuda_get_physical_warp_size()*mmq_get_nwarps_device()/2, 1)
+static __global__ void mul_mat_q_stream_k_fixup(
+        const int32_t * __restrict__ ids_dst, const int32_t * __restrict__ expert_bounds, float * __restrict__ dst,
+        float * __restrict__ tmp_last_tile, const uint3 blocks_per_ne00, const int nrows_x, const int ncols_dst,
+        const int stride_col_dst, const uint3 nchannels_y, const int stride_channel_dst, const uint3 nsamples_y,
+        const int stride_sample_dst, const uint3 ntx) {
+    constexpr int mmq_y           = get_mmq_y_device();
+    constexpr int qk              = ggml_cuda_type_traits<type>::qk;
+    constexpr int ITER_K          = get_iter_k(type);
+    constexpr int blocks_per_iter = ITER_K / qk;
 
-    constexpr int     blocks_per_iter = ITER_K / qk;
-    const     int64_t blocks_per_ne00 = ncols_x / qk;
-
-    constexpr int nwarps = mmq_get_nwarps_device();
+    constexpr int nwarps = mmq_get_nwarps_device()/2;
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
-    float sum[mmq_x*mmq_y / (nwarps*warp_size)] = {0.0f};
+    float sum[mmq_x / nwarps] = {0.0f};
+    const int i = blockIdx.y*warp_size + threadIdx.x;
 
-    const int ntx  = (ncols_max + mmq_x - 1) / mmq_x;
-    const int nty  = (nrows_x   + mmq_y - 1) / mmq_y;
+    const int nty = (nrows_x + mmq_y - 1) / mmq_y;
 
     const int bidx0 = blockIdx.x;
 
     // kbc == k block continuous, current index in continuous ijk space.
-    int64_t kbc0      = (int64_t) bidx0     *nsamples_y*nchannels_y*ntx*nty*blocks_per_ne00 / gridDim.x;
-    int64_t kbc0_stop = (int64_t)(bidx0 + 1)*nsamples_y*nchannels_y*ntx*nty*blocks_per_ne00 / gridDim.x;
+    int kbc0      = int64_t(blockIdx.x)    *(nsamples_y.z*nchannels_y.z*ntx.z*nty*blocks_per_ne00.z) / gridDim.x;
+    int kbc0_stop = int64_t(blockIdx.x + 1)*(nsamples_y.z*nchannels_y.z*ntx.z*nty*blocks_per_ne00.z) / gridDim.x;
 
-    kbc0      -= (kbc0      % blocks_per_ne00) % blocks_per_iter;
-    kbc0_stop -= (kbc0_stop % blocks_per_ne00) % blocks_per_iter;
+    kbc0      -= fastmodulo(kbc0,      blocks_per_ne00) % blocks_per_iter;
+    kbc0_stop -= fastmodulo(kbc0_stop, blocks_per_ne00) % blocks_per_iter;
 
     const bool did_not_have_any_data   = kbc0 == kbc0_stop;
-    const bool wrote_beginning_of_tile = kbc0 % blocks_per_ne00 == 0;
-    const bool did_not_write_last      = kbc0/blocks_per_ne00 == kbc0_stop/blocks_per_ne00 && kbc0_stop % blocks_per_ne00 != 0;
+    const bool wrote_beginning_of_tile = fastmodulo(kbc0, blocks_per_ne00) == 0;
+    const bool did_not_write_last      = fastdiv(kbc0, blocks_per_ne00) == fastdiv(kbc0_stop, blocks_per_ne00) && fastmodulo(kbc0_stop, blocks_per_ne00) != 0;
     if (did_not_have_any_data || wrote_beginning_of_tile || did_not_write_last) {
         return;
     }
@@ -3925,11 +3918,11 @@ static __global__ void mul_mat_q_stream_k_fixup(const int32_t * ids_dst,
 
     // Iterate over previous blocks and sum up partial sums written to fixup buffer.
     // All CUDA blocks that get here must have a previous block that needs a fixup.
-    int64_t bidx = bidx0 - 1;
-    int64_t kbc_stop = kbc0;
+    int bidx = bidx0 - 1;
+    int kbc_stop = kbc0;
     while(true) {
-        int64_t kbc = bidx*nsamples_y*nchannels_y*ntx*nty*blocks_per_ne00 / gridDim.x;
-        kbc -= (kbc % blocks_per_ne00) % blocks_per_iter;
+        int kbc = int64_t(bidx)*(nsamples_y.z*nchannels_y.z*ntx.z*nty*blocks_per_ne00.z) / gridDim.x;
+        kbc -= fastmodulo(kbc, blocks_per_ne00) % blocks_per_iter;
 
         if (kbc == kbc_stop) { // Did not have any data.
             bidx--;
@@ -3939,20 +3932,16 @@ static __global__ void mul_mat_q_stream_k_fixup(const int32_t * ids_dst,
 
         any_fixup = true;
 
+
 #pragma unroll
         for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
             const int j = j0 + threadIdx.y;
 
-#pragma unroll
-            for (int i0 = 0; i0 < mmq_y; i0 += warp_size) {
-                const int i = i0 + threadIdx.x;
-
-                sum[(j0/nwarps) * (mmq_y/warp_size) + i0/warp_size] += tmp_last_tile[bidx*(mmq_x*mmq_y) + j*mmq_y + i];
-            }
+            sum[j0/nwarps] += tmp_last_tile[bidx*(mmq_x*mmq_y) + j*mmq_y + i];
         }
 
         // If this block started in a previous tile we are done and don't need to combine additional partial results.
-        if (kbc % blocks_per_ne00 == 0 || kbc/blocks_per_ne00 < kbc0/blocks_per_ne00) {
+        if (fastmodulo(kbc, blocks_per_ne00) == 0 || fastdiv(kbc, blocks_per_ne00) < fastdiv(kbc0, blocks_per_ne00)) {
             break;
         }
         bidx--;
@@ -3963,14 +3952,16 @@ static __global__ void mul_mat_q_stream_k_fixup(const int32_t * ids_dst,
         return;
     }
 
-    int tmp = kbc0;
-    const int it = tmp / (nsamples_y*nchannels_y*ntx*blocks_per_ne00);
-    tmp -= it * (nsamples_y*nchannels_y*ntx*blocks_per_ne00);
-    const int wt = tmp / (nchannels_y*ntx*blocks_per_ne00);
-    tmp -= wt * (nchannels_y*ntx*blocks_per_ne00);
-    const int zt = tmp / (ntx*blocks_per_ne00);
-    tmp -= zt * (ntx*blocks_per_ne00);
-    const int jt = tmp / blocks_per_ne00;
+    int tmp = fastdiv(kbc0, blocks_per_ne00);
+    uint2 tmp2 = fast_div_modulo(tmp, ntx);
+    const int jt = tmp2.y;
+    tmp = tmp2.x;
+    tmp2 = fast_div_modulo(tmp, nchannels_y);
+    const int zt = tmp2.y;
+    tmp = tmp2.x;
+    tmp2 = fast_div_modulo(tmp, nsamples_y);
+    const int wt = tmp2.y;
+    const int it = tmp2.x;
 
     if (!ids_dst) {
         const int offset_dst = wt*stride_sample_dst + zt*stride_channel_dst + jt*mmq_x*stride_col_dst + it*mmq_y;
@@ -3978,6 +3969,9 @@ static __global__ void mul_mat_q_stream_k_fixup(const int32_t * ids_dst,
 
         const int i_max = nrows_x   - it*mmq_y - 1;
         const int j_max = ncols_dst - jt*mmq_x - 1;
+        if (need_check && i > i_max) {
+            return;
+        }
 
 #pragma unroll
         for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
@@ -3987,16 +3981,7 @@ static __global__ void mul_mat_q_stream_k_fixup(const int32_t * ids_dst,
                 return;
             }
 
-#pragma unroll
-            for (int i0 = 0; i0 < mmq_y; i0 += warp_size) {
-                const int i = i0 + threadIdx.x;
-
-                if (need_check && i > i_max) {
-                    continue;
-                }
-
-                dst[j*stride_col_dst + i] += sum[(j0/nwarps) * (mmq_y/warp_size) + i0/warp_size];
-            }
+            dst[j*stride_col_dst + i] += sum[j0/nwarps];
         }
         return;
     }
@@ -4016,6 +4001,9 @@ static __global__ void mul_mat_q_stream_k_fixup(const int32_t * ids_dst,
 
     const int i_max = nrows_x  - it*mmq_y - 1;
     const int j_max = col_diff - jt*mmq_x - 1;
+    if (need_check && i > i_max) {
+        return;
+    }
 
 #pragma unroll
     for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
@@ -4025,16 +4013,7 @@ static __global__ void mul_mat_q_stream_k_fixup(const int32_t * ids_dst,
             return;
         }
 
-#pragma unroll
-        for (int i0 = 0; i0 < mmq_y; i0 += warp_size) {
-            const int i = i0 + threadIdx.x;
-
-            if (need_check && i > i_max) {
-                continue;
-            }
-
-            dst[ids_dst_shared[j]*stride_col_dst + i] += sum[(j0/nwarps) * (mmq_y/warp_size) + i0/warp_size];
-        }
+        dst[ids_dst_shared[j]*stride_col_dst + i] += sum[j0/nwarps];
     }
 }
 
@@ -4082,29 +4061,44 @@ static void launch_mul_mat_q(ggml_backend_cuda_context & ctx, const mmq_args & a
     const int channel_ratio = args.nchannels_y / args.nchannels_x;
     const int sample_ratio  = args.nsamples_y  / args.nsamples_x;
 
+    const uint3 blocks_per_ne00_fd = init_fastdiv_values(args.ncols_x / ggml_cuda_type_traits<type>::qk);
+    const uint3 ntx_fd             = init_fastdiv_values(ntx);
+    const uint3 nchannels_y_fd     = init_fastdiv_values(args.nchannels_y);
+    const uint3 nsamples_y_fd      = init_fastdiv_values(args.nsamples_y);
+    const uint3 channel_ratio_fd   = init_fastdiv_values(channel_ratio);
+    const uint3 sample_ratio_fd    = init_fastdiv_values(sample_ratio);
+
     if (!args.use_stream_k) {
         if (args.nrows_x % mmq_y == 0) {
             constexpr bool need_check = false;
             mul_mat_q<type, mmq_x, need_check><<<block_nums_xy_tiling, block_dims, nbytes_shared, stream>>>
                 (args.x, args.y, args.ids_dst, args.expert_bounds, args.dst, nullptr,
-                 args.ncols_x, args.nrows_x, args.ncols_dst, args.stride_row_x, args.ncols_y, args.nrows_dst,
-                 channel_ratio, args.nchannels_y, args.stride_channel_x, args.stride_channel_y, args.stride_channel_dst,
-                 sample_ratio, args.nsamples_y, args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
-                 args.ncols_max);
+                 blocks_per_ne00_fd, args.nrows_x, args.ncols_dst, args.stride_row_x, args.ncols_y, args.nrows_dst,
+                 channel_ratio_fd, nchannels_y_fd, args.stride_channel_x, args.stride_channel_y, args.stride_channel_dst,
+                 sample_ratio_fd, nsamples_y_fd, args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
+                 ntx_fd);
         } else {
             constexpr bool need_check = true;
             mul_mat_q<type, mmq_x, need_check><<<block_nums_xy_tiling, block_dims, nbytes_shared, stream>>>
                 (args.x, args.y, args.ids_dst, args.expert_bounds, args.dst, nullptr,
-                 args.ncols_x, args.nrows_x, args.ncols_dst, args.stride_row_x, args.ncols_y, args.nrows_dst,
-                 channel_ratio, args.nchannels_y, args.stride_channel_x, args.stride_channel_y, args.stride_channel_dst,
-                 sample_ratio, args.nsamples_y, args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
-                 args.ncols_max);
+                 blocks_per_ne00_fd, args.nrows_x, args.ncols_dst, args.stride_row_x, args.ncols_y, args.nrows_dst,
+                 channel_ratio_fd, nchannels_y_fd, args.stride_channel_x, args.stride_channel_y, args.stride_channel_dst,
+                 sample_ratio_fd, nsamples_y_fd, args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
+                 ntx_fd);
         }
         return;
     }
 
-    const dim3 block_nums_stream_k(nsm, 1, 1);
-    const bool fixup_needed = ntx*nty*ntzw % nsm != 0;
+    // For the stream-k kernel it is possible to run it with tiling by setting the number of CUDA blocks equal to the number of tiles.
+    // This is worthwhile if the efficiency of tiling is high and skipping the fixup kernel is more important.
+    const int ntiles_dst = ntx * nty * ntzw;
+    const int tiles_nwaves = (ntiles_dst + nsm - 1) / nsm;
+    const int tiles_efficiency_percent = 100 * ntiles_dst / (nsm*tiles_nwaves);
+    const dim3 block_nums_stream_k(GGML_CUDA_CC_IS_NVIDIA(cc) && tiles_efficiency_percent >= 90 ? ntiles_dst : nsm, 1, 1);
+
+    GGML_ASSERT(ntiles_dst * blocks_per_ne00_fd.z < (1 << 30)); // Assert that variable kbc will not overflow.
+
+    const bool fixup_needed = ntiles_dst % block_nums_stream_k.x != 0;
 
     ggml_cuda_pool & pool = ctx.pool(id);
     ggml_cuda_pool_alloc<float> tmp_fixup(pool);
@@ -4112,40 +4106,45 @@ static void launch_mul_mat_q(ggml_backend_cuda_context & ctx, const mmq_args & a
         tmp_fixup.alloc(block_nums_stream_k.x * mmq_x*mmq_y);
     }
 
+    const dim3 block_nums_fixup(block_nums_stream_k.x, mmq_y/warp_size, 1);
+    const dim3 block_dims_fixup(block_dims.x, block_dims.y/2, block_dims.z);
+
     if (args.nrows_x % mmq_y == 0) {
         constexpr bool need_check = false;
         mul_mat_q<type, mmq_x, need_check><<<block_nums_stream_k, block_dims, nbytes_shared, stream>>>
             (args.x, args.y, args.ids_dst, args.expert_bounds, args.dst, tmp_fixup.ptr,
-             args.ncols_x, args.nrows_x, args.ncols_dst, args.stride_row_x, args.ncols_y, args.nrows_dst,
-             channel_ratio, args.nchannels_y, args.stride_channel_x, args.stride_channel_y, args.stride_channel_dst,
-             sample_ratio, args.nsamples_y, args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
-             args.ncols_max);
+             blocks_per_ne00_fd, args.nrows_x, args.ncols_dst, args.stride_row_x, args.ncols_y, args.nrows_dst,
+             channel_ratio_fd, nchannels_y_fd, args.stride_channel_x, args.stride_channel_y, args.stride_channel_dst,
+             sample_ratio_fd, nsamples_y_fd, args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
+             ntx_fd);
 
         if (!fixup_needed) {
             return;
         }
 
-        mul_mat_q_stream_k_fixup<type, mmq_x, need_check><<<block_nums_stream_k, block_dims, 0, stream>>>
-            (args.ids_dst, args.expert_bounds, args.dst, tmp_fixup.ptr, args.ncols_x, args.nrows_x, args.ncols_dst,
-             args.nrows_dst, args.nchannels_y, args.stride_channel_dst, args.nsamples_y, args.stride_sample_dst,
-             args.ncols_max);
+        CUDA_CHECK(cudaGetLastError());
+        mul_mat_q_stream_k_fixup<type, mmq_x, need_check><<<block_nums_fixup, block_dims_fixup, 0, stream>>>
+            (args.ids_dst, args.expert_bounds, args.dst, tmp_fixup.ptr, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+             args.nrows_dst, nchannels_y_fd, args.stride_channel_dst, nsamples_y_fd, args.stride_sample_dst,
+             ntx_fd);
     } else {
         constexpr bool need_check = true;
         mul_mat_q<type, mmq_x, need_check><<<block_nums_stream_k, block_dims, nbytes_shared, stream>>>
             (args.x, args.y, args.ids_dst, args.expert_bounds, args.dst, tmp_fixup.ptr,
-             args.ncols_x, args.nrows_x, args.ncols_dst, args.stride_row_x, args.ncols_y, args.nrows_dst,
-             channel_ratio, args.nchannels_y, args.stride_channel_x, args.stride_channel_y, args.stride_channel_dst,
-             sample_ratio, args.nsamples_y, args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
-             args.ncols_max);
+             blocks_per_ne00_fd, args.nrows_x, args.ncols_dst, args.stride_row_x, args.ncols_y, args.nrows_dst,
+             channel_ratio_fd, nchannels_y_fd, args.stride_channel_x, args.stride_channel_y, args.stride_channel_dst,
+             sample_ratio_fd, nsamples_y_fd, args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
+             ntx_fd);
 
         if (!fixup_needed) {
             return;
         }
 
-        mul_mat_q_stream_k_fixup<type, mmq_x, need_check><<<block_nums_stream_k, block_dims, 0, stream>>>
-            (args.ids_dst, args.expert_bounds, args.dst, tmp_fixup.ptr, args.ncols_x, args.nrows_x, args.ncols_dst,
-             args.nrows_dst, args.nchannels_y, args.stride_channel_dst, args.nsamples_y, args.stride_sample_dst,
-             args.ncols_max);
+        CUDA_CHECK(cudaGetLastError());
+        mul_mat_q_stream_k_fixup<type, mmq_x, need_check><<<block_nums_fixup, block_dims_fixup, 0, stream>>>
+            (args.ids_dst, args.expert_bounds, args.dst, tmp_fixup.ptr, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+             args.nrows_dst, nchannels_y_fd, args.stride_channel_dst, nsamples_y_fd, args.stride_sample_dst,
+             ntx_fd);
     }
 }
 

--- a/server/src/qwen35/qwen35_target_graph.cpp
+++ b/server/src/qwen35/qwen35_target_graph.cpp
@@ -864,13 +864,6 @@ static ggml_tensor * build_delta_net_block(
     q_c = ggml_l2_norm(ctx, q_c, w.rms_eps);
     k_c = ggml_l2_norm(ctx, k_c, w.rms_eps);
 
-    // Repeat Q and K from num_k_heads to num_v_heads so they match V's layout
-    // (only needed if not using the fused op's broadcast support).
-    if (num_k_heads != num_v_heads) {
-        q_c = ggml_repeat_4d(ctx, q_c, head_k_dim, num_v_heads, n_seq_tokens, n_seqs);
-        k_c = ggml_repeat_4d(ctx, k_c, head_k_dim, num_v_heads, n_seq_tokens, n_seqs);
-    }
-
     // ── SSM state (recurrent): reshape to [S_v, S_v, H_v, n_seqs]
     ggml_tensor * s = ggml_reshape_4d(ctx, ssm_state,
         head_v_dim, head_v_dim, num_v_heads, n_seqs);
@@ -920,7 +913,19 @@ static ggml_tensor * build_delta_net_block(
     ggml_tensor * new_state = nullptr;
 
     if (use_chunked) {
-        auto r = build_delta_net_chunked(ctx, q_c, k_c, v_c, g_tensor, beta, s);
+        // Fused GDN broadcasts compact Q/K heads directly. The opt-in chunked
+        // formulation still requires Q/K and V to have the same head count,
+        // so retain materialization only on this fallback path.
+        ggml_tensor * chunked_q = q_c;
+        ggml_tensor * chunked_k = k_c;
+        if (num_k_heads != num_v_heads) {
+            chunked_q = ggml_repeat_4d(
+                ctx, q_c, head_k_dim, num_v_heads, n_seq_tokens, n_seqs);
+            chunked_k = ggml_repeat_4d(
+                ctx, k_c, head_k_dim, num_v_heads, n_seq_tokens, n_seqs);
+        }
+        auto r = build_delta_net_chunked(
+            ctx, chunked_q, chunked_k, v_c, g_tensor, beta, s);
         output    = r.output;
         new_state = r.new_state;
         goto after_delta_net;

--- a/server/test/test_gdn_grouped_cuda.cpp
+++ b/server/test/test_gdn_grouped_cuda.cpp
@@ -1,0 +1,251 @@
+// Numerical parity for the classic and grouped-column fused Gated DeltaNet
+// kernels. Each arm gets a separate graph and a freshly restored recurrent
+// state so in-place state updates cannot hide a divergence.
+
+#include "ggml.h"
+#include "ggml-alloc.h"
+#include "ggml-backend.h"
+#include "ggml-cuda.h"
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <random>
+#include <vector>
+
+namespace {
+
+constexpr int64_t kStateDim = 128;
+constexpr int64_t kQkHeads = 16;
+constexpr int64_t kValueHeads = 48;
+constexpr double kMaxNmse = 1e-6;
+
+struct Inputs {
+    std::vector<float> q;
+    std::vector<float> k;
+    std::vector<float> v;
+    std::vector<float> g;
+    std::vector<float> beta;
+    std::vector<float> state;
+};
+
+struct Result {
+    std::vector<float> output;
+    std::vector<float> state;
+    bool ok = false;
+};
+
+struct ErrorStats {
+    double nmse = 0.0;
+    double max_abs = 0.0;
+    bool finite = true;
+};
+
+void normalize_qk(std::vector<float> & values, int64_t n_tokens) {
+    for (int64_t token = 0; token < n_tokens; ++token) {
+        for (int64_t head = 0; head < kQkHeads; ++head) {
+            float * row = values.data() +
+                (token * kQkHeads + head) * kStateDim;
+            double sum_sq = 0.0;
+            for (int64_t i = 0; i < kStateDim; ++i) {
+                sum_sq += static_cast<double>(row[i]) * row[i];
+            }
+            const float inverse_norm =
+                1.0f / std::sqrt(static_cast<float>(sum_sq) + 1e-6f);
+            for (int64_t i = 0; i < kStateDim; ++i) {
+                row[i] *= inverse_norm;
+            }
+        }
+    }
+}
+
+Inputs make_inputs(int64_t n_tokens, uint32_t seed) {
+    std::mt19937 rng(seed);
+    std::uniform_real_distribution<float> unit(-1.0f, 1.0f);
+    std::uniform_real_distribution<float> gate(-0.10f, -0.001f);
+    std::uniform_real_distribution<float> beta_dist(0.05f, 0.95f);
+
+    Inputs inputs;
+    inputs.q.resize(static_cast<size_t>(kStateDim * kQkHeads * n_tokens));
+    inputs.k.resize(inputs.q.size());
+    inputs.v.resize(static_cast<size_t>(kStateDim * kValueHeads * n_tokens));
+    inputs.g.resize(static_cast<size_t>(kValueHeads * n_tokens));
+    inputs.beta.resize(inputs.g.size());
+    inputs.state.resize(static_cast<size_t>(kStateDim * kStateDim * kValueHeads));
+    for (float & value : inputs.q) value = unit(rng);
+    for (float & value : inputs.k) value = unit(rng);
+    for (float & value : inputs.v) value = 0.5f * unit(rng);
+    for (float & value : inputs.g) value = gate(rng);
+    for (float & value : inputs.beta) value = beta_dist(rng);
+    for (float & value : inputs.state) value = 0.1f * unit(rng);
+    normalize_qk(inputs.q, n_tokens);
+    normalize_qk(inputs.k, n_tokens);
+    return inputs;
+}
+
+Result run_kernel(
+        ggml_backend_t backend,
+        const Inputs & inputs,
+        int64_t n_tokens,
+        bool grouped) {
+    if (grouped) {
+        unsetenv("DFLASH_GDN_NO_GROUPED_COLS");
+        setenv("DFLASH_GDN_FORCE_GROUPED_COLS", "1", 1);
+    } else {
+        unsetenv("DFLASH_GDN_FORCE_GROUPED_COLS");
+        setenv("DFLASH_GDN_NO_GROUPED_COLS", "1", 1);
+    }
+
+    ggml_init_params params = {32 * 1024 * 1024, nullptr, true};
+    ggml_context * ctx = ggml_init(params);
+    Result result;
+    if (ctx == nullptr) {
+        return result;
+    }
+
+    ggml_tensor * q = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F32, kStateDim, kQkHeads, n_tokens, 1);
+    ggml_tensor * k = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F32, kStateDim, kQkHeads, n_tokens, 1);
+    ggml_tensor * v = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F32, kStateDim, kValueHeads, n_tokens, 1);
+    ggml_tensor * g = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F32, 1, kValueHeads, n_tokens, 1);
+    ggml_tensor * beta = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F32, 1, kValueHeads, n_tokens, 1);
+    ggml_tensor * state = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F32, kStateDim, kStateDim, kValueHeads, 1);
+    for (ggml_tensor * input : {q, k, v, g, beta, state}) {
+        ggml_set_input(input);
+    }
+
+    ggml_tensor * packed = ggml_gated_delta_net(ctx, q, k, v, g, beta, state);
+    ggml_gated_delta_net_set_skip_intermediate(packed, true);
+    const size_t element_size = ggml_element_size(packed);
+    ggml_tensor * output = ggml_view_4d(
+        ctx, packed,
+        kStateDim, kValueHeads, n_tokens, 1,
+        kStateDim * element_size,
+        kStateDim * kValueHeads * element_size,
+        kStateDim * kValueHeads * n_tokens * element_size,
+        0);
+    ggml_tensor * final_state = ggml_view_4d(
+        ctx, packed,
+        kStateDim, kStateDim, kValueHeads, 1,
+        kStateDim * element_size,
+        kStateDim * kStateDim * element_size,
+        kStateDim * kStateDim * kValueHeads * element_size,
+        kStateDim * kValueHeads * n_tokens * element_size);
+    output = ggml_cont(ctx, output);
+    final_state = ggml_cont(ctx, final_state);
+    ggml_set_output(output);
+    ggml_set_output(final_state);
+
+    ggml_cgraph * graph = ggml_new_graph_custom(ctx, GGML_DEFAULT_GRAPH_SIZE, false);
+    ggml_build_forward_expand(graph, output);
+    ggml_build_forward_expand(graph, final_state);
+    ggml_gallocr_t alloc = ggml_gallocr_new(
+        ggml_backend_get_default_buffer_type(backend));
+    bool ok = alloc != nullptr && ggml_gallocr_alloc_graph(alloc, graph);
+    if (ok) {
+        ggml_backend_tensor_set(q, inputs.q.data(), 0, inputs.q.size() * sizeof(float));
+        ggml_backend_tensor_set(k, inputs.k.data(), 0, inputs.k.size() * sizeof(float));
+        ggml_backend_tensor_set(v, inputs.v.data(), 0, inputs.v.size() * sizeof(float));
+        ggml_backend_tensor_set(g, inputs.g.data(), 0, inputs.g.size() * sizeof(float));
+        ggml_backend_tensor_set(
+            beta, inputs.beta.data(), 0, inputs.beta.size() * sizeof(float));
+        ggml_backend_tensor_set(
+            state, inputs.state.data(), 0, inputs.state.size() * sizeof(float));
+        ok = ggml_backend_graph_compute(backend, graph) == GGML_STATUS_SUCCESS;
+    }
+
+    result.output.resize(
+        static_cast<size_t>(kStateDim * kValueHeads * n_tokens));
+    result.state.resize(inputs.state.size());
+    if (ok) {
+        ggml_backend_tensor_get(
+            output, result.output.data(), 0, result.output.size() * sizeof(float));
+        ggml_backend_tensor_get(
+            final_state, result.state.data(), 0, result.state.size() * sizeof(float));
+    }
+    result.ok = ok;
+
+    if (alloc != nullptr) ggml_gallocr_free(alloc);
+    ggml_free(ctx);
+    return result;
+}
+
+ErrorStats compare(
+        const std::vector<float> & expected,
+        const std::vector<float> & actual) {
+    ErrorStats stats;
+    double squared_error = 0.0;
+    double expected_energy = 0.0;
+    for (size_t i = 0; i < expected.size(); ++i) {
+        if (!std::isfinite(expected[i]) || !std::isfinite(actual[i])) {
+            stats.finite = false;
+            break;
+        }
+        const double difference =
+            static_cast<double>(expected[i]) - static_cast<double>(actual[i]);
+        squared_error += difference * difference;
+        expected_energy += static_cast<double>(expected[i]) * expected[i];
+        stats.max_abs = std::fmax(stats.max_abs, std::fabs(difference));
+    }
+    stats.nmse = expected_energy > 0.0 ? squared_error / expected_energy : INFINITY;
+    return stats;
+}
+
+bool run_case(ggml_backend_t backend, int64_t n_tokens, uint32_t seed) {
+    const Inputs inputs = make_inputs(n_tokens, seed);
+    const Result classic = run_kernel(backend, inputs, n_tokens, false);
+    const Result grouped = run_kernel(backend, inputs, n_tokens, true);
+    const ErrorStats output_error = compare(classic.output, grouped.output);
+    const ErrorStats state_error = compare(classic.state, grouped.state);
+    const bool pass = classic.ok && grouped.ok &&
+        output_error.finite && state_error.finite &&
+        output_error.nmse <= kMaxNmse && state_error.nmse <= kMaxNmse;
+    std::printf(
+        "[%s] tokens=%lld output_nmse=%.6e output_max=%.6e "
+        "state_nmse=%.6e state_max=%.6e\n",
+        pass ? "PASS" : "FAIL",
+        static_cast<long long>(n_tokens),
+        output_error.nmse,
+        output_error.max_abs,
+        state_error.nmse,
+        state_error.max_abs);
+    return pass;
+}
+
+} // namespace
+
+int main() {
+    if (ggml_backend_cuda_get_device_count() == 0) {
+        std::printf("SKIP: no CUDA device available\n");
+        return 0;
+    }
+    ggml_backend_t backend = ggml_backend_cuda_init(0);
+    if (backend == nullptr) {
+        std::fprintf(stderr, "FAIL: unable to initialize CUDA backend\n");
+        return 1;
+    }
+
+    int failures = 0;
+    const int64_t cases[] = {1, 221, 477, 512, 768};
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
+        if (!run_case(backend, cases[i], 0x47444E00u + static_cast<uint32_t>(i))) {
+            ++failures;
+        }
+    }
+    unsetenv("DFLASH_GDN_FORCE_GROUPED_COLS");
+    unsetenv("DFLASH_GDN_NO_GROUPED_COLS");
+    ggml_backend_free(backend);
+
+    if (failures != 0) {
+        std::fprintf(stderr, "FAILED: %d grouped GDN parity case(s)\n", failures);
+        return 1;
+    }
+    std::printf("ALL PASS: grouped GDN matches classic for Qwen3.5 shapes\n");
+    return 0;
+}

--- a/server/test/test_gdn_grouped_policy.cpp
+++ b/server/test/test_gdn_grouped_policy.cpp
@@ -1,0 +1,45 @@
+#include "gated_delta_net_policy.h"
+
+#include <cstdio>
+
+namespace {
+
+bool expect(const char * name, bool actual, bool expected) {
+    if (actual == expected) {
+        return true;
+    }
+    std::fprintf(stderr, "FAIL: %s returned %s, expected %s\n",
+        name,
+        actual ? "true" : "false",
+        expected ? "true" : "false");
+    return false;
+}
+
+} // namespace
+
+int main() {
+    bool pass = true;
+
+    pass &= expect("Ampere single-token decode",
+        ggml_cuda_gdn_use_grouped_columns(true, 1, false, false), false);
+    pass &= expect("Ampere partial prefill",
+        ggml_cuda_gdn_use_grouped_columns(true, 511, false, false), false);
+    pass &= expect("Ampere prefill threshold",
+        ggml_cuda_gdn_use_grouped_columns(true, 512, false, false), true);
+    pass &= expect("Ampere larger prefill",
+        ggml_cuda_gdn_use_grouped_columns(true, 512, false, false), true);
+    pass &= expect("non-Ampere default",
+        ggml_cuda_gdn_use_grouped_columns(false, 1, false, false), true);
+    pass &= expect("disable override",
+        ggml_cuda_gdn_use_grouped_columns(true, 512, false, true), false);
+    pass &= expect("force override",
+        ggml_cuda_gdn_use_grouped_columns(true, 1, true, false), true);
+    pass &= expect("force wins over disable",
+        ggml_cuda_gdn_use_grouped_columns(true, 1, true, true), true);
+
+    if (!pass) {
+        return 1;
+    }
+    std::printf("PASS: grouped GDN policy preserves decode and selects Ampere prefill\n");
+    return 0;
+}

--- a/server/test/test_mmq_streamk_iq4_xs.cpp
+++ b/server/test/test_mmq_streamk_iq4_xs.cpp
@@ -1,0 +1,255 @@
+// CUDA correctness coverage for the IQ4_XS MMQ stream-k scheduler.
+//
+// These five shapes reproduce the scheduler transitions validated on an
+// 82-SM sm_86 GPU while backporting llama.cpp #22298:
+//   - high-efficiency tiling without fixup
+//   - a partial output-row tile
+//   - stream-k with fixup
+//   - the exact two-wave boundary
+//   - a deeper K dimension
+//
+// On CUDA devices with a different SM count the exact scheduling decisions can
+// differ, but the cases remain useful MMQ correctness coverage. Each case uses
+// the same deterministic quantized weights and F32 activations on the CPU and
+// CUDA backends, rejects non-finite output, and applies GGML's MUL_MAT oracle
+// threshold of NMSE <= 5e-4.
+
+#include "ggml.h"
+#include "ggml-alloc.h"
+#include "ggml-backend.h"
+#include "ggml-cpu.h"
+#include "ggml-cuda.h"
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr double kMaxNmse = 5e-4;
+
+struct Shape {
+    const char * name;
+    int64_t m;
+    int64_t n;
+    int64_t k;
+};
+
+bool compute_mul_mat(
+        ggml_backend_t backend,
+        const Shape & shape,
+        const std::vector<uint8_t> & weights,
+        const std::vector<float> & activations,
+        std::vector<float> & output,
+        std::string & error) {
+    constexpr size_t kContextSize = 1024 * 1024;
+    ggml_init_params params = {kContextSize, nullptr, true};
+    ggml_context * ctx = ggml_init(params);
+    if (ctx == nullptr) {
+        error = "ggml_init failed";
+        return false;
+    }
+
+    ggml_tensor * a = ggml_new_tensor_2d(ctx, GGML_TYPE_IQ4_XS, shape.k, shape.m);
+    ggml_tensor * b = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, shape.k, shape.n);
+    ggml_set_name(a, "iq4_xs_weights");
+    ggml_set_name(b, "f32_activations");
+    ggml_set_input(a);
+    ggml_set_input(b);
+
+    ggml_tensor * out = ggml_mul_mat(ctx, a, b);
+    ggml_set_name(out, "mul_mat_output");
+    ggml_set_output(out);
+
+    if (!ggml_backend_supports_op(backend, out)) {
+        error = "backend does not support IQ4_XS MUL_MAT";
+        ggml_free(ctx);
+        return false;
+    }
+
+    ggml_cgraph * graph = ggml_new_graph(ctx);
+    ggml_build_forward_expand(graph, out);
+
+    ggml_gallocr_t alloc = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend));
+    if (alloc == nullptr) {
+        error = "ggml_gallocr_new failed";
+        ggml_free(ctx);
+        return false;
+    }
+    if (!ggml_gallocr_alloc_graph(alloc, graph)) {
+        error = "ggml_gallocr_alloc_graph failed";
+        ggml_gallocr_free(alloc);
+        ggml_free(ctx);
+        return false;
+    }
+
+    if (weights.size() != ggml_nbytes(a) ||
+        activations.size() * sizeof(float) != ggml_nbytes(b)) {
+        error = "host data size does not match graph inputs";
+        ggml_gallocr_free(alloc);
+        ggml_free(ctx);
+        return false;
+    }
+
+    ggml_backend_tensor_set(a, weights.data(), 0, weights.size());
+    ggml_backend_tensor_set(b, activations.data(), 0, activations.size() * sizeof(float));
+
+    const ggml_status status = ggml_backend_graph_compute(backend, graph);
+    if (status != GGML_STATUS_SUCCESS) {
+        error = "ggml_backend_graph_compute failed with status " + std::to_string(status);
+        ggml_gallocr_free(alloc);
+        ggml_free(ctx);
+        return false;
+    }
+    ggml_backend_synchronize(backend);
+
+    output.resize(static_cast<size_t>(shape.m * shape.n));
+    if (output.size() * sizeof(float) != ggml_nbytes(out)) {
+        error = "unexpected MUL_MAT output size";
+        ggml_gallocr_free(alloc);
+        ggml_free(ctx);
+        return false;
+    }
+    ggml_backend_tensor_get(out, output.data(), 0, output.size() * sizeof(float));
+
+    ggml_gallocr_free(alloc);
+    ggml_free(ctx);
+    return true;
+}
+
+bool run_case(ggml_backend_t cpu, ggml_backend_t cuda, const Shape & shape, uint32_t seed) {
+    std::mt19937 rng(seed);
+    std::uniform_real_distribution<float> distribution(-1.0f, 1.0f);
+
+    std::vector<float> weights_f32(static_cast<size_t>(shape.k * shape.m));
+    std::vector<float> activations(static_cast<size_t>(shape.k * shape.n));
+    for (float & value : weights_f32) {
+        value = distribution(rng);
+    }
+    for (float & value : activations) {
+        value = distribution(rng);
+    }
+
+    const size_t quantized_size = ggml_row_size(GGML_TYPE_IQ4_XS, shape.k) * shape.m;
+    std::vector<uint8_t> weights_iq4_xs(quantized_size);
+    const size_t written = ggml_quantize_chunk(
+        GGML_TYPE_IQ4_XS,
+        weights_f32.data(),
+        weights_iq4_xs.data(),
+        0,
+        shape.m,
+        shape.k,
+        nullptr);
+    if (written != quantized_size) {
+        std::fprintf(stderr,
+            "[FAIL] %s: IQ4_XS quantizer wrote %zu bytes, expected %zu\n",
+            shape.name, written, quantized_size);
+        return false;
+    }
+
+    std::vector<float> cpu_output;
+    std::vector<float> cuda_output;
+    std::string error;
+    if (!compute_mul_mat(cpu, shape, weights_iq4_xs, activations, cpu_output, error)) {
+        std::fprintf(stderr, "[FAIL] %s: CPU: %s\n", shape.name, error.c_str());
+        return false;
+    }
+    if (!compute_mul_mat(cuda, shape, weights_iq4_xs, activations, cuda_output, error)) {
+        std::fprintf(stderr, "[FAIL] %s: CUDA: %s\n", shape.name, error.c_str());
+        return false;
+    }
+
+    double squared_error = 0.0;
+    double reference_energy = 0.0;
+    double max_abs_error = 0.0;
+    bool finite = true;
+    for (size_t i = 0; i < cpu_output.size(); ++i) {
+        const double reference = cpu_output[i];
+        const double candidate = cuda_output[i];
+        if (!std::isfinite(reference) || !std::isfinite(candidate)) {
+            finite = false;
+            break;
+        }
+        const double difference = reference - candidate;
+        squared_error += difference * difference;
+        reference_energy += reference * reference;
+        max_abs_error = std::fmax(max_abs_error, std::fabs(difference));
+    }
+
+    const double nmse = reference_energy > 0.0
+        ? squared_error / reference_energy
+        : INFINITY;
+    const bool pass = finite && nmse <= kMaxNmse;
+    std::printf(
+        "[%s] %-20s m=%lld n=%lld k=%lld finite=%s nmse=%.6e max_abs=%.6e\n",
+        pass ? "PASS" : "FAIL",
+        shape.name,
+        static_cast<long long>(shape.m),
+        static_cast<long long>(shape.n),
+        static_cast<long long>(shape.k),
+        finite ? "yes" : "no",
+        nmse,
+        max_abs_error);
+    return pass;
+}
+
+} // namespace
+
+int main() {
+    const int device_count = ggml_backend_cuda_get_device_count();
+    if (device_count == 0) {
+        std::printf("SKIP: no CUDA device available\n");
+        return 0;
+    }
+
+    char description[256] = {};
+    ggml_backend_cuda_get_device_description(0, description, sizeof(description));
+    std::printf("IQ4_XS MMQ stream-k correctness: device=%s, NMSE limit=%.1e\n",
+        description, kMaxNmse);
+
+    ggml_backend_t cpu = ggml_backend_cpu_init();
+    ggml_backend_t cuda = ggml_backend_cuda_init(0);
+    if (cpu == nullptr || cuda == nullptr) {
+        std::fprintf(stderr, "FAIL: unable to initialize CPU and CUDA backends\n");
+        if (cpu != nullptr) {
+            ggml_backend_free(cpu);
+        }
+        if (cuda != nullptr) {
+            ggml_backend_free(cuda);
+        }
+        return 1;
+    }
+    ggml_backend_cpu_set_n_threads(cpu, 4);
+
+    const Shape shapes[] = {
+        {"no_fixup",         5120, 512,  256},
+        {"partial_rows",     5000, 512,  256},
+        {"streamk_fixup",    4096, 512,  256},
+        {"two_wave_boundary", 5121, 512, 256},
+        {"deeper_k",         5120, 512, 1024},
+    };
+
+    int failures = 0;
+    for (size_t i = 0; i < sizeof(shapes) / sizeof(shapes[0]); ++i) {
+        if (!run_case(cpu, cuda, shapes[i], 0x4D4D5100u + static_cast<uint32_t>(i))) {
+            ++failures;
+        }
+    }
+
+    ggml_backend_free(cuda);
+    ggml_backend_free(cpu);
+    ggml_quantize_free();
+
+    if (failures != 0) {
+        std::fprintf(stderr, "FAILED: %d/%zu IQ4_XS MMQ cases\n",
+            failures, sizeof(shapes) / sizeof(shapes[0]));
+        return 1;
+    }
+    std::printf("ALL PASS: %zu/%zu IQ4_XS MMQ cases\n",
+        sizeof(shapes) / sizeof(shapes[0]),
+        sizeof(shapes) / sizeof(shapes[0]));
+    return 0;
+}

--- a/server/test/test_qwen35_gdn_broadcast.cpp
+++ b/server/test/test_qwen35_gdn_broadcast.cpp
@@ -1,0 +1,187 @@
+// Structural contract for Qwen3.5's fused Gated DeltaNet graph.
+//
+// Qwen3.5 projects 16 Q/K groups and 48 V heads. The fused GDN kernels use
+// modulo head indexing for Q/K, so the graph builder must preserve the compact
+// 16-head tensors instead of materializing two 16 -> 48 repeats.
+
+#include "internal.h"
+
+#include <cstdlib>
+#include <cstdio>
+
+namespace {
+
+using dflash::common::TargetCache;
+using dflash::common::TargetLayer;
+using dflash::common::TargetWeights;
+using dflash::common::build_qwen35_layer;
+
+ggml_tensor * tensor_1d(ggml_context * ctx, int64_t ne0) {
+    return ggml_new_tensor_1d(ctx, GGML_TYPE_F32, ne0);
+}
+
+ggml_tensor * tensor_2d(ggml_context * ctx, int64_t ne0, int64_t ne1) {
+    return ggml_new_tensor_2d(ctx, GGML_TYPE_F32, ne0, ne1);
+}
+
+bool is_qk_head_repeat(const ggml_tensor * node) {
+    return node->op == GGML_OP_REPEAT &&
+           node->src[0] != nullptr &&
+           node->src[0]->ne[1] == 16 &&
+           node->ne[1] == 48;
+}
+
+} // namespace
+
+int main() {
+    constexpr int64_t kHidden = 192;
+    constexpr int64_t kIntermediate = 64;
+    constexpr int64_t kTokens = 3;
+    constexpr int64_t kState = 4;
+    constexpr int64_t kGroups = 16;
+    constexpr int64_t kHeads = 48;
+    constexpr int64_t kInner = kState * kHeads;
+    constexpr int64_t kConv = 4;
+    constexpr int64_t kConvChannels = kInner + 2 * kGroups * kState;
+
+    ggml_init_params params = {4 * 1024 * 1024, nullptr, true};
+    ggml_context * ctx = ggml_init(params);
+    if (ctx == nullptr) {
+        std::fprintf(stderr, "FAIL: ggml_init returned null\n");
+        return 1;
+    }
+
+    TargetWeights weights;
+    weights.n_layer = 1;
+    weights.n_embd = kHidden;
+    weights.n_ff = kIntermediate;
+    weights.full_attention_interval = 4;
+    weights.ssm_d_conv = kConv;
+    weights.ssm_d_inner = kInner;
+    weights.ssm_d_state = kState;
+    weights.ssm_dt_rank = kHeads;
+    weights.ssm_n_group = kGroups;
+    weights.n_capture_layers = 0;
+    weights.layers.resize(1);
+
+    TargetLayer & layer = weights.layers[0];
+    layer.attn_norm = tensor_1d(ctx, kHidden);
+    layer.attn_post_norm = tensor_1d(ctx, kHidden);
+    layer.wqkv = tensor_2d(ctx, kHidden, kConvChannels);
+    layer.wqkv_gate = tensor_2d(ctx, kHidden, kInner);
+    layer.ssm_conv1d = tensor_2d(ctx, kConv, kConvChannels);
+    layer.ssm_beta = tensor_2d(ctx, kHidden, kHeads);
+    layer.ssm_alpha = tensor_2d(ctx, kHidden, kHeads);
+    layer.ssm_a = tensor_1d(ctx, kHeads);
+    layer.ssm_dt_bias = tensor_1d(ctx, kHeads);
+    layer.ssm_norm = tensor_1d(ctx, kState);
+    layer.ssm_out = tensor_2d(ctx, kInner, kHidden);
+    layer.w_gate = tensor_2d(ctx, kHidden, kIntermediate);
+    layer.w_up = tensor_2d(ctx, kHidden, kIntermediate);
+    layer.w_down = tensor_2d(ctx, kIntermediate, kHidden);
+
+    TargetCache cache;
+    cache.conv_state.push_back(tensor_2d(ctx, kConv - 1, kConvChannels));
+    cache.ssm_state.push_back(ggml_new_tensor_3d(
+        ctx, GGML_TYPE_F32, kState, kState, kHeads));
+
+    ggml_tensor * input = tensor_2d(ctx, kHidden, kTokens);
+    ggml_cgraph * graph = ggml_new_graph_custom(ctx, 4096, false);
+    ggml_tensor * output = build_qwen35_layer(
+        ctx, graph, weights, cache,
+        /*layer_idx=*/0,
+        input,
+        /*positions=*/nullptr,
+        /*attn_mask=*/nullptr,
+        /*kv_start=*/0,
+        kTokens,
+        /*capture=*/false);
+    ggml_build_forward_expand(graph, output);
+
+    const ggml_tensor * gdn = nullptr;
+    int gdn_count = 0;
+    int repeat_count = 0;
+    const int node_count = ggml_graph_n_nodes(graph);
+    for (int i = 0; i < node_count; ++i) {
+        const ggml_tensor * node = ggml_graph_node(graph, i);
+        if (node->op == GGML_OP_GATED_DELTA_NET) {
+            gdn = node;
+            ++gdn_count;
+        }
+        if (is_qk_head_repeat(node)) {
+            ++repeat_count;
+        }
+    }
+
+    bool pass = true;
+    if (gdn_count != 1 || gdn == nullptr) {
+        std::fprintf(stderr, "FAIL: expected one fused GDN node, found %d\n", gdn_count);
+        pass = false;
+    } else {
+        if (gdn->src[0]->ne[1] != kGroups || gdn->src[1]->ne[1] != kGroups) {
+            std::fprintf(stderr,
+                "FAIL: fused GDN received materialized Q/K heads (%lld/%lld, expected %lld/%lld)\n",
+                static_cast<long long>(gdn->src[0]->ne[1]),
+                static_cast<long long>(gdn->src[1]->ne[1]),
+                static_cast<long long>(kGroups),
+                static_cast<long long>(kGroups));
+            pass = false;
+        }
+        if (gdn->src[2]->ne[1] != kHeads) {
+            std::fprintf(stderr,
+                "FAIL: fused GDN received %lld V heads, expected %lld\n",
+                static_cast<long long>(gdn->src[2]->ne[1]),
+                static_cast<long long>(kHeads));
+            pass = false;
+        }
+    }
+    if (repeat_count != 0) {
+        std::fprintf(stderr,
+            "FAIL: graph materialized %d Q/K 16 -> 48 head repeat(s)\n",
+            repeat_count);
+        pass = false;
+    }
+
+    // The opt-in chunked graph does not implement Q/K head broadcasting yet;
+    // it must retain the two materialized repeats that the fused path removes.
+    setenv("DFLASH27B_CHUNKED", "1", 1);
+    ggml_tensor * chunked_input = tensor_2d(ctx, kHidden, kTokens);
+    ggml_cgraph * chunked_graph = ggml_new_graph_custom(ctx, 4096, false);
+    ggml_tensor * chunked_output = build_qwen35_layer(
+        ctx, chunked_graph, weights, cache,
+        /*layer_idx=*/0,
+        chunked_input,
+        /*positions=*/nullptr,
+        /*attn_mask=*/nullptr,
+        /*kv_start=*/0,
+        kTokens,
+        /*capture=*/false);
+    ggml_build_forward_expand(chunked_graph, chunked_output);
+    unsetenv("DFLASH27B_CHUNKED");
+
+    int chunked_repeat_count = 0;
+    int chunked_gdn_count = 0;
+    for (int i = 0; i < ggml_graph_n_nodes(chunked_graph); ++i) {
+        const ggml_tensor * node = ggml_graph_node(chunked_graph, i);
+        if (is_qk_head_repeat(node)) {
+            ++chunked_repeat_count;
+        }
+        if (node->op == GGML_OP_GATED_DELTA_NET) {
+            ++chunked_gdn_count;
+        }
+    }
+    if (chunked_repeat_count != 2 || chunked_gdn_count != 0) {
+        std::fprintf(stderr,
+            "FAIL: chunked GDN graph has %d Q/K repeat(s) and %d fused node(s), expected 2/0\n",
+            chunked_repeat_count, chunked_gdn_count);
+        pass = false;
+    }
+
+    ggml_free(ctx);
+    if (!pass) {
+        return 1;
+    }
+
+    std::printf("PASS: fused GDN consumes compact Q/K heads (16/16) with 48 V heads\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

- keep Q/K at their compact 16-head shape for fused Qwen3.5 Gated DeltaNet instead of materializing two 16-to-48 repeats
- select the existing grouped-column GDN kernel automatically for NVIDIA Ampere prefill launches of at least 512 tokens while retaining the classic decode/partial-chunk path
- preserve the existing force/disable diagnostics and the opt-in chunked fallback's required Q/K repeats
- add pure selector, graph-structure, and focused CUDA numerical parity tests

## Dependency

This is stacked on #518 (`perf(cuda): reduce MMQ stream-k overhead`). The branch is current `main` (`0e002364`) plus #518 (`506cd972`) plus this commit (`3c0be1f`). Once #518 merges, this PR's visible diff should collapse to the GDN/QK change only.

## Performance

Matched Q4_K_M / F16-F16 KV prefill on one RTX 3090, CUDA 12.6, one slot, prompt caches disabled, one generated token, default ubatch 512, and no GDN/ubatch environment overrides. Each value pools ten measured samples from an A-B-B-A run with one warmup and five measurements per phase.

| Prompt depth | Lucebox stack | llama.cpp | Delta |
|---:|---:|---:|---:|
| 1K | 1341.47 tok/s | 1278.72 tok/s | +4.91% |
| 8K | 1393.73 tok/s | 1359.53 tok/s | +2.52% |
| 16K | 1332.63 tok/s | 1306.86 tok/s | +1.97% |

The deltas are approximately 7.0x, 7.3x, and 5.5x their combined standard errors. The exact same prompt payload and model artifact were used, but the runtimes report a two-token accounting difference (988/986, 8156/8154, and 16349/16347), so this is not presented as bit-identical tokenizer accounting. The raw result's AutoLuce content ID is `measurement-792d2c28b337ed544dc8c1e3e3bd699c65d8c2b4f182813dfac272c1359fb047`.

## Correctness

- `gdn_grouped_policy`: verifies the 512-token Ampere threshold and override precedence
- `qwen35_gdn_broadcast`: verifies compact Q/K reaches fused GDN and the chunked fallback retains exactly two repeats
- `gdn_grouped_cuda`: compares forced classic and grouped output/final state on separate graphs with freshly restored state at 1, 221, 477, 512, and 768 tokens using the real 16-Q/K-head / 48-value-head shape; all NMSE values are approximately `1e-14`, below the `1e-6` gate

## Verification

```text
cmake --build /tmp/lucebox-prefill-gdn-q4-build --target dflash_server test_gdn_grouped_policy test_qwen35_gdn_broadcast test_gdn_grouped_cuda -j4
ctest --test-dir /tmp/lucebox-prefill-gdn-q4-build -R '^(gdn_grouped_policy|qwen35_gdn_broadcast|gdn_grouped_cuda)$' --output-on-failure
```

All three tests pass on SM86.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

