### PR TITLE
fix(ds4): honor sampler settings in decode

### DIFF
--- a/server/src/deepseek4/deepseek4_backend.cpp
+++ b/server/src/deepseek4/deepseek4_backend.cpp
@@ -881,7 +881,14 @@ bool DeepSeek4Backend::do_decode(int committed, int n_gen,
     const auto phase_t0 = Clock::now();
     DeepSeek4StepTelemetry tel_acc;
     int steps = 0;
-    std::vector<int32_t> history = history_prefix;
+    const bool process_logits = sampler_.needs_logit_processing();
+    std::vector<int32_t> history;
+    if (process_logits) {
+        history = history_prefix;
+        if (n_gen > 0) {
+            history.reserve(history.size() + (size_t)n_gen);
+        }
+    }
 
     for (int generated = 0; generated < n_gen; generated++) {
         if (io.cancelled) break;
@@ -929,7 +936,7 @@ bool DeepSeek4Backend::do_decode(int committed, int n_gen,
 
         int32_t next_token = 0;
         const auto sample_t0 = Clock::now();
-        if (sampler_.needs_logit_processing()) {
+        if (process_logits) {
             next_token = sample_logits(logits.data(), w_.n_vocab, sampler_,
                                        history, sampler_rng_);
         } else {
@@ -942,7 +949,9 @@ bool DeepSeek4Backend::do_decode(int committed, int n_gen,
             }
         }
         if (timing) tel_acc.sample_us += elapsed_us(sample_t0, Clock::now());
-        history.push_back(next_token);
+        if (process_logits) {
+            history.push_back(next_token);
+        }
         out_tokens.push_back(next_token);
         const auto emit_t0 = Clock::now();
         io.emit(next_token);

--- a/server/src/deepseek4/deepseek4_backend.cpp
+++ b/server/src/deepseek4/deepseek4_backend.cpp
@@ -871,6 +871,7 @@ int DeepSeek4Backend::do_prefill(const std::vector<int32_t> & tokens,
 }
 
 bool DeepSeek4Backend::do_decode(int committed, int n_gen,
+                                  const std::vector<int32_t> & history_prefix,
                                   std::vector<int32_t> & out_tokens,
                                   const DaemonIO & io,
                                   const BudgetHook & budget_hook,
@@ -880,6 +881,7 @@ bool DeepSeek4Backend::do_decode(int committed, int n_gen,
     const auto phase_t0 = Clock::now();
     DeepSeek4StepTelemetry tel_acc;
     int steps = 0;
+    std::vector<int32_t> history = history_prefix;
 
     for (int generated = 0; generated < n_gen; generated++) {
         if (io.cancelled) break;
@@ -929,7 +931,7 @@ bool DeepSeek4Backend::do_decode(int committed, int n_gen,
         const auto sample_t0 = Clock::now();
         if (sampler_.needs_logit_processing()) {
             next_token = sample_logits(logits.data(), w_.n_vocab, sampler_,
-                                       out_tokens, sampler_rng_);
+                                       history, sampler_rng_);
         } else {
             float max_val = logits[0];
             for (int i = 1; i < w_.n_vocab; i++) {
@@ -940,6 +942,7 @@ bool DeepSeek4Backend::do_decode(int committed, int n_gen,
             }
         }
         if (timing) tel_acc.sample_us += elapsed_us(sample_t0, Clock::now());
+        history.push_back(next_token);
         out_tokens.push_back(next_token);
         const auto emit_t0 = Clock::now();
         io.emit(next_token);
@@ -1038,7 +1041,7 @@ GenerateResult DeepSeek4Backend::generate_impl(const GenerateRequest & req,
     gen_tokens.reserve(req.n_gen);
 
     bool forced_close = false;
-    if (!do_decode(committed, req.n_gen, gen_tokens, out_io,
+    if (!do_decode(committed, req.n_gen, req.prompt, gen_tokens, out_io,
                    req.budget_hook, &forced_close)) {
         result.fail(GenerateErrorCode::DecodeFailed);
         return result;

--- a/server/src/deepseek4/deepseek4_backend.cpp
+++ b/server/src/deepseek4/deepseek4_backend.cpp
@@ -1000,8 +1000,11 @@ GenerateResult DeepSeek4Backend::generate_impl(const GenerateRequest & req,
     // Decode
     auto t1 = Clock::now();
     const bool budget_requires_ar = !req.budget_hook.close_token_ids.empty();
+    // The DSpark verifier is greedy-only. Route sampling and penalties through
+    // AR so the request's sampler contract is not silently ignored.
+    const bool sampling_requires_ar = sampler_.needs_logit_processing();
     if (spec_enabled_ && spec_drafter_ && req.n_gen > 0 &&
-        !req.force_ar_decode && !budget_requires_ar) {
+        !req.force_ar_decode && !budget_requires_ar && !sampling_requires_ar) {
         if (last_logits_.empty()) {
             result.fail(GenerateErrorCode::DecodeFailed, "spec: no prefill logits");
             return result;

--- a/server/src/deepseek4/deepseek4_backend.cpp
+++ b/server/src/deepseek4/deepseek4_backend.cpp
@@ -925,10 +925,12 @@ bool DeepSeek4Backend::do_decode(int committed, int n_gen,
             }
         }
 
-        // Sample (argmax for now)
         int32_t next_token = 0;
-        {
-            const auto sample_t0 = Clock::now();
+        const auto sample_t0 = Clock::now();
+        if (sampler_.needs_logit_processing()) {
+            next_token = sample_logits(logits.data(), w_.n_vocab, sampler_,
+                                       out_tokens, sampler_rng_);
+        } else {
             float max_val = logits[0];
             for (int i = 1; i < w_.n_vocab; i++) {
                 if (logits[i] > max_val) {
@@ -936,8 +938,8 @@ bool DeepSeek4Backend::do_decode(int committed, int n_gen,
                     next_token = i;
                 }
             }
-            if (timing) tel_acc.sample_us += elapsed_us(sample_t0, Clock::now());
         }
+        if (timing) tel_acc.sample_us += elapsed_us(sample_t0, Clock::now());
         out_tokens.push_back(next_token);
         const auto emit_t0 = Clock::now();
         io.emit(next_token);
@@ -958,6 +960,10 @@ GenerateResult DeepSeek4Backend::generate_impl(const GenerateRequest & req,
     GenerateResult result;
     DaemonIO out_io = io.with_token_callback(req.on_token);
     auto t0 = Clock::now();
+    sampler_ = req.sampler;
+    if (req.do_sample && sampler_.seed != 0) {
+        sampler_rng_.seed(sampler_.seed);
+    }
 
     // Prefill
     int committed = do_prefill(req.prompt, out_io);

--- a/server/src/deepseek4/deepseek4_backend.h
+++ b/server/src/deepseek4/deepseek4_backend.h
@@ -93,6 +93,7 @@ private:
 
     // Autoregressive decode loop.
     bool do_decode(int committed, int n_gen,
+                   const std::vector<int32_t> & history_prefix,
                    std::vector<int32_t> & out_tokens,
                    const DaemonIO & io,
                    const BudgetHook & budget_hook = {},

--- a/server/tests/test_deepseek4_unit.cpp
+++ b/server/tests/test_deepseek4_unit.cpp
@@ -1385,6 +1385,46 @@ static void test_layer_split_restore_preserves_full_sampling_history() {
     std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
 }
 
+static void test_backend_sampling_penalizes_prompt_history() {
+    std::fprintf(stderr, "  test_backend_sampling_penalizes_prompt_history ...");
+
+    DeepSeek4BackendConfig cfg;
+    DeepSeek4Backend backend(cfg);
+    backend.w_.n_vocab = 3;
+
+    std::vector<int32_t> emitted;
+    DaemonIO io;
+    io.on_token = [&](int32_t tok) {
+        emitted.push_back(tok);
+        return true;
+    };
+
+    auto decode_one = [&](const SamplerCfg & sampler) {
+        backend.last_logits_ = {0.0f, 4.0f, 3.0f};
+        backend.sampler_ = sampler;
+        emitted.clear();
+        std::vector<int32_t> generated;
+        const bool ok = backend.do_decode(
+            /*committed=*/1,
+            /*n_gen=*/1,
+            /*history_prefix=*/{1},
+            generated,
+            io);
+        TEST_ASSERT(ok);
+        TEST_ASSERT(emitted == generated);
+        return generated.empty() ? int32_t{-1} : generated.front();
+    };
+
+    SamplerCfg greedy;
+    TEST_ASSERT(decode_one(greedy) == 1);
+
+    SamplerCfg penalized;
+    penalized.rep_pen = 2.0f;
+    TEST_ASSERT(decode_one(penalized) == 2);
+
+    std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
+}
+
 static void test_loader_rejects_missing_required_metadata(ggml_backend_t backend) {
     std::fprintf(stderr, "  test_loader_rejects_missing_required_metadata ...");
 
@@ -2842,6 +2882,7 @@ int main() {
     test_layer_split_sampler_uses_prompt_history();
     test_layer_split_sampler_appends_generated_tokens();
     test_layer_split_restore_preserves_full_sampling_history();
+    test_backend_sampling_penalizes_prompt_history();
     test_loader_rejects_missing_required_metadata(backend);
     test_loader_rejects_invalid_compress_ratio_type(backend);
     test_loader_rejects_zero_vocab_size(backend);


### PR DESCRIPTION
## Summary

- honor `GenerateRequest.sampler` in the single-device DeepSeek4 decode path
- seed penalties with the prompt and append committed generated tokens to sampling history
- retain the existing direct argmax path, without allocating or copying history when logit processing is inactive
- add a model-free regression test against the actual DeepSeek4 decode loop

## Why

`DeepSeek4Backend` always selected the maximum logit and never read the request sampler. Temperature sampling and repetition, frequency, and presence penalties were therefore ignored. Penalties also require the prompt plus generated tokens as history; generated-only history gives incorrect first-token behavior.

This PR is intentionally limited to the single-device backend. Layer-split sampling remains a separate change so each runtime can be reviewed and tested independently.

## Validation

- configured with GCC 11 / CUDA 12.0, matching the working local toolchain
- `cmake --build server/build-gcc11 --target test_deepseek4_unit -j 4`
- `./server/build-gcc11/test_deepseek4_unit` — passed; GPU-only HC test skipped because the leased GPU was unavailable
- `git diff --check`

The regression test uses identical logits and prompt history to verify both branches: inert greedy sampling selects the original argmax, while a repetition penalty applied to a prompt token changes the selected token.
