### PR TITLE
refactor(draft): codify proposal row layout

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -1069,6 +1069,12 @@ if(DFLASH27B_TESTS)
         list(APPEND _raw_unit_test_targets test_recurrent_snapshot)
     endif()
 
+    # Pure proposal-shape contract test: no ggml, GPU, or model files.
+    add_executable(test_draft_contract test/test_draft_contract.cpp)
+    target_include_directories(test_draft_contract PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src)
+    add_test(NAME draft_contract COMMAND test_draft_contract)
+
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_server_unit.cpp")
         set(_server_unit_sources
             test/test_unit_main.cpp
@@ -1230,6 +1236,9 @@ if(DFLASH27B_TESTS)
     # 'make check' — build every registered unit-test target, including the
     # lightweight feature gate added on main, then run the complete CTest set.
     set(_check_deps ${_raw_unit_test_targets})
+    if(TARGET test_draft_contract)
+        list(APPEND _check_deps test_draft_contract)
+    endif()
     if(TARGET test_platform_compat)
         list(APPEND _check_deps test_platform_compat)
     endif()

--- a/server/src/draft/draft_contract.h
+++ b/server/src/draft/draft_contract.h
@@ -1,0 +1,31 @@
+#pragma once
+
+namespace dflash::common {
+
+// Draft artifacts expose one of two row layouts. Existing DFlash and DS4
+// DSpark artifacts include the accepted seed in row zero; proposal-only
+// artifacts such as Bonsai rely on the runtime to prepend the accepted anchor
+// before target verification.
+enum class DraftProposalLayout {
+    SeedThenProposals,
+    ProposalsOnly,
+};
+
+struct DraftProposalShape {
+    int draft_rows = 0;
+    DraftProposalLayout layout = DraftProposalLayout::SeedThenProposals;
+
+    constexpr int first_proposal_row() const noexcept {
+        return layout == DraftProposalLayout::ProposalsOnly ? 0 : 1;
+    }
+
+    constexpr int proposal_count() const noexcept {
+        const int count = draft_rows - first_proposal_row();
+        return count > 0 ? count : 0;
+    }
+
+    // Verification always includes the already accepted anchor exactly once.
+    constexpr int verify_width() const noexcept { return 1 + proposal_count(); }
+};
+
+}  // namespace dflash::common

--- a/server/src/internal.h
+++ b/server/src/internal.h
@@ -25,6 +25,7 @@
 #include "gguf.h"
 
 #include "dflash27b.h"
+#include "draft/draft_contract.h"
 
 namespace dflash::common {
 
@@ -314,6 +315,11 @@ struct DraftWeights {
     int n_target_layers = DFLASH27B_DRAFT_N_TARGET_LAYERS;  // captured target layers (5)
     std::vector<int> capture_layer_ids;                     // explicit captured target-layer ids (GGUF dflash.target_layer_ids); empty = derive from count
     int mask_token_id   = DFLASH27B_DRAFT_MASK_TOKEN_ID;    // noise mask token
+    DraftProposalLayout proposal_layout = DraftProposalLayout::SeedThenProposals;
+
+    DraftProposalShape proposal_shape() const {
+        return DraftProposalShape{block_size, proposal_layout};
+    }
 
     // Optional Domino causal correction head. When present, greedy chain
     // speculative decode corrects each draft token with a lightweight GRU

--- a/server/test/test_draft_contract.cpp
+++ b/server/test/test_draft_contract.cpp
@@ -1,0 +1,28 @@
+#include "draft/draft_contract.h"
+
+using namespace dflash::common;
+
+constexpr DraftProposalShape legacy{16, DraftProposalLayout::SeedThenProposals};
+static_assert(legacy.first_proposal_row() == 1);
+static_assert(legacy.proposal_count() == 15);
+static_assert(legacy.verify_width() == 16);
+
+constexpr DraftProposalShape native{4, DraftProposalLayout::ProposalsOnly};
+static_assert(native.first_proposal_row() == 0);
+static_assert(native.proposal_count() == 4);
+static_assert(native.verify_width() == 5);
+
+constexpr DraftProposalShape anchor_only{1, DraftProposalLayout::SeedThenProposals};
+static_assert(anchor_only.proposal_count() == 0);
+static_assert(anchor_only.verify_width() == 1);
+
+constexpr DraftProposalShape empty_native{0, DraftProposalLayout::ProposalsOnly};
+static_assert(empty_native.proposal_count() == 0);
+static_assert(empty_native.verify_width() == 1);
+
+constexpr DraftProposalShape default_shape{};
+static_assert(default_shape.layout == DraftProposalLayout::SeedThenProposals);
+static_assert(default_shape.proposal_count() == 0);
+static_assert(default_shape.verify_width() == 1);
+
+int main() { return 0; }


### PR DESCRIPTION
## Summary

Make the draft proposal-row layout explicit instead of deriving every artifact as seed plus proposals.

This adds a small DraftProposalShape contract with two layouts:

- SeedThenProposals for existing DFlash and DS4 artifacts
- ProposalsOnly for draft artifacts that emit candidate rows without the accepted seed

DraftWeights defaults to SeedThenProposals, so existing artifacts keep their current behavior.

## Why

The current block_size field is used both as an artifact row count and as a target verification width. Those values are equal for seed-plus-proposal artifacts, but not for proposal-only artifacts: four proposal rows require a five-row target verification batch after the accepted anchor is prepended.

Encoding that distinction as row-layout metadata keeps proposal count and verification width unambiguous without model-name conditionals. No runtime path consumes the new field in this PR; it establishes the shared representation used by follow-up integrations.

## Validation

The CPU-only contract test covers:

- existing 16-row layout: 15 proposals, verify width 16
- proposal-only 4-row layout: 4 proposals, verify width 5
- zero and one-row boundaries: zero proposals, verify width 1
- default layout compatibility

```text
c++ -std=c++17 -Wall -Wextra -Werror -Iserver/src server/test/test_draft_contract.cpp -o /tmp/test_draft_contract
/tmp/test_draft_contract
git diff --check origin/main...HEAD
```

All passed locally. The test links no GGML or GPU library and is included in both forms of the CMake check target.

No throughput benchmark is included because this PR does not change a runtime graph, kernel, scheduler, or model-loading path.