### PR TITLE
fix(ds4): use monolithic backend for single-device launches, not only for HIP

### DIFF
--- a/server/src/common/backend_factory.cpp
+++ b/server/src/common/backend_factory.cpp
@@ -238,11 +238,10 @@ std::unique_ptr<ModelBackend> create_backend(const BackendArgs & args) {
             return nullptr;
         }
 
-        // HIP single-device launches cannot rely on the CUDA/Halo auto-split
-        // path; use the single-backend loader, which can fall back to hybrid
-        // expert placement when a full monolithic load does not fit.
-        if (target_backend == PlacementBackend::Hip &&
-            !args.device.is_layer_split() &&
+        // A single local device uses the monolithic backend. Reserve the
+        // layer-split adapter for explicit multi-device placement or remote
+        // target shards.
+        if (!args.device.is_layer_split() &&
             !args.remote_target_shard.enabled()) {
             DeepSeek4BackendConfig cfg;
             cfg.model_path = args.model_path;
@@ -262,8 +261,7 @@ std::unique_ptr<ModelBackend> create_backend(const BackendArgs & args) {
             return backend;
         }
 
-        // CUDA builds keep the layer-split backend so they can auto-split
-        // across CUDA and remote HIP target shards.
+        // Explicit local splits and CUDA/HIP remote splits use the adapter.
         DeepSeek4LayerSplitAdapterConfig cfg;
         cfg.target_path        = args.model_path;
         cfg.device             = args.device;


### PR DESCRIPTION
## Summary

- route DeepSeek 4 single-device launches through `DeepSeek4Backend` on **both** CUDA and HIP
- reserve `LayerSplitBackend` for explicit multi-device placement or a configured remote target shard
- preserve automatic CUDA/Halo layer splitting whenever remote target-shard IPC is enabled

## Why

CUDA launches previously always selected `DeepSeek4LayerSplitAdapter`. Without an explicit or remote split, its automatic sizing capped the local shard at 42 layers, so a single H200 executed a virtual `[0, 42) + [42, 43)` split on the same GPU.

That virtual boundary adds split orchestration overhead and prevents the full-model fused decode path, whose eligibility requires the same range to start at layer 0 and own the output layer. A single local device should instead use the monolithic backend; devices that cannot fit the full model can use its existing hybrid-expert fallback.

## Expected behavior

| Configuration | Backend | Behavior |
|---|---|---|
| H200/Halo single | `DeepSeek4Backend` | Full monolithic |
| 3090 single | `DeepSeek4Backend` | Full attempt → hybrid fallback |
| 3090 + Halo IPC | `LayerSplitBackend` | Auto-split CUDA/Halo |
| Multi-GPU explicit | `LayerSplitBackend` | Layer split |

## Validation

- `git diff --check`
- Run on H200 both single and virtual split (based on https://github.com/Luce-Org/lucebox/pull/507)

