### PR TITLE
fix(server): Parse Bare Tool-Name XML Calls

### DIFF
--- a/server/src/server/tool_parser.cpp
+++ b/server/src/server/tool_parser.cpp
@@ -8,6 +8,7 @@
 // 5. call:<ns>?<verb>{relaxed-JSON args}    (gemma plain-text emissions)
 // 6. Bare JSON objects with name+arguments fields
 // 7. Whole-response JSON args for exactly one declared tool
+// 8. <TOOL_NAME>...<parameter=K>V</parameter>...</function>  (bare tool tag)
 //
 // Pattern 5 runs *before* pattern 6 so that args like
 //   call:outer{"name": "inner", "arguments": {}}
@@ -181,6 +182,11 @@ static const std::regex & re_bare_function_xml() {
 
 static const std::regex & re_function_signature() {
     static std::regex r(R"(<function=([A-Za-z_][\w.\-]*?)\(([\s\S]*?)\)</function>)");
+    return r;
+}
+
+static const std::regex & re_bare_tool_name_xml() {
+    static std::regex r(R"(<([A-Za-z_][\w.\-]*?)>([\s\S]*?)(?:</function>|</\1>))");
     return r;
 }
 
@@ -753,6 +759,25 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
             json args;
             if (!parse_function_sig_args((*it)[2].str(), args)) continue;
             add_call((*it)[1].str(), args, pos, pos + it->length());
+        }
+    }
+
+    // Pattern 3b: <TOOL_NAME>...params...</function>. Some agents/models
+    // emit the selected tool name as the XML tag itself, then close with the
+    // Qwen </function> tag. Only accept requested tools and real parameter
+    // tags so arbitrary XML-ish prose remains visible text.
+    if (tools.is_array() && !tools.empty()) {
+        auto begin = std::sregex_iterator(text.begin(), text.end(), re_bare_tool_name_xml());
+        auto end = std::sregex_iterator();
+        for (auto it = begin; it != end; ++it) {
+            size_t pos = it->position();
+            if (overlaps(removals, pos)) continue;
+            std::string fn_name = (*it)[1].str();
+            std::string params = (*it)[2].str();
+            if (!tool_allowed(tools, fn_name)) continue;
+            if (params.find("<parameter=") == std::string::npos) continue;
+            add_call(fn_name, parse_xml_params(params, fn_name, tools),
+                     pos, pos + it->length());
         }
     }
 

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -335,6 +335,40 @@ static void test_parse_bare_function_xml() {
     }
 }
 
+static void test_parse_bare_tool_name_xml_with_function_close() {
+    std::string text =
+        "\n\n\nLet me find the correct line range for the tests array.\n\n\n"
+        "<bash>\n"
+        "<parameter=command>\n"
+        "grep -n \"f5.test\" /workspace/project/tests/bootstrap.cjs\n"
+        "</parameter>\n"
+        "</function>\n";
+    json tools = json::array({
+        {{"type", "function"},
+         {"function", {
+             {"name", "bash"},
+             {"parameters", {
+                 {"type", "object"},
+                 {"properties", {
+                     {"command", {{"type", "string"}}}
+                 }}
+             }}
+         }}}
+    });
+    auto result = parse_tool_calls(text, tools);
+    TEST_ASSERT(result.tool_calls.size() == 1);
+    if (!result.tool_calls.empty()) {
+        TEST_ASSERT(result.tool_calls[0].name == "bash");
+        auto args = json::parse(result.tool_calls[0].arguments);
+        TEST_ASSERT(args["command"] ==
+                    "grep -n \"f5.test\" /workspace/project/tests/bootstrap.cjs");
+    }
+    TEST_ASSERT(result.cleaned_text.find("<bash>") == std::string::npos);
+    TEST_ASSERT(result.cleaned_text.find("</function>") == std::string::npos);
+    TEST_ASSERT(result.cleaned_text.find("Let me find the correct line range") !=
+                std::string::npos);
+}
+
 static void test_parse_json_tool_call() {
     std::string text =
         "{\"name\": \"search\", \"arguments\": {\"query\": \"hello world\"}}";
@@ -4423,6 +4457,7 @@ int main() {
     std::fprintf(stderr, "\n── Tool parser ──\n");
     RUN_TEST(test_parse_tool_call_xml);
     RUN_TEST(test_parse_bare_function_xml);
+    RUN_TEST(test_parse_bare_tool_name_xml_with_function_close);
     RUN_TEST(test_parse_json_tool_call);
     RUN_TEST(test_parse_single_tool_bare_json_args);
     RUN_TEST(test_parse_single_tool_bare_json_args_allows_empty_optional_object);


### PR DESCRIPTION
Adds a narrow compatibility case for model output that uses the tool name as
the XML tag itself:

```xml
<bash>
<parameter=command>
grep -n "f5.test" /workspace/project/tests/bootstrap.cjs
</parameter>
</function>
```

Before this change, the C++ server did not parse this as a tool call. The raw
XML stayed in visible assistant text and the turn finished as normal text
instead of `tool_calls` / `tool_use`.

## Bug

Observed through a Pi agent session using Lucebox as the model runtime.

The session record showed reasoning was already correctly separated:

```json
{
  "type": "thinking",
  "thinkingSignature": "reasoning_content"
}
```

But the malformed tool call was left in the visible text content:

```xml
<bash>
<parameter=command>
grep -n "f5.test" /workspace/project/tests/bootstrap.cjs
</parameter>
</function>
```

The agent therefore displayed the tool XML as assistant text and did not run
the tool.

## Change

- Adds parser support for bare tool-name XML:

  ```xml
  <TOOL_NAME>
  <parameter=KEY>VALUE</parameter>
  </function>
  ```

- Also accepts a matching generic XML close:

  ```xml
  </TOOL_NAME>
  ```

- Keeps the behavior constrained:
  - only runs when request `tools` are present
  - only accepts names in the declared tool list
  - requires at least one `<parameter=...>` tag
  - reuses the existing XML parameter parser and argument JSON serialization

This avoids turning arbitrary XML-ish prose into tool calls.

Review follow-up:

- The matching generic close is implemented as a backreference (`</TOOL_NAME>`)
  rather than "any XML close" so the regex cannot stop early on inner tags like
  `</parameter>`.
- The fixture asserts that `</function>` is fully stripped from visible content.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



