### PR TITLE
fix(ds4): propagate sampler config in layer split

### DIFF
--- a/server/src/deepseek4/deepseek4_layer_split_adapter.cpp
+++ b/server/src/deepseek4/deepseek4_layer_split_adapter.cpp
@@ -405,7 +405,10 @@ bool DeepSeek4LayerSplitAdapter::init_mixed_target_split() {
 }
 
 void DeepSeek4LayerSplitAdapter::begin_request(const GenerateRequest & req) {
-    (void)req;
+    sampler_ = req.sampler;
+    if (req.do_sample && sampler_.seed != 0) {
+        sampler_rng_.seed(sampler_.seed);
+    }
 }
 
 void DeepSeek4LayerSplitAdapter::reset_request_state() {

--- a/server/tests/test_deepseek4_unit.cpp
+++ b/server/tests/test_deepseek4_unit.cpp
@@ -621,6 +621,27 @@ static void test_hc_state_dimensions() {
     std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
 }
 
+static void test_layer_split_request_propagates_sampler() {
+    std::fprintf(stderr, "  test_layer_split_request_propagates_sampler ...");
+
+    DeepSeek4LayerSplitAdapter adapter({});
+    GenerateRequest req;
+    req.do_sample = true;
+    req.sampler.temp = 0.25f;
+    req.sampler.top_p = 0.9f;
+    req.sampler.seed = 42;
+
+    adapter.begin_request(req);
+
+    TEST_ASSERT(adapter.sampler_.temp == req.sampler.temp);
+    TEST_ASSERT(adapter.sampler_.top_p == req.sampler.top_p);
+    TEST_ASSERT(adapter.sampler_.seed == req.sampler.seed);
+    std::mt19937_64 expected(req.sampler.seed);
+    TEST_ASSERT(adapter.sampler_rng_() == expected());
+
+    std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
+}
+
 static void test_loader_rejects_missing_required_metadata(ggml_backend_t backend) {
     std::fprintf(stderr, "  test_loader_rejects_missing_required_metadata ...");
 
@@ -1558,6 +1579,7 @@ int main() {
     test_auto_split_computation();
     test_layer_range_validation();
     test_hc_state_dimensions();
+    test_layer_split_request_propagates_sampler();
     test_loader_rejects_missing_required_metadata(backend);
     test_loader_rejects_invalid_compress_ratio_type(backend);
     test_loader_rejects_zero_vocab_size(backend);


### PR DESCRIPTION
## Summary

- propagate request sampler settings into the DeepSeek4 layer-split adapter
- reseed the layer-split sampler RNG when sampling with an explicit seed
- add unit coverage for sampler propagation and deterministic seeding

## Scope

This PR covers the layer-split path. #527 remains focused on single-device decode correctness.

## Known limitation

`run_layer_split_ar_decode()` currently supplies generated tokens to `sample_logits()`, but not the prompt or restored-prefix history. Temperature, top-k, and top-p propagation are covered here; repetition, frequency, and presence penalties remain incomplete until both decode paths share a proper request-history contract.

## Validation

- `git diff --check` passed
- unit coverage verifies sampler propagation and deterministic seeding
- runtime GPU validation pending
