### PR TITLE
perf(ds4): compute greedy argmax on GPU (monolithic and layer split)

### DIFF
--- a/server/deps/llama.cpp/ggml/src/ggml-cpu/vec.h
+++ b/server/deps/llama.cpp/ggml/src/ggml-cpu/vec.h
@@ -1584,8 +1584,10 @@ inline static void ggml_vec_argmax_f32(const int n, int * s, const float * x) {
     float max = -INFINITY;
     int idx = 0;
     for (int i = 0; i < n; ++i) {
-        max = MAX(max, x[i]);
-        if (max == x[i]) { idx = i; }
+        if (x[i] > max) {
+            max = x[i];
+            idx = i;
+        }
     }
     *s = idx;
 }

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/argmax.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/argmax.cu
@@ -8,13 +8,13 @@
 static __global__ void argmax_f32(const float * __restrict__ x, int32_t * __restrict__ dst, const int64_t ncols) {
     const int64_t row = blockIdx.x;
 
-    float maxval = -FLT_MAX;
+    float maxval = -INFINITY;
     int   argmax = -1;
     const float * rowx = x + row * ncols;
 
     for (int32_t col = threadIdx.x; col < ncols; col += blockDim.x) {
         const float val = rowx[col];
-        if (val > maxval) {
+        if (val > maxval || (val == maxval && (argmax < 0 || col < argmax))) {
             maxval = val;
             argmax = col;
         }
@@ -24,7 +24,8 @@ static __global__ void argmax_f32(const float * __restrict__ x, int32_t * __rest
     for (int offset = WARP_SIZE/2; offset > 0; offset >>= 1) {
         const float val = __shfl_xor_sync(0xFFFFFFFF, maxval, offset, WARP_SIZE);
         const int   col = __shfl_xor_sync(0xFFFFFFFF, argmax, offset, WARP_SIZE);
-        if (val > maxval) {
+        if (col >= 0 &&
+            (val > maxval || (val == maxval && (argmax < 0 || col < argmax)))) {
             maxval = val;
             argmax = col;
         }
@@ -53,7 +54,8 @@ static __global__ void argmax_f32(const float * __restrict__ x, int32_t * __rest
             for (int offset = WARP_SIZE/2; offset > 0; offset >>= 1) {
                 const float val = __shfl_xor_sync(0xFFFFFFFF, maxval, offset, WARP_SIZE);
                 const int   col = __shfl_xor_sync(0xFFFFFFFF, argmax, offset, WARP_SIZE);
-                if (val > maxval) {
+                if (col >= 0 &&
+                    (val > maxval || (val == maxval && (argmax < 0 || col < argmax)))) {
                     maxval = val;
                     argmax = col;
                 }

--- a/server/src/common/layer_split_backend.cpp
+++ b/server/src/common/layer_split_backend.cpp
@@ -170,7 +170,20 @@ bool LayerSplitBackend::snapshot_adopt(int slot,
 GenerateResult LayerSplitBackend::restore_and_generate_impl(
         int slot, const GenerateRequest & req, const DaemonIO & io) {
     GenerateResult result;
-    if (!adapter_ || !adapter_->snapshot_restore(slot)) {
+    if (!adapter_ || !adapter_->snapshot_used(slot)) {
+        result.fail(GenerateErrorCode::InvalidSnapshotSlot);
+        io.emit(-1);
+        return result;
+    }
+    if (!adapter_->snapshot_compatible(slot, req)) {
+        std::fprintf(stderr,
+            "[pc] snapshot slot=%d is incompatible with request sampling mode; "
+            "fresh prefill fallback\n",
+            slot);
+        return run_from_state(req, io, /*base_pos=*/0, /*reset_state=*/true,
+                              req.prompt);
+    }
+    if (!adapter_->snapshot_restore(slot)) {
         result.fail(GenerateErrorCode::InvalidSnapshotSlot);
         io.emit(-1);
         return result;

--- a/server/src/common/layer_split_backend.h
+++ b/server/src/common/layer_split_backend.h
@@ -65,6 +65,12 @@ public:
     virtual void snapshot_free(int slot) { (void)slot; }
     virtual bool snapshot_used(int slot) const { (void)slot; return false; }
     virtual int snapshot_cur_pos(int slot) const { (void)slot; return 0; }
+    virtual bool snapshot_compatible(int slot,
+                                     const GenerateRequest & req) const {
+        (void)slot;
+        (void)req;
+        return true;
+    }
     virtual bool snapshot_restore(int slot) { (void)slot; return false; }
     virtual ModelBackend::SnapshotRef snapshot_ref(int slot) const {
         (void)slot;

--- a/server/src/deepseek4/deepseek4_backend.cpp
+++ b/server/src/deepseek4/deepseek4_backend.cpp
@@ -893,6 +893,7 @@ bool DeepSeek4Backend::do_decode(int committed, int n_gen,
                                   bool * forced_close_out) {
     if (forced_close_out) *forced_close_out = false;
     const bool timing = env_flag_enabled("DFLASH_DS4_TIMING");
+    const bool need_logits = sampler_.needs_logit_processing();
     const auto phase_t0 = Clock::now();
     DeepSeek4StepTelemetry tel_acc;
     int steps = 0;

--- a/server/src/deepseek4/deepseek4_backend.cpp
+++ b/server/src/deepseek4/deepseek4_backend.cpp
@@ -893,7 +893,6 @@ bool DeepSeek4Backend::do_decode(int committed, int n_gen,
                                   bool * forced_close_out) {
     if (forced_close_out) *forced_close_out = false;
     const bool timing = env_flag_enabled("DFLASH_DS4_TIMING");
-    const bool need_logits = sampler_.needs_logit_processing();
     const auto phase_t0 = Clock::now();
     DeepSeek4StepTelemetry tel_acc;
     int steps = 0;

--- a/server/src/deepseek4/deepseek4_backend.cpp
+++ b/server/src/deepseek4/deepseek4_backend.cpp
@@ -678,6 +678,7 @@ bool DeepSeek4Backend::park(ParkTarget target) {
         free_deepseek4_snapshot(snapshots_[i]);
     }
     last_logits_.clear();
+    last_argmax_ = -1;
     free_deepseek4_cache(cache_);
     stream_engine_.destroy();
     moe_hybrid_.reset();
@@ -779,6 +780,7 @@ int DeepSeek4Backend::do_prefill(const std::vector<int32_t> & tokens,
         reset_deepseek4_cache(cache_);
     }
     last_logits_.clear();
+    last_argmax_ = -1;
     int spec_capture_from = n_total;
     if (spec_enabled_ && spec_drafter_) {
         const int feat_row = spec_drafter_->n_target_layers * w_.n_embd;
@@ -803,6 +805,7 @@ int DeepSeek4Backend::do_prefill(const std::vector<int32_t> & tokens,
             spec_capture_from = 0;
         }
     }
+    const bool need_logits = sampler_.needs_logit_processing();
     const bool timing = env_flag_enabled("DFLASH_DS4_TIMING");
     const auto phase_t0 = Clock::now();
     DeepSeek4StepTelemetry tel_acc;
@@ -821,6 +824,7 @@ int DeepSeek4Backend::do_prefill(const std::vector<int32_t> & tokens,
         if (timing) step_tel.embed_us = elapsed_us(embed_t0, Clock::now());
 
         std::vector<float> logits;
+        int32_t argmax = -1;
         Ds4VerifyHooks spec_hooks;
         std::vector<float> spec_cap;
         Ds4VerifyHooks * hp = nullptr;
@@ -839,7 +843,9 @@ int DeepSeek4Backend::do_prefill(const std::vector<int32_t> & tokens,
             std::vector<float> hc_state;
             ok = deepseek4_step_layer_range(
                 backend_, w_, cache_, hc_state, embed.data(), n_tok, pos,
-                0, w_.n_layer, &logits, /*out_argmax=*/nullptr,
+                0, w_.n_layer,
+                need_logits ? &logits : nullptr,
+                need_logits ? nullptr : &argmax,
                 tokens.data() + i,
                 timing ? &step_tel : nullptr,
                 cfg_.prefill_mode != PrefillAttentionMode::Sparse, hp);
@@ -862,7 +868,15 @@ int DeepSeek4Backend::do_prefill(const std::vector<int32_t> & tokens,
             add_step_tel(tel_acc, step_tel);
             steps++;
         }
-        last_logits_ = std::move(logits);
+        if (moe_hybrid_ || need_logits) {
+            last_logits_ = std::move(logits);
+        } else {
+            if (argmax < 0 || argmax >= w_.n_vocab) {
+                std::fprintf(stderr, "[deepseek4] prefill produced invalid argmax token: %d\n", argmax);
+                return -1;
+            }
+            last_argmax_ = argmax;
+        }
         pos += n_tok;
     }
     if (timing) {
@@ -907,9 +921,14 @@ bool DeepSeek4Backend::do_decode(int committed, int n_gen,
             break;
         }
 
-        // Get last logits and sample
+        // The all-hot monolithic path computes greedy argmax in the GGML GPU
+        // graph and reads back one int32. Hybrid expert placement and sampled
+        // or penalized requests still use the full-logit paths below.
         std::vector<float> logits;
-        if (generated == 0 && !last_logits_.empty()) {
+        int32_t next_token = -1;
+        if (generated == 0 && last_argmax_ >= 0) {
+            next_token = last_argmax_;
+        } else if (generated == 0 && !last_logits_.empty()) {
             logits = last_logits_;
         } else {
             std::vector<float> embed(w_.n_embd);
@@ -920,12 +939,25 @@ bool DeepSeek4Backend::do_decode(int committed, int n_gen,
             if (timing) step_tel.embed_us = elapsed_us(embed_t0, Clock::now());
 
             const int pos = std::max(0, committed + generated - 1);
-            if (!deepseek4_step(backend_, w_, cache_, embed.data(), 1,
-                                pos, logits,
-                                moe_hybrid_.get(), &tok_to_eval,
-                                moe_hybrid_ ? &stream_engine_ : nullptr,
-                                timing ? &step_tel : nullptr,
-                                routing_stats_.get())) {
+            bool ok = false;
+            if (moe_hybrid_) {
+                ok = deepseek4_step(backend_, w_, cache_, embed.data(), 1,
+                                    pos, logits,
+                                    moe_hybrid_.get(), &tok_to_eval,
+                                    &stream_engine_,
+                                    timing ? &step_tel : nullptr,
+                                    routing_stats_.get());
+            } else {
+                std::vector<float> hc_state;
+                ok = deepseek4_step_layer_range(backend_, w_, cache_, hc_state,
+                                                embed.data(), 1, pos,
+                                                0, w_.n_layer,
+                                                process_logits ? &logits : nullptr,
+                                                process_logits ? nullptr : &next_token,
+                                                &tok_to_eval,
+                                                timing ? &step_tel : nullptr);
+            }
+            if (!ok) {
                 std::fprintf(stderr, "[deepseek4] decode step failed\n");
                 return false;
             }
@@ -935,23 +967,39 @@ bool DeepSeek4Backend::do_decode(int committed, int n_gen,
             }
         }
 
-        int32_t next_token = 0;
-        const auto sample_t0 = Clock::now();
-        if (process_logits) {
-            next_token = sample_logits(logits.data(), w_.n_vocab, sampler_,
-                                       history, sampler_rng_);
-        } else {
-            float max_val = logits[0];
-            for (int i = 1; i < w_.n_vocab; i++) {
-                if (logits[i] > max_val) {
-                    max_val = logits[i];
-                    next_token = i;
+        // Full-logit paths either apply the configured sampler or use the
+        // hybrid placement's legacy CPU argmax fallback.
+        // TODO(ds4): add an argmax-only output to deepseek4_step() so shared
+        // expert/MoE hybrid decode also avoids the full-vocabulary D2H copy.
+        if (next_token < 0) {
+            if (logits.size() != (size_t) w_.n_vocab) {
+                std::fprintf(stderr,
+                             "[deepseek4] invalid logits payload: expected=%d got=%zu\n",
+                             w_.n_vocab, logits.size());
+                return false;
+            }
+            const auto sample_t0 = Clock::now();
+            if (process_logits) {
+                next_token = sample_logits(logits.data(), w_.n_vocab, sampler_,
+                                           history, sampler_rng_);
+            } else {
+                next_token = 0;
+                float max_val = logits[0];
+                for (int i = 1; i < w_.n_vocab; i++) {
+                    if (logits[i] > max_val) {
+                        max_val = logits[i];
+                        next_token = i;
+                    }
                 }
             }
+            if (timing) tel_acc.sample_us += elapsed_us(sample_t0, Clock::now());
         }
-        if (timing) tel_acc.sample_us += elapsed_us(sample_t0, Clock::now());
         if (process_logits) {
             history.push_back(next_token);
+        }
+        if (next_token >= w_.n_vocab) {
+            std::fprintf(stderr, "[deepseek4] decode produced invalid argmax token: %d\n", next_token);
+            return false;
         }
         out_tokens.push_back(next_token);
         const auto emit_t0 = Clock::now();
@@ -1006,13 +1054,18 @@ GenerateResult DeepSeek4Backend::generate_impl(const GenerateRequest & req,
     const bool sampling_requires_ar = sampler_.needs_logit_processing();
     if (spec_enabled_ && spec_drafter_ && req.n_gen > 0 &&
         !req.force_ar_decode && !budget_requires_ar && !sampling_requires_ar) {
-        if (last_logits_.empty()) {
-            result.fail(GenerateErrorCode::DecodeFailed, "spec: no prefill logits");
+        // Greedy all-hot prefill retains the GPU argmax token; hybrid prefill
+        // still retains full logits and seeds via a host argmax scan.
+        int seed = last_argmax_;
+        if (seed < 0 && !last_logits_.empty()) {
+            seed = 0;
+            float mv = last_logits_[0];
+            for (int i = 1; i < w_.n_vocab; i++) if (last_logits_[i] > mv) { mv = last_logits_[i]; seed = i; }
+        }
+        if (seed < 0) {
+            result.fail(GenerateErrorCode::DecodeFailed, "spec: no prefill output");
             return result;
         }
-        int seed = 0;
-        { float mv = last_logits_[0];
-          for (int i = 1; i < w_.n_vocab; i++) if (last_logits_[i] > mv) { mv = last_logits_[i]; seed = i; } }
         std::vector<int32_t> gen;
         gen.push_back(seed);
         out_io.emit(seed);

--- a/server/src/deepseek4/deepseek4_backend.cpp
+++ b/server/src/deepseek4/deepseek4_backend.cpp
@@ -839,7 +839,8 @@ int DeepSeek4Backend::do_prefill(const std::vector<int32_t> & tokens,
             std::vector<float> hc_state;
             ok = deepseek4_step_layer_range(
                 backend_, w_, cache_, hc_state, embed.data(), n_tok, pos,
-                0, w_.n_layer, &logits, tokens.data() + i,
+                0, w_.n_layer, &logits, /*out_argmax=*/nullptr,
+                tokens.data() + i,
                 timing ? &step_tel : nullptr,
                 cfg_.prefill_mode != PrefillAttentionMode::Sparse, hp);
         }

--- a/server/src/deepseek4/deepseek4_backend.h
+++ b/server/src/deepseek4/deepseek4_backend.h
@@ -76,6 +76,7 @@ private:
     static constexpr int PREFIX_SLOTS = 64;
     DeepSeek4Snapshot      snapshots_[PREFIX_SLOTS];
     std::vector<float>     last_logits_;
+    int32_t                last_argmax_ = -1;
 
     // DSpark speculative decode (opt-in: DFLASH_DS4_SPEC=1 + DFLASH_DS4_DRAFT=<gguf>).
     bool                           spec_enabled_ = false;

--- a/server/src/deepseek4/deepseek4_dspark_spec.cpp
+++ b/server/src/deepseek4/deepseek4_dspark_spec.cpp
@@ -379,8 +379,8 @@ bool deepseek4_dspark_verify_forward(ggml_backend_t backend,
     hooks.capture_out = &capture_out;
     hooks.all_logits_out = &all_logits;
     if (!deepseek4_step_layer_range(backend, w, cache, hc_state, embed, n_tokens, kv_start,
-                                    0, w.n_layer, &last_logits, token_ids,
-                                    telemetry, allow_graph_reuse,
+                                    0, w.n_layer, &last_logits, /*out_argmax=*/nullptr,
+                                    token_ids, telemetry, allow_graph_reuse,
                                     &hooks)) {
         std::fprintf(stderr, "[ds4-verify] step_layer_range returned false (n_tokens=%d kv_start=%d)\n",
                      n_tokens, kv_start);

--- a/server/src/deepseek4/deepseek4_graph.cpp
+++ b/server/src/deepseek4/deepseek4_graph.cpp
@@ -246,7 +246,8 @@ struct DeepSeek4CachedDecodeOutputGraph {
 
     bool valid() const {
         return owner_ctx && backend && n_tokens > 0 &&
-               sg.ctx && sg.gf && sg.alloc && sg.hidden_input && sg.logits;
+               sg.ctx && sg.gf && sg.alloc && sg.hidden_input && sg.logits &&
+               sg.argmax_tokens;
     }
 
     void free() {
@@ -498,8 +499,11 @@ static bool build_cached_decode_output_graph(
     ggml_set_input(out.sg.hidden_input);
     ggml_tensor * normed = build_rms_norm(out.sg.ctx, out.sg.hidden_input, w.out_norm, w.rms_eps);
     out.sg.logits = ggml_mul_mat(out.sg.ctx, w.output, normed);
+    out.sg.argmax_tokens = ggml_argmax(out.sg.ctx, out.sg.logits);
     ggml_set_output(out.sg.logits);
+    ggml_set_output(out.sg.argmax_tokens);
     out.sg.gf = ggml_new_graph_custom(out.sg.ctx, 1024, false);
+    ggml_build_forward_expand(out.sg.gf, out.sg.argmax_tokens);
     ggml_build_forward_expand(out.sg.gf, out.sg.logits);
 
     out.sg.alloc = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend));
@@ -4272,7 +4276,7 @@ bool deepseek4_step(
     std::vector<float> hc_state;
     return deepseek4_step_layer_range(
         backend, w, cache, hc_state, embed, n_tokens, kv_start,
-        0, w.n_layer, &out_logits, token_ids, telemetry,
+        0, w.n_layer, &out_logits, /*out_argmax=*/nullptr, token_ids, telemetry,
         /*allow_decode_graph_reuse=*/verify_hooks == nullptr, verify_hooks);
 }
 
@@ -4726,7 +4730,11 @@ static bool ds4_build_fused_decode_graph(
     ggml_tensor * final_2d = ggml_reshape_2d(ctx, final_embd, n_embd, 1);
     ggml_tensor * out_normed = build_rms_norm(ctx, final_2d, w.out_norm, w.rms_eps);
     fg.logits = ggml_mul_mat(ctx, w.output, out_normed);
+    fg.sg.logits = fg.logits;
+    fg.sg.argmax_tokens = ggml_argmax(ctx, fg.logits);
     ggml_set_output(fg.logits);
+    ggml_set_output(fg.sg.argmax_tokens);
+    ggml_build_forward_expand(gf, fg.sg.argmax_tokens);
     ggml_build_forward_expand(gf, fg.logits);
 
     if (!fg.sg.alloc) {
@@ -4743,8 +4751,9 @@ static bool ds4_build_fused_decode_graph(
 
 #include "deepseek4_fused_verify.inc"
 
-// Returns 1 on success (out_logits filled), 0 to fall back to the per-layer
-// path, -1 on a hard failure after cache state may have been touched.
+// Returns 1 on success, 0 to fall back to the per-layer path, or -1 on a hard
+// failure after cache state may have been touched. Full logits are copied only
+// when requested; greedy decode reads the GPU-side argmax token instead.
 static int ds4_try_fused_decode_step(
         DeepSeek4FusedDecodeCache & fc,
         ggml_backend_t backend,
@@ -4756,7 +4765,8 @@ static int ds4_try_fused_decode_step(
         std::vector<int32_t> & hash_scratch,
         const float * embed,
         int kv_start,
-        std::vector<float> & out_logits,
+        std::vector<float> * out_logits,
+        int32_t * out_argmax,
         const int32_t * token_ids,
         DeepSeek4StepTelemetry * telemetry) {
     if (fc.disabled) return 0;
@@ -4927,11 +4937,17 @@ static int ds4_try_fused_decode_step(
     }
     if (telemetry) telemetry->full_graph_compute_us += ds4_elapsed_us(compute_t0, Ds4TimingClock::now());
 
-    // ── Read logits ─────────────────────────────────────────────────
+    // ── Read requested output ───────────────────────────────────────
     const auto read_t0 = Ds4TimingClock::now();
-    out_logits.resize((size_t) w.n_vocab);
-    ggml_backend_tensor_get(fg->logits, out_logits.data(), 0,
-                            sizeof(float) * (size_t) w.n_vocab);
+    if (out_logits) {
+        out_logits->resize((size_t) w.n_vocab);
+        ggml_backend_tensor_get(fg->logits, out_logits->data(), 0,
+                                sizeof(float) * (size_t) w.n_vocab);
+    }
+    if (out_argmax) {
+        ggml_backend_tensor_get(fg->sg.argmax_tokens, out_argmax, 0,
+                                sizeof(*out_argmax));
+    }
     if (telemetry) telemetry->full_graph_read_us += ds4_elapsed_us(read_t0, Ds4TimingClock::now());
     return 1;
 }
@@ -5705,12 +5721,14 @@ bool deepseek4_step_layer_range(
         int layer_begin,
         int layer_end,
         std::vector<float> * out_logits,
+        int32_t * out_argmax,
         const int32_t * token_ids,
         DeepSeek4StepTelemetry * telemetry,
         bool allow_decode_graph_reuse,
         Ds4VerifyHooks * verify_hooks) {
     const auto step_t0 = Ds4TimingClock::now();
 
+    if (out_argmax) *out_argmax = -1;
     // ── Partial layer-range forward with HC ─────────────────────────────
     const int n_embd = w.n_embd;
     const int n_hc = w.n_hc;
@@ -5763,6 +5781,7 @@ bool deepseek4_step_layer_range(
                     embed + (size_t) off * input_width,
                     chunk, kv_start + off, layer_begin, layer_end,
                     out_logits ? &chunk_out : nullptr,
+                    /*out_argmax=*/nullptr,
                     token_ids ? token_ids + off : nullptr,
                     telemetry, allow_decode_graph_reuse, chunk_hooks_ptr)) {
                 return false;
@@ -5887,16 +5906,31 @@ bool deepseek4_step_layer_range(
 
     // Large full-model prefill batches use the device-resident layer-major
     // pipeline. DSpark verification remains on its exact q=2..4 path below.
+    // The pipeline emits last-position logits; greedy argmax requests reuse
+    // them through a scratch buffer and a host-side scan.
     if (n_tokens > 4 &&
         n_tokens <= DS4_MAX_LAYER_MAJOR_PREFILL_TOKENS && layer_begin == 0 &&
-        is_last_shard && out_logits && ds4_backend_is_gpu(backend)) {
+        is_last_shard && (out_logits || out_argmax) &&
+        ds4_backend_is_gpu(backend)) {
+        std::vector<float> layer_major_logits_scratch;
+        std::vector<float> & layer_major_logits =
+            out_logits ? *out_logits : layer_major_logits_scratch;
         const int prc = ds4_try_layer_major_prefill(
             fused_decode_graph_cache, backend, w, cache,
             hc_layer_weights_range, hc_output_weights_range,
             hash_routing_tables_range, scratch.hash_expert_ids, embed,
-            n_tokens, kv_start, *out_logits, token_ids, telemetry);
+            n_tokens, kv_start, layer_major_logits, token_ids, telemetry);
         if (prc < 0) return false;
         if (prc > 0) {
+            if (out_argmax && !layer_major_logits.empty()) {
+                int32_t best = 0;
+                for (size_t v = 1; v < layer_major_logits.size(); ++v) {
+                    if (layer_major_logits[v] > layer_major_logits[(size_t) best]) {
+                        best = (int32_t) v;
+                    }
+                }
+                *out_argmax = best;
+            }
             if (telemetry) {
                 telemetry->total_us += ds4_elapsed_us(
                     step_t0, Ds4TimingClock::now());
@@ -5929,11 +5963,11 @@ bool deepseek4_step_layer_range(
     }
     std::vector<float> fused_debug_logits;
     if (n_tokens == 1 && allow_decode_graph_reuse && layer_begin == 0 && is_last_shard &&
-        out_logits && ds4_backend_is_gpu(backend) && w.fused_decode) {
+        (out_logits || out_argmax) && ds4_backend_is_gpu(backend) && w.fused_decode) {
         const int rc = ds4_try_fused_decode_step(
             fused_decode_graph_cache, backend, w, cache, hc_layer_weights_range,
             hc_output_weights_range, hash_routing_tables_range, scratch.hash_expert_ids,
-            embed, kv_start, *out_logits, token_ids, telemetry);
+            embed, kv_start, out_logits, out_argmax, token_ids, telemetry);
         if (rc < 0) return false;
         if (rc > 0) {
             const int np = kv_start + 1;
@@ -6491,7 +6525,7 @@ bool deepseek4_step_layer_range(
     }
 
     // ── Output: HC pre → norm → lm_head (or return hidden state) ────────
-    if (is_last_shard && out_logits) {
+    if (is_last_shard && (out_logits || out_argmax)) {
         // Final HC pre for output
         const auto output_t0 = Ds4TimingClock::now();
         std::vector<float> & final_embd = scratch.final_embd;
@@ -6517,9 +6551,16 @@ bool deepseek4_step_layer_range(
             if (ggml_backend_graph_compute(backend, cached_decode_output_graph.sg.gf) != GGML_STATUS_SUCCESS) {
                 return false;
             }
-            out_logits->resize((size_t)w.n_vocab);
-            ggml_backend_tensor_get(cached_decode_output_graph.sg.logits,
-                                    out_logits->data(), 0, sizeof(float) * (size_t)w.n_vocab);
+            if (out_logits) {
+                out_logits->resize((size_t)w.n_vocab);
+                ggml_backend_tensor_get(cached_decode_output_graph.sg.logits,
+                                        out_logits->data(), 0,
+                                        sizeof(float) * (size_t)w.n_vocab);
+            }
+            if (out_argmax) {
+                ggml_backend_tensor_get(cached_decode_output_graph.sg.argmax_tokens,
+                                        out_argmax, 0, sizeof(*out_argmax));
+            }
         } else {
             const size_t ctx_size = 16 * 1024 * 1024;
             ggml_init_params params{};
@@ -6536,8 +6577,11 @@ bool deepseek4_step_layer_range(
             ggml_set_input(inp);
             ggml_tensor * normed = build_rms_norm(ctx, inp, w.out_norm, w.rms_eps);
             ggml_tensor * logits = ggml_mul_mat(ctx, w.output, normed);
+            ggml_tensor * argmax_tokens = ggml_argmax(ctx, logits);
             ggml_set_output(logits);
+            ggml_set_output(argmax_tokens);
             ggml_cgraph * gf = ggml_new_graph_custom(ctx, 1024, false);
+            ggml_build_forward_expand(gf, argmax_tokens);
             ggml_build_forward_expand(gf, logits);
 
             if (!cached_dynamic_output_alloc.valid() ||
@@ -6563,15 +6607,23 @@ bool deepseek4_step_layer_range(
                 return false;
             }
 
-            out_logits->resize((size_t)w.n_vocab);
             const size_t logits_offset = last_only ? 0 :
                 (size_t)(n_tokens - 1) * (size_t)w.n_vocab * sizeof(float);
-            ggml_backend_tensor_get(logits, out_logits->data(), logits_offset,
-                                    sizeof(float) * (size_t)w.n_vocab);
+            if (out_logits) {
+                out_logits->resize((size_t)w.n_vocab);
+                ggml_backend_tensor_get(logits, out_logits->data(), logits_offset,
+                                        sizeof(float) * (size_t)w.n_vocab);
+            }
             if (verify_hooks && verify_hooks->all_logits_out) {
                 verify_hooks->all_logits_out->resize((size_t) w.n_vocab * n_tokens);
                 ggml_backend_tensor_get(logits, verify_hooks->all_logits_out->data(), 0,
                                         sizeof(float) * (size_t) w.n_vocab * n_tokens);
+            }
+            if (out_argmax) {
+                const size_t argmax_offset = last_only ? 0 :
+                    (size_t)(n_tokens - 1) * sizeof(*out_argmax);
+                ggml_backend_tensor_get(argmax_tokens, out_argmax, argmax_offset,
+                                        sizeof(*out_argmax));
             }
             ggml_free(ctx);
         }

--- a/server/src/deepseek4/deepseek4_graph.cpp
+++ b/server/src/deepseek4/deepseek4_graph.cpp
@@ -5789,6 +5789,7 @@ bool deepseek4_step_layer_range(
         std::vector<float> capture_all;
         std::vector<float> logits_all;
         std::vector<float> last_out;
+        int32_t last_chunk_argmax = -1;
         hc_all.reserve((size_t) hc_dim * n_tokens);
         if (out_logits && !is_last_shard) {
             shard_out_all.reserve((size_t) hc_dim * n_tokens);
@@ -5817,12 +5818,13 @@ bool deepseek4_step_layer_range(
                 chunk_hooks.all_logits_out = verify_hooks->all_logits_out ? &chunk_logits : nullptr;
                 chunk_hooks_ptr = &chunk_hooks;
             }
+            const bool last_chunk = (off + chunk >= n_tokens);
             if (!deepseek4_step_layer_range(
                     backend, w, cache, chunk_hc,
                     embed + (size_t) off * input_width,
                     chunk, kv_start + off, layer_begin, layer_end,
                     out_logits ? &chunk_out : nullptr,
-                    /*out_argmax=*/nullptr,
+                    (out_argmax && last_chunk) ? &last_chunk_argmax : nullptr,
                     token_ids ? token_ids + off : nullptr,
                     telemetry, allow_decode_graph_reuse, chunk_hooks_ptr)) {
                 return false;
@@ -5845,6 +5847,9 @@ bool deepseek4_step_layer_range(
         hc_state = std::move(hc_all);
         if (out_logits) {
             *out_logits = is_last_shard ? std::move(last_out) : std::move(shard_out_all);
+        }
+        if (out_argmax) {
+            *out_argmax = last_chunk_argmax;
         }
         if (verify_hooks && verify_hooks->capture_out) {
             *verify_hooks->capture_out = std::move(capture_all);

--- a/server/src/deepseek4/deepseek4_graph.cpp
+++ b/server/src/deepseek4/deepseek4_graph.cpp
@@ -242,12 +242,14 @@ struct DeepSeek4CachedDecodeOutputGraph {
     const ggml_context * owner_ctx = nullptr;
     ggml_backend_t backend = nullptr;
     int n_tokens = 0;
+    bool computes_argmax = false;
     StepGraph sg;
 
-    bool valid() const {
+    bool valid(bool want_argmax) const {
         return owner_ctx && backend && n_tokens > 0 &&
                sg.ctx && sg.gf && sg.alloc && sg.hidden_input && sg.logits &&
-               sg.argmax_tokens;
+               computes_argmax == want_argmax &&
+               (!want_argmax || sg.argmax_tokens);
     }
 
     void free() {
@@ -255,6 +257,7 @@ struct DeepSeek4CachedDecodeOutputGraph {
         owner_ctx = nullptr;
         backend = nullptr;
         n_tokens = 0;
+        computes_argmax = false;
     }
 };
 
@@ -482,7 +485,8 @@ static bool build_cached_decode_output_graph(
         DeepSeek4CachedDecodeOutputGraph & out,
         ggml_backend_t backend,
         const DeepSeek4Weights & w,
-        int n_tokens) {
+        int n_tokens,
+        bool want_argmax) {
     out.free();
 
     const size_t ctx_size = 16 * 1024 * 1024;
@@ -497,14 +501,13 @@ static bool build_cached_decode_output_graph(
 
     out.sg.hidden_input = ggml_new_tensor_2d(out.sg.ctx, GGML_TYPE_F32, w.n_embd, n_tokens);
     ggml_set_input(out.sg.hidden_input);
-    ggml_tensor * normed = build_rms_norm(out.sg.ctx, out.sg.hidden_input, w.out_norm, w.rms_eps);
-    out.sg.logits = ggml_mul_mat(out.sg.ctx, w.output, normed);
-    out.sg.argmax_tokens = ggml_argmax(out.sg.ctx, out.sg.logits);
-    ggml_set_output(out.sg.logits);
-    ggml_set_output(out.sg.argmax_tokens);
+    const DeepSeek4OutputProjection projection = deepseek4_build_output_projection(
+        out.sg.ctx, out.sg.hidden_input, w.out_norm, w.output, w.rms_eps,
+        want_argmax);
+    out.sg.logits = projection.logits;
+    out.sg.argmax_tokens = projection.argmax;
     out.sg.gf = ggml_new_graph_custom(out.sg.ctx, 1024, false);
-    ggml_build_forward_expand(out.sg.gf, out.sg.argmax_tokens);
-    ggml_build_forward_expand(out.sg.gf, out.sg.logits);
+    deepseek4_build_output_graph(out.sg.gf, projection, want_argmax);
 
     out.sg.alloc = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend));
     if (!ggml_gallocr_alloc_graph(out.sg.alloc, out.sg.gf)) {
@@ -515,6 +518,7 @@ static bool build_cached_decode_output_graph(
     out.owner_ctx = w.ctx;
     out.backend = backend;
     out.n_tokens = n_tokens;
+    out.computes_argmax = want_argmax;
     return true;
 }
 
@@ -524,6 +528,32 @@ static ggml_tensor * build_rms_norm(ggml_context * ctx, ggml_tensor * x,
                                      ggml_tensor * weight, float eps) {
     ggml_tensor * normed = ggml_rms_norm(ctx, x, eps);
     return ggml_mul(ctx, normed, weight);
+}
+
+DeepSeek4OutputProjection deepseek4_build_output_projection(
+        ggml_context * ctx,
+        ggml_tensor * hidden,
+        ggml_tensor * out_norm,
+        ggml_tensor * output,
+        float rms_eps,
+        bool want_argmax) {
+    DeepSeek4OutputProjection projection;
+    ggml_tensor * normed = build_rms_norm(ctx, hidden, out_norm, rms_eps);
+    projection.logits = ggml_mul_mat(ctx, output, normed);
+    if (want_argmax) {
+        projection.argmax = ggml_argmax(ctx, projection.logits);
+    }
+    return projection;
+}
+
+void deepseek4_build_output_graph(
+        ggml_cgraph * gf,
+        const DeepSeek4OutputProjection & projection,
+        bool want_argmax) {
+    ggml_tensor * output = want_argmax ? projection.argmax : projection.logits;
+    GGML_ASSERT(output != nullptr);
+    ggml_set_output(output);
+    ggml_build_forward_expand(gf, output);
 }
 
 // ─── Helper: Clamped SwiGLU ─────────────────────────────────────────────
@@ -4304,6 +4334,7 @@ struct DeepSeek4FusedDecodeGraph {
     ggml_tensor * mask_bundle = nullptr;   // additive score mask (0 / -1e30), may be null
     std::vector<ggml_tensor *> hash_ids;
     ggml_tensor * logits = nullptr;
+    bool computes_argmax = false;
 
     void reset_nodes() {
         inp_embed = nullptr;
@@ -4311,13 +4342,15 @@ struct DeepSeek4FusedDecodeGraph {
         i64_bundle = nullptr;
         mask_bundle = nullptr;
         logits = nullptr;
+        computes_argmax = false;
         hash_ids.clear();
         shape_key.clear();
         last_use = 0;
     }
 
     bool built() const {
-        return sg.ctx && sg.gf && logits;
+        return sg.ctx && sg.gf && logits &&
+               (!computes_argmax || sg.argmax_tokens);
     }
 
     void destroy() {
@@ -4565,6 +4598,7 @@ static bool ds4_build_fused_decode_graph(
         const std::vector<HashRoutingTableCpu> & hash_tables,
         int kv_start,
         bool have_token_ids,
+        bool want_argmax,
         std::vector<int64_t> && shape_key) {
     step_graph_free(fg.sg);
     fg.reset_nodes();
@@ -4728,14 +4762,13 @@ static bool ds4_build_fused_decode_graph(
     ggml_tensor * final_embd = ggml_ds4_hc_out(ctx, omix, obase, hc_flat, n_hc,
                                                hc_out_weights.scale_data[0]);
     ggml_tensor * final_2d = ggml_reshape_2d(ctx, final_embd, n_embd, 1);
-    ggml_tensor * out_normed = build_rms_norm(ctx, final_2d, w.out_norm, w.rms_eps);
-    fg.logits = ggml_mul_mat(ctx, w.output, out_normed);
+    const DeepSeek4OutputProjection projection = deepseek4_build_output_projection(
+        ctx, final_2d, w.out_norm, w.output, w.rms_eps, want_argmax);
+    fg.logits = projection.logits;
     fg.sg.logits = fg.logits;
-    fg.sg.argmax_tokens = ggml_argmax(ctx, fg.logits);
-    ggml_set_output(fg.logits);
-    ggml_set_output(fg.sg.argmax_tokens);
-    ggml_build_forward_expand(gf, fg.sg.argmax_tokens);
-    ggml_build_forward_expand(gf, fg.logits);
+    fg.sg.argmax_tokens = projection.argmax;
+    fg.computes_argmax = want_argmax;
+    deepseek4_build_output_graph(gf, projection, want_argmax);
 
     if (!fg.sg.alloc) {
         fg.sg.alloc = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend));
@@ -4798,10 +4831,12 @@ static int ds4_try_fused_decode_step(
     }
 
     const int token_pos = kv_start;
+    const bool want_argmax = out_argmax != nullptr;
     std::vector<int64_t> key;
-    key.reserve((size_t) w.n_layer + 2);
+    key.reserve((size_t) w.n_layer + 3);
     key.push_back(w.n_swa);
     key.push_back(token_ids ? 1 : 0);
+    key.push_back(want_argmax ? 1 : 0);
     for (int il = 0; il < w.n_layer; ++il) {
         const int ratio = (int) w.compress_ratios[il];
         DeepSeek4LayerCache & lc = cache.layers[(size_t) il];
@@ -4836,7 +4871,8 @@ static int ds4_try_fused_decode_step(
         const auto build_t0 = Ds4TimingClock::now();
         if (!ds4_build_fused_decode_graph(fc, *fg, backend, w, cache,
                                           hc_weights, hc_out_weights, hash_tables,
-                                          kv_start, token_ids != nullptr, std::move(key))) {
+                                          kv_start, token_ids != nullptr, want_argmax,
+                                          std::move(key))) {
             std::fprintf(stderr,
                          "[deepseek4] fused decode graph build failed; using per-layer path\n");
             step_graph_free(fg->sg);
@@ -5728,6 +5764,11 @@ bool deepseek4_step_layer_range(
         Ds4VerifyHooks * verify_hooks) {
     const auto step_t0 = Ds4TimingClock::now();
 
+    if (out_logits && out_argmax) {
+        std::fprintf(stderr,
+                     "[deepseek4] request either full logits or argmax, not both\n");
+        return false;
+    }
     if (out_argmax) *out_argmax = -1;
     // ── Partial layer-range forward with HC ─────────────────────────────
     const int n_embd = w.n_embd;
@@ -6538,11 +6579,14 @@ bool deepseek4_step_layer_range(
                         w.hc_eps);
 
         if (reuse_decode_graphs) {
-            if (!cached_decode_output_graph.valid() ||
+            const bool want_argmax = out_argmax != nullptr;
+            if (!cached_decode_output_graph.valid(want_argmax) ||
                 cached_decode_output_graph.owner_ctx != w.ctx ||
                 cached_decode_output_graph.backend != backend ||
                 cached_decode_output_graph.n_tokens != n_tokens) {
-                if (!build_cached_decode_output_graph(cached_decode_output_graph, backend, w, n_tokens)) {
+                if (!build_cached_decode_output_graph(
+                        cached_decode_output_graph, backend, w, n_tokens,
+                        want_argmax)) {
                     return false;
                 }
             }
@@ -6575,14 +6619,13 @@ bool deepseek4_step_layer_range(
             ggml_tensor * inp = ggml_new_tensor_2d(
                 ctx, GGML_TYPE_F32, n_embd, output_tokens);
             ggml_set_input(inp);
-            ggml_tensor * normed = build_rms_norm(ctx, inp, w.out_norm, w.rms_eps);
-            ggml_tensor * logits = ggml_mul_mat(ctx, w.output, normed);
-            ggml_tensor * argmax_tokens = ggml_argmax(ctx, logits);
-            ggml_set_output(logits);
-            ggml_set_output(argmax_tokens);
+            const DeepSeek4OutputProjection projection = deepseek4_build_output_projection(
+                ctx, inp, w.out_norm, w.output, w.rms_eps,
+                out_argmax != nullptr);
+            ggml_tensor * logits = projection.logits;
+            ggml_tensor * argmax_tokens = projection.argmax;
             ggml_cgraph * gf = ggml_new_graph_custom(ctx, 1024, false);
-            ggml_build_forward_expand(gf, argmax_tokens);
-            ggml_build_forward_expand(gf, logits);
+            deepseek4_build_output_graph(gf, projection, out_argmax != nullptr);
 
             if (!cached_dynamic_output_alloc.valid() ||
                 cached_dynamic_output_alloc.owner_ctx != w.ctx ||

--- a/server/src/deepseek4/deepseek4_internal.h
+++ b/server/src/deepseek4/deepseek4_internal.h
@@ -383,6 +383,7 @@ bool deepseek4_step_layer_range(
     int                         layer_begin,
     int                         layer_end,
     std::vector<float> *        out_logits,
+    int32_t *                   out_argmax = nullptr,
     const int32_t *             token_ids = nullptr,
     DeepSeek4StepTelemetry *    telemetry = nullptr,
     bool                        allow_decode_graph_reuse = true,

--- a/server/src/deepseek4/deepseek4_internal.h
+++ b/server/src/deepseek4/deepseek4_internal.h
@@ -341,6 +341,26 @@ int deepseek4_safe_compressor_batch_tokens(const DeepSeek4Weights & w,
                                            int kv_start,
                                            int n_tokens);
 
+struct DeepSeek4OutputProjection {
+    ggml_tensor * logits = nullptr;
+    ggml_tensor * argmax = nullptr;
+};
+
+// Shared output tail used by cached, dynamic, and fused DS4 graphs. Exactly
+// one output mode is built so sampling never executes an unused argmax.
+DeepSeek4OutputProjection deepseek4_build_output_projection(
+    ggml_context * ctx,
+    ggml_tensor * hidden,
+    ggml_tensor * out_norm,
+    ggml_tensor * output,
+    float         rms_eps,
+    bool          want_argmax);
+
+void deepseek4_build_output_graph(
+    ggml_cgraph *                       gf,
+    const DeepSeek4OutputProjection &   projection,
+    bool                                want_argmax);
+
 // Forward: single step (prefill chunk or decode token).
 // embed: [n_embd, n_tokens] input embeddings (post-embedding lookup).
 // hc_state: [n_hc * n_embd] persistent HC residual (updated in-place).

--- a/server/src/deepseek4/deepseek4_layer_split_adapter.cpp
+++ b/server/src/deepseek4/deepseek4_layer_split_adapter.cpp
@@ -662,6 +662,7 @@ bool DeepSeek4LayerSplitAdapter::snapshot_save(int slot) {
     snap.last_tok = last_tok_;
     snap.hc_state = hc_state_;
     snap.prefill_last_logits = prefill_last_logits_;
+    snap.needs_logit_processing = sampler_.needs_logit_processing();
     snap.used = true;
     return true;
 }
@@ -676,6 +677,7 @@ void DeepSeek4LayerSplitAdapter::snapshot_free(int slot) {
     snap.last_tok = -1;
     snap.hc_state.clear();
     snap.prefill_last_logits.clear();
+    snap.needs_logit_processing = false;
     snap.used = false;
     if (snap.shards.size() != shards_.size()) snap.shards.resize(shards_.size());
     if (use_mixed_target_split()) {
@@ -698,6 +700,13 @@ bool DeepSeek4LayerSplitAdapter::snapshot_used(int slot) const {
 int DeepSeek4LayerSplitAdapter::snapshot_cur_pos(int slot) const {
     if (slot < 0 || slot >= PREFIX_SLOTS) return 0;
     return snapshots_[slot].cur_pos;
+}
+
+bool DeepSeek4LayerSplitAdapter::snapshot_compatible(
+        int slot, const GenerateRequest & req) const {
+    return snapshot_used(slot) &&
+        snapshots_[slot].needs_logit_processing ==
+            req.sampler.needs_logit_processing();
 }
 
 bool DeepSeek4LayerSplitAdapter::snapshot_restore(int slot) {

--- a/server/src/deepseek4/deepseek4_layer_split_adapter.cpp
+++ b/server/src/deepseek4/deepseek4_layer_split_adapter.cpp
@@ -414,6 +414,7 @@ void DeepSeek4LayerSplitAdapter::begin_request(const GenerateRequest & req) {
 void DeepSeek4LayerSplitAdapter::reset_request_state() {
     cur_pos_ = 0;
     last_tok_ = -1;
+    prefill_last_logits_.clear();
     const size_t hc_size = hc_state_.size();
     std::fill(hc_state_.begin(), hc_state_.end(), 0.0f);
 
@@ -473,20 +474,21 @@ bool DeepSeek4LayerSplitAdapter::run_forward(
     }
 
     // Local multi-GPU path: run each shard's layers sequentially and pass HC
-    // state at the boundaries. The final shard computes argmax on the GPU so
-    // greedy decode returns next_tok without copying the full vocabulary.
+    // state at the boundaries. Sampling requests full logits; greedy decode
+    // requests only the GPU argmax token.
     last_tok = -1;
     for (size_t si = 0; si < shards_.size(); ++si) {
         auto & shard = shards_[si];
         const bool is_last = (si == shards_.size() - 1);
         std::vector<float> * shard_logits = is_last ? logits_out : nullptr;
+        int32_t * shard_argmax = (is_last && !logits_out) ? &last_tok : nullptr;
         DeepSeek4StepTelemetry step_tel;
 
         if (!deepseek4_step_layer_range(
                 shard.backend, shard.weights, shard.cache,
                 hc_state_, embed.data(), n_tokens, base_pos,
                 shard.layer_begin, shard.layer_end,
-                shard_logits, is_last ? &last_tok : nullptr,
+                shard_logits, shard_argmax,
                 tokens.data(), timing ? &step_tel : nullptr)) {
             std::fprintf(stderr, "[deepseek4-split] forward failed on shard %zu\n", si);
             return false;
@@ -495,7 +497,10 @@ bool DeepSeek4LayerSplitAdapter::run_forward(
     }
 
     cur_pos_ = base_pos + n_tokens;
-    if (last_tok < 0) {
+    if (logits_out) {
+        // The sampler replaces this placeholder from the returned logits.
+        last_tok = tokens.back();
+    } else if (last_tok < 0) {
         std::fprintf(stderr, "[deepseek4-split] local forward produced no argmax token\n");
         return false;
     }
@@ -595,7 +600,9 @@ bool DeepSeek4LayerSplitAdapter::prefill(
                                     prompt.begin() + chunk_end);
 
         std::vector<float> * logits_out =
-            (chunk_end >= n_prompt) ? &prefill_last_logits_ : nullptr;
+            (chunk_end >= n_prompt && sampler_.needs_logit_processing())
+                ? &prefill_last_logits_
+                : nullptr;
 
         if (!run_forward(chunk, base_pos + offset, last_tok, logits_out)) {
             return false;

--- a/server/src/deepseek4/deepseek4_layer_split_adapter.cpp
+++ b/server/src/deepseek4/deepseek4_layer_split_adapter.cpp
@@ -472,8 +472,10 @@ bool DeepSeek4LayerSplitAdapter::run_forward(
         return run_mixed_forward(tokens, base_pos, last_tok, logits_out);
     }
 
-    // Local multi-GPU path: run each shard's layers sequentially
-    // Pass HC state between shards at boundaries
+    // Local multi-GPU path: run each shard's layers sequentially and pass HC
+    // state at the boundaries. The final shard computes argmax on the GPU so
+    // greedy decode returns next_tok without copying the full vocabulary.
+    last_tok = -1;
     for (size_t si = 0; si < shards_.size(); ++si) {
         auto & shard = shards_[si];
         const bool is_last = (si == shards_.size() - 1);
@@ -484,7 +486,8 @@ bool DeepSeek4LayerSplitAdapter::run_forward(
                 shard.backend, shard.weights, shard.cache,
                 hc_state_, embed.data(), n_tokens, base_pos,
                 shard.layer_begin, shard.layer_end,
-                shard_logits, tokens.data(), timing ? &step_tel : nullptr)) {
+                shard_logits, is_last ? &last_tok : nullptr,
+                tokens.data(), timing ? &step_tel : nullptr)) {
             std::fprintf(stderr, "[deepseek4-split] forward failed on shard %zu\n", si);
             return false;
         }
@@ -492,7 +495,10 @@ bool DeepSeek4LayerSplitAdapter::run_forward(
     }
 
     cur_pos_ = base_pos + n_tokens;
-    last_tok = tokens.back();
+    if (last_tok < 0) {
+        std::fprintf(stderr, "[deepseek4-split] local forward produced no argmax token\n");
+        return false;
+    }
     last_tok_ = last_tok;
 
     if (logits_out && !logits_out->empty()) {
@@ -535,7 +541,8 @@ bool DeepSeek4LayerSplitAdapter::run_mixed_forward(
                                      local_shard.cache, hc_state_,
                                      embed.data(), n_tokens, base_pos,
                                      local_shard.layer_begin, local_shard.layer_end,
-                                     &hidden_out, tokens.data(), timing ? &local_tel : nullptr)) {
+                                     &hidden_out, /*out_argmax=*/nullptr,
+                                     tokens.data(), timing ? &local_tel : nullptr)) {
         std::fprintf(stderr, "[deepseek4-split] local shard forward failed\n");
         return false;
     }

--- a/server/src/deepseek4/deepseek4_layer_split_adapter.h
+++ b/server/src/deepseek4/deepseek4_layer_split_adapter.h
@@ -65,6 +65,8 @@ public:
     void snapshot_free(int slot) override;
     bool snapshot_used(int slot) const override;
     int snapshot_cur_pos(int slot) const override;
+    bool snapshot_compatible(int slot,
+                             const GenerateRequest & req) const override;
     bool snapshot_restore(int slot) override;
     int current_last_token() const override { return last_tok_; }
 
@@ -102,6 +104,7 @@ private:
         std::vector<float> hc_state;
         std::vector<float> prefill_last_logits;
         std::vector<DeepSeek4Snapshot> shards;
+        bool needs_logit_processing = false;
         bool used = false;
     };
     std::vector<Snapshot> snapshots_;

--- a/server/src/deepseek4/deepseek4_target_shard_ipc_daemon.cpp
+++ b/server/src/deepseek4/deepseek4_target_shard_ipc_daemon.cpp
@@ -228,6 +228,7 @@ int run_deepseek4_target_shard_ipc_daemon(
         const bool timing = target_shard_timing_enabled();
 
         std::vector<float> logits;
+        int32_t final_argmax = -1;
         const float * shard_input = req.boundary_activation->data();
         for (size_t i = 0; i < shards.size(); ++i) {
             auto & shard = shards[i];
@@ -241,7 +242,8 @@ int run_deepseek4_target_shard_ipc_daemon(
                 shard.backend, shard.weights, shard.cache, hc_state,
                 shard_input, n_tokens, req.base_pos,
                 shard.layer_begin, shard.layer_end,
-                is_last ? &logits : nullptr,
+                (is_last && req.want_logits) ? &logits : nullptr,
+                is_last ? &final_argmax : nullptr,
                 req.token_ids ? req.token_ids->data() : nullptr,
                 timing ? &tel : nullptr);
             if (!ok) {
@@ -261,23 +263,19 @@ int run_deepseek4_target_shard_ipc_daemon(
         }
 
         const int vocab = shards.back().weights.n_vocab;
-        if (vocab <= 0 || logits.size() != (size_t)vocab) {
+        if (final_argmax < 0 || final_argmax >= vocab) {
+            std::fprintf(stderr,
+                         "[deepseek4-target-shard] invalid argmax token: vocab=%d token=%d\n",
+                         vocab, final_argmax);
+            return false;
+        }
+        if (req.want_logits && logits.size() != (size_t)vocab) {
             std::fprintf(stderr,
                          "[deepseek4-target-shard] invalid logits payload: expected=%d got=%zu\n",
                          vocab, logits.size());
             return false;
         }
-
-        const float * last_logits = logits.data();
-        int32_t best = 0;
-        float best_val = last_logits[0];
-        for (int i = 1; i < vocab; ++i) {
-            if (last_logits[i] > best_val) {
-                best_val = last_logits[i];
-                best = i;
-            }
-        }
-        resp.last_tok = best;
+        resp.last_tok = final_argmax;
         if (req.want_logits) {
             resp.logits = std::move(logits);
         }

--- a/server/src/deepseek4/deepseek4_target_shard_ipc_daemon.cpp
+++ b/server/src/deepseek4/deepseek4_target_shard_ipc_daemon.cpp
@@ -229,6 +229,7 @@ int run_deepseek4_target_shard_ipc_daemon(
 
         std::vector<float> logits;
         int32_t final_argmax = -1;
+        const bool want_argmax = !req.want_logits;
         const float * shard_input = req.boundary_activation->data();
         for (size_t i = 0; i < shards.size(); ++i) {
             auto & shard = shards[i];
@@ -243,7 +244,7 @@ int run_deepseek4_target_shard_ipc_daemon(
                 shard_input, n_tokens, req.base_pos,
                 shard.layer_begin, shard.layer_end,
                 (is_last && req.want_logits) ? &logits : nullptr,
-                is_last ? &final_argmax : nullptr,
+                (is_last && want_argmax) ? &final_argmax : nullptr,
                 req.token_ids ? req.token_ids->data() : nullptr,
                 timing ? &tel : nullptr);
             if (!ok) {
@@ -263,7 +264,7 @@ int run_deepseek4_target_shard_ipc_daemon(
         }
 
         const int vocab = shards.back().weights.n_vocab;
-        if (final_argmax < 0 || final_argmax >= vocab) {
+        if (want_argmax && (final_argmax < 0 || final_argmax >= vocab)) {
             std::fprintf(stderr,
                          "[deepseek4-target-shard] invalid argmax token: vocab=%d token=%d\n",
                          vocab, final_argmax);
@@ -275,7 +276,7 @@ int run_deepseek4_target_shard_ipc_daemon(
                          vocab, logits.size());
             return false;
         }
-        resp.last_tok = final_argmax;
+        resp.last_tok = want_argmax ? final_argmax : -1;
         if (req.want_logits) {
             resp.logits = std::move(logits);
         }

--- a/server/src/deepseek4/deepseek4_target_shard_ipc_daemon.cpp
+++ b/server/src/deepseek4/deepseek4_target_shard_ipc_daemon.cpp
@@ -227,9 +227,23 @@ int run_deepseek4_target_shard_ipc_daemon(
         }
         const bool timing = target_shard_timing_enabled();
 
+        // The shared target-shard protocol treats want_argmax (a per-position
+        // argmax vector, one id per token) and want_logits as independent
+        // outputs. DeepSeek4's GPU argmax only produces the final-position
+        // greedy token, surfaced through last_tok, so it cannot satisfy a
+        // per-position argmax request; reject it rather than silently dropping
+        // the argmax payload and desyncing the stream.
+        if (req.want_argmax) {
+            std::fprintf(stderr,
+                         "[deepseek4-target-shard] per-position argmax output is not supported\n");
+            return false;
+        }
+
         std::vector<float> logits;
         int32_t final_argmax = -1;
-        const bool want_argmax = !req.want_logits;
+        // Greedy requests (no logits wanted) read back only the final-position
+        // token from the GPU argmax; sampling requests read the full logits.
+        const bool want_final_token = !req.want_logits;
         const float * shard_input = req.boundary_activation->data();
         for (size_t i = 0; i < shards.size(); ++i) {
             auto & shard = shards[i];
@@ -244,7 +258,7 @@ int run_deepseek4_target_shard_ipc_daemon(
                 shard_input, n_tokens, req.base_pos,
                 shard.layer_begin, shard.layer_end,
                 (is_last && req.want_logits) ? &logits : nullptr,
-                (is_last && want_argmax) ? &final_argmax : nullptr,
+                (is_last && want_final_token) ? &final_argmax : nullptr,
                 req.token_ids ? req.token_ids->data() : nullptr,
                 timing ? &tel : nullptr);
             if (!ok) {
@@ -264,7 +278,7 @@ int run_deepseek4_target_shard_ipc_daemon(
         }
 
         const int vocab = shards.back().weights.n_vocab;
-        if (want_argmax && (final_argmax < 0 || final_argmax >= vocab)) {
+        if (want_final_token && (final_argmax < 0 || final_argmax >= vocab)) {
             std::fprintf(stderr,
                          "[deepseek4-target-shard] invalid argmax token: vocab=%d token=%d\n",
                          vocab, final_argmax);
@@ -276,7 +290,7 @@ int run_deepseek4_target_shard_ipc_daemon(
                          vocab, logits.size());
             return false;
         }
-        resp.last_tok = want_argmax ? final_argmax : -1;
+        resp.last_tok = want_final_token ? final_argmax : -1;
         if (req.want_logits) {
             resp.logits = std::move(logits);
         }

--- a/server/tests/test_deepseek4_unit.cpp
+++ b/server/tests/test_deepseek4_unit.cpp
@@ -1348,6 +1348,7 @@ public:
     }
     bool supports_cpu_sampling() const override { return true; }
     void free_drafter() override {}
+    bool snapshot_used(int slot) const override { return slot == 0; }
     int snapshot_cur_pos(int) const override { return 1; }
     bool snapshot_restore(int) override {
         restore_called = true;
@@ -1421,6 +1422,64 @@ static void test_backend_sampling_penalizes_prompt_history() {
     SamplerCfg penalized;
     penalized.rep_pen = 2.0f;
     TEST_ASSERT(decode_one(penalized) == 2);
+
+    std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
+}
+
+class TestLayerSplitSnapshotAdapter final : public LayerSplitAdapter {
+public:
+    const char * name() const override { return "test-snapshot"; }
+    bool init() override { return true; }
+    int max_context() const override { return 64; }
+    void reset_request_state() override { reset_called = true; }
+    bool prefill(const std::vector<int32_t> & prompt,
+                 int, int & last_tok) override {
+        prefilled.insert(prefilled.end(), prompt.begin(), prompt.end());
+        last_tok = 2;
+        return true;
+    }
+    bool decode_ar(int, int, int,
+                   const std::vector<int32_t> &,
+                   std::vector<int32_t> &,
+                   const DaemonIO &) override {
+        return true;
+    }
+    void free_drafter() override {}
+    bool snapshot_used(int slot) const override { return slot == 0; }
+    int snapshot_cur_pos(int) const override { return 1; }
+    bool snapshot_compatible(int, const GenerateRequest &) const override {
+        return false;
+    }
+    bool snapshot_restore(int) override {
+        restore_called = true;
+        return true;
+    }
+    int current_last_token() const override { return 1; }
+    void shutdown() override {}
+
+    bool reset_called = false;
+    bool restore_called = false;
+    std::vector<int32_t> prefilled;
+};
+
+static void test_layer_split_incompatible_snapshot_falls_back() {
+    std::fprintf(stderr,
+                 "  test_layer_split_incompatible_snapshot_falls_back ...");
+
+    auto adapter = std::make_unique<TestLayerSplitSnapshotAdapter>();
+    auto * observed = adapter.get();
+    LayerSplitBackend backend(std::move(adapter));
+    GenerateRequest req;
+    req.prompt = {1, 2, 3};
+    req.n_gen = 0;
+
+    const GenerateResult result =
+        backend.restore_and_generate_impl(0, req, DaemonIO{});
+
+    TEST_ASSERT(result.ok());
+    TEST_ASSERT(!observed->restore_called);
+    TEST_ASSERT(observed->reset_called);
+    TEST_ASSERT(observed->prefilled == req.prompt);
 
     std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
 }
@@ -1748,10 +1807,18 @@ static void test_snapshot_save_restore() {
     adapter.last_tok_ = 4242;
     adapter.hc_state_ = {1.0f, 2.0f, 3.0f, 4.0f};
     adapter.prefill_last_logits_ = {9.0f, 8.0f, 7.0f};
+    adapter.sampler_.rep_pen = 1.5f;
 
     TEST_ASSERT(adapter.snapshot_save(0));
     TEST_ASSERT(adapter.snapshot_used(0));
     TEST_ASSERT(adapter.snapshot_cur_pos(0) == 7);
+    TEST_ASSERT(adapter.snapshots_[0].needs_logit_processing);
+
+    GenerateRequest sampling_req;
+    sampling_req.sampler.rep_pen = 1.5f;
+    TEST_ASSERT(adapter.snapshot_compatible(0, sampling_req));
+    GenerateRequest greedy_req;
+    TEST_ASSERT(!adapter.snapshot_compatible(0, greedy_req));
 
     adapter.cur_pos_ = 0;
     adapter.last_tok_ = -1;
@@ -1790,6 +1857,7 @@ static void test_snapshot_save_restore() {
     TEST_ASSERT(!adapter.snapshot_used(0));
     TEST_ASSERT(adapter.snapshots_[0].hc_state.empty());
     TEST_ASSERT(adapter.snapshots_[0].prefill_last_logits.empty());
+    TEST_ASSERT(!adapter.snapshots_[0].needs_logit_processing);
     TEST_ASSERT(adapter.snapshots_[0].shards.size() == 1);
     TEST_ASSERT(!adapter.snapshots_[0].shards[0].ctx);
     TEST_ASSERT(!adapter.snapshot_restore(0));
@@ -2967,6 +3035,7 @@ int main() {
     test_layer_split_sampler_appends_generated_tokens();
     test_layer_split_restore_preserves_full_sampling_history();
     test_backend_sampling_penalizes_prompt_history();
+    test_layer_split_incompatible_snapshot_falls_back();
     test_loader_rejects_missing_required_metadata(backend);
     test_loader_rejects_invalid_compress_ratio_type(backend);
     test_loader_rejects_zero_vocab_size(backend);

--- a/server/tests/test_deepseek4_unit.cpp
+++ b/server/tests/test_deepseek4_unit.cpp
@@ -1806,6 +1806,7 @@ static void test_reset_request_state() {
     adapter.cur_pos_ = 9;
     adapter.last_tok_ = 77;
     adapter.hc_state_.assign(8, 5.0f);
+    adapter.prefill_last_logits_ = {1.0f, 2.0f};
     adapter.shards_.resize(2);
     for (auto & shard : adapter.shards_) {
         shard.cache.cur_pos = 11;
@@ -1819,6 +1820,7 @@ static void test_reset_request_state() {
     adapter.reset_request_state();
     TEST_ASSERT(adapter.cur_pos_ == 0);
     TEST_ASSERT(adapter.last_tok_ == -1);
+    TEST_ASSERT(adapter.prefill_last_logits_.empty());
     for (float v : adapter.hc_state_) {
         TEST_ASSERT(v == 0.0f);
     }
@@ -2104,137 +2106,185 @@ static void test_ffn_graph_reuse_microbench(ggml_backend_t backend) {
                  rebuild_total_ms / iters, cached_total_ms / iters);
 }
 
-static void test_output_graph_reuse_microbench(ggml_backend_t backend) {
-    std::fprintf(stderr, "  test_output_graph_reuse_microbench ...");
+enum class TestOutputPath {
+    Cached,
+    Dynamic,
+    Fused,
+};
 
-    constexpr int n_embd = 64;
-    constexpr int n_vocab = 256;
-    constexpr int n_tokens = 64;
-    constexpr int iters = 8;
-    std::vector<float> inp((size_t) n_embd * n_tokens);
-    std::vector<float> norm_w((size_t) n_embd);
-    std::vector<float> lm_head((size_t) n_embd * n_vocab);
-    std::vector<float> rebuild_logits((size_t) n_vocab * n_tokens);
-    std::vector<float> cached_logits((size_t) n_vocab * n_tokens);
-    std::vector<int32_t> cached_argmax((size_t) n_tokens, -1);
-
-    std::mt19937 rng(7);
-    std::uniform_real_distribution<float> dist(-0.2f, 0.2f);
-    for (float & x : inp) x = dist(rng);
-    for (float & x : norm_w) x = 1.0f + dist(rng);
-    for (float & x : lm_head) x = dist(rng);
-
-    auto build_and_run = [&](std::vector<float> & out) {
-        ggml_context * ctx = make_test_context(4u << 20);
-        TEST_ASSERT_MSG(ctx != nullptr, "ggml_init failed");
-        if (!ctx) return false;
-
-        ggml_tensor * inp_t = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, n_embd, n_tokens);
-        ggml_tensor * norm_w_t = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, n_embd);
-        ggml_tensor * lm_head_t = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, n_embd, n_vocab);
-        ggml_set_input(inp_t);
-        ggml_set_input(norm_w_t);
-        ggml_set_input(lm_head_t);
-        ggml_tensor * norm = ggml_mul(ctx, ggml_rms_norm(ctx, inp_t, 1.0e-6f), norm_w_t);
-        ggml_tensor * logits = ggml_mul_mat(ctx, lm_head_t, norm);
-        ggml_set_output(logits);
-        ggml_cgraph * gf = ggml_new_graph_custom(ctx, 128, false);
-        ggml_build_forward_expand(gf, logits);
-        ggml_gallocr_t alloc = ggml_gallocr_new(ggml_backend_cpu_buffer_type());
-        bool ok = ggml_gallocr_alloc_graph(alloc, gf);
-        TEST_ASSERT(ok);
-        if (ok) {
-            ggml_backend_tensor_set(inp_t, inp.data(), 0, inp.size() * sizeof(float));
-            ggml_backend_tensor_set(norm_w_t, norm_w.data(), 0, norm_w.size() * sizeof(float));
-            ggml_backend_tensor_set(lm_head_t, lm_head.data(), 0, lm_head.size() * sizeof(float));
-            ok = ggml_backend_graph_compute(backend, gf) == GGML_STATUS_SUCCESS;
-            TEST_ASSERT(ok);
-            if (ok) {
-                ggml_backend_tensor_get(logits, out.data(), 0, out.size() * sizeof(float));
-            }
-        }
-        ggml_gallocr_free(alloc);
-        ggml_free(ctx);
-        return ok;
-    };
-
-    double rebuild_total_ms = 0.0;
-    for (int iter = 0; iter < iters; ++iter) {
-        const auto t0 = TestClock::now();
-        bool ok = build_and_run(rebuild_logits);
-        const auto t1 = TestClock::now();
-        TEST_ASSERT(ok);
-        rebuild_total_ms += elapsed_ms(t0, t1);
+static const char * test_output_path_name(TestOutputPath path) {
+    switch (path) {
+        case TestOutputPath::Cached:  return "cached";
+        case TestOutputPath::Dynamic: return "dynamic";
+        case TestOutputPath::Fused:   return "fused";
     }
+    return "unknown";
+}
 
+static int count_graph_ops(ggml_cgraph * gf, ggml_op op) {
+    int count = 0;
+    for (int i = 0; i < ggml_graph_n_nodes(gf); ++i) {
+        if (ggml_graph_node(gf, i)->op == op) ++count;
+    }
+    return count;
+}
+
+struct TestOutputRun {
+    bool ok = false;
+    std::vector<float> logits;
+    int32_t argmax = -1;
+};
+
+static TestOutputRun run_output_path(
+        ggml_backend_t backend,
+        TestOutputPath path,
+        bool want_argmax,
+        const std::vector<float> & input,
+        const std::vector<float> & norm_weight,
+        const std::vector<float> & lm_head,
+        int n_embd,
+        int n_vocab) {
+    const int n_tokens = path == TestOutputPath::Dynamic ? 4 : 1;
+    TestOutputRun result;
     ggml_context * ctx = make_test_context(4u << 20);
     TEST_ASSERT_MSG(ctx != nullptr, "ggml_init failed");
-    if (!ctx) {
-        std::fprintf(stderr, " FAIL\n");
-        return;
-    }
-    ggml_tensor * inp_t = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, n_embd, n_tokens);
-    ggml_tensor * norm_w_t = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, n_embd);
-    ggml_tensor * lm_head_t = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, n_embd, n_vocab);
-    ggml_set_input(inp_t);
-    ggml_set_input(norm_w_t);
-    ggml_set_input(lm_head_t);
-    ggml_tensor * norm = ggml_mul(ctx, ggml_rms_norm(ctx, inp_t, 1.0e-6f), norm_w_t);
-    ggml_tensor * logits = ggml_mul_mat(ctx, lm_head_t, norm);
-    ggml_tensor * argmax_tokens = ggml_argmax(ctx, logits);
-    ggml_set_output(logits);
-    ggml_set_output(argmax_tokens);
-    ggml_cgraph * gf = ggml_new_graph_custom(ctx, 128, false);
-    ggml_build_forward_expand(gf, argmax_tokens);
-    ggml_build_forward_expand(gf, logits);
-    ggml_gallocr_t alloc = ggml_gallocr_new(ggml_backend_cpu_buffer_type());
-    bool alloc_ok = ggml_gallocr_alloc_graph(alloc, gf);
-    TEST_ASSERT(alloc_ok);
-    if (!alloc_ok) {
-        ggml_gallocr_free(alloc);
-        ggml_free(ctx);
-        std::fprintf(stderr, " FAIL\n");
-        return;
-    }
-    ggml_backend_tensor_set(norm_w_t, norm_w.data(), 0, norm_w.size() * sizeof(float));
-    ggml_backend_tensor_set(lm_head_t, lm_head.data(), 0, lm_head.size() * sizeof(float));
+    if (!ctx) return result;
 
-    double cached_total_ms = 0.0;
-    for (int iter = 0; iter < iters; ++iter) {
-        const auto t0 = TestClock::now();
-        ggml_backend_tensor_set(inp_t, inp.data(), 0, inp.size() * sizeof(float));
-        bool ok = ggml_backend_graph_compute(backend, gf) == GGML_STATUS_SUCCESS;
-        const auto t1 = TestClock::now();
-        TEST_ASSERT(ok);
-        if (ok) {
-            ggml_backend_tensor_get(logits, cached_logits.data(), 0, cached_logits.size() * sizeof(float));
-            ggml_backend_tensor_get(argmax_tokens, cached_argmax.data(), 0,
-                                    cached_argmax.size() * sizeof(int32_t));
-        }
-        cached_total_ms += elapsed_ms(t0, t1);
+    ggml_tensor * input_t = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, n_embd, n_tokens);
+    ggml_tensor * norm_t = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, n_embd);
+    ggml_tensor * output_t = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, n_embd, n_vocab);
+    ggml_set_input(input_t);
+    ggml_set_input(norm_t);
+    ggml_set_input(output_t);
+
+    // The fused path attaches the same production output tail to an existing
+    // graph. Keep one preceding op here so the test covers that composition.
+    ggml_tensor * hidden = path == TestOutputPath::Fused
+        ? ggml_scale(ctx, input_t, 1.0f)
+        : input_t;
+    const DeepSeek4OutputProjection projection = deepseek4_build_output_projection(
+        ctx, hidden, norm_t, output_t, 1.0e-6f, want_argmax);
+    ggml_cgraph * gf = ggml_new_graph_custom(ctx, 128, false);
+    deepseek4_build_output_graph(gf, projection, want_argmax);
+
+    TEST_ASSERT(count_graph_ops(gf, GGML_OP_ARGMAX) == (want_argmax ? 1 : 0));
+    ggml_gallocr_t alloc = ggml_gallocr_new(
+        ggml_backend_get_default_buffer_type(backend));
+    const bool allocated = alloc && ggml_gallocr_alloc_graph(alloc, gf);
+    TEST_ASSERT(allocated);
+    if (!allocated) {
+        if (alloc) ggml_gallocr_free(alloc);
+        ggml_free(ctx);
+        return result;
+    }
+
+    const int iterations = path == TestOutputPath::Cached ? 2 : 1;
+    for (int i = 0; i < iterations; ++i) {
+        // The graph allocator may reuse any declared input after a compute.
+        // Restore the complete synthetic fixture before every cached replay.
+        ggml_backend_tensor_set(input_t, input.data(), 0,
+                                (size_t)n_embd * n_tokens * sizeof(float));
+        ggml_backend_tensor_set(norm_t, norm_weight.data(), 0,
+                                norm_weight.size() * sizeof(float));
+        ggml_backend_tensor_set(output_t, lm_head.data(), 0,
+                                lm_head.size() * sizeof(float));
+
+        result.ok = ggml_backend_graph_compute(backend, gf) == GGML_STATUS_SUCCESS;
+        TEST_ASSERT(result.ok);
+        if (!result.ok) break;
+    }
+
+    const size_t token_offset = (size_t)(n_tokens - 1);
+    if (result.ok && want_argmax) {
+        ggml_backend_tensor_get(projection.argmax, &result.argmax,
+                                token_offset * sizeof(int32_t), sizeof(int32_t));
+    } else if (result.ok) {
+        result.logits.resize((size_t)n_vocab);
+        ggml_backend_tensor_get(projection.logits, result.logits.data(),
+                                token_offset * (size_t)n_vocab * sizeof(float),
+                                result.logits.size() * sizeof(float));
     }
 
     ggml_gallocr_free(alloc);
     ggml_free(ctx);
+    return result;
+}
 
-    for (size_t i = 0; i < cached_logits.size(); ++i) {
-        TEST_ASSERT_MSG(std::isfinite(cached_logits[i]), "cached output logits must be finite");
-        TEST_ASSERT_MSG(std::isfinite(rebuild_logits[i]), "rebuilt output logits must be finite");
+static void test_output_paths_argmax(ggml_backend_t backend, const char * backend_name) {
+    std::fprintf(stderr, "  test_output_paths_argmax[%s] ...", backend_name);
+    constexpr int n_embd = 64;
+    constexpr int n_vocab = 256;
+    constexpr int max_tokens = 4;
+    std::vector<float> input((size_t)n_embd * max_tokens);
+    std::vector<float> norm_weight((size_t)n_embd, 1.0f);
+    std::vector<float> lm_head((size_t)n_embd * n_vocab, 0.0f);
+    for (int token = 0; token < max_tokens; ++token) {
+        for (int dim = 0; dim < n_embd; ++dim) {
+            input[(size_t)token * n_embd + (size_t)dim] =
+                0.01f * (float)(dim + 1) + 0.1f * (float)token;
+        }
     }
-    for (int token = 0; token < n_tokens; ++token) {
+    constexpr int expected_token = 73;
+    for (int dim = 0; dim < n_embd; ++dim) {
+        lm_head[(size_t)expected_token * n_embd + (size_t)dim] = 1.0f;
+    }
+
+    for (TestOutputPath path : {TestOutputPath::Cached,
+                                TestOutputPath::Dynamic,
+                                TestOutputPath::Fused}) {
+        const TestOutputRun logits = run_output_path(
+            backend, path, false, input, norm_weight, lm_head, n_embd, n_vocab);
+        const TestOutputRun argmax = run_output_path(
+            backend, path, true, input, norm_weight, lm_head, n_embd, n_vocab);
+        TEST_ASSERT_MSG(logits.ok && argmax.ok, test_output_path_name(path));
+        if (!logits.ok || !argmax.ok) continue;
+
         int32_t expected = 0;
-        const size_t offset = (size_t) token * n_vocab;
         for (int vocab = 1; vocab < n_vocab; ++vocab) {
-            if (cached_logits[offset + (size_t) vocab] >
-                cached_logits[offset + (size_t) expected]) {
+            if (logits.logits[(size_t)vocab] > logits.logits[(size_t)expected]) {
                 expected = vocab;
             }
         }
-        TEST_ASSERT(cached_argmax[(size_t) token] == expected);
+        TEST_ASSERT_MSG(expected == expected_token, test_output_path_name(path));
+        TEST_ASSERT_MSG(argmax.argmax == expected, test_output_path_name(path));
     }
+    std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
+}
 
-    std::fprintf(stderr, " rebuild_avg=%.3fms cached_avg=%.3fms\n",
-                 rebuild_total_ms / iters, cached_total_ms / iters);
+static void test_argmax_tie_breaking(ggml_backend_t backend, const char * backend_name) {
+    std::fprintf(stderr, "  test_argmax_tie_breaking[%s] ...", backend_name);
+    constexpr int n_vocab = 96;
+    std::vector<float> logits((size_t)n_vocab, -10.0f);
+    logits[1] = 5.0f;
+    logits[2] = 5.0f;
+    logits[33] = 5.0f;
+    logits[64] = 5.0f;
+
+    ggml_context * ctx = make_test_context();
+    TEST_ASSERT(ctx != nullptr);
+    if (!ctx) return;
+    ggml_tensor * logits_t = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, n_vocab, 1);
+    ggml_set_input(logits_t);
+    ggml_tensor * argmax_t = ggml_argmax(ctx, logits_t);
+    ggml_set_output(argmax_t);
+    ggml_cgraph * gf = ggml_new_graph_custom(ctx, 32, false);
+    ggml_build_forward_expand(gf, argmax_t);
+    ggml_gallocr_t alloc = ggml_gallocr_new(
+        ggml_backend_get_default_buffer_type(backend));
+    const bool allocated = alloc && ggml_gallocr_alloc_graph(alloc, gf);
+    TEST_ASSERT(allocated);
+    if (allocated) {
+        ggml_backend_tensor_set(logits_t, logits.data(), 0,
+                                logits.size() * sizeof(float));
+        const bool ok = ggml_backend_graph_compute(backend, gf) == GGML_STATUS_SUCCESS;
+        TEST_ASSERT(ok);
+        int32_t actual = -1;
+        if (ok) ggml_backend_tensor_get(argmax_t, &actual, 0, sizeof(actual));
+        TEST_ASSERT_MSG(actual == 1, "argmax ties must select the lowest token id");
+    }
+    if (alloc) ggml_gallocr_free(alloc);
+    ggml_free(ctx);
+    std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
 }
 
 #if defined(GGML_USE_CUDA) || defined(GGML_USE_HIP)
@@ -2534,6 +2584,23 @@ static void test_hc_post_strided_split_gpu() {
     ggml_free(ctx);
     ggml_backend_free(backend);
     std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
+}
+
+static void test_output_paths_gpu() {
+    ggml_backend_t backend = ggml_backend_cuda_init(0);
+    if (!backend) {
+        std::fprintf(stderr,
+                     "  test_output_paths_argmax[gpu] ... skipped (no GPU backend)\n");
+        return;
+    }
+#if defined(GGML_USE_HIP)
+    const char * backend_name = "hip";
+#else
+    const char * backend_name = "cuda";
+#endif
+    test_output_paths_argmax(backend, backend_name);
+    test_argmax_tie_breaking(backend, backend_name);
+    ggml_backend_free(backend);
 }
 
 static void test_cpu_hc_sinkhorn_ref(float * out, const float * mix, const float * scale,
@@ -2917,11 +2984,13 @@ int main() {
     test_ipc_mode_registration();
     test_target_shard_daemon_validation();
     test_ffn_graph_reuse_microbench(backend);
-    test_output_graph_reuse_microbench(backend);
+    test_output_paths_argmax(backend, "cpu");
+    test_argmax_tie_breaking(backend, "cpu");
 #if defined(GGML_USE_CUDA) || defined(GGML_USE_HIP)
     test_ds4_flash_attention_keep_cap_gpu();
     test_ds4_flash_attention_inverse_rope_fallback_gpu();
     test_hc_post_strided_split_gpu();
+    test_output_paths_gpu();
     test_hc_pre_kernel_gpu();
 #endif
 

--- a/server/tests/test_deepseek4_unit.cpp
+++ b/server/tests/test_deepseek4_unit.cpp
@@ -2116,6 +2116,7 @@ static void test_output_graph_reuse_microbench(ggml_backend_t backend) {
     std::vector<float> lm_head((size_t) n_embd * n_vocab);
     std::vector<float> rebuild_logits((size_t) n_vocab * n_tokens);
     std::vector<float> cached_logits((size_t) n_vocab * n_tokens);
+    std::vector<int32_t> cached_argmax((size_t) n_tokens, -1);
 
     std::mt19937 rng(7);
     std::uniform_real_distribution<float> dist(-0.2f, 0.2f);
@@ -2180,8 +2181,11 @@ static void test_output_graph_reuse_microbench(ggml_backend_t backend) {
     ggml_set_input(lm_head_t);
     ggml_tensor * norm = ggml_mul(ctx, ggml_rms_norm(ctx, inp_t, 1.0e-6f), norm_w_t);
     ggml_tensor * logits = ggml_mul_mat(ctx, lm_head_t, norm);
+    ggml_tensor * argmax_tokens = ggml_argmax(ctx, logits);
     ggml_set_output(logits);
+    ggml_set_output(argmax_tokens);
     ggml_cgraph * gf = ggml_new_graph_custom(ctx, 128, false);
+    ggml_build_forward_expand(gf, argmax_tokens);
     ggml_build_forward_expand(gf, logits);
     ggml_gallocr_t alloc = ggml_gallocr_new(ggml_backend_cpu_buffer_type());
     bool alloc_ok = ggml_gallocr_alloc_graph(alloc, gf);
@@ -2204,6 +2208,8 @@ static void test_output_graph_reuse_microbench(ggml_backend_t backend) {
         TEST_ASSERT(ok);
         if (ok) {
             ggml_backend_tensor_get(logits, cached_logits.data(), 0, cached_logits.size() * sizeof(float));
+            ggml_backend_tensor_get(argmax_tokens, cached_argmax.data(), 0,
+                                    cached_argmax.size() * sizeof(int32_t));
         }
         cached_total_ms += elapsed_ms(t0, t1);
     }
@@ -2214,6 +2220,17 @@ static void test_output_graph_reuse_microbench(ggml_backend_t backend) {
     for (size_t i = 0; i < cached_logits.size(); ++i) {
         TEST_ASSERT_MSG(std::isfinite(cached_logits[i]), "cached output logits must be finite");
         TEST_ASSERT_MSG(std::isfinite(rebuild_logits[i]), "rebuilt output logits must be finite");
+    }
+    for (int token = 0; token < n_tokens; ++token) {
+        int32_t expected = 0;
+        const size_t offset = (size_t) token * n_vocab;
+        for (int vocab = 1; vocab < n_vocab; ++vocab) {
+            if (cached_logits[offset + (size_t) vocab] >
+                cached_logits[offset + (size_t) expected]) {
+                expected = vocab;
+            }
+        }
+        TEST_ASSERT(cached_argmax[(size_t) token] == expected);
     }
 
     std::fprintf(stderr, " rebuild_avg=%.3fms cached_avg=%.3fms\n",


### PR DESCRIPTION
## Summary

Compute the DeepSeek4 greedy argmax in the GGML GPU graph and return a single token id instead of the full `n_vocab` (129280) logits vector. Applies to the all-hot monolithic backend and to local/remote layer-split execution. Sampling and penalty requests keep the full-logits path; the hybrid MoE path keeps its CPU fallback.

## What changed

- greedy prefill/decode emit one int32 argmax token instead of ~505 KiB of logits
- cached, dynamic, fused, and layer-major output graphs build only the requested logits-or-argmax path
- CPU/CUDA/HIP argmax tie-breaking unified to the lowest token id
- prefix-cache snapshots record their terminal representation (logits vs argmax); an incompatible restore falls back to fresh prefill

## Performance

Reduces the greedy return payload from ~505 KiB (full `n_vocab` logits) to 4 bytes (one token id) per token. The saving is small on this hardware — a unified-memory copy or a local IPC transfer was never the bottleneck — and scales with the transport cost:

- monolithic HIP (Strix Halo, unified memory): greedy **24.8** vs sampled **23.2** tok/s. Greedy edges ahead, though that gap also reflects greedy skipping the sampler, not the argmax read alone.
- layer split, 3090 CUDA[0,10) + Strix Halo HIP[10,43): greedy **12.4** vs sampled **12.2** tok/s — within noise; per-token time is compute-bound on the remote shard and the local IPC copy is cheap.
- scales up for networked shards (eliminates ~505 KiB/token of boundary traffic) and faster-compute setups where the fixed transfer is a larger share of per-token time.

Correct and non-regressive in every configuration measured.

## Follow-up

DSpark speculative decode does not benefit from this change: its greedy verify step reads back the full per-position logits (`all_logits_out`) to check each drafted token, so it never touches the single-output GPU argmax path. A future PR could extend the same idea to the verify — compute the per-position argmax on the GPU and return the drafted token ids instead of q × full-logits — alongside skipping the output projection on non-final prefill positions.

## Validation

- unit tests (CPU + CUDA + HIP): output-path selection, argmax tie-breaking, snapshot compatibility + fresh-prefill fallback, sampler history
- GPU e2e: monolithic HIP greedy/sampled; layer-split CUDA+HIP greedy/sampled — valid tokens, no `invalid argmax token`
- fixed during GPU validation: layer-split greedy **prefill** dropped the argmax on the compressor-split batch path for non-zero-`layer_begin` shards (returned -1); the last chunk's argmax is now propagated

## Rebase notes

Rebased onto main after DSpark spec decode (#496), indexed layer-major prefill (#520), and sampler-history fixes (#527/#536). Greedy DSpark seeds from the retained argmax token; layer-major prefill satisfies argmax-only requests via a host-side scan; fused verify graphs require an argmax tensor only when built to compute one.
