### PR TITLE
feat: Qwen3.6 target tensor parallelism

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,8 @@ Pages the attention KV cache through a fixed pool of GPU slots; cold 64-token ch
 | `--draft-device <dev>` | same as target | Draft backend; mixed backend needs `--draft-ipc-bin` |
 | `--target-gpu N` | `0` | Target GPU index |
 | `--draft-gpu N` | same as target | Draft GPU index; offload draft to a second GPU |
-| `--target-devices <list>` / `--target-layer-split` | single GPU | Layer-split target across GPUs |
+| `--target-devices <list>` / `--target-layer-split` | single GPU | Select target GPUs and optional layer-split weights |
+| `--target-split-mode {layer,tensor}` | `layer` | Multi-GPU strategy; tensor mode currently supports dense Qwen3.5/3.6 on local CUDA GPUs |
 | `--target-split-fast-rollback` | off | Qwen35 local layer-split only: enable exact F32 per-token checkpoints and skip accepted-token replay. Adds checkpoint VRAM (~1.65 GiB for the measured Qwen3.6-27B q=16 split). |
 | `DFLASH_SPLIT_FAST_ROLLBACK=1` | off | Environment equivalent of `--target-split-fast-rollback`. |
 | `--draft-ipc-bin <path>` | — | Out-of-process draft binary (mixed CUDA/HIP) |
@@ -390,6 +391,22 @@ Pages the attention KV cache through a fixed pool of GPU slots; cold 64-token ch
 | `DFLASH_TARGET_GPU=N` | `0` | Env var equivalent of `--target-gpu` |
 | `DFLASH_DRAFT_GPU=N` | same as target | Env var equivalent of `--draft-gpu` |
 | `DFLASH_MODEL_NAME=<name>` | `dflash` | Env var equivalent of `--model-name`; sets the `/v1/models` id and selects the matching `share/model_cards/<name>.json` |
+
+Tensor parallelism uses NCCL collectives between the selected devices and does
+not include other visible GPUs in its communicator. For example, this runs the
+Qwen3.6 target on GPU 1 and GPU 2 while leaving GPU 0 available:
+
+```bash
+dflash_server model.gguf \
+  --target-devices cuda:1,cuda:2 \
+  --target-split-mode tensor
+```
+
+Tensor mode requires at least two homogeneous local CUDA devices. It currently
+rejects weighted layer placement, target-shard IPC, and prefill compression.
+The token embedding stays on the host and the LM head is mirrored because the
+server performs argmax inside the target graph; transformer attention, FFN,
+DeltaNet weights, and runtime state are split across the selected GPUs.
 
 **MoE expert offload (Spark)**
 

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -317,6 +317,7 @@ add_library(dflash_common STATIC
     src/qwen35/qwen35_target_shard_ipc_daemon.cpp
     src/qwen35/layer_split_daemon.cpp
     src/qwen35/qwen35_backend.cpp
+    src/qwen35/qwen35_tensor_parallel.cpp
     src/qwen35/qwen35_layer_split_adapter.cpp
     src/qwen35/qwen35_dflash_target.cpp
     src/qwen35/qwen35_layer_split_dflash_target.cpp
@@ -725,6 +726,10 @@ if(DFLASH27B_TESTS)
             hip::host)
         list(APPEND _raw_unit_test_targets test_rocmfpx_mmq)
     endif()
+    add_executable(test_qwen35_tensor_parallel test/test_qwen35_tensor_parallel.cpp)
+    target_include_directories(test_qwen35_tensor_parallel PRIVATE ${DFLASH27B_SRC_INCLUDE_DIRS})
+    target_link_libraries(test_qwen35_tensor_parallel PRIVATE dflash_common)
+    add_test(NAME qwen35_tensor_parallel COMMAND test_qwen35_tensor_parallel)
 
     if(DFLASH27B_GPU_BACKEND STREQUAL "cuda" AND _dflash_cuda_min_sm GREATER_EQUAL 80 AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_flashprefill_kernels.cpp")
         add_executable(test_flashprefill_kernels test/test_flashprefill_kernels.cpp)

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -684,6 +684,16 @@ if(DFLASH27B_TESTS)
         list(APPEND _raw_unit_test_targets test_cuda_pool_shutdown)
     endif()
 
+    if(DFLASH27B_GPU_BACKEND STREQUAL "cuda"
+       AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_cuda_comm_api.cpp")
+        add_executable(test_cuda_comm_api test/test_cuda_comm_api.cpp)
+        target_include_directories(test_cuda_comm_api PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/deps/llama.cpp/ggml/include)
+        target_link_libraries(test_cuda_comm_api PRIVATE
+            ggml-cuda ggml ggml-base)
+        add_test(NAME cuda_comm_api COMMAND test_cuda_comm_api)
+    endif()
+
     add_executable(test_rocmfp4 deps/llama.cpp/ggml/rocmfp4/test_rocmfp4.c)
     target_link_libraries(test_rocmfp4 PRIVATE ggml-base)
     if(UNIX)

--- a/server/deps/llama.cpp/VENDOR.md
+++ b/server/deps/llama.cpp/VENDOR.md
@@ -12,7 +12,7 @@ This directory contains the ggml-only subset used by Lucebox Hub.
 - Reconstruction: `luce-dflash@6fbe72d67069136bbd370be703e1d4f441b5e942` plus cherry-picked PRs `#35`, `#37`, upstream `llama.cpp #22298`, and the target-only GGML delta from `Luce-Org/lucebox-ggml#39`
 - Vendored paths: `LICENSE`, `common/jinja`, `common/log.h`, `common/unicode.*`, `ggml`, `gguf-py`
 
-Open ggml feature PRs are intentionally not included until they are merged, except for explicitly listed hub test PRs.
+Open ggml feature PRs are not included unless they are explicitly listed above as a vendored source.
 
 ## Hub-local heterogeneous execution patches
 

--- a/server/deps/llama.cpp/VENDOR.md
+++ b/server/deps/llama.cpp/VENDOR.md
@@ -8,7 +8,8 @@ This directory contains the ggml-only subset used by Lucebox Hub.
 - Included merged PR: `#35` (`0fe65d9354b7c5da52a7741d2e37ba85f0d0c925`)
 - Included test PR: `#37` (`0699be81480428f01b9b7ac49a09a2d51c77f8df`)
 - Included upstream backport: `llama.cpp #22298` (`9725a313be0528214c4a02fed906ddaf7b3f712e`)
-- Reconstruction: `luce-dflash@6fbe72d67069136bbd370be703e1d4f441b5e942` plus cherry-picked PRs `#35`, `#37`, and upstream `llama.cpp #22298`
+- Included tensor-parallel source PR: `Luce-Org/lucebox-ggml#39` (`a6eb14b8d678c23f111b7acfcfe6b51b2ea95c46`); this target-only snapshot omits the rank-local tensor accessor used only by the stacked DFlash integration.
+- Reconstruction: `luce-dflash@6fbe72d67069136bbd370be703e1d4f441b5e942` plus cherry-picked PRs `#35`, `#37`, upstream `llama.cpp #22298`, and the target-only GGML delta from `Luce-Org/lucebox-ggml#39`
 - Vendored paths: `LICENSE`, `common/jinja`, `common/log.h`, `common/unicode.*`, `ggml`, `gguf-py`
 
 Open ggml feature PRs are intentionally not included until they are merged, except for explicitly listed hub test PRs.

--- a/server/deps/llama.cpp/ggml/include/ggml-alloc.h
+++ b/server/deps/llama.cpp/ggml/include/ggml-alloc.h
@@ -76,6 +76,7 @@ GGML_API size_t ggml_gallocr_get_buffer_size(ggml_gallocr_t galloc, int buffer_i
 // Utils
 // Create a buffer and allocate all the tensors in a ggml_context
 // ggml_backend_alloc_ctx_tensors_from_buft_size returns the size of the buffer that would be allocated by ggml_backend_alloc_ctx_tensors_from_buft
+// ggml_backend_alloc_ctx_tensors_from_buft returns NULL on failure or if all tensors in ctx are already allocated or zero-sized
 GGML_API size_t                       ggml_backend_alloc_ctx_tensors_from_buft_size(struct ggml_context * ctx, ggml_backend_buffer_type_t buft);
 GGML_API struct ggml_backend_buffer * ggml_backend_alloc_ctx_tensors_from_buft(struct ggml_context * ctx, ggml_backend_buffer_type_t buft);
 GGML_API struct ggml_backend_buffer * ggml_backend_alloc_ctx_tensors(struct ggml_context * ctx, ggml_backend_t backend);

--- a/server/deps/llama.cpp/ggml/include/ggml-backend.h
+++ b/server/deps/llama.cpp/ggml/include/ggml-backend.h
@@ -202,8 +202,11 @@ extern "C" {
 
     // Common functions that may be obtained using ggml_backend_reg_get_proc_address
 
-    // AllReduce operation for tensor parallelism (meta backend)
-    typedef bool                         (*ggml_backend_allreduce_tensor_t)(ggml_backend_t * backends, struct ggml_tensor ** tensors, size_t n_backends);
+    // Context management and operations for faster communication between backends, used for tensor parallelism (meta backend)
+    typedef void * (*ggml_backend_comm_init_t)(ggml_backend_t * backends, size_t n_backends);
+    typedef void   (*ggml_backend_comm_free_t)(void * comm_ctx);
+    typedef bool   (*ggml_backend_comm_allreduce_tensor_t)(void * comm_ctx, struct ggml_tensor ** tensors);
+
     // Split buffer type for tensor parallelism (old)
     typedef ggml_backend_buffer_type_t   (*ggml_backend_split_buffer_type_t)(int main_device, const float * tensor_split);
     // Set the number of threads for the backend
@@ -410,11 +413,15 @@ extern "C" {
         //   - most tensors have n_segments == 1 and a contiguous slice of the tensor data
         //   - some tensors have an inhomogenenous data layout along the split axis,
         //     those tensors are divided into segments which are each individually split across devices
-        //   - ne has one entry per segment and device that add up to ggml_tensor::ne for that axis,
-        //     the outer/inner loops are over segments/devices like [seg0_dev0, seg0_dev1, seg1_dev0, seg1_dev1],
+        //   - ne has one entry per segment and device and that segment repeats nr times,
+        //     in total when accounting for repetitions the segments add up to ggml_tensor::ne for that axis,
+        //     the outer/inner loops are over segments/devices like [seg0_dev0_r0, seg0_dev1_r0, seg0_dev0_r1, seg0_dev1_r1, seg1_dev0_r0, seg1_dev1_r0],
         //   - for example, a transformer may have a fused QKV matrix rather than 3 matrices, those would be 3 separate segments
-        //     that each need to be split individually across devices so that each device gets a slice of Q, K, and V
+        //     that each need to be split individually across devices so that each device gets a slice of Q, K, and V,
+        //     the Q matrix can be larger than the K and V matrices so this can either be expressed as 3 segments or as 2 segments
+        //     where the segment for K/V repeats twice
         int64_t  ne[16*GGML_BACKEND_META_MAX_DEVICES];
+        uint32_t nr[16];
         uint32_t n_segments;
     };
 
@@ -426,6 +433,9 @@ extern "C" {
     //       express this as a backend registry functionality instead
     GGML_API ggml_backend_dev_t ggml_backend_meta_device(
         ggml_backend_dev_t * devs, size_t n_devs, ggml_backend_meta_get_split_state_t get_split_state, void * get_split_state_ud);
+
+    // True when a buffer type is owned by a tensor-parallel meta device.
+    GGML_API bool ggml_backend_buft_is_meta(ggml_backend_buffer_type_t buft);
 
     //
     // Utils

--- a/server/deps/llama.cpp/ggml/include/ggml-backend.h
+++ b/server/deps/llama.cpp/ggml/include/ggml-backend.h
@@ -421,8 +421,8 @@ extern "C" {
         //     the Q matrix can be larger than the K and V matrices so this can either be expressed as 3 segments or as 2 segments
         //     where the segment for K/V repeats twice
         int64_t  ne[16*GGML_BACKEND_META_MAX_DEVICES];
-        uint32_t nr[16];
         uint32_t n_segments;
+        uint32_t nr[16];
     };
 
     // function to assign split states for statically allocated tensors, compute tensor split states will be assigned to be compatible:

--- a/server/deps/llama.cpp/ggml/src/ggml-backend-meta.cpp
+++ b/server/deps/llama.cpp/ggml/src/ggml-backend-meta.cpp
@@ -212,7 +212,15 @@ static ggml_backend_dev_t ggml_backend_meta_dev_simple_dev(ggml_backend_dev_t me
 
 ggml_backend_dev_t ggml_backend_meta_device(
         ggml_backend_dev_t * devs, size_t n_devs, ggml_backend_meta_get_split_state_t get_split_state, void * get_split_state_ud) {
-    GGML_ASSERT(n_devs <= GGML_BACKEND_META_MAX_DEVICES);
+    if (devs == nullptr || get_split_state == nullptr || n_devs == 0 ||
+        n_devs > GGML_BACKEND_META_MAX_DEVICES) {
+        return nullptr;
+    }
+    for (size_t i = 0; i < n_devs; ++i) {
+        if (devs[i] == nullptr) {
+            return nullptr;
+        }
+    }
     // TODO: this is not thread-safe - needs to be fixed
     static std::vector<std::unique_ptr<ggml_backend_meta_device_context>>         ctxs;
     static std::map<ggml_backend_meta_device_context, struct ggml_backend_device> meta_devs;
@@ -514,7 +522,7 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
     };
 
     auto handle_generic = [&](const std::vector<ggml_backend_meta_split_state> & src_ss, bool scalar_only) -> ggml_backend_meta_split_state {
-        ggml_backend_meta_split_state ret = {GGML_BACKEND_SPLIT_AXIS_NONE, {0}, {1}, 1};
+        ggml_backend_meta_split_state ret = {GGML_BACKEND_SPLIT_AXIS_NONE, {0}, 1, {1}};
         for (size_t i = 0; i < GGML_MAX_SRC; i++) {
             if (tensor->src[i] == nullptr || tensor->src[i] == tensor) {
                 continue;
@@ -522,15 +530,15 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
             if (ret.axis == GGML_BACKEND_SPLIT_AXIS_NONE) {
                 ret = src_ss[i];
             } else if (!split_states_equal(src_ss[i], ret)) {
-                ret = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, {1}, 1};
+                ret = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, 1, {1}};
                 break;
             }
         }
         if (ret.axis == GGML_BACKEND_SPLIT_AXIS_NONE) {
-            ret = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, {1}, 1};
+            ret = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, 1, {1}};
         }
         if (scalar_only && ret.axis >= 0 && ret.axis < GGML_MAX_DIMS) {
-            ret = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, {1}, 1};
+            ret = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, 1, {1}};
         }
         GGML_ASSERT(ret.axis != GGML_BACKEND_SPLIT_AXIS_UNKNOWN);
         return ret;
@@ -603,7 +611,7 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
 
     auto handle_mul_mat = [&](const std::vector<ggml_backend_meta_split_state> & src_ss) -> ggml_backend_meta_split_state {
         if (src_ss[0].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED && src_ss[1].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED) {
-            return {GGML_BACKEND_SPLIT_AXIS_MIRRORED, {0}, {1}, 1};
+            return {GGML_BACKEND_SPLIT_AXIS_MIRRORED, {0}, 1, {1}};
         }
         if (src_ss[0].axis == GGML_BACKEND_SPLIT_AXIS_1 && src_ss[1].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED) {
             ggml_backend_meta_split_state ret = src_ss[0];
@@ -617,10 +625,10 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
         }
         if (src_ss[0].axis == GGML_BACKEND_SPLIT_AXIS_0 && src_ss[1].axis == GGML_BACKEND_SPLIT_AXIS_0) {
             GGML_ASSERT(split_states_equal(src_ss[0], src_ss[1]));
-            return {assume_sync ? GGML_BACKEND_SPLIT_AXIS_MIRRORED : GGML_BACKEND_SPLIT_AXIS_PARTIAL, {0}, {1}, 1};
+            return {assume_sync ? GGML_BACKEND_SPLIT_AXIS_MIRRORED : GGML_BACKEND_SPLIT_AXIS_PARTIAL, {0}, 1, {1}};
         }
         GGML_ABORT("fatal error");
-        //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, {1}, 1};
+        //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, 1, {1}};
     };
 
     auto handle_reshape = [&](const std::vector<ggml_backend_meta_split_state> & src_ss) -> ggml_backend_meta_split_state {
@@ -629,9 +637,12 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
             case GGML_BACKEND_SPLIT_AXIS_1:
             case GGML_BACKEND_SPLIT_AXIS_2:
             case GGML_BACKEND_SPLIT_AXIS_3: {
+                if (ggml_are_same_shape(tensor, tensor->src[0])) {
+                    return src_ss[0];
+                }
                 GGML_ASSERT(src_ss[0].n_segments == 1);
                 if (src_ss[0].axis == ggml_n_dims(tensor->src[0]) - 1 && src_ss[0].nr[0] == 1) {
-                    return {ggml_backend_meta_split_axis(ggml_n_dims(tensor) - 1), {0}, {1}, 1};
+                    return {ggml_backend_meta_split_axis(ggml_n_dims(tensor) - 1), {0}, 1, {1}};
                 }
                 int64_t base_ne_in = tensor->src[0]->ne[0];
                 for (int dim = 1; dim <= src_ss[0].axis; dim++) {
@@ -642,12 +653,12 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
                 for (int dim = 0; dim < GGML_MAX_DIMS; dim++) {
                     const int64_t base_ne_out_next = base_ne_out *= tensor->ne[dim];
                     if (base_ne_out_next % base_ne_in == 0) {
-                        return {ggml_backend_meta_split_axis(dim), {0}, {uint32_t(base_ne_out_next/base_ne_in)}, 1};
+                        return {ggml_backend_meta_split_axis(dim), {0}, 1, {uint32_t(base_ne_out_next/base_ne_in)}};
                     }
                     if (base_ne_out_next > base_ne_in) {
                         GGML_ASSERT(src_ss[0].n_segments == 1);
                         GGML_ASSERT(src_ss[0].nr[0]      == 1);
-                        return {ggml_backend_meta_split_axis(dim), {0}, {1}, 1};
+                        return {ggml_backend_meta_split_axis(dim), {0}, 1, {1}};
                     }
                     base_ne_out = base_ne_out_next;
                 }
@@ -659,7 +670,7 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
             }
             default: {
                 GGML_ABORT("fatal error");
-                //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, {1}, 1};
+                //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, 1, {1}};
             }
         }
     };
@@ -694,7 +705,7 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
         if (!ggml_is_permuted(tensor) && !ggml_is_permuted(tensor->src[0]) && axis >= 0 && axis < GGML_MAX_DIMS-1) {
             for (int dim = 0; dim < GGML_MAX_DIMS-1; dim++) {
                 if (tensor->nb[dim+1] == tensor->src[0]->nb[axis+1]) {
-                    return {ggml_backend_meta_split_axis(dim), {0}, {1}, 1};
+                    return {ggml_backend_meta_split_axis(dim), {0}, 1, {1}};
                 }
             }
             GGML_ABORT("fatal error");
@@ -703,7 +714,7 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
             return src_ss[0];
         }
         GGML_ABORT("view of permuted tensor not implemented");
-        //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, {1}, 1};
+        //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, 1, {1}};
     };
 
     auto handle_permute = [&](const std::vector<ggml_backend_meta_split_state> & src_ss) -> ggml_backend_meta_split_state {
@@ -712,8 +723,10 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
             case GGML_BACKEND_SPLIT_AXIS_1:
             case GGML_BACKEND_SPLIT_AXIS_2:
             case GGML_BACKEND_SPLIT_AXIS_3: {
-                GGML_ASSERT(src_ss[0].n_segments == 1 || src_ss[0].nr[0] == 1);
-                return {ggml_backend_meta_split_axis(tensor->op_params[src_ss[0].axis]), {0}, {src_ss[0].nr[0]}, 1};
+                ggml_backend_meta_split_state result = src_ss[0];
+                result.axis = ggml_backend_meta_split_axis(
+                    tensor->op_params[src_ss[0].axis]);
+                return result;
             }
             case GGML_BACKEND_SPLIT_AXIS_MIRRORED:
             case GGML_BACKEND_SPLIT_AXIS_PARTIAL: {
@@ -721,7 +734,7 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
             }
             default: {
                 GGML_ABORT("fatal error");
-                //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, {1}, 1};
+                //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, 1, {1}};
             }
         }
     };
@@ -730,8 +743,10 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
         switch (src_ss[0].axis) {
             case GGML_BACKEND_SPLIT_AXIS_0:
             case GGML_BACKEND_SPLIT_AXIS_1: {
-                GGML_ASSERT(src_ss[0].n_segments == 1 || src_ss[0].nr[0] == 1);
-                return {ggml_backend_meta_split_axis(int(src_ss[0].axis) ^ 1), {0}, {src_ss[0].nr[0]}, 1};
+                ggml_backend_meta_split_state result = src_ss[0];
+                result.axis = ggml_backend_meta_split_axis(
+                    int(src_ss[0].axis) ^ 1);
+                return result;
             }
             case GGML_BACKEND_SPLIT_AXIS_2:
             case GGML_BACKEND_SPLIT_AXIS_3:
@@ -741,7 +756,7 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
             }
             default: {
                 GGML_ABORT("fatal error");
-                //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, {1}, 1};
+                //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, 1, {1}};
             }
         }
     };
@@ -779,16 +794,16 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
         GGML_ASSERT(                             src_ss[2].axis == GGML_BACKEND_SPLIT_AXIS_2);
         GGML_ASSERT(tensor->src[4] == nullptr || src_ss[3].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED);
         GGML_ASSERT(tensor->src[4] == nullptr || src_ss[4].axis == GGML_BACKEND_SPLIT_AXIS_0);
-        return {GGML_BACKEND_SPLIT_AXIS_1, {0}, {1}, 1};
+        return {GGML_BACKEND_SPLIT_AXIS_1, {0}, 1, {1}};
     };
 
     auto handle_ssm_conv = [&](const std::vector<ggml_backend_meta_split_state> & src_ss) -> ggml_backend_meta_split_state {
         if (src_ss[0].axis == src_ss[1].axis) {
             if (src_ss[0].axis == GGML_BACKEND_SPLIT_AXIS_0) {
-                return {GGML_BACKEND_SPLIT_AXIS_1, {0}, {1}, 1};
+                return {GGML_BACKEND_SPLIT_AXIS_1, {0}, 1, {1}};
             }
             if (src_ss[0].axis == GGML_BACKEND_SPLIT_AXIS_1) {
-                return {GGML_BACKEND_SPLIT_AXIS_0, {0}, {1}, 1};
+                return {GGML_BACKEND_SPLIT_AXIS_0, {0}, 1, {1}};
             }
         }
         return handle_generic(src_ss, /*scalar_only =*/ false);
@@ -808,12 +823,12 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
         // state shape is (S_v*S_v*H, K, n_seqs); the heads dim is nested inside axis 0,
         // so a head-aligned split on the input cache reshapes to axis 0 here (not axis 2).
         GGML_ASSERT(src_ss[5].axis == GGML_BACKEND_SPLIT_AXIS_2 || src_ss[5].axis == GGML_BACKEND_SPLIT_AXIS_1 || src_ss[5].axis == GGML_BACKEND_SPLIT_AXIS_0);
-        return {GGML_BACKEND_SPLIT_AXIS_0, {0}, {1}, 1};
+        return {GGML_BACKEND_SPLIT_AXIS_0, {0}, 1, {1}};
     };
 
     auto calculate_split_state = [&]() -> ggml_backend_meta_split_state {
         if (ggml_nelements(tensor) == 0) {
-            return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, {1}, 1};
+            return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, 1, {1}};
         }
         if (ggml_backend_buffer_get_usage(tensor->buffer) != GGML_BACKEND_BUFFER_USAGE_COMPUTE && tensor->view_src == nullptr) {
             ggml_backend_dev_t dev = ggml_backend_buft_get_device(ggml_backend_buffer_get_type(tensor->buffer));
@@ -840,10 +855,10 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
             return ret;
         }
 
-        std::vector<ggml_backend_meta_split_state> src_ss(GGML_MAX_SRC, {GGML_BACKEND_SPLIT_AXIS_NONE, {0}, {1}, 1});
+        std::vector<ggml_backend_meta_split_state> src_ss(GGML_MAX_SRC, {GGML_BACKEND_SPLIT_AXIS_NONE, {0}, 1, {1}});
         for (size_t i = 0; i < GGML_MAX_SRC; i++) {
             if (tensor->src[i] == nullptr || tensor->src[i] == tensor) {
-                src_ss[i] = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, {1}, 1};
+                src_ss[i] = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, 1, {1}};
                 continue;
             }
             src_ss[i] = ggml_backend_meta_get_split_state(stc, tensor->src[i], /*assume_sync =*/ true);
@@ -853,7 +868,7 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
         ggml_backend_meta_split_state split_state;
         switch (tensor->op) {
             case GGML_OP_NONE: {
-                split_state = {GGML_BACKEND_SPLIT_AXIS_MIRRORED, {0}, {1}, 1};
+                split_state = {GGML_BACKEND_SPLIT_AXIS_MIRRORED, {0}, 1, {1}};
             } break;
             case GGML_OP_DUP: {
                 split_state = handle_generic(src_ss, /*scalar_only =*/ true);
@@ -1067,10 +1082,14 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
             } break;
             default: {
                 GGML_ABORT("ggml op not implemented: %s", ggml_op_name(tensor->op));
-                split_state = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, {1}, 1};
+                split_state = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, 1, {1}};
             } break;
         }
-        if (split_state.axis >= 0 && split_state.axis < GGML_MAX_DIMS) {
+        // Multi-segment handlers propagate a complete physical layout. The
+        // ratio pass below is only for one-segment states whose per-rank sizes
+        // still need to be derived from their inputs.
+        if (split_state.axis >= 0 && split_state.axis < GGML_MAX_DIMS &&
+            split_state.n_segments == 1) {
             bool first_src_split_by_axis = true;
             const size_t n_bufs = ggml_backend_meta_buffer_n_bufs(tensor->buffer);
 
@@ -1124,6 +1143,23 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
         buf_ctx->split_state_cache[key].first = calculate_split_state();
         memcpy(buf_ctx->split_state_cache[key].second, tensor, sizeof(buf_ctx->split_state_cache[key].second));
         if (buf_ctx->debug > 0) {
+            auto format_split_state = [&](const ggml_backend_meta_split_state & split_state) {
+                std::string result;
+                for (size_t s = 0; s < split_state.n_segments; ++s) {
+                    if (!result.empty()) {
+                        result += "; ";
+                    }
+                    result += "{";
+                    for (size_t j = 0; j < n_bufs; ++j) {
+                        if (j > 0) {
+                            result += ", ";
+                        }
+                        result += std::to_string(split_state.ne[s*n_bufs + j]);
+                    }
+                    result += "}x" + std::to_string(split_state.nr[s]);
+                }
+                return result;
+            };
             std::string srcs_info;
             for (size_t i = 0; i < GGML_MAX_SRC; i++) {
                 if (tensor->src[i] == nullptr) {
@@ -1132,26 +1168,14 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
                 if (!srcs_info.empty()) {
                     srcs_info += ", ";
                 }
-                const ggml_backend_meta_split_state split_state = ggml_backend_meta_get_split_state(tensor->src[0], true);
-                GGML_ASSERT(split_state.n_segments == 1);
+                const ggml_backend_meta_split_state split_state =
+                    ggml_backend_meta_get_split_state(tensor->src[i], true);
                 const char * axis_name = ggml_backend_meta_split_axis_name(split_state.axis);
-                std::string ne_info;
-                for (size_t j = 0; j < n_bufs; j++) {
-                    if (!ne_info.empty()) {
-                        ne_info += ", ";
-                    }
-                    ne_info += std::to_string(split_state.ne[j]) + "x" + std::to_string(split_state.nr[0]);
-                }
+                const std::string ne_info = format_split_state(split_state);
                 srcs_info += std::string(tensor->src[i]->name) + "[" + ggml_op_name(tensor->src[i]->op) + ", " + axis_name + ", {" + ne_info + "}]";
             }
-            std::string ne_info;
-            for (size_t j = 0; j < n_bufs; j++) {
-                if (!ne_info.empty()) {
-                    ne_info += ", ";
-                }
-                const ggml_backend_meta_split_state & ss = buf_ctx->split_state_cache[key].first;
-                ne_info += std::to_string(ss.ne[j]) + "x" + std::to_string(ss.nr[0]);
-            }
+            const std::string ne_info =
+                format_split_state(buf_ctx->split_state_cache[key].first);
             GGML_LOG_DEBUG("SPLIT_STATE: {%s} -> %s[%s, %s, {%s}]\n", srcs_info.c_str(), tensor->name, ggml_op_name(tensor->op),
                 ggml_backend_meta_split_axis_name(buf_ctx->split_state_cache[key].first.axis), ne_info.c_str());
         }
@@ -1765,12 +1789,14 @@ static void ggml_backend_meta_free(ggml_backend_t backend) {
 
 static void ggml_backend_meta_set_tensor_async(ggml_backend_t backend, ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
     const size_t n_backends = ggml_backend_meta_n_backends(backend);
-    GGML_ASSERT(offset == 0);
     GGML_ASSERT(ggml_is_contiguous(tensor));
 
     const ggml_backend_meta_split_state split_state = ggml_backend_meta_get_split_state(tensor, /*assume_sync =*/ false);
-    GGML_ASSERT(split_state.n_segments == 1);
-    GGML_ASSERT(split_state.nr[0]      == 1);
+    if (split_state.n_segments != 1 || split_state.nr[0] != 1) {
+        ggml_backend_tensor_set(tensor, data, offset, size);
+        return;
+    }
+    GGML_ASSERT(offset == 0);
 
     switch (split_state.axis) {
         case GGML_BACKEND_SPLIT_AXIS_0:
@@ -1810,12 +1836,14 @@ static void ggml_backend_meta_set_tensor_async(ggml_backend_t backend, ggml_tens
 
 static void ggml_backend_meta_get_tensor_async(ggml_backend_t backend, const ggml_tensor * tensor, void * data, size_t offset, size_t size) {
     const size_t n_backends = ggml_backend_meta_n_backends(backend);
-    GGML_ASSERT(offset == 0);
     GGML_ASSERT(ggml_is_contiguous(tensor));
 
     const ggml_backend_meta_split_state split_state = ggml_backend_meta_get_split_state(tensor, /*assume_sync =*/ false);
-    GGML_ASSERT(split_state.n_segments == 1);
-    GGML_ASSERT(split_state.nr[0]      == 1);
+    if (split_state.n_segments != 1 || split_state.nr[0] != 1) {
+        ggml_backend_tensor_get(tensor, data, offset, size);
+        return;
+    }
+    GGML_ASSERT(offset == 0);
 
     switch (split_state.axis) {
         case GGML_BACKEND_SPLIT_AXIS_0:
@@ -2127,28 +2155,15 @@ static enum ggml_status ggml_backend_meta_graph_compute(ggml_backend_t backend, 
     auto allreduce_fallback = [&](size_t i) -> ggml_status {
         std::vector<ggml_cgraph *> step_cgraphs(n_backends, nullptr);
 
-        // Zero out nodes that were disabled due to having a zero-sized slice:
+        // Zero out nodes that were disabled due to having a zero-sized slice.
+        // A scale-by-zero graph is not sufficient because 0 * NaN is NaN.
         for (size_t j = 0; j < n_backends; j++) {
             auto & bcj = backend_ctx->backend_configs[j];
             ggml_tensor * node = bcj.cgraphs[i].cgraph_main->nodes[bcj.cgraphs[i].cgraph_main->n_nodes - 1];
             if (node->flags & GGML_TENSOR_FLAG_COMPUTE) {
                 continue;
             }
-            ggml_tensor * node_zero = get_node_aux(node);
-            node_zero->op = GGML_OP_SCALE; // FIXME 0.0f * NaN == NaN
-            node_zero->src[0] = node;
-            ggml_set_op_params_f32(node_zero, 0, 0.0f);
-            node_zero->data = node->data;
-            node_zero->buffer = node->buffer;
-            node_zero->flags |= GGML_TENSOR_FLAG_COMPUTE;
-
-            step_cgraphs[j] = get_cgraph_aux();
-            step_cgraphs[j]->nodes[0] = node_zero;
-            step_cgraphs[j]->n_nodes = 1;
-            const ggml_status status = ggml_backend_graph_compute_async(bcj.backend, step_cgraphs[j]);
-            if (status != GGML_STATUS_SUCCESS) {
-                return status;
-            }
+            ggml_backend_tensor_memset(node, 0, 0, ggml_nbytes(node));
         }
         std::fill(step_cgraphs.begin(), step_cgraphs.end(), nullptr);
 

--- a/server/deps/llama.cpp/ggml/src/ggml-backend-meta.cpp
+++ b/server/deps/llama.cpp/ggml/src/ggml-backend-meta.cpp
@@ -13,6 +13,7 @@
 #include <cstring>
 #include <map>
 #include <memory>
+#include <set>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -392,64 +393,103 @@ static ggml_backend_buffer_type_t ggml_backend_meta_device_get_host_buffer_type(
 // meta backend buffer
 //
 
+// Container to hold the tensor slices per simple ggml backend buffer.
+struct ggml_backend_meta_simple_tensor_container {
+    std::vector<ggml_context_ptr> ctxs;
+    std::map<const ggml_tensor *, std::vector<ggml_tensor *>> simple_tensors;
+
+    ggml_backend_meta_simple_tensor_container(const ggml_init_params & params, const int n_simple) {
+        ctxs.reserve(n_simple);
+        for (int i = 0; i < n_simple; i++) {
+            ctxs.emplace_back(ggml_init(params));
+        }
+    }
+    ggml_backend_meta_simple_tensor_container() {}
+};
+
 struct ggml_backend_meta_buffer_context {
+    // FIXME
+    // Most tensors can simply be stored statically in their own buffer.
+    // Externally created views however also need a mapping to simple tensors but they use the buffer of the view source.
+    // If external views are simply using that buffer they will slowly deplete its memory.
+    // Current solution: rotating set of 2 "compute" containers to hold external views, works correctly for llama.cpp.
+    // Long-term: tie the lifetime of external views to the meta backend executing the graph instead,
+    //     currently not possible due to graph-external operations in the backend scheduler.
+    ggml_backend_meta_simple_tensor_container stc_static;
+    ggml_backend_meta_simple_tensor_container stc_compute[2];
+    int stc_compute_index      = 0;
+    int stc_compute_index_next = 0;
+    std::vector<ggml_backend_buffer_ptr> bufs;
+
+    // FIXME
+    // The size of the split state cache is unbounded and can theoretically grow infinitely large.
+    // However, it is also expensive to build and clearing it on every rebuild in ggml_backend_meta_graph_compute is too expensive.
     static constexpr size_t nbtc = GGML_TENSOR_SIZE - sizeof(ggml_tensor::padding);
-
     std::map<std::pair<const ggml_tensor *, bool>, std::pair<ggml_backend_meta_split_state, char[nbtc]>> split_state_cache;
-    std::map<          const ggml_tensor *,        std::vector<ggml_tensor *>>                           simple_tensors;
-
-    struct buffer_config {
-        ggml_context          * ctx;
-        ggml_backend_buffer_t   buf;
-
-        buffer_config(ggml_context * ctx, ggml_backend_buffer_t buf) : ctx(ctx), buf(buf) {}
-    };
-    std::vector<buffer_config> buf_configs;
 
     int debug;
 
-    ggml_backend_meta_buffer_context() {
+    ggml_backend_meta_buffer_context(
+            ggml_backend_meta_simple_tensor_container & stc_static,
+            ggml_backend_meta_simple_tensor_container & stc_compute_0,
+            ggml_backend_meta_simple_tensor_container & stc_compute_1,
+            const std::vector<ggml_backend_buffer_t> & bufs)
+            : stc_static(std::move(stc_static)), stc_compute{std::move(stc_compute_0), std::move(stc_compute_1)} {
+        this->bufs.reserve(bufs.size());
+        for (ggml_backend_buffer_t buf : bufs) {
+            this->bufs.emplace_back(buf);
+        }
         const char * GGML_META_DEBUG = getenv("GGML_META_DEBUG");
         debug = GGML_META_DEBUG ? atoi(GGML_META_DEBUG) : 0;
+    }
+
+    ggml_backend_meta_simple_tensor_container & get_simple_tensor_container(const ggml_tensor * tensor) {
+        if (stc_static.simple_tensors.find(tensor) != stc_static.simple_tensors.end()) {
+            return stc_static;
+        }
+        return stc_compute[stc_compute_index];
     }
 };
 
 static void ggml_backend_meta_buffer_free_buffer(ggml_backend_buffer_t buffer) {
     GGML_ASSERT(ggml_backend_buffer_is_meta(buffer));
     ggml_backend_meta_buffer_context * buf_ctx = (ggml_backend_meta_buffer_context *) buffer->context;
-    for (auto & [ctx, buf] : buf_ctx->buf_configs) {
-        ggml_backend_buffer_free(buf);
-        ggml_free(ctx);
-    }
     delete buf_ctx;
 }
 
 static size_t ggml_backend_meta_buffer_n_bufs(ggml_backend_buffer_t meta_buf) {
     GGML_ASSERT(ggml_backend_buffer_is_meta(meta_buf));
     ggml_backend_meta_buffer_context * buf_ctx = (ggml_backend_meta_buffer_context *) meta_buf->context;
-    return buf_ctx->buf_configs.size();
+    return buf_ctx->bufs.size();
 }
 
 static ggml_backend_buffer_t ggml_backend_meta_buffer_simple_buffer(ggml_backend_buffer_t meta_buf, size_t index) {
     GGML_ASSERT(ggml_backend_buffer_is_meta(meta_buf));
     ggml_backend_meta_buffer_context * buf_ctx = (ggml_backend_meta_buffer_context *) meta_buf->context;
-    GGML_ASSERT(index < buf_ctx->buf_configs.size());
-    return buf_ctx->buf_configs[index].buf;
+    GGML_ASSERT(index < buf_ctx->bufs.size());
+    return buf_ctx->bufs[index].get();
 }
 
 static struct ggml_tensor * ggml_backend_meta_buffer_simple_tensor(const struct ggml_tensor * tensor, size_t index) {
     GGML_ASSERT(ggml_backend_buffer_is_meta(tensor->buffer));
     ggml_backend_meta_buffer_context * buf_ctx = (ggml_backend_meta_buffer_context *) tensor->buffer->context;
-    GGML_ASSERT(index < buf_ctx->buf_configs.size());
+    GGML_ASSERT(index < buf_ctx->bufs.size());
 
-    auto it = buf_ctx->simple_tensors.find(tensor);
-    if (it == buf_ctx->simple_tensors.end()) {
+    ggml_backend_meta_simple_tensor_container & stc = buf_ctx->get_simple_tensor_container(tensor);
+    auto it = stc.simple_tensors.find(tensor);
+    if (it == stc.simple_tensors.end()) {
         return nullptr;
     }
     return it->second[index];
 }
 
-static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(const struct ggml_tensor * tensor, bool assume_sync) {
+static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(const struct ggml_tensor * tensor, bool assume_sync);
+
+static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
+        ggml_backend_meta_simple_tensor_container & stc, const struct ggml_tensor * tensor, bool assume_sync) {
+    // FIXME Currently this function preserves/erases the information in n_segments and nr in an inconsistent way.
+    // Since the operations in question are developed specifically for llama.cpp this currently does not manifest as a bug there.
+    // However, in a broader ggml context with arbitrary ggml graphs this can lead to unexpected results.
     const size_t n_bufs = ggml_backend_meta_buffer_n_bufs(tensor->buffer);
     ggml_backend_meta_buffer_context * buf_ctx = (ggml_backend_meta_buffer_context *) tensor->buffer->context;
 
@@ -460,11 +500,11 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(co
         for (size_t j = 0; j < n_bufs; j++) {
             int64_t sum_a = 0;
             for (size_t s = 0; s < a.n_segments; s++) {
-                sum_a += a.ne[s*n_bufs + j];
+                sum_a += a.ne[s*n_bufs + j] * a.nr[s];
             }
             int64_t sum_b = 0;
             for (size_t s = 0; s < b.n_segments; s++) {
-                sum_b += b.ne[s*n_bufs + j];
+                sum_b += b.ne[s*n_bufs + j] * b.nr[s];
             }
             if (sum_a != sum_b) {
                 return false;
@@ -474,7 +514,7 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(co
     };
 
     auto handle_generic = [&](const std::vector<ggml_backend_meta_split_state> & src_ss, bool scalar_only) -> ggml_backend_meta_split_state {
-        ggml_backend_meta_split_state ret = {GGML_BACKEND_SPLIT_AXIS_NONE, {0}, 1};
+        ggml_backend_meta_split_state ret = {GGML_BACKEND_SPLIT_AXIS_NONE, {0}, {1}, 1};
         for (size_t i = 0; i < GGML_MAX_SRC; i++) {
             if (tensor->src[i] == nullptr || tensor->src[i] == tensor) {
                 continue;
@@ -482,15 +522,15 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(co
             if (ret.axis == GGML_BACKEND_SPLIT_AXIS_NONE) {
                 ret = src_ss[i];
             } else if (!split_states_equal(src_ss[i], ret)) {
-                ret = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, 1};
+                ret = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, {1}, 1};
                 break;
             }
         }
         if (ret.axis == GGML_BACKEND_SPLIT_AXIS_NONE) {
-            ret = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, 1};
+            ret = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, {1}, 1};
         }
         if (scalar_only && ret.axis >= 0 && ret.axis < GGML_MAX_DIMS) {
-            ret = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, 1};
+            ret = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, {1}, 1};
         }
         GGML_ASSERT(ret.axis != GGML_BACKEND_SPLIT_AXIS_UNKNOWN);
         return ret;
@@ -513,6 +553,20 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(co
 
     // Some ops process data on a per-row bases:
     auto handle_per_row = [&](const std::vector<ggml_backend_meta_split_state> & src_ss) -> ggml_backend_meta_split_state {
+        if (src_ss[0].axis == GGML_BACKEND_SPLIT_AXIS_0) {
+            std::fprintf(stderr,
+                    "meta per-row split violation: op=%s tensor=%s shape=[%lld,%lld,%lld,%lld] "
+                    "src=%s src_shape=[%lld,%lld,%lld,%lld] axis=%d\n",
+                    ggml_op_name(tensor->op), tensor->name,
+                    (long long) tensor->ne[0], (long long) tensor->ne[1],
+                    (long long) tensor->ne[2], (long long) tensor->ne[3],
+                    tensor->src[0] ? tensor->src[0]->name : "(null)",
+                    tensor->src[0] ? (long long) tensor->src[0]->ne[0] : 0,
+                    tensor->src[0] ? (long long) tensor->src[0]->ne[1] : 0,
+                    tensor->src[0] ? (long long) tensor->src[0]->ne[2] : 0,
+                    tensor->src[0] ? (long long) tensor->src[0]->ne[3] : 0,
+                    (int) src_ss[0].axis);
+        }
         GGML_ASSERT(src_ss[0].axis != GGML_BACKEND_SPLIT_AXIS_0);
         return src_ss[0];
     };
@@ -549,42 +603,24 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(co
 
     auto handle_mul_mat = [&](const std::vector<ggml_backend_meta_split_state> & src_ss) -> ggml_backend_meta_split_state {
         if (src_ss[0].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED && src_ss[1].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED) {
-            return {GGML_BACKEND_SPLIT_AXIS_MIRRORED, {0}, 1};
+            return {GGML_BACKEND_SPLIT_AXIS_MIRRORED, {0}, {1}, 1};
         }
         if (src_ss[0].axis == GGML_BACKEND_SPLIT_AXIS_1 && src_ss[1].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED) {
             ggml_backend_meta_split_state ret = src_ss[0];
             ret.axis = GGML_BACKEND_SPLIT_AXIS_0;
+            ret.nr[0] = 1;
             ret.n_segments = 1;
             return ret;
         }
         if (src_ss[1].axis == GGML_BACKEND_SPLIT_AXIS_1 && src_ss[0].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED) {
-            ggml_backend_meta_split_state ret = src_ss[1];
-            ret.n_segments = 1;
-            return ret;
+            return src_ss[1];
         }
         if (src_ss[0].axis == GGML_BACKEND_SPLIT_AXIS_0 && src_ss[1].axis == GGML_BACKEND_SPLIT_AXIS_0) {
             GGML_ASSERT(split_states_equal(src_ss[0], src_ss[1]));
-            return {assume_sync ? GGML_BACKEND_SPLIT_AXIS_MIRRORED : GGML_BACKEND_SPLIT_AXIS_PARTIAL, {0}, 1};
+            return {assume_sync ? GGML_BACKEND_SPLIT_AXIS_MIRRORED : GGML_BACKEND_SPLIT_AXIS_PARTIAL, {0}, {1}, 1};
         }
         GGML_ABORT("fatal error");
-        //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, 1};
-    };
-
-    auto handle_cpy = [&](const std::vector<ggml_backend_meta_split_state> & src_ss) -> ggml_backend_meta_split_state {
-        if (src_ss[0].axis >= 0 && src_ss[0].axis < GGML_MAX_DIMS) {
-            int64_t ne_split_src = tensor->src[0]->ne[0];
-            for (int dim = 1; dim <= src_ss[0].axis; dim++) {
-                ne_split_src *= tensor->src[0]->ne[dim];
-            }
-            int64_t ne_split_dst = 1;
-            for (int dim = 0; dim < GGML_MAX_DIMS; dim++) {
-                ne_split_dst *= tensor->ne[dim];
-                if (ne_split_dst == ne_split_src) {
-                    return {ggml_backend_meta_split_axis(dim), {0}, 1};
-                }
-            }
-        }
-        return handle_generic(src_ss, /*scalar_only =*/ false);
+        //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, {1}, 1};
     };
 
     auto handle_reshape = [&](const std::vector<ggml_backend_meta_split_state> & src_ss) -> ggml_backend_meta_split_state {
@@ -593,33 +629,25 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(co
             case GGML_BACKEND_SPLIT_AXIS_1:
             case GGML_BACKEND_SPLIT_AXIS_2:
             case GGML_BACKEND_SPLIT_AXIS_3: {
-                GGML_ASSERT(!ggml_is_permuted(tensor) && !ggml_is_permuted(tensor->src[0]));
-                if (src_ss[0].axis == ggml_n_dims(tensor->src[0]) - 1) {
-                    return {ggml_backend_meta_split_axis(ggml_n_dims(tensor) - 1), {0}, 1};
+                GGML_ASSERT(src_ss[0].n_segments == 1);
+                if (src_ss[0].axis == ggml_n_dims(tensor->src[0]) - 1 && src_ss[0].nr[0] == 1) {
+                    return {ggml_backend_meta_split_axis(ggml_n_dims(tensor) - 1), {0}, {1}, 1};
                 }
-                std::vector<int64_t> base_ne_in;
-                base_ne_in.reserve(GGML_MAX_DIMS - src_ss[0].axis);
-                {
-                    base_ne_in.push_back(1);
-                    int dim = 0;
-                    for (; dim <= src_ss[0].axis; dim++) {
-                        base_ne_in[0] *= tensor->src[0]->ne[dim];
-                    }
-                    for (; dim <= GGML_MAX_DIMS; dim++) {
-                        base_ne_in.push_back(base_ne_in.back() * tensor->src[0]->ne[dim]);
-                    }
+                int64_t base_ne_in = tensor->src[0]->ne[0];
+                for (int dim = 1; dim <= src_ss[0].axis; dim++) {
+                    base_ne_in *= tensor->src[0]->ne[dim];
                 }
+                base_ne_in /= src_ss[0].nr[0];
                 int64_t base_ne_out = 1;
                 for (int dim = 0; dim < GGML_MAX_DIMS; dim++) {
                     const int64_t base_ne_out_next = base_ne_out *= tensor->ne[dim];
-                    for (const int64_t & bni : base_ne_in) {
-                        if (bni == base_ne_out_next) {
-                            return {ggml_backend_meta_split_axis(dim), {0}, 1};
-                        }
+                    if (base_ne_out_next % base_ne_in == 0) {
+                        return {ggml_backend_meta_split_axis(dim), {0}, {uint32_t(base_ne_out_next/base_ne_in)}, 1};
                     }
-                    if (base_ne_out_next > base_ne_in[0]) {
-                        GGML_ASSERT(dim + 1 < GGML_MAX_DIMS);
-                        return {ggml_backend_meta_split_axis(dim + 1), {0}, 1};
+                    if (base_ne_out_next > base_ne_in) {
+                        GGML_ASSERT(src_ss[0].n_segments == 1);
+                        GGML_ASSERT(src_ss[0].nr[0]      == 1);
+                        return {ggml_backend_meta_split_axis(dim), {0}, {1}, 1};
                     }
                     base_ne_out = base_ne_out_next;
                 }
@@ -631,9 +659,16 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(co
             }
             default: {
                 GGML_ABORT("fatal error");
-                //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, 1};
+                //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, {1}, 1};
             }
         }
+    };
+
+    auto handle_cpy = [&](const std::vector<ggml_backend_meta_split_state> & src_ss) -> ggml_backend_meta_split_state {
+        if (src_ss[0].axis >= 0 && src_ss[0].axis < GGML_MAX_DIMS) {
+            return handle_reshape(src_ss);
+        }
+        return handle_generic(src_ss, /*scalar_only =*/ false);
     };
 
     auto handle_view = [&](const std::vector<ggml_backend_meta_split_state> & src_ss) -> ggml_backend_meta_split_state {
@@ -659,7 +694,7 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(co
         if (!ggml_is_permuted(tensor) && !ggml_is_permuted(tensor->src[0]) && axis >= 0 && axis < GGML_MAX_DIMS-1) {
             for (int dim = 0; dim < GGML_MAX_DIMS-1; dim++) {
                 if (tensor->nb[dim+1] == tensor->src[0]->nb[axis+1]) {
-                    return {ggml_backend_meta_split_axis(dim), {0}, 1};
+                    return {ggml_backend_meta_split_axis(dim), {0}, {1}, 1};
                 }
             }
             GGML_ABORT("fatal error");
@@ -668,7 +703,7 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(co
             return src_ss[0];
         }
         GGML_ABORT("view of permuted tensor not implemented");
-        //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, 1};
+        //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, {1}, 1};
     };
 
     auto handle_permute = [&](const std::vector<ggml_backend_meta_split_state> & src_ss) -> ggml_backend_meta_split_state {
@@ -677,7 +712,8 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(co
             case GGML_BACKEND_SPLIT_AXIS_1:
             case GGML_BACKEND_SPLIT_AXIS_2:
             case GGML_BACKEND_SPLIT_AXIS_3: {
-                return {ggml_backend_meta_split_axis(tensor->op_params[src_ss[0].axis]), {0}, 1};
+                GGML_ASSERT(src_ss[0].n_segments == 1 || src_ss[0].nr[0] == 1);
+                return {ggml_backend_meta_split_axis(tensor->op_params[src_ss[0].axis]), {0}, {src_ss[0].nr[0]}, 1};
             }
             case GGML_BACKEND_SPLIT_AXIS_MIRRORED:
             case GGML_BACKEND_SPLIT_AXIS_PARTIAL: {
@@ -685,7 +721,7 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(co
             }
             default: {
                 GGML_ABORT("fatal error");
-                //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, 1};
+                //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, {1}, 1};
             }
         }
     };
@@ -694,7 +730,8 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(co
         switch (src_ss[0].axis) {
             case GGML_BACKEND_SPLIT_AXIS_0:
             case GGML_BACKEND_SPLIT_AXIS_1: {
-                return {ggml_backend_meta_split_axis(int(src_ss[0].axis) ^ 1), {0}, 1};
+                GGML_ASSERT(src_ss[0].n_segments == 1 || src_ss[0].nr[0] == 1);
+                return {ggml_backend_meta_split_axis(int(src_ss[0].axis) ^ 1), {0}, {src_ss[0].nr[0]}, 1};
             }
             case GGML_BACKEND_SPLIT_AXIS_2:
             case GGML_BACKEND_SPLIT_AXIS_3:
@@ -704,7 +741,7 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(co
             }
             default: {
                 GGML_ABORT("fatal error");
-                //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, 1};
+                //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, {1}, 1};
             }
         }
     };
@@ -742,16 +779,16 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(co
         GGML_ASSERT(                             src_ss[2].axis == GGML_BACKEND_SPLIT_AXIS_2);
         GGML_ASSERT(tensor->src[4] == nullptr || src_ss[3].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED);
         GGML_ASSERT(tensor->src[4] == nullptr || src_ss[4].axis == GGML_BACKEND_SPLIT_AXIS_0);
-        return {GGML_BACKEND_SPLIT_AXIS_1, {0}, 1};
+        return {GGML_BACKEND_SPLIT_AXIS_1, {0}, {1}, 1};
     };
 
     auto handle_ssm_conv = [&](const std::vector<ggml_backend_meta_split_state> & src_ss) -> ggml_backend_meta_split_state {
         if (src_ss[0].axis == src_ss[1].axis) {
             if (src_ss[0].axis == GGML_BACKEND_SPLIT_AXIS_0) {
-                return {GGML_BACKEND_SPLIT_AXIS_1, {0}, 1};
+                return {GGML_BACKEND_SPLIT_AXIS_1, {0}, {1}, 1};
             }
             if (src_ss[0].axis == GGML_BACKEND_SPLIT_AXIS_1) {
-                return {GGML_BACKEND_SPLIT_AXIS_0, {0}, 1};
+                return {GGML_BACKEND_SPLIT_AXIS_0, {0}, {1}, 1};
             }
         }
         return handle_generic(src_ss, /*scalar_only =*/ false);
@@ -759,8 +796,8 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(co
 
     auto handle_gated_delta_net = [&](const std::vector<ggml_backend_meta_split_state> & src_ss) -> ggml_backend_meta_split_state {
         if (src_ss[0].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED && src_ss[1].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED &&
-            src_ss[2].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED && src_ss[3].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED &&
-            src_ss[4].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED && src_ss[5].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED) {
+                src_ss[2].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED && src_ss[3].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED &&
+                src_ss[4].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED && src_ss[5].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED) {
             return src_ss[0];
         }
         GGML_ASSERT(src_ss[0].axis == GGML_BACKEND_SPLIT_AXIS_1);
@@ -768,44 +805,55 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(co
         GGML_ASSERT(src_ss[2].axis == GGML_BACKEND_SPLIT_AXIS_1);
         GGML_ASSERT(src_ss[3].axis == GGML_BACKEND_SPLIT_AXIS_1);
         GGML_ASSERT(src_ss[4].axis == GGML_BACKEND_SPLIT_AXIS_1);
-        GGML_ASSERT(src_ss[5].axis == GGML_BACKEND_SPLIT_AXIS_2);
-        return {GGML_BACKEND_SPLIT_AXIS_0, {0}, 1};
+        // state shape is (S_v*S_v*H, K, n_seqs); the heads dim is nested inside axis 0,
+        // so a head-aligned split on the input cache reshapes to axis 0 here (not axis 2).
+        GGML_ASSERT(src_ss[5].axis == GGML_BACKEND_SPLIT_AXIS_2 || src_ss[5].axis == GGML_BACKEND_SPLIT_AXIS_1 || src_ss[5].axis == GGML_BACKEND_SPLIT_AXIS_0);
+        return {GGML_BACKEND_SPLIT_AXIS_0, {0}, {1}, 1};
     };
 
     auto calculate_split_state = [&]() -> ggml_backend_meta_split_state {
         if (ggml_nelements(tensor) == 0) {
-            return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, 1};
+            return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, {1}, 1};
         }
         if (ggml_backend_buffer_get_usage(tensor->buffer) != GGML_BACKEND_BUFFER_USAGE_COMPUTE && tensor->view_src == nullptr) {
             ggml_backend_dev_t dev = ggml_backend_buft_get_device(ggml_backend_buffer_get_type(tensor->buffer));
             const ggml_backend_meta_device_context * dev_ctx = (const ggml_backend_meta_device_context *) dev->context;
             ggml_backend_meta_split_state ret = dev_ctx->get_split_state(tensor, dev_ctx->get_split_state_ud);
+            for (size_t s = 0; s < ret.n_segments; ++s) {
+                // nr predates multi-segment repetition in callback users. Keep
+                // zero-initialized legacy callbacks equivalent to one repeat.
+                if (ret.nr[s] == 0) {
+                    ret.nr[s] = 1;
+                }
+            }
             if (ret.axis >= 0 && ret.axis <= GGML_MAX_DIMS) {
                 const int64_t granularity = ret.axis == GGML_BACKEND_SPLIT_AXIS_0 ? ggml_blck_size(tensor->type) : 1;
                 int64_t ne_sum = 0;
-                for (size_t sj = 0; sj < ret.n_segments*n_bufs; sj++) {
-                    GGML_ASSERT(ret.ne[sj] % granularity == 0);
-                    ne_sum += ret.ne[sj];
+                for (size_t s = 0; s < ret.n_segments; s++) {
+                    for (size_t j = 0; j < n_bufs; j++) {
+                        GGML_ASSERT(ret.ne[s*n_bufs + j] % granularity == 0);
+                        ne_sum += ret.ne[s*n_bufs + j] * ret.nr[s];
+                    }
                 }
                 GGML_ASSERT(ne_sum == tensor->ne[ret.axis]);
             }
             return ret;
         }
 
-        std::vector<ggml_backend_meta_split_state> src_ss(GGML_MAX_SRC, {GGML_BACKEND_SPLIT_AXIS_NONE, {0}, 1});
+        std::vector<ggml_backend_meta_split_state> src_ss(GGML_MAX_SRC, {GGML_BACKEND_SPLIT_AXIS_NONE, {0}, {1}, 1});
         for (size_t i = 0; i < GGML_MAX_SRC; i++) {
             if (tensor->src[i] == nullptr || tensor->src[i] == tensor) {
-                src_ss[i] = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, 1};
+                src_ss[i] = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, {1}, 1};
                 continue;
             }
-            src_ss[i] = ggml_backend_meta_get_split_state(tensor->src[i], /*assume_sync =*/ true);
+            src_ss[i] = ggml_backend_meta_get_split_state(stc, tensor->src[i], /*assume_sync =*/ true);
             GGML_ASSERT(src_ss[i].axis != GGML_BACKEND_SPLIT_AXIS_UNKNOWN);
         }
 
         ggml_backend_meta_split_state split_state;
         switch (tensor->op) {
             case GGML_OP_NONE: {
-                split_state = {GGML_BACKEND_SPLIT_AXIS_MIRRORED, {0}, 1};
+                split_state = {GGML_BACKEND_SPLIT_AXIS_MIRRORED, {0}, {1}, 1};
             } break;
             case GGML_OP_DUP: {
                 split_state = handle_generic(src_ss, /*scalar_only =*/ true);
@@ -828,6 +876,11 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(co
             case GGML_OP_LOG:
             case GGML_OP_SIN:
             case GGML_OP_COS: {
+                split_state = handle_generic(src_ss, /*scalar_only =*/ false);
+            } break;
+            case GGML_OP_TURBO_WHT: {
+                // The transform is independent for each row and preserves the
+                // tensor shape, so the source partition remains valid.
                 split_state = handle_generic(src_ss, /*scalar_only =*/ false);
             } break;
             case GGML_OP_SUM: {
@@ -1014,7 +1067,7 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(co
             } break;
             default: {
                 GGML_ABORT("ggml op not implemented: %s", ggml_op_name(tensor->op));
-                split_state = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, 1};
+                split_state = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, {1}, 1};
             } break;
         }
         if (split_state.axis >= 0 && split_state.axis < GGML_MAX_DIMS) {
@@ -1032,23 +1085,25 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(co
                             split_state.ne[s*n_bufs + j] = 0;
                         }
                         for (size_t s = 0; s < src_ss[i].n_segments; s++) {
-                            split_state.ne[j] += src_ss[i].ne[s*n_bufs + j];
+                            split_state.ne[j] += src_ss[i].ne[s*n_bufs + j] * src_ss[i].nr[s];
                         }
                         split_state.ne[j] *= tensor->ne[split_state.axis];
                         if (split_state.ne[j] != 0 || tensor->src[i]->ne[src_ss[i].axis] != 0) {
-                            GGML_ASSERT(split_state.ne[j] % tensor->src[i]->ne[src_ss[i].axis] == 0);
-                            split_state.ne[j] /= tensor->src[i]->ne[src_ss[i].axis];
+                            const int64_t div = tensor->src[i]->ne[src_ss[i].axis] * split_state.nr[0];
+                            GGML_ASSERT(split_state.ne[j] % div == 0);
+                            split_state.ne[j] /= div;
                         }
                     }
                 } else {
+                    GGML_ASSERT(split_state.n_segments == 1);
                     for (size_t j = 0; j < n_bufs; j++) {
+                        // Assert that ratio is consistent:
                         int64_t sum = 0;
                         for (size_t s = 0; s < src_ss[i].n_segments; s++) {
-                            sum += src_ss[i].ne[s*n_bufs + j];
+                            sum += src_ss[i].ne[s*n_bufs + j] * src_ss[i].nr[s];
                         }
-                        // Assert that ratio is consistent:
-                        GGML_ASSERT(split_state.ne[j] * tensor->src[i]->ne[src_ss[i].axis]
-                                               == sum * tensor->ne[split_state.axis]);
+                        GGML_ASSERT(split_state.ne[j]*split_state.nr[0] * tensor->src[i]->ne[src_ss[i].axis]
+                                                                 == sum * tensor->ne[split_state.axis]);
                     }
                 }
                 first_src_split_by_axis = false;
@@ -1078,13 +1133,14 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(co
                     srcs_info += ", ";
                 }
                 const ggml_backend_meta_split_state split_state = ggml_backend_meta_get_split_state(tensor->src[0], true);
+                GGML_ASSERT(split_state.n_segments == 1);
                 const char * axis_name = ggml_backend_meta_split_axis_name(split_state.axis);
                 std::string ne_info;
                 for (size_t j = 0; j < n_bufs; j++) {
                     if (!ne_info.empty()) {
                         ne_info += ", ";
                     }
-                    ne_info += std::to_string(split_state.ne[j]);
+                    ne_info += std::to_string(split_state.ne[j]) + "x" + std::to_string(split_state.nr[0]);
                 }
                 srcs_info += std::string(tensor->src[i]->name) + "[" + ggml_op_name(tensor->src[i]->op) + ", " + axis_name + ", {" + ne_info + "}]";
             }
@@ -1093,7 +1149,8 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(co
                 if (!ne_info.empty()) {
                     ne_info += ", ";
                 }
-                ne_info += std::to_string(buf_ctx->split_state_cache[key].first.ne[j]);
+                const ggml_backend_meta_split_state & ss = buf_ctx->split_state_cache[key].first;
+                ne_info += std::to_string(ss.ne[j]) + "x" + std::to_string(ss.nr[0]);
             }
             GGML_LOG_DEBUG("SPLIT_STATE: {%s} -> %s[%s, %s, {%s}]\n", srcs_info.c_str(), tensor->name, ggml_op_name(tensor->op),
                 ggml_backend_meta_split_axis_name(buf_ctx->split_state_cache[key].first.axis), ne_info.c_str());
@@ -1105,8 +1162,10 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(co
 #ifndef NDEBUG
     if (ret.axis >= 0 && ret.axis < GGML_MAX_DIMS) {
         int64_t ne_ret = 0;
-        for (size_t sj = 0; sj < ret.n_segments*n_bufs; sj++) {
-            ne_ret += ret.ne[sj];
+        for (size_t s = 0; s < ret.n_segments; s++) {
+            for (size_t j = 0; j < n_bufs; j++) {
+                ne_ret += ret.ne[s*n_bufs + j] * ret.nr[s];
+            }
         }
         assert(ne_ret == tensor->ne[int(ret.axis)]);
     }
@@ -1114,17 +1173,23 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(co
     return ret;
 }
 
+static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(const struct ggml_tensor * tensor, bool assume_sync) {
+    GGML_ASSERT(ggml_backend_buffer_is_meta(tensor->buffer));
+    ggml_backend_meta_buffer_context * buf_ctx = (ggml_backend_meta_buffer_context *) tensor->buffer->context;
+    return ggml_backend_meta_get_split_state(buf_ctx->get_simple_tensor_container(tensor), tensor, assume_sync);
+}
+
 static void * ggml_backend_meta_buffer_get_base(ggml_backend_buffer_t buffer) {
     GGML_UNUSED(buffer);
     return (void *) 0x1000000000000000; // FIXME
 }
 
-static enum ggml_status ggml_backend_meta_buffer_init_tensor(ggml_backend_buffer_t buffer, ggml_tensor * tensor) {
-    GGML_ASSERT(ggml_backend_buffer_is_meta(buffer));
-    ggml_backend_meta_buffer_context * buf_ctx = (ggml_backend_meta_buffer_context *) buffer->context;
-    const size_t n_simple_bufs = ggml_backend_meta_buffer_n_bufs(buffer);
+static enum ggml_status ggml_backend_meta_buffer_init_tensor_impl(ggml_backend_meta_simple_tensor_container & stc, ggml_tensor * tensor) {
+    GGML_ASSERT(ggml_backend_buffer_is_meta(tensor->buffer));
+    ggml_backend_meta_buffer_context * buf_ctx = (ggml_backend_meta_buffer_context *) tensor->buffer->context;
+    const size_t n_simple_bufs = ggml_backend_meta_buffer_n_bufs(tensor->buffer);
 
-    const ggml_backend_meta_split_state split_state = ggml_backend_meta_get_split_state(tensor, /*assume_sync =*/ true);
+    const ggml_backend_meta_split_state split_state = ggml_backend_meta_get_split_state(stc, tensor, /*assume_sync =*/ true);
     GGML_ASSERT(ggml_nelements(tensor) == 0 || split_state.axis != GGML_BACKEND_SPLIT_AXIS_UNKNOWN);
     GGML_ASSERT(split_state.n_segments <= 16);
 
@@ -1139,15 +1204,15 @@ static enum ggml_status ggml_backend_meta_buffer_init_tensor(ggml_backend_buffer
     std::vector<ggml_tensor *> simple_tensors;
     simple_tensors.reserve(n_simple_bufs);
     for (size_t j = 0; j < n_simple_bufs; j++) {
-        ggml_context          * simple_ctx = buf_ctx->buf_configs[j].ctx;
-        ggml_backend_buffer_t   simple_buf = buf_ctx->buf_configs[j].buf;
+        ggml_context          * simple_ctx = stc.ctxs[j].get();
+        ggml_backend_buffer_t   simple_buf = buf_ctx->bufs[j].get();
 
         if (split_dim >= 0 && split_dim < GGML_MAX_DIMS) {
             // TODO: the following assert fails for llama-parallel even though the results are correct:
             // GGML_ASSERT(ggml_is_contiguously_allocated(tensor));
             ne[split_dim] = 0;
             for (size_t s = 0; s < split_state.n_segments; s++) {
-                ne[split_dim] += split_state.ne[s*n_simple_bufs + j];
+                ne[split_dim] += split_state.ne[s*n_simple_bufs + j] * split_state.nr[s];
             }
             for (int i = 0; i < GGML_MAX_DIMS; i++) {
                 if (tensor->nb[i] > tensor->nb[split_dim]) {
@@ -1170,7 +1235,7 @@ static enum ggml_status ggml_backend_meta_buffer_init_tensor(ggml_backend_buffer
         if (t_ij->view_src != nullptr && ggml_backend_buffer_is_meta(t_ij->view_src->buffer)) {
             t_ij->view_src = ggml_backend_meta_buffer_simple_tensor(tensor->view_src, j);
             if (t_ij->view_offs > 0 && split_dim >= 0 && split_dim < GGML_MAX_DIMS) {
-                GGML_ASSERT(ne[split_dim] != 0 && tensor->ne[split_dim] != 0);
+                GGML_ASSERT(tensor->ne[split_dim] != 0);
                 const int split_dim_view_src = ggml_backend_meta_get_split_state(tensor->view_src, /*assume_sync =*/ true).axis;
                 GGML_ASSERT(split_dim_view_src >= 0 && split_dim_view_src < GGML_MAX_DIMS);
 
@@ -1193,7 +1258,7 @@ static enum ggml_status ggml_backend_meta_buffer_init_tensor(ggml_backend_buffer
             t_ij->data = (char *) t_ij->view_src->data + t_ij->view_offs;
         } else if (simple_buf != nullptr) {
             t_ij->data = (char *) ggml_backend_buffer_get_base(simple_buf)
-                + size_t(tensor->data) - size_t(ggml_backend_buffer_get_base(buffer));
+                + size_t(tensor->data) - size_t(ggml_backend_buffer_get_base(tensor->buffer));
         }
         t_ij->extra = tensor->extra;
         for (int i = 0; i < GGML_MAX_SRC; i++) {
@@ -1207,53 +1272,110 @@ static enum ggml_status ggml_backend_meta_buffer_init_tensor(ggml_backend_buffer
 
         simple_tensors.push_back(t_ij);
     }
-    buf_ctx->simple_tensors[tensor] = simple_tensors;
+
+    // If one of the sources has a zero-sized slice, disable the computation:
+    for (int i = 0; i < GGML_MAX_SRC; i++) {
+        if (tensor->src[i] == nullptr || !ggml_backend_buffer_is_meta(tensor->src[i]->buffer)) {
+            continue;
+        }
+
+        const ggml_backend_meta_split_state split_state_src = ggml_backend_meta_get_split_state(tensor->src[i], /*assume_sync =*/ true);
+        if (split_state_src.axis < 0 || split_state_src.axis >= GGML_MAX_DIMS) {
+            continue;
+        }
+        for (size_t j = 0; j < n_simple_bufs; j++) {
+            int64_t ne_sum = 0;
+            for (size_t s = 0; s < split_state_src.n_segments; s++) {
+                ne_sum += split_state_src.ne[s*n_simple_bufs + j] * split_state_src.nr[s];
+            }
+            if (ne_sum == 0) {
+                simple_tensors[j]->flags &= ~GGML_TENSOR_FLAG_COMPUTE;
+            }
+        }
+    }
+
+    stc.simple_tensors[tensor] = simple_tensors;
 
     return GGML_STATUS_SUCCESS;
 }
 
+static enum ggml_status ggml_backend_meta_buffer_init_tensor(ggml_backend_buffer_t buffer, ggml_tensor * tensor) {
+    GGML_ASSERT(ggml_backend_buffer_is_meta(buffer));
+    ggml_backend_meta_buffer_context * buf_ctx = (ggml_backend_meta_buffer_context *) buffer->context;
+    buf_ctx->stc_compute_index = buf_ctx->stc_compute_index_next;
+    return ggml_backend_meta_buffer_init_tensor_impl(buf_ctx->get_simple_tensor_container(tensor), tensor);
+}
+
 static void ggml_backend_meta_buffer_set_tensor(ggml_backend_buffer_t buffer, ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
+    if (size == 0) return;
     const size_t n_bufs = ggml_backend_meta_buffer_n_bufs(buffer);
     GGML_ASSERT(ggml_is_contiguous(tensor));
 
     const ggml_backend_meta_split_state split_state = ggml_backend_meta_get_split_state(tensor, /*assume_sync =*/ false);
 
-    if (split_state.n_segments != 1) {
+    if (split_state.n_segments != 1 || split_state.nr[0] != 1) {
         GGML_ASSERT(split_state.axis >= 0 && split_state.axis < GGML_MAX_DIMS);
-        GGML_ASSERT(offset == 0);
-        GGML_ASSERT(size == ggml_nbytes(tensor));
-        GGML_ASSERT(tensor->ne[3] == 1);
+        GGML_ASSERT(split_state.nr[0] != 0);
         size_t offset_data = 0;
         std::vector<size_t> simple_offsets(n_bufs, 0);
         if (split_state.axis == GGML_BACKEND_SPLIT_AXIS_0) {
             GGML_ASSERT(tensor->ne[2] == 1);
+
+            const size_t row_stride = tensor->nb[1];
+            GGML_ASSERT(offset % row_stride == 0);
+            GGML_ASSERT(size   % row_stride == 0);
+            const int64_t row_start = offset / row_stride;
+            const int64_t row_count = size   / row_stride;
+            GGML_ASSERT(row_start + row_count <= tensor->ne[1]);
+
             const int64_t blck_size = ggml_blck_size(tensor->type);
             for (size_t s = 0; s < split_state.n_segments; s++) {
+                for (size_t r = 0; r < split_state.nr[s]; r++) {
+                    for (size_t j = 0; j < n_bufs; j++) {
+                        ggml_tensor * simple_tensor = ggml_backend_meta_buffer_simple_tensor(tensor, j);
+                        GGML_ASSERT(split_state.ne[s*n_bufs + j] % blck_size == 0);
+                        const size_t nbytes = split_state.ne[s*n_bufs + j]/blck_size * tensor->nb[0];
+                        ggml_backend_tensor_set_2d(simple_tensor, (const char *) data + offset_data,
+                            simple_offsets[j] + row_start * simple_tensor->nb[1], nbytes,
+                            row_count, simple_tensor->nb[1], tensor->nb[1]);
+                        offset_data       += nbytes;
+                        simple_offsets[j] += nbytes;
+                    }
+                }
+            }
+            GGML_ASSERT(offset_data*row_count == size);
+            return;
+        }
+        GGML_ASSERT(split_state.axis == GGML_BACKEND_SPLIT_AXIS_1 ||
+                    split_state.axis == GGML_BACKEND_SPLIT_AXIS_2);
+        const int axis = split_state.axis;
+        const size_t row_stride = tensor->nb[axis + 1];
+        if (offset % row_stride != 0 || size % row_stride != 0) {
+            GGML_LOG_ERROR("meta set_tensor unaligned: tensor=%s axis=%d offset=%zu size=%zu stride=%zu ne=[%lld,%lld,%lld,%lld]\n",
+                tensor->name, axis, offset, size, row_stride,
+                (long long) tensor->ne[0], (long long) tensor->ne[1],
+                (long long) tensor->ne[2], (long long) tensor->ne[3]);
+        }
+        GGML_ASSERT(offset % row_stride == 0);
+        GGML_ASSERT(size   % row_stride == 0);
+        const int64_t row_start = offset / row_stride;
+        const int64_t row_count = size   / row_stride;
+        GGML_ASSERT(row_start + row_count <= tensor->ne[axis + 1]);
+
+        for (size_t s = 0; s < split_state.n_segments; s++) {
+            for (size_t r = 0; r < split_state.nr[s]; r++) {
                 for (size_t j = 0; j < n_bufs; j++) {
                     ggml_tensor * simple_tensor = ggml_backend_meta_buffer_simple_tensor(tensor, j);
-                    GGML_ASSERT(split_state.ne[s*n_bufs + j] % blck_size == 0);
-                    const size_t nbytes = split_state.ne[s*n_bufs + j]/blck_size * tensor->nb[0];
-                    ggml_backend_tensor_set_2d(simple_tensor, (const char *) data + offset_data, simple_offsets[j], nbytes,
-                        tensor->ne[1], simple_tensor->nb[1], tensor->nb[1]);
+                    const size_t nbytes = split_state.ne[s*n_bufs + j] * tensor->nb[axis];
+                    ggml_backend_tensor_set_2d(simple_tensor, (const char *) data + offset_data,
+                        simple_offsets[j] + row_start * simple_tensor->nb[axis + 1], nbytes,
+                        row_count, simple_tensor->nb[axis + 1], tensor->nb[axis + 1]);
                     offset_data       += nbytes;
                     simple_offsets[j] += nbytes;
                 }
             }
-            GGML_ASSERT(offset_data*tensor->ne[1] == size);
-            return;
         }
-        GGML_ASSERT(split_state.axis == GGML_BACKEND_SPLIT_AXIS_1);
-        for (size_t s = 0; s < split_state.n_segments; s++) {
-            for (size_t j = 0; j < n_bufs; j++) {
-                ggml_tensor * simple_tensor = ggml_backend_meta_buffer_simple_tensor(tensor, j);
-                const size_t nbytes = split_state.ne[s*n_bufs + j] * tensor->nb[1];
-                ggml_backend_tensor_set_2d(simple_tensor, (const char *) data + offset_data, simple_offsets[j], nbytes,
-                    tensor->ne[2], simple_tensor->nb[2], tensor->nb[2]);
-                offset_data       += nbytes;
-                simple_offsets[j] += nbytes;
-            }
-        }
-        GGML_ASSERT(offset_data*tensor->ne[2] == size);
+        GGML_ASSERT(offset_data*row_count == size);
         return;
     }
 
@@ -1261,21 +1383,32 @@ static void ggml_backend_meta_buffer_set_tensor(ggml_backend_buffer_t buffer, gg
         case GGML_BACKEND_SPLIT_AXIS_0:
         case GGML_BACKEND_SPLIT_AXIS_1:
         case GGML_BACKEND_SPLIT_AXIS_2: {
-            // Exploit that tensors are contiguous to splice it with simple tensors as "chunks".
             const size_t chunk_size_full = tensor->nb[split_state.axis + 1];
-            GGML_ASSERT(offset % chunk_size_full == 0);
-            GGML_ASSERT(size   % chunk_size_full == 0);
-            const int64_t i_start =  offset        /chunk_size_full;
-            const int64_t i_stop  = (offset + size)/chunk_size_full;
-            size_t offset_j = 0;
-            for (size_t j = 0; j < n_bufs; j++) {
-                ggml_tensor * simple_tensor = ggml_backend_meta_buffer_simple_tensor(tensor, j);
-                const size_t chunk_size_j = simple_tensor->nb[split_state.axis + 1];
-                const size_t simple_offset = i_start * chunk_size_j;
-                ggml_backend_tensor_set_2d(simple_tensor, (const char *) data + offset_j, simple_offset, chunk_size_j, i_stop - i_start, chunk_size_j, chunk_size_full);
-                offset_j += chunk_size_j;
+            const size_t request_end = offset + size;
+            const size_t outer_first = offset / chunk_size_full;
+            const size_t outer_last = (request_end - 1) / chunk_size_full;
+            for (size_t outer = outer_first; outer <= outer_last; ++outer) {
+                const size_t logical_chunk = outer * chunk_size_full;
+                size_t rank_begin = logical_chunk;
+                for (size_t j = 0; j < n_bufs; ++j) {
+                    ggml_tensor * simple_tensor =
+                        ggml_backend_meta_buffer_simple_tensor(tensor, j);
+                    const size_t chunk_size_j =
+                        simple_tensor->nb[split_state.axis + 1];
+                    const size_t rank_end = rank_begin + chunk_size_j;
+                    const size_t copy_begin = std::max(offset, rank_begin);
+                    const size_t copy_end = std::min(request_end, rank_end);
+                    if (copy_begin < copy_end) {
+                        ggml_backend_tensor_set(
+                            simple_tensor,
+                            (const char *) data + copy_begin - offset,
+                            outer * chunk_size_j + copy_begin - rank_begin,
+                            copy_end - copy_begin);
+                    }
+                    rank_begin = rank_end;
+                }
+                GGML_ASSERT(rank_begin == logical_chunk + chunk_size_full);
             }
-            GGML_ASSERT(offset_j == chunk_size_full);
         } break;
         case GGML_BACKEND_SPLIT_AXIS_MIRRORED: {
             for (size_t j = 0; j < n_bufs; j++) {
@@ -1303,31 +1436,108 @@ static void ggml_backend_meta_buffer_set_tensor(ggml_backend_buffer_t buffer, gg
 }
 
 static void ggml_backend_meta_buffer_get_tensor(ggml_backend_buffer_t buffer, const ggml_tensor * tensor, void * data, size_t offset, size_t size) {
+    if (size == 0) return;
     const size_t n_bufs = ggml_backend_meta_buffer_n_bufs(buffer);
     GGML_ASSERT(ggml_is_contiguous(tensor));
 
     const ggml_backend_meta_split_state split_state = ggml_backend_meta_get_split_state(tensor, /*assume_sync =*/ false);
-    GGML_ASSERT(split_state.n_segments == 1);
+
+    if (split_state.n_segments != 1 || split_state.nr[0] != 1) {
+        GGML_ASSERT(split_state.axis >= 0 && split_state.axis < GGML_MAX_DIMS);
+        GGML_ASSERT(split_state.nr[0] != 0);
+        size_t offset_data = 0;
+        std::vector<size_t> simple_offsets(n_bufs, 0);
+        if (split_state.axis == GGML_BACKEND_SPLIT_AXIS_0) {
+            GGML_ASSERT(tensor->ne[2] == 1);
+
+            const size_t row_stride = tensor->nb[1];
+            GGML_ASSERT(offset % row_stride == 0);
+            GGML_ASSERT(size   % row_stride == 0);
+            const int64_t row_start = offset / row_stride;
+            const int64_t row_count = size   / row_stride;
+            GGML_ASSERT(row_start + row_count <= tensor->ne[1]);
+
+            const int64_t blck_size = ggml_blck_size(tensor->type);
+            for (size_t s = 0; s < split_state.n_segments; s++) {
+                for (size_t r = 0; r < split_state.nr[s]; r++) {
+                    for (size_t j = 0; j < n_bufs; j++) {
+                        const ggml_tensor * simple_tensor = ggml_backend_meta_buffer_simple_tensor(tensor, j);
+                        GGML_ASSERT(split_state.ne[s*n_bufs + j] % blck_size == 0);
+                        const size_t nbytes = split_state.ne[s*n_bufs + j]/blck_size * tensor->nb[0];
+                        ggml_backend_tensor_get_2d(simple_tensor, (char *) data + offset_data,
+                            simple_offsets[j] + row_start * simple_tensor->nb[1], nbytes,
+                            row_count, simple_tensor->nb[1], tensor->nb[1]);
+                        offset_data       += nbytes;
+                        simple_offsets[j] += nbytes;
+                    }
+                }
+            }
+            GGML_ASSERT(offset_data*row_count == size);
+            return;
+        }
+        GGML_ASSERT(split_state.axis == GGML_BACKEND_SPLIT_AXIS_1 ||
+                    split_state.axis == GGML_BACKEND_SPLIT_AXIS_2);
+        const int axis = split_state.axis;
+        const size_t row_stride = tensor->nb[axis + 1];
+        if (offset % row_stride != 0 || size % row_stride != 0) {
+            GGML_LOG_ERROR("meta get_tensor unaligned: tensor=%s axis=%d offset=%zu size=%zu stride=%zu ne=[%lld,%lld,%lld,%lld]\n",
+                tensor->name, axis, offset, size, row_stride,
+                (long long) tensor->ne[0], (long long) tensor->ne[1],
+                (long long) tensor->ne[2], (long long) tensor->ne[3]);
+        }
+        GGML_ASSERT(offset % row_stride == 0);
+        GGML_ASSERT(size   % row_stride == 0);
+        const int64_t row_start = offset / row_stride;
+        const int64_t row_count = size   / row_stride;
+        GGML_ASSERT(row_start + row_count <= tensor->ne[axis + 1]);
+
+        for (size_t s = 0; s < split_state.n_segments; s++) {
+            for (size_t r = 0; r < split_state.nr[s]; r++) {
+                for (size_t j = 0; j < n_bufs; j++) {
+                    const ggml_tensor * simple_tensor = ggml_backend_meta_buffer_simple_tensor(tensor, j);
+                    const size_t nbytes = split_state.ne[s*n_bufs + j] * tensor->nb[axis];
+                    ggml_backend_tensor_get_2d(simple_tensor, (char *) data + offset_data,
+                        simple_offsets[j] + row_start * simple_tensor->nb[axis + 1], nbytes,
+                        row_count, simple_tensor->nb[axis + 1], tensor->nb[axis + 1]);
+                    offset_data       += nbytes;
+                    simple_offsets[j] += nbytes;
+                }
+            }
+        }
+        GGML_ASSERT(offset_data*row_count == size);
+        return;
+    }
 
     switch (split_state.axis) {
         case GGML_BACKEND_SPLIT_AXIS_0:
         case GGML_BACKEND_SPLIT_AXIS_1:
         case GGML_BACKEND_SPLIT_AXIS_2: {
-            // Exploit that tensors are contiguous to splice it with simple tensors as "chunks".
             const size_t chunk_size_full = tensor->nb[split_state.axis + 1];
-            GGML_ASSERT(offset % chunk_size_full == 0);
-            GGML_ASSERT(size   % chunk_size_full == 0);
-            const int64_t i_start =  offset        /chunk_size_full;
-            const int64_t i_stop  = (offset + size)/chunk_size_full;
-            size_t offset_j = 0;
-            for (size_t j = 0; j < n_bufs; j++){
-                const ggml_tensor * simple_tensor = ggml_backend_meta_buffer_simple_tensor(tensor, j);
-                const size_t chunk_size_j = simple_tensor->nb[split_state.axis + 1];
-                const size_t simple_offset = i_start * chunk_size_j;
-                ggml_backend_tensor_get_2d(simple_tensor, (char *) data + offset_j, simple_offset, chunk_size_j, i_stop - i_start, chunk_size_j, chunk_size_full);
-                offset_j += chunk_size_j;
+            const size_t request_end = offset + size;
+            const size_t outer_first = offset / chunk_size_full;
+            const size_t outer_last = (request_end - 1) / chunk_size_full;
+            for (size_t outer = outer_first; outer <= outer_last; ++outer) {
+                const size_t logical_chunk = outer * chunk_size_full;
+                size_t rank_begin = logical_chunk;
+                for (size_t j = 0; j < n_bufs; ++j) {
+                    const ggml_tensor * simple_tensor =
+                        ggml_backend_meta_buffer_simple_tensor(tensor, j);
+                    const size_t chunk_size_j =
+                        simple_tensor->nb[split_state.axis + 1];
+                    const size_t rank_end = rank_begin + chunk_size_j;
+                    const size_t copy_begin = std::max(offset, rank_begin);
+                    const size_t copy_end = std::min(request_end, rank_end);
+                    if (copy_begin < copy_end) {
+                        ggml_backend_tensor_get(
+                            simple_tensor,
+                            (char *) data + copy_begin - offset,
+                            outer * chunk_size_j + copy_begin - rank_begin,
+                            copy_end - copy_begin);
+                    }
+                    rank_begin = rank_end;
+                }
+                GGML_ASSERT(rank_begin == logical_chunk + chunk_size_full);
             }
-            GGML_ASSERT(offset_j == chunk_size_full);
         } break;
         case GGML_BACKEND_SPLIT_AXIS_MIRRORED: {
             // TODO other simple backend may be better
@@ -1348,8 +1558,9 @@ static void ggml_backend_meta_buffer_clear(ggml_backend_buffer_t buffer, uint8_t
 }
 
 static void ggml_backend_meta_buffer_reset(ggml_backend_buffer_t buffer) {
-    const size_t n_buffers = ggml_backend_meta_buffer_n_bufs(buffer);
-    for (size_t i = 0; i < n_buffers; i++) {
+    GGML_ASSERT(ggml_backend_buffer_is_meta(buffer));
+    ggml_backend_meta_buffer_context * buf_ctx = (ggml_backend_meta_buffer_context *) buffer->context;
+    for (size_t i = 0; i < buf_ctx->bufs.size(); i++) {
         ggml_backend_buffer_reset(ggml_backend_meta_buffer_simple_buffer(buffer, i));
     }
 }
@@ -1375,20 +1586,24 @@ bool ggml_backend_buffer_is_meta(ggml_backend_buffer_t buf) {
 static ggml_backend_buffer_t ggml_backend_meta_buffer_type_alloc_buffer(ggml_backend_buffer_type_t buft, size_t size) {
     const size_t n_simple_bufts = ggml_backend_meta_buft_n_bufts(buft);
 
-    ggml_init_params params = {
-        /*.mem_size   =*/ 1024*1024*1024, // FIXME
+    const ggml_init_params params = {
+        /*.mem_size   =*/ 1024*1024*ggml_tensor_overhead(), // FIXME
         /*.mem_buffer =*/ nullptr,
         /*.no_alloc   =*/ true,
     };
+    ggml_backend_meta_simple_tensor_container stc_static;
+    ggml_backend_meta_simple_tensor_container stc_compute_0(params, n_simple_bufts);
+    ggml_backend_meta_simple_tensor_container stc_compute_1(params, n_simple_bufts);
 
-    ggml_backend_meta_buffer_context * buf_ctx = new ggml_backend_meta_buffer_context();
     size_t max_size = 0;
-    buf_ctx->buf_configs.reserve(n_simple_bufts);
+    std::vector<ggml_backend_buffer_t> bufs;
+    bufs.reserve(n_simple_bufts);
     for (size_t i = 0; i < n_simple_bufts; i++) {
-        ggml_backend_buffer_t simple_buf = ggml_backend_buft_alloc_buffer(ggml_backend_meta_buft_simple_buft(buft, i), size);
-        max_size = std::max(max_size, ggml_backend_buffer_get_size(simple_buf));
-        buf_ctx->buf_configs.emplace_back(ggml_init(params), simple_buf);
+        bufs.push_back(ggml_backend_buft_alloc_buffer(ggml_backend_meta_buft_simple_buft(buft, i), size));
+        GGML_ASSERT(bufs.back() != nullptr);
+        max_size = std::max(max_size, ggml_backend_buffer_get_size(bufs.back()));
     }
+    ggml_backend_meta_buffer_context * buf_ctx = new ggml_backend_meta_buffer_context(stc_static, stc_compute_0, stc_compute_1, bufs);
 
     return ggml_backend_buffer_init(buft, ggml_backend_meta_buffer_iface, buf_ctx, max_size);
 }
@@ -1396,28 +1611,53 @@ static ggml_backend_buffer_t ggml_backend_meta_buffer_type_alloc_buffer(ggml_bac
 struct ggml_backend_buffer * ggml_backend_meta_alloc_ctx_tensors_from_buft(struct ggml_context * ctx, ggml_backend_buffer_type_t buft) {
     const size_t n_simple_bufts = ggml_backend_meta_buft_n_bufts(buft);
 
-    ggml_init_params params = {
-        /*.mem_size   =*/ 1024*1024*1024, // FIXME
+    constexpr size_t compute_headroom = 16; // Maximum number of views per statically allocated tensor that can be created between evals.
+    const ggml_init_params params_static = {
+        /*.mem_size   =*/ ggml_get_mem_size(ctx),
         /*.mem_buffer =*/ nullptr,
         /*.no_alloc   =*/ true,
     };
+    const ggml_init_params params_compute = {
+        /*.mem_size   =*/ compute_headroom*ggml_get_mem_size(ctx),
+        /*.mem_buffer =*/ nullptr,
+        /*.no_alloc   =*/ true,
+    };
+    ggml_backend_meta_simple_tensor_container stc_static   (params_static,  n_simple_bufts);
+    ggml_backend_meta_simple_tensor_container stc_compute_0(params_compute, n_simple_bufts);
+    ggml_backend_meta_simple_tensor_container stc_compute_1(params_compute, n_simple_bufts);
 
-    ggml_backend_meta_buffer_context * meta_buf_ctx = new ggml_backend_meta_buffer_context();
-    meta_buf_ctx->buf_configs.reserve(n_simple_bufts);
-    for (size_t i = 0; i < n_simple_bufts; i++) {
-        meta_buf_ctx->buf_configs.emplace_back(ggml_init(params), nullptr);
-    }
+    std::vector<ggml_backend_buffer_t> bufs(n_simple_bufts, nullptr);
+    ggml_backend_meta_buffer_context * meta_buf_ctx = new ggml_backend_meta_buffer_context(stc_static, stc_compute_0, stc_compute_1, bufs);
 
     ggml_backend_buffer_t meta_buf = ggml_backend_buffer_init(buft, ggml_backend_meta_buffer_iface, meta_buf_ctx, 0);
     for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != nullptr; t = ggml_get_next_tensor(ctx, t)) {
         t->buffer = meta_buf;
-        ggml_backend_meta_buffer_init_tensor(meta_buf, t);
+        ggml_backend_meta_buffer_init_tensor_impl(meta_buf_ctx->stc_static, t);
         t->data = (void *) 0x2000000000000000; // FIXME
     }
     for (size_t i = 0; i < n_simple_bufts; i++) {
-        meta_buf_ctx->buf_configs[i].buf = ggml_backend_alloc_ctx_tensors_from_buft(
-            meta_buf_ctx->buf_configs[i].ctx, ggml_backend_meta_buft_simple_buft(buft, i));
-        meta_buf->size = std::max(meta_buf->size, ggml_backend_buffer_get_size(meta_buf_ctx->buf_configs[i].buf));
+        ggml_context * ctx = meta_buf_ctx->stc_static.ctxs[i].get();
+        ggml_backend_buffer_type_t simple_buft = ggml_backend_meta_buft_simple_buft(buft, i);
+
+        // If a ggml_context only has zero-sized tensors, ggml_backend_alloc_ctx_tensors_from_buft returns NULL.
+        // For those edge cases, allocate a dummy buffer instead.
+        bool any_nonzero_slice = false;
+        for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != nullptr; t = ggml_get_next_tensor(ctx, t)) {
+            if (ggml_nelements(t) != 0) {
+                any_nonzero_slice = true;
+                break;
+            }
+        }
+        if (any_nonzero_slice) {
+            meta_buf_ctx->bufs[i].reset(ggml_backend_alloc_ctx_tensors_from_buft(ctx, simple_buft));
+        } else {
+            meta_buf_ctx->bufs[i].reset(ggml_backend_buft_alloc_buffer(simple_buft, 0));
+            for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != nullptr; t = ggml_get_next_tensor(ctx, t)) {
+                t->buffer = meta_buf_ctx->bufs[i].get();
+            }
+        }
+        GGML_ASSERT(meta_buf_ctx->bufs[i]);
+        meta_buf->size = std::max(meta_buf->size, ggml_backend_buffer_get_size(meta_buf_ctx->bufs[i].get()));
     }
     return meta_buf;
 }
@@ -1441,44 +1681,72 @@ struct ggml_backend_meta_context {
     struct backend_config {
         ggml_backend_t backend;
 
-        std::vector<cgraph_config> cgraphs;
-        std::vector<ggml_tensor *> nodes;
-        ggml_backend_buffer_ptr    buf;
+        std::vector<cgraph_config>           cgraphs;
+        std::vector<ggml_tensor *>           nodes;
+        std::vector<ggml_backend_buffer_ptr> bufs;
 
-        backend_config(ggml_backend_t backend) : backend(backend) {}
+        backend_config(ggml_backend_t backend, const size_t n_reduce_steps) : backend(backend) {
+            bufs.resize(n_reduce_steps);
+        }
     };
     std::string                 name;
     std::vector<backend_config> backend_configs;
     ggml_context_ptr            ctx;
     std::vector<ggml_cgraph *>  cgraphs_aux;
     std::vector<ggml_tensor *>  nodes_aux;
+    size_t                      n_reduce_steps;
     int                         max_nnodes    = 0;
     size_t                      max_tmp_size  = 0;
     size_t                      max_subgraphs = 0;
+    size_t                      n_subgraphs   = 0;
+    uint64_t                    uid           = 0;
+
+    void *                               comm_ctx       = nullptr;
+    ggml_backend_comm_allreduce_tensor_t comm_allreduce = nullptr;
 
     ggml_backend_meta_context(ggml_backend_dev_t meta_dev, const char * params) {
         const size_t n_devs = ggml_backend_meta_dev_n_devs(meta_dev);
+        n_reduce_steps = std::ceil(std::log2(n_devs));
         name = "Meta(";
+        std::vector<ggml_backend_t> simple_backends;
         backend_configs.reserve(n_devs);
+        simple_backends.reserve(n_devs);
         for (size_t i = 0; i < n_devs; i++) {
             ggml_backend_dev_t simple_dev = ggml_backend_meta_dev_simple_dev(meta_dev, i);
             if (i > 0) {
                 name += ",";
             }
             name += ggml_backend_dev_name(simple_dev);
-            backend_configs.emplace_back(ggml_backend_dev_init(simple_dev, params));
+            simple_backends.push_back(ggml_backend_dev_init(simple_dev, params));
+            backend_configs.emplace_back(simple_backends.back(), n_reduce_steps);
         }
         name += ")";
+
+        if (n_devs > 1) {
+            ggml_backend_comm_init_t comm_init = (ggml_backend_comm_init_t) ggml_backend_reg_get_proc_address(
+                ggml_backend_dev_backend_reg(ggml_backend_get_device(simple_backends[0])), "ggml_backend_comm_init");
+            if (comm_init != nullptr) {
+                comm_ctx = comm_init(simple_backends.data(), simple_backends.size());
+            }
+        }
+        if (comm_ctx != nullptr) {
+            comm_allreduce = (ggml_backend_comm_allreduce_tensor_t)
+                ggml_backend_reg_get_proc_address(ggml_backend_dev_backend_reg(
+                    ggml_backend_get_device(simple_backends[0])), "ggml_backend_comm_allreduce_tensor");
+            GGML_ASSERT(comm_allreduce != nullptr);
+        }
     }
 
     ~ggml_backend_meta_context() {
+        if (comm_ctx != nullptr) {
+            ggml_backend_comm_free_t comm_free = (ggml_backend_comm_free_t) ggml_backend_reg_get_proc_address(
+                ggml_backend_dev_backend_reg(ggml_backend_get_device(backend_configs[0].backend)), "ggml_backend_comm_free");
+            GGML_ASSERT(comm_free != nullptr);
+            comm_free(comm_ctx);
+        }
         for (auto & bc : backend_configs) {
             ggml_backend_free(bc.backend);
         }
-    }
-
-    size_t n_reduce_steps() const {
-        return std::ceil(std::log2(backend_configs.size()));
     }
 };
 
@@ -1502,6 +1770,7 @@ static void ggml_backend_meta_set_tensor_async(ggml_backend_t backend, ggml_tens
 
     const ggml_backend_meta_split_state split_state = ggml_backend_meta_get_split_state(tensor, /*assume_sync =*/ false);
     GGML_ASSERT(split_state.n_segments == 1);
+    GGML_ASSERT(split_state.nr[0]      == 1);
 
     switch (split_state.axis) {
         case GGML_BACKEND_SPLIT_AXIS_0:
@@ -1518,6 +1787,9 @@ static void ggml_backend_meta_set_tensor_async(ggml_backend_t backend, ggml_tens
                 ggml_backend_t simple_backend = ggml_backend_meta_simple_backend(backend, j);
                 ggml_tensor * simple_tensor = ggml_backend_meta_buffer_simple_tensor(tensor, j);
                 const size_t chunk_size_j = simple_tensor->nb[split_state.axis + 1];
+                if (chunk_size_j == 0) {
+                    continue;
+                }
                 ggml_backend_tensor_set_2d_async(simple_backend, simple_tensor, (const char *) data + offset_j, offset, chunk_size_j,
                     i_stop - i_start, chunk_size_j, chunk_size_full);
                 offset_j += chunk_size_j;
@@ -1543,6 +1815,7 @@ static void ggml_backend_meta_get_tensor_async(ggml_backend_t backend, const ggm
 
     const ggml_backend_meta_split_state split_state = ggml_backend_meta_get_split_state(tensor, /*assume_sync =*/ false);
     GGML_ASSERT(split_state.n_segments == 1);
+    GGML_ASSERT(split_state.nr[0]      == 1);
 
     switch (split_state.axis) {
         case GGML_BACKEND_SPLIT_AXIS_0:
@@ -1559,6 +1832,9 @@ static void ggml_backend_meta_get_tensor_async(ggml_backend_t backend, const ggm
                 ggml_backend_t simple_backend = ggml_backend_meta_simple_backend(backend, j);
                 const ggml_tensor * simple_tensor = ggml_backend_meta_buffer_simple_tensor(tensor, j);
                 const size_t chunk_size_j = simple_tensor->nb[split_state.axis + 1];
+                if (chunk_size_j == 0) {
+                    continue;
+                }
                 ggml_backend_tensor_get_2d_async(simple_backend, simple_tensor, (char *) data + offset_j, offset, chunk_size_j,
                     i_stop - i_start, chunk_size_j, chunk_size_full);
                 offset_j += chunk_size_j;
@@ -1589,6 +1865,9 @@ static enum ggml_status ggml_backend_meta_graph_compute(ggml_backend_t backend, 
     const size_t n_backends = ggml_backend_meta_n_backends(backend);
     ggml_backend_meta_context * backend_ctx = (ggml_backend_meta_context *) backend->context;
 
+    // If the previous cgraph had a defined UID it can be used to skip rebuilding the subgraphs per simple backend.
+    const bool needs_rebuild = (cgraph->uid == 0) || (cgraph->uid != backend_ctx->uid);
+
     bool max_nnodes_raised = false;
     if (cgraph->n_nodes > backend_ctx->max_nnodes) {
         for (size_t j = 0; j < n_backends; j++) {
@@ -1598,173 +1877,219 @@ static enum ggml_status ggml_backend_meta_graph_compute(ggml_backend_t backend, 
         }
         backend_ctx->max_nnodes = cgraph->n_nodes;
         max_nnodes_raised = true;
+        assert(needs_rebuild);
     }
-    for (size_t j = 0; j < n_backends; j++) {
-        auto & bcj = backend_ctx->backend_configs[j];
 
-        for (int i = 0; i < cgraph->n_nodes; i++) {
-            ggml_tensor * node = cgraph->nodes[i];
-            if (node->view_src != nullptr && node->view_src->op == GGML_OP_NONE && ggml_backend_buffer_is_host(node->view_src->buffer)) {
-                // FIXME s_copy_main is on the CPU and its view seems to be incorrectly added to the graph nodes.
-                // For regular usage this doesn't matter since it's a noop but trying to call ggml_backend_meta_buffer_simple_tensor results in a crash.
-                bcj.nodes[i] = node;
-                continue;
+    if (needs_rebuild) {
+        std::set<ggml_backend_buffer_t> used_buffers;
+        for (int i = 0; i < cgraph->n_leafs; i++) {
+            if (ggml_backend_buffer_is_meta(cgraph->leafs[i]->buffer)) {
+                used_buffers.emplace(cgraph->leafs[i]->buffer);
             }
-            bcj.nodes[i] = ggml_backend_meta_buffer_simple_tensor(node, j);
-            GGML_ASSERT(bcj.nodes[i]);
         }
-    }
-
-    size_t n_subgraphs  = 0;
-    size_t max_tmp_size = 0;
-    {
-        // For MoE models it may make sense to delay the AllReduce in order to reduce I/O:
-        auto get_i_delayed = [&](const int i) -> int {
-            int id = i; // i_delayed
-            int idr = i; // i_delayed return, last safe return value
-
-            ggml_tensor * node = cgraph->nodes[id];
-            int32_t n_used = ggml_node_get_use_count(cgraph, id);
-            if (id + 1 >= cgraph->n_nodes) {
-                return idr;
-            }
-            {
-                ggml_tensor * next = cgraph->nodes[id+1];
-                if (next->op == GGML_OP_ADD_ID && next->src[0] == node &&
-                        ggml_backend_meta_get_split_state(next->src[1], false).axis == GGML_BACKEND_SPLIT_AXIS_PARTIAL &&
-                        ggml_backend_meta_get_split_state(next->src[2], false).axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED) {
-                    node = next;
-                    id++;
-                    idr = id;
-                    n_used = ggml_node_get_use_count(cgraph, id);
-                }
-            }
-            if (id + 1 >= cgraph->n_nodes) {
-                return idr;
-            }
-            {
-                ggml_tensor * next = cgraph->nodes[id+1];
-                if (next->op == GGML_OP_MUL && next->src[0] == node &&
-                        ggml_backend_meta_get_split_state(next->src[1], false).axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED) {
-                    node = next;
-                    id++;
-                    idr = id;
-                    n_used = ggml_node_get_use_count(cgraph, id);
-                }
-            }
-
-            if (n_used != node->ne[1] || id + 2*n_used-1 >= cgraph->n_nodes) {
-                return idr;
-            }
-            for (int32_t k = 0; k < n_used; k++) {
-                ggml_tensor * next = cgraph->nodes[id+1];
-                if (next->op != GGML_OP_VIEW || next->view_src != node || next->view_offs != k*node->nb[1] ||
-                        next->ne[0] != node->ne[0] || next->ne[1] != node->ne[2] || next->nb[1] != node->nb[2] ||
-                        ggml_node_get_use_count(cgraph, id+1) != 1) {
-                    return idr;
-                }
-                id++;
-            }
-            {
-                ggml_tensor * next = cgraph->nodes[id+1];
-                if (next->op != GGML_OP_ADD || next->src[0] != cgraph->nodes[id - (n_used-1)] ||
-                        next->src[1] != cgraph->nodes[id - (n_used-2)] || ggml_node_get_use_count(cgraph, id+1) != 1) {
-                    return idr;
-                }
-                id++;
-            }
-            for (int32_t k = 0; k < n_used - 2; k++) {
-                ggml_tensor * next = cgraph->nodes[id+1];
-                if (next->op != GGML_OP_ADD || next->src[0] != cgraph->nodes[id] ||
-                        next->src[1] != cgraph->nodes[id - (n_used-2)] || ggml_node_get_use_count(cgraph, id+1) != 1) {
-                    return idr;
-                }
-                id++;
-            }
-            idr = id;
-            return idr;
-        };
-
-        int i_start = 0;
         for (int i = 0; i < cgraph->n_nodes; i++) {
-            ggml_tensor * node = cgraph->nodes[i];
-            if (node->view_src != nullptr && node->view_src->op == GGML_OP_NONE && ggml_backend_buffer_is_host(node->view_src->buffer)) {
-                continue;
+            if (ggml_backend_buffer_is_meta(cgraph->nodes[i]->buffer)) {
+                used_buffers.emplace(cgraph->nodes[i]->buffer);
             }
-            const ggml_backend_meta_split_state split_state = ggml_backend_meta_get_split_state(node, /*assume_sync =*/ false);
-            if (split_state.axis == GGML_BACKEND_SPLIT_AXIS_PARTIAL) {
-                max_tmp_size = std::max(max_tmp_size, ggml_nbytes(node));
+        }
+        for (ggml_backend_buffer_t buf : used_buffers) {
+            ggml_backend_meta_buffer_context * buf_ctx = (ggml_backend_meta_buffer_context *) buf->context;
+            buf_ctx->stc_compute_index_next = buf_ctx->stc_compute_index ^ 1;
+            ggml_backend_meta_simple_tensor_container & stc = buf_ctx->stc_compute[buf_ctx->stc_compute_index_next];
+            for (ggml_context_ptr & ctx : stc.ctxs) {
+                ggml_reset(ctx.get());
             }
-            const bool new_subgraph = i + 1 == cgraph->n_nodes || split_state.axis == GGML_BACKEND_SPLIT_AXIS_PARTIAL;
-            if (!new_subgraph) {
-                continue;
-            }
+            stc.simple_tensors.clear();
+        }
+        size_t n_subgraphs  = 0;
+        size_t max_tmp_size = 0;
 
-            i = get_i_delayed(i);
+        for (size_t j = 0; j < n_backends; j++) {
+            auto & bcj = backend_ctx->backend_configs[j];
 
+            for (int i = 0; i < cgraph->n_nodes; i++) {
+                ggml_tensor * node = cgraph->nodes[i];
+                if (node->view_src != nullptr && node->view_src->op == GGML_OP_NONE && ggml_backend_buffer_is_host(node->view_src->buffer)) {
+                    // FIXME s_copy_main is on the CPU and its view seems to be incorrectly added to the graph nodes.
+                    // For regular usage this doesn't matter since it's a noop but trying to call ggml_backend_meta_buffer_simple_tensor results in a crash.
+                    bcj.nodes[i] = node;
+                    continue;
+                }
+                bcj.nodes[i] = ggml_backend_meta_buffer_simple_tensor(node, j);
+                GGML_ASSERT(bcj.nodes[i]);
+            }
+        }
+
+        {
+            // For MoE models it may make sense to delay the AllReduce in order to reduce I/O:
+            auto get_i_delayed = [&](const int i) -> int {
+                int id = i; // i_delayed
+                int idr = i; // i_delayed return, last safe return value
+
+                ggml_tensor * node = cgraph->nodes[id];
+                int32_t n_used = ggml_node_get_use_count(cgraph, id);
+                if (id + 1 >= cgraph->n_nodes) {
+                    return idr;
+                }
+                {
+                    ggml_tensor * next = cgraph->nodes[id+1];
+                    if (next->op == GGML_OP_ADD_ID && next->src[0] == node &&
+                            ggml_backend_meta_get_split_state(next->src[1], false).axis == GGML_BACKEND_SPLIT_AXIS_PARTIAL &&
+                            ggml_backend_meta_get_split_state(next->src[2], false).axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED) {
+                        node = next;
+                        id++;
+                        idr = id;
+                        n_used = ggml_node_get_use_count(cgraph, id);
+                    }
+                }
+                if (id + 1 >= cgraph->n_nodes) {
+                    return idr;
+                }
+                {
+                    ggml_tensor * next = cgraph->nodes[id+1];
+                    if (next->op == GGML_OP_MUL && next->src[0] == node &&
+                            ggml_backend_meta_get_split_state(next->src[1], false).axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED) {
+                        node = next;
+                        id++;
+                        idr = id;
+                        n_used = ggml_node_get_use_count(cgraph, id);
+                    }
+                }
+
+                if (n_used != node->ne[1] || id + 2*n_used-1 >= cgraph->n_nodes) {
+                    return idr;
+                }
+                for (int32_t k = 0; k < n_used; k++) {
+                    ggml_tensor * next = cgraph->nodes[id+1];
+                    if (next->op != GGML_OP_VIEW || next->view_src != node || next->view_offs != k*node->nb[1] ||
+                            next->ne[0] != node->ne[0] || next->ne[1] != node->ne[2] || next->nb[1] != node->nb[2] ||
+                            ggml_node_get_use_count(cgraph, id+1) != 1) {
+                        return idr;
+                    }
+                    id++;
+                }
+                {
+                    ggml_tensor * next = cgraph->nodes[id+1];
+                    if (next->op != GGML_OP_ADD || next->src[0] != cgraph->nodes[id - (n_used-1)] ||
+                            next->src[1] != cgraph->nodes[id - (n_used-2)] || ggml_node_get_use_count(cgraph, id+1) != 1) {
+                        return idr;
+                    }
+                    id++;
+                }
+                for (int32_t k = 0; k < n_used - 2; k++) {
+                    ggml_tensor * next = cgraph->nodes[id+1];
+                    if (next->op != GGML_OP_ADD || next->src[0] != cgraph->nodes[id] ||
+                            next->src[1] != cgraph->nodes[id - (n_used-2)] || ggml_node_get_use_count(cgraph, id+1) != 1) {
+                        return idr;
+                    }
+                    id++;
+                }
+                idr = id;
+                return idr;
+            };
+
+            int i_start = 0;
+            for (int i = 0; i < cgraph->n_nodes; i++) {
+                ggml_tensor * node = cgraph->nodes[i];
+                if (node->view_src != nullptr && node->view_src->op == GGML_OP_NONE && ggml_backend_buffer_is_host(node->view_src->buffer)) {
+                    continue;
+                }
+                const ggml_backend_meta_split_state split_state = ggml_backend_meta_get_split_state(node, /*assume_sync =*/ false);
+                if (split_state.axis == GGML_BACKEND_SPLIT_AXIS_PARTIAL) {
+                    max_tmp_size = std::max(max_tmp_size, ggml_nbytes(node));
+                }
+                const bool new_subgraph = i + 1 == cgraph->n_nodes || split_state.axis == GGML_BACKEND_SPLIT_AXIS_PARTIAL;
+                if (!new_subgraph) {
+                    continue;
+                }
+
+                const int i_delayed = get_i_delayed(i);
+
+                // If we can delay the AllReduce we need to consider the interaction with zero-sized tensor slices.
+                // A backend with such a slice would normally have valid data after participating in the AllReduce with a node that has
+                //     its compute flag disabled and thus gets its data zeroed out.
+                // If the AllReduce is delayed then the nodes until that point also need to have their compute flag disabled.
+                if (i_delayed > i) {
+                    for (size_t j = 0; j < n_backends; j++) {
+                        auto & bcj = backend_ctx->backend_configs[j];
+                        if ((bcj.nodes[i]->flags & GGML_TENSOR_FLAG_COMPUTE) == 0) {
+                            for (int ii = i + 1; ii <= i_delayed; ii++) {
+                                bcj.nodes[ii]->flags &= ~GGML_TENSOR_FLAG_COMPUTE;
+                            }
+                        }
+                    }
+                }
+
+                i = i_delayed;
+
+                for (size_t j = 0; j < n_backends; j++) {
+                    auto & bcj = backend_ctx->backend_configs[j];
+                    bcj.cgraphs[n_subgraphs].offset = i_start;
+                }
+                n_subgraphs++;
+                i_start = i + 1;
+            }
+            GGML_ASSERT(i_start == cgraph->n_nodes);
+        }
+
+        backend_ctx->uid         = cgraph->uid;
+        backend_ctx->n_subgraphs = n_subgraphs;
+
+        if (max_tmp_size > backend_ctx->max_tmp_size) {
             for (size_t j = 0; j < n_backends; j++) {
                 auto & bcj = backend_ctx->backend_configs[j];
-                bcj.cgraphs[n_subgraphs].offset = i_start;
+                for (size_t i = 0; i < backend_ctx->n_reduce_steps; i++) {
+                    bcj.bufs[i].reset(ggml_backend_alloc_buffer(bcj.backend, max_tmp_size));
+                }
             }
-            n_subgraphs++;
-            i_start = i + 1;
+            backend_ctx->max_tmp_size = max_tmp_size;
         }
-        GGML_ASSERT(i_start == cgraph->n_nodes);
-    }
 
-    if (max_tmp_size > backend_ctx->max_tmp_size) {
-        for (size_t j = 0; j < n_backends; j++) {
-            auto & bcj = backend_ctx->backend_configs[j];
-            bcj.buf.reset(ggml_backend_alloc_buffer(bcj.backend, max_tmp_size));
-        }
-        backend_ctx->max_tmp_size = max_tmp_size;
-    }
-
-
-    if (max_nnodes_raised || n_subgraphs > backend_ctx->max_subgraphs) {
-        backend_ctx->max_subgraphs = std::max(backend_ctx->max_subgraphs, n_subgraphs);
-        const size_t n_reduce_steps = backend_ctx->n_reduce_steps();
-        const size_t n_nodes_per_device = 2 * n_reduce_steps; // tmp + ADD per step
-        const size_t n_cgraphs_per_device = n_reduce_steps;    // 1 ADD graph per step
-        const size_t mem_per_device_graphs_main = backend_ctx->max_subgraphs*ggml_graph_overhead_custom(backend_ctx->max_nnodes, cgraph->grads);
-        const size_t mem_per_device_graphs_aux = n_cgraphs_per_device*backend_ctx->max_subgraphs*ggml_graph_overhead_custom(1, cgraph->grads);
-        const size_t mem_per_device_nodes_aux = n_nodes_per_device*backend_ctx->max_subgraphs*ggml_tensor_overhead();
-        ggml_init_params params = {
-            /*.mem_size   =*/ n_backends * (mem_per_device_graphs_main + mem_per_device_graphs_aux + mem_per_device_nodes_aux),
-            /*.mem_buffer =*/ nullptr,
-            /*.no_alloc   =*/ true,
-        };
-        backend_ctx->ctx.reset(ggml_init(params));
-        for (size_t j = 0; j < n_backends; j++) {
-            auto & bcj = backend_ctx->backend_configs[j];
-            for (size_t i = 0; i < n_subgraphs; i++) {
-                bcj.cgraphs[i].cgraph_main = ggml_new_graph_custom(backend_ctx->ctx.get(), cgraph->n_nodes, /*grads =*/ false);
+        if (max_nnodes_raised || n_subgraphs > backend_ctx->max_subgraphs) {
+            backend_ctx->max_subgraphs = std::max(backend_ctx->max_subgraphs, n_subgraphs);
+            const size_t n_nodes_per_device = 3 * backend_ctx->n_reduce_steps; // tmp + ADD (+zeroing) graph per step and device
+            const size_t n_cgraphs_per_device = 2 * backend_ctx->n_reduce_steps; // ADD ( + zeroing) graph per step and device
+            const size_t mem_per_device_graphs_main = backend_ctx->max_subgraphs*ggml_graph_overhead_custom(backend_ctx->max_nnodes, cgraph->grads);
+            const size_t mem_per_device_graphs_aux = n_cgraphs_per_device*backend_ctx->max_subgraphs*ggml_graph_overhead_custom(1, cgraph->grads);
+            const size_t mem_per_device_nodes_aux = n_nodes_per_device*backend_ctx->max_subgraphs*ggml_tensor_overhead();
+            const ggml_init_params params = {
+                /*.mem_size   =*/ n_backends * (mem_per_device_graphs_main + mem_per_device_graphs_aux + mem_per_device_nodes_aux),
+                /*.mem_buffer =*/ nullptr,
+                /*.no_alloc   =*/ true,
+            };
+            backend_ctx->ctx.reset(ggml_init(params));
+            for (size_t j = 0; j < n_backends; j++) {
+                auto & bcj = backend_ctx->backend_configs[j];
+                for (size_t i = 0; i < n_subgraphs; i++) {
+                    bcj.cgraphs[i].cgraph_main = ggml_new_graph_custom(backend_ctx->ctx.get(), cgraph->n_nodes, /*grads =*/ false);
+                }
+            }
+            backend_ctx->cgraphs_aux.resize(n_backends*n_cgraphs_per_device*backend_ctx->max_subgraphs);
+            for (size_t k = 0; k < backend_ctx->cgraphs_aux.size(); k++) {
+                backend_ctx->cgraphs_aux[k] = ggml_new_graph_custom(backend_ctx->ctx.get(), 1, cgraph->grads);
+            }
+            backend_ctx->nodes_aux.resize(n_backends*n_nodes_per_device*backend_ctx->max_subgraphs);
+            for (size_t k = 0; k < backend_ctx->nodes_aux.size(); k++) {
+                backend_ctx->nodes_aux[k] = ggml_new_tensor_1d(backend_ctx->ctx.get(), GGML_TYPE_F32, 1);
             }
         }
-        backend_ctx->cgraphs_aux.resize(n_backends*n_cgraphs_per_device*backend_ctx->max_subgraphs);
-        for (size_t k = 0; k < backend_ctx->cgraphs_aux.size(); k++) {
-            backend_ctx->cgraphs_aux[k] = ggml_new_graph_custom(backend_ctx->ctx.get(), 1, cgraph->grads);
-        }
-        backend_ctx->nodes_aux.resize(n_backends*n_nodes_per_device*backend_ctx->max_subgraphs);
-        for (size_t k = 0; k < backend_ctx->nodes_aux.size(); k++) {
-            backend_ctx->nodes_aux[k] = ggml_new_tensor_1d(backend_ctx->ctx.get(), GGML_TYPE_F32, 1);
-        }
-    }
 
-    for (size_t j = 0; j < n_backends; j++) {
-        auto & bcj = backend_ctx->backend_configs[j];
-        for (size_t i_graph = 0; i_graph < n_subgraphs; i_graph++) {
-            ggml_cgraph * cgraph_ij = bcj.cgraphs[i_graph].cgraph_main;
-            const size_t i_node_start = bcj.cgraphs[i_graph].offset;
-            const size_t i_node_stop = i_graph + 1 < n_subgraphs ? bcj.cgraphs[i_graph + 1].offset : cgraph->n_nodes;
-            cgraph_ij->n_nodes = i_node_stop - i_node_start;
-            ggml_hash_set_reset(&cgraph_ij->visited_hash_set);
-            for (size_t i_node = i_node_start; i_node < i_node_stop; i_node++) {
-                ggml_tensor * node_ij = bcj.nodes[i_node];
-                cgraph_ij->nodes[i_node - i_node_start] = node_ij;
-                const size_t hash_pos_orig = ggml_hash_find(&cgraph->visited_hash_set, cgraph->nodes[i_node]);
-                const size_t hash_pos_ij = ggml_hash_insert(&cgraph_ij->visited_hash_set, node_ij);
-                cgraph_ij->use_counts[hash_pos_ij] = cgraph->use_counts[hash_pos_orig];
+        for (size_t j = 0; j < n_backends; j++) {
+            auto & bcj = backend_ctx->backend_configs[j];
+            for (size_t i_graph = 0; i_graph < n_subgraphs; i_graph++) {
+                ggml_cgraph * cgraph_ij = bcj.cgraphs[i_graph].cgraph_main;
+                const size_t i_node_start = bcj.cgraphs[i_graph].offset;
+                const size_t i_node_stop = i_graph + 1 < n_subgraphs ? bcj.cgraphs[i_graph + 1].offset : cgraph->n_nodes;
+                cgraph_ij->n_nodes = i_node_stop - i_node_start;
+                ggml_hash_set_reset(&cgraph_ij->visited_hash_set);
+                for (size_t i_node = i_node_start; i_node < i_node_stop; i_node++) {
+                    ggml_tensor * node_ij = bcj.nodes[i_node];
+                    cgraph_ij->nodes[i_node - i_node_start] = node_ij;
+                    const size_t hash_pos_orig = ggml_hash_find(&cgraph->visited_hash_set, cgraph->nodes[i_node]);
+                    const size_t hash_pos_ij = ggml_hash_insert(&cgraph_ij->visited_hash_set, node_ij);
+                    cgraph_ij->use_counts[hash_pos_ij] = cgraph->use_counts[hash_pos_orig];
+                }
+                cgraph_ij->uid = ggml_graph_next_uid();
             }
         }
     }
@@ -1772,11 +2097,6 @@ static enum ggml_status ggml_backend_meta_graph_compute(ggml_backend_t backend, 
     size_t iga = 0; // i graph aux
     size_t ina = 0; // i node aux
 
-    // FIXME usage_counts
-    auto get_cgraph_aux = [&]() -> ggml_cgraph * {
-        ggml_cgraph * ret = backend_ctx->cgraphs_aux[iga++];
-        return ret;
-    };
     auto get_node_aux = [&](ggml_tensor * t) -> ggml_tensor * {
         ggml_tensor * ret = backend_ctx->nodes_aux[ina++];
         memset(ret, 0, sizeof(ggml_tensor));
@@ -1788,75 +2108,111 @@ static enum ggml_status ggml_backend_meta_graph_compute(ggml_backend_t backend, 
         }
         return ret;
     };
+    auto set_tmp_data = [&](ggml_tensor * tensor, const size_t j, const size_t i_buf) {
+        auto & bcj = backend_ctx->backend_configs[j];
+        ggml_backend_buffer_ptr & buf_ptr = bcj.bufs[i_buf];
+        if (!buf_ptr || ggml_backend_buffer_get_size(buf_ptr.get()) < backend_ctx->max_tmp_size) {
+            buf_ptr.reset(ggml_backend_alloc_buffer(bcj.backend, backend_ctx->max_tmp_size));
+        }
+        tensor->buffer = buf_ptr.get();
+        tensor->data   = ggml_backend_buffer_get_base(buf_ptr.get());
+    };
+    // FIXME usage_counts
+    auto get_cgraph_aux = [&]() -> ggml_cgraph * {
+        ggml_cgraph * ret = backend_ctx->cgraphs_aux[iga++];
+        return ret;
+    };
 
     // Preferentially use backend-specific allreduce_tensor_async (e.g. NCCL for CUDA), use a generic fallback if unavailable:
     auto allreduce_fallback = [&](size_t i) -> ggml_status {
         std::vector<ggml_cgraph *> step_cgraphs(n_backends, nullptr);
 
-        for (size_t offset_j = 1; offset_j < n_backends; offset_j *= 2) {
+        // Zero out nodes that were disabled due to having a zero-sized slice:
+        for (size_t j = 0; j < n_backends; j++) {
+            auto & bcj = backend_ctx->backend_configs[j];
+            ggml_tensor * node = bcj.cgraphs[i].cgraph_main->nodes[bcj.cgraphs[i].cgraph_main->n_nodes - 1];
+            if (node->flags & GGML_TENSOR_FLAG_COMPUTE) {
+                continue;
+            }
+            ggml_tensor * node_zero = get_node_aux(node);
+            node_zero->op = GGML_OP_SCALE; // FIXME 0.0f * NaN == NaN
+            node_zero->src[0] = node;
+            ggml_set_op_params_f32(node_zero, 0, 0.0f);
+            node_zero->data = node->data;
+            node_zero->buffer = node->buffer;
+            node_zero->flags |= GGML_TENSOR_FLAG_COMPUTE;
+
+            step_cgraphs[j] = get_cgraph_aux();
+            step_cgraphs[j]->nodes[0] = node_zero;
+            step_cgraphs[j]->n_nodes = 1;
+            const ggml_status status = ggml_backend_graph_compute_async(bcj.backend, step_cgraphs[j]);
+            if (status != GGML_STATUS_SUCCESS) {
+                return status;
+            }
+        }
+        std::fill(step_cgraphs.begin(), step_cgraphs.end(), nullptr);
+
+        auto push_data = [&](const size_t j_src, const size_t j_dst, const size_t i_buf) {
+            assert(step_cgraphs[j_dst] == nullptr);
+            auto & bcj_src = backend_ctx->backend_configs[j_src];
+            auto & bcj_dst = backend_ctx->backend_configs[j_dst];
+
+            ggml_tensor * node_src = bcj_src.cgraphs[i].cgraph_main->nodes[bcj_src.cgraphs[i].cgraph_main->n_nodes - 1];
+            ggml_tensor * node_dst = bcj_dst.cgraphs[i].cgraph_main->nodes[bcj_dst.cgraphs[i].cgraph_main->n_nodes - 1];
+            GGML_ASSERT(ggml_is_contiguous(node_src));
+            GGML_ASSERT(ggml_is_contiguous(node_dst));
+
+            ggml_tensor * node_tmp = get_node_aux(node_dst);
+            set_tmp_data(node_tmp, j_dst, i_buf);
+
+            ggml_backend_tensor_copy_async(bcj_src.backend, bcj_dst.backend, node_src, node_tmp);
+
+            ggml_tensor * node_red = get_node_aux(node_dst);
+            node_red->view_src = node_dst->view_src == nullptr ? node_dst : node_dst->view_src;
+            node_red->view_offs = node_dst->view_offs;
+            node_red->op = GGML_OP_ADD;
+            node_red->src[0] = node_dst;
+            node_red->src[1] = node_tmp;
+            node_red->flags |= GGML_TENSOR_FLAG_COMPUTE;
+            ggml_backend_view_init(node_red);
+
+            ggml_cgraph * cgraph_aux = get_cgraph_aux();
+            cgraph_aux->nodes[0] = node_red;
+            cgraph_aux->n_nodes = 1;
+            step_cgraphs[j_dst] = cgraph_aux;
+        };
+
+        size_t offset_j = n_backends/2;
+        while ((offset_j & (offset_j - 1)) != 0) {
+            offset_j--;
+        }
+        const size_t offset_j_max = offset_j;
+        size_t i_buf = 0;
+
+        // If n_backends is not a power of 2, fold in the excess prior to butterfly reduction:
+        for (size_t j_src = 2*offset_j_max; j_src < n_backends; j_src++) {
+            const size_t j_dst = j_src - 2*offset_j_max;
+            push_data(j_src, j_dst, i_buf);
+            const ggml_status status = ggml_backend_graph_compute_async(backend_ctx->backend_configs[j_dst].backend, step_cgraphs[j_dst]);
+            if (status != GGML_STATUS_SUCCESS) {
+                return status;
+            }
+            i_buf = 1;
+        }
+
+        // Butterfly reduction:
+        for (; offset_j >= 1; offset_j /= 2) {
             std::fill(step_cgraphs.begin(), step_cgraphs.end(), nullptr);
 
-            for (size_t j = 0; j < n_backends; j++) {
+            for (size_t j = 0; j < 2*offset_j_max; j++) {
                 const size_t j_other = j ^ offset_j;
-                if (j_other > j) {
+                if (j_other >= n_backends) {
                     continue;
                 }
-
-                auto & bcj1 = backend_ctx->backend_configs[j];
-                auto & bcj2 = backend_ctx->backend_configs[j_other];
-
-                ggml_tensor * node1 = bcj1.cgraphs[i].cgraph_main->nodes[bcj1.cgraphs[i].cgraph_main->n_nodes - 1];
-                ggml_tensor * node2 = bcj2.cgraphs[i].cgraph_main->nodes[bcj2.cgraphs[i].cgraph_main->n_nodes - 1];
-                GGML_ASSERT(ggml_is_contiguous(node1));
-                GGML_ASSERT(ggml_is_contiguous(node2));
-
-                // Tmp tensors to receive P2P copies
-                ggml_tensor * node_tmp_1 = get_node_aux(node1);
-                node_tmp_1->buffer = bcj1.buf.get();
-                node_tmp_1->data = ggml_backend_buffer_get_base(bcj1.buf.get());
-
-                ggml_tensor * node_tmp_2 = get_node_aux(node2);
-                node_tmp_2->buffer = bcj2.buf.get();
-                node_tmp_2->data = ggml_backend_buffer_get_base(bcj2.buf.get());
-
-                // 2 P2P copies: exchange full buffers
-                ggml_backend_tensor_copy_async(bcj1.backend, bcj2.backend, node1, node_tmp_2);
-                ggml_backend_tensor_copy_async(bcj2.backend, bcj1.backend, node2, node_tmp_1);
-
-                // Local ADD: node1 += tmp1 (in-place via view)
-                ggml_tensor * node_red_1 = get_node_aux(node1);
-                node_red_1->view_src = node1->view_src == nullptr ? node1 : node1->view_src;
-                node_red_1->view_offs = node1->view_offs;
-                node_red_1->op = GGML_OP_ADD;
-                node_red_1->src[0] = node1;
-                node_red_1->src[1] = node_tmp_1;
-                node_red_1->flags |= GGML_TENSOR_FLAG_COMPUTE;
-                ggml_backend_view_init(node_red_1);
-
-                // Local ADD: node2 += tmp2 (in-place via view)
-                ggml_tensor * node_red_2 = get_node_aux(node2);
-                node_red_2->view_src = node2->view_src == nullptr ? node2 : node2->view_src;
-                node_red_2->view_offs = node2->view_offs;
-                node_red_2->op = GGML_OP_ADD;
-                node_red_2->src[0] = node2;
-                node_red_2->src[1] = node_tmp_2;
-                node_red_2->flags |= GGML_TENSOR_FLAG_COMPUTE;
-                ggml_backend_view_init(node_red_2);
-
-                // Build 1-node cgraphs for the ADD ops
-                ggml_cgraph * cgraph_aux_1 = get_cgraph_aux();
-                cgraph_aux_1->nodes[0] = node_red_1;
-                cgraph_aux_1->n_nodes = 1;
-                step_cgraphs[j] = cgraph_aux_1;
-
-                ggml_cgraph * cgraph_aux_2 = get_cgraph_aux();
-                cgraph_aux_2->nodes[0] = node_red_2;
-                cgraph_aux_2->n_nodes = 1;
-                step_cgraphs[j_other] = cgraph_aux_2;
+                push_data(j, j_other, i_buf);
             }
 
-            // Execute local ADDs for this step
-            for (size_t j = 0; j < n_backends; j++) {
+            for (size_t j = 0; j < 2*offset_j_max; j++) {
                 if (step_cgraphs[j] == nullptr) {
                     continue;
                 }
@@ -1866,12 +2222,25 @@ static enum ggml_status ggml_backend_meta_graph_compute(ggml_backend_t backend, 
                     return status;
                 }
             }
+            i_buf++;
         }
+        assert(i_buf == backend_ctx->n_reduce_steps);
+
+        // If n_backends is not a power of 2, copy back the reduced tensors to the excess:
+        for (size_t j = 2*offset_j_max; j < n_backends; j++) {
+            auto & bcj_src = backend_ctx->backend_configs[j - 2*offset_j_max];
+            auto & bcj_dst = backend_ctx->backend_configs[j];
+
+            ggml_tensor * node_src = bcj_src.cgraphs[i].cgraph_main->nodes[bcj_src.cgraphs[i].cgraph_main->n_nodes - 1];
+            ggml_tensor * node_dst = bcj_dst.cgraphs[i].cgraph_main->nodes[bcj_dst.cgraphs[i].cgraph_main->n_nodes - 1];
+            ggml_backend_tensor_copy_async(bcj_src.backend, bcj_dst.backend, node_src, node_dst);
+        }
+
         return GGML_STATUS_SUCCESS;
     };
 
 
-    for (size_t i = 0; i < n_subgraphs; i++) {
+    for (size_t i = 0; i < backend_ctx->n_subgraphs; i++) {
         for (size_t j = 0; j < n_backends; j++) {
             auto & bcj = backend_ctx->backend_configs[j];
             const ggml_status status = ggml_backend_graph_compute_async(bcj.backend, bcj.cgraphs[i].cgraph_main);
@@ -1880,22 +2249,17 @@ static enum ggml_status ggml_backend_meta_graph_compute(ggml_backend_t backend, 
             }
         }
 
-        if (n_backends > 1 && i < n_subgraphs - 1) {
+        if (n_backends > 1 && i < backend_ctx->n_subgraphs - 1) {
             bool backend_allreduce_success = false;
-            ggml_backend_allreduce_tensor_t allreduce_tensor = (ggml_backend_allreduce_tensor_t) ggml_backend_reg_get_proc_address(
-                ggml_backend_dev_backend_reg(ggml_backend_get_device(backend_ctx->backend_configs[0].backend)), "ggml_backend_allreduce_tensor");
-            if (allreduce_tensor) {
-                std::vector<ggml_backend_t> backends;
-                backends.reserve(n_backends);
+            if (backend_ctx->comm_ctx) {
                 std::vector<ggml_tensor *> nodes;
                 nodes.reserve(n_backends);
                 for (size_t j = 0; j < n_backends; j++) {
                     auto & bcj = backend_ctx->backend_configs[j];
-                    backends.push_back(bcj.backend);
                     ggml_cgraph * cgraph_ij = bcj.cgraphs[i].cgraph_main;
                     nodes.push_back(cgraph_ij->nodes[cgraph_ij->n_nodes-1]);
                 }
-                backend_allreduce_success = allreduce_tensor(backends.data(), nodes.data(), n_backends);
+                backend_allreduce_success = backend_ctx->comm_allreduce(backend_ctx->comm_ctx, nodes.data());
             }
 
             if (!backend_allreduce_success) {

--- a/server/deps/llama.cpp/ggml/src/ggml-backend.cpp
+++ b/server/deps/llama.cpp/ggml/src/ggml-backend.cpp
@@ -1112,6 +1112,8 @@ void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct ggml_cgra
         GGML_ABORT("%s: failed to initialize context\n", __func__);
     }
 
+    graph->uid = ggml_graph_next_uid();
+
     // pass 1: assign backends to ops with pre-allocated inputs
     for (int i = 0; i < graph->n_leafs; i++) {
         struct ggml_tensor * leaf = graph->leafs[i];
@@ -1686,6 +1688,11 @@ void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct ggml_cgra
         sched->leaf_backend_ids[graph_copy->n_leafs] = tensor_backend_id(leaf);
         assert(graph_copy->size > graph_copy->n_leafs);
         graph_copy->leafs[graph_copy->n_leafs++] = leaf;
+    }
+
+    // set ids for all splits
+    for (int i = 0; i < sched->n_splits; ++i) {
+        sched->splits[i].graph.uid = ggml_graph_next_uid();
     }
 }
 

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/common.cuh
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/common.cuh
@@ -1143,10 +1143,6 @@ struct ggml_cuda_device_info {
     cuda_device_info devices[GGML_CUDA_MAX_DEVICES] = {};
 
     std::array<float, GGML_CUDA_MAX_DEVICES> default_tensor_split = {};
-
-#ifdef GGML_USE_NCCL
-    ncclComm_t comms[GGML_CUDA_MAX_DEVICES];
-#endif // GGML_USE_NCCL
 };
 
 const ggml_cuda_device_info & ggml_cuda_info();
@@ -1236,6 +1232,7 @@ struct ggml_cuda_graph {
     bool warmup_complete = false;
     // GGML_CUDA_GRAPH_STATS=1 counters
     uint64_t stat_total = 0, stat_replay = 0, stat_capture = 0, stat_eager = 0;
+    uint64_t uid = 0;
     struct node_properties {
         ggml_tensor node;
         void *   node_src_data_ptrs[GGML_MAX_SRC];

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -1341,11 +1341,23 @@ static void ggml_backend_cuda_comm_free(void * comm_ctx_v) {
 
 static void * ggml_backend_cuda_comm_init(ggml_backend_t * backends, size_t n_backends) {
 #ifdef GGML_USE_NCCL
+    if (n_backends == 0 || n_backends > GGML_CUDA_MAX_DEVICES) {
+        return nullptr;
+    }
+
+    std::array<bool, GGML_CUDA_MAX_DEVICES> seen_devices = {};
     for (size_t i = 0; i < n_backends; i++) {
         if (!ggml_backend_is_cuda(backends[i])) {
             return nullptr;
         }
+        ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *) backends[i]->context;
+        if (cuda_ctx->device < 0 || cuda_ctx->device >= GGML_CUDA_MAX_DEVICES ||
+            seen_devices[cuda_ctx->device]) {
+            return nullptr;
+        }
+        seen_devices[cuda_ctx->device] = true;
     }
+
     ggml_backend_cuda_comm_context * ret = new ggml_backend_cuda_comm_context;
     std::vector<int> dev_ids;
     ret->backends.reserve(n_backends);
@@ -1454,6 +1466,20 @@ static bool ggml_backend_cuda_comm_allreduce_tensor(void * comm_ctx_v, struct gg
     GGML_UNUSED_VARS(comm_ctx_v, tensors);
     return false;
 #endif // GGML_USE_NCCL
+}
+
+bool ggml_backend_cuda_allreduce_tensor(
+        ggml_backend_t * backends,
+        struct ggml_tensor ** tensors,
+        size_t n_backends) {
+    void * comm_ctx = ggml_backend_cuda_comm_init(backends, n_backends);
+    if (comm_ctx == nullptr) {
+        return false;
+    }
+
+    const bool result = ggml_backend_cuda_comm_allreduce_tensor(comm_ctx, tensors);
+    ggml_backend_cuda_comm_free(comm_ctx);
+    return result;
 }
 
 ggml_backend_buffer_type_t ggml_backend_cuda_split_buffer_type(int main_device, const float * tensor_split) {

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -458,14 +458,6 @@ static ggml_cuda_device_info ggml_cuda_init() {
         }
     }
 
-#ifdef GGML_USE_NCCL
-    int dev_ids[GGML_CUDA_MAX_DEVICES];
-    for (int id = 0; id < info.device_count; ++id) {
-        dev_ids[id] = id;
-    }
-    NCCL_CHECK(ncclCommInitAll(info.comms, info.device_count, dev_ids));
-#endif // GGML_USE_NCCL
-
     return info;
 }
 
@@ -1322,66 +1314,51 @@ static const ggml_backend_buffer_type_i ggml_backend_cuda_split_buffer_type_inte
     /* .is_host          = */ ggml_backend_cuda_split_buffer_type_is_host,
 };
 
-bool ggml_backend_cuda_allreduce_tensor(ggml_backend_t * backends, struct ggml_tensor ** tensors, size_t n_backends) {
 #ifdef GGML_USE_NCCL
-    const int64_t ne = ggml_nelements(tensors[0]);
-    // FIXME the input of llm_graph_context::build_in_out_ids can produce a tensor with 0 elements if n_outputs == 0
-    // This then causes a crash in this function
-    if (ne == 0) {
-        return true;
-    }
-    for (size_t i = 0; i < n_backends; ++i) {
-        GGML_ASSERT(tensors[i] != nullptr);
-        GGML_ASSERT(ggml_nelements(tensors[i]) == ne);
-        GGML_ASSERT(ggml_is_contiguously_allocated(tensors[i]));
-    }
+struct ggml_backend_cuda_comm_context {
+    std::vector<ggml_backend_t> backends;
+    std::vector<ncclComm_t> comms;
 
-    const ggml_cuda_device_info info = ggml_cuda_info();
-
-    // For small tensors, simply reduce them as FP32.
-    // The following heuristic for how "small" a tensor should be is based on RTX 4090s connected via 16x PCIe 4.0.
-    if ((n_backends <= 2 && ne < 32768) || (n_backends == 3 && ne < 131072) || (n_backends >= 4 && ne < 262144)) {
-        NCCL_CHECK(ncclGroupStart());
-        for (size_t i = 0; i < n_backends; ++i) {
-            ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *) backends[i]->context;
-            NCCL_CHECK(ncclAllReduce(tensors[i]->data, tensors[i]->data, ne, ncclFloat, ncclSum, info.comms[cuda_ctx->device], cuda_ctx->stream()));
+    ~ggml_backend_cuda_comm_context() {
+        for (ncclComm_t comm : comms) {
+            NCCL_CHECK(ncclCommDestroy(comm));
         }
-        NCCL_CHECK(ncclGroupEnd());
-
-        return true;
     }
+};
+#endif // GGML_USE_NCCL
 
-    // For large tensors it's faster to compress them to BF16 for the reduction:
-    to_bf16_cuda_t to_bf16 = ggml_get_to_bf16_cuda(GGML_TYPE_F32);
-    to_fp32_cuda_t to_fp32 = ggml_get_to_fp32_cuda(GGML_TYPE_BF16);
+static void ggml_backend_cuda_comm_free(void * comm_ctx_v) {
+#ifdef GGML_USE_NCCL
+    if (comm_ctx_v == nullptr) {
+        return;
+    }
+    ggml_backend_cuda_comm_context * comm_ctx = (ggml_backend_cuda_comm_context *) comm_ctx_v;
+    delete comm_ctx;
+#else
+    GGML_UNUSED(comm_ctx_v);
+#endif // GGML_USE_NCCL
+}
 
-    ggml_cuda_pool_alloc<nv_bfloat16> tmp[GGML_CUDA_MAX_DEVICES];
-    for (size_t i = 0; i < n_backends; ++i) {
+static void * ggml_backend_cuda_comm_init(ggml_backend_t * backends, size_t n_backends) {
+#ifdef GGML_USE_NCCL
+    for (size_t i = 0; i < n_backends; i++) {
+        if (!ggml_backend_is_cuda(backends[i])) {
+            return nullptr;
+        }
+    }
+    ggml_backend_cuda_comm_context * ret = new ggml_backend_cuda_comm_context;
+    std::vector<int> dev_ids;
+    ret->backends.reserve(n_backends);
+    dev_ids.reserve(n_backends);
+    for (size_t i = 0; i < n_backends; i++) {
+        ret->backends.push_back(backends[i]);
         ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *) backends[i]->context;
-        tmp[i].pool = &cuda_ctx->pool();
-        tmp[i].alloc(ne);
-
-        ggml_cuda_set_device(i);
-        to_bf16(tensors[i]->data, tmp[i].get(), ne, cuda_ctx->stream());
-        CUDA_CHECK(cudaGetLastError());
+        dev_ids.push_back(cuda_ctx->device);
     }
 
-    NCCL_CHECK(ncclGroupStart());
-    for (size_t i = 0; i < n_backends; ++i) {
-        ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *) backends[i]->context;
-        NCCL_CHECK(ncclAllReduce(tmp[i].get(), tmp[i].get(), ne, ncclBfloat16, ncclSum, info.comms[cuda_ctx->device], cuda_ctx->stream()));
-    }
-    NCCL_CHECK(ncclGroupEnd());
-
-    for (size_t i = 0; i < n_backends; ++i) {
-        ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *) backends[i]->context;
-
-        ggml_cuda_set_device(i);
-        to_fp32(tmp[i].get(), (float *) tensors[i]->data, ne, cuda_ctx->stream());
-        CUDA_CHECK(cudaGetLastError());
-    }
-
-    return true;
+    ret->comms.resize(n_backends);
+    NCCL_CHECK(ncclCommInitAll(ret->comms.data(), n_backends, dev_ids.data()));
+    return ret;
 #else
     // If NCCL is installed it is used by default for optimal performance.
     // However, NVIDIA does not distribute NCCL with CUDA so users may be unwittingly missing this package.
@@ -1394,7 +1371,87 @@ bool ggml_backend_cuda_allreduce_tensor(ggml_backend_t * backends, struct ggml_t
         warning_printed = true;
     }
 #endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
-    GGML_UNUSED_VARS(backends, tensors, n_backends);
+    GGML_UNUSED_VARS(backends, n_backends);
+    return nullptr;
+#endif // GGML_USE_NCCL
+}
+
+static bool ggml_backend_cuda_comm_allreduce_tensor(void * comm_ctx_v, struct ggml_tensor ** tensors) {
+#ifdef GGML_USE_NCCL
+    const int64_t ne = ggml_nelements(tensors[0]);
+    // FIXME the input of llm_graph_context::build_in_out_ids can produce a tensor with 0 elements if n_outputs == 0
+    // This then causes a crash in this function
+    if (ne == 0) {
+        return true;
+    }
+
+    GGML_ASSERT(comm_ctx_v != nullptr);
+    ggml_backend_cuda_comm_context * comm_ctx = (ggml_backend_cuda_comm_context *) comm_ctx_v;
+    const size_t n_backends = comm_ctx->backends.size();
+
+    for (size_t i = 0; i < n_backends; ++i) {
+        GGML_ASSERT(tensors[i] != nullptr);
+        GGML_ASSERT(ggml_nelements(tensors[i]) == ne);
+        GGML_ASSERT(ggml_is_contiguously_allocated(tensors[i]));
+    }
+
+    // For small tensors, simply reduce them as FP32.
+    // The following heuristic for how "small" a tensor should be is based on RTX 4090s connected via 16x PCIe 4.0.
+    if ((n_backends <= 2 && ne < 32768) || (n_backends == 3 && ne < 131072) || (n_backends >= 4 && ne < 262144)) {
+        for (size_t i = 0; i < n_backends; ++i) {
+            if ((tensors[i]->flags & GGML_TENSOR_FLAG_COMPUTE) == 0) {
+                ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *) comm_ctx->backends[i]->context;
+                ggml_cuda_set_device(cuda_ctx->device);
+                CUDA_CHECK(cudaMemsetAsync(tensors[i]->data, 0, ggml_nbytes(tensors[i]), cuda_ctx->stream()));
+            }
+        }
+        NCCL_CHECK(ncclGroupStart());
+        for (size_t i = 0; i < n_backends; ++i) {
+            ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *) comm_ctx->backends[i]->context;
+            NCCL_CHECK(ncclAllReduce(tensors[i]->data, tensors[i]->data, ne, ncclFloat, ncclSum, comm_ctx->comms[i], cuda_ctx->stream()));
+        }
+        NCCL_CHECK(ncclGroupEnd());
+
+        return true;
+    }
+
+    // For large tensors it's faster to compress them to BF16 for the reduction:
+    to_bf16_cuda_t to_bf16 = ggml_get_to_bf16_cuda(GGML_TYPE_F32);
+    to_fp32_cuda_t to_fp32 = ggml_get_to_fp32_cuda(GGML_TYPE_BF16);
+
+    ggml_cuda_pool_alloc<nv_bfloat16> tmp[GGML_CUDA_MAX_DEVICES];
+    for (size_t i = 0; i < n_backends; ++i) {
+        ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *) comm_ctx->backends[i]->context;
+        tmp[i].pool = &cuda_ctx->pool();
+        tmp[i].alloc(ne);
+
+        ggml_cuda_set_device(cuda_ctx->device);
+        if (tensors[i]->flags & GGML_TENSOR_FLAG_COMPUTE) {
+            to_bf16(tensors[i]->data, tmp[i].get(), ne, cuda_ctx->stream());
+        } else {
+            CUDA_CHECK(cudaMemsetAsync(tmp[i].get(), 0, ne * sizeof(nv_bfloat16), cuda_ctx->stream()));
+        }
+        CUDA_CHECK(cudaGetLastError());
+    }
+
+    NCCL_CHECK(ncclGroupStart());
+    for (size_t i = 0; i < n_backends; ++i) {
+        ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *) comm_ctx->backends[i]->context;
+        NCCL_CHECK(ncclAllReduce(tmp[i].get(), tmp[i].get(), ne, ncclBfloat16, ncclSum, comm_ctx->comms[i], cuda_ctx->stream()));
+    }
+    NCCL_CHECK(ncclGroupEnd());
+
+    for (size_t i = 0; i < n_backends; ++i) {
+        ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *) comm_ctx->backends[i]->context;
+
+        ggml_cuda_set_device(cuda_ctx->device);
+        to_fp32(tmp[i].get(), (float *) tensors[i]->data, ne, cuda_ctx->stream());
+        CUDA_CHECK(cudaGetLastError());
+    }
+
+    return true;
+#else
+    GGML_UNUSED_VARS(comm_ctx_v, tensors);
     return false;
 #endif // GGML_USE_NCCL
 }
@@ -3553,6 +3610,15 @@ static bool ggml_cuda_graph_update_required(ggml_backend_cuda_context * cuda_ctx
     const void * graph_key = ggml_cuda_graph_get_key(cgraph);
     ggml_cuda_graph * graph = cuda_ctx->cuda_graph(graph_key);
 
+    if (cgraph->uid != 0 &&
+        cgraph->uid == graph->uid) {
+        GGML_LOG_DEBUG("CUDA Graph id %zu reused\n", cgraph->uid);
+        GGML_ASSERT((int)graph->node_props.size() == cgraph->n_nodes);
+        return false;
+    }
+
+    graph->uid = cgraph->uid;
+
     // Check if the graph size has changed
     if ((int)graph->node_props.size() != cgraph->n_nodes) {
         res = true;
@@ -4716,6 +4782,8 @@ static enum ggml_status ggml_backend_cuda_graph_compute(ggml_backend_t backend, 
     if (!ggml_cuda_graphs_disabled_override &&
         !ggml_cuda_graphs_disabled_for_device(cuda_ctx->device) &&
         graph->is_enabled()) {
+        static const bool log_graph_warmup =
+            getenv("GGML_CUDA_GRAPH_WARMUP_LOG") != nullptr;
         const bool graph_compatible = ggml_cuda_graph_check_compability(cgraph);
         if (graph_compatible) {
             const bool can_skip_props_check = ggml_cuda_skip_props_check
@@ -4729,7 +4797,9 @@ static enum ggml_status ggml_backend_cuda_graph_compute(ggml_backend_t backend, 
                 // Warmup: need at least 2 calls with no property change on the 2nd call
                 if (!properties_changed) {
                     graph->warmup_complete = true;
-                    GGML_LOG_DEBUG("%s: CUDA graph warmup complete\n", __func__);
+                    if (log_graph_warmup) {
+                        GGML_LOG_DEBUG("%s: CUDA graph warmup complete\n", __func__);
+                    }
                     use_cuda_graph = true;
                     cuda_graph_update_required = true;
                 }
@@ -4739,7 +4809,9 @@ static enum ggml_status ggml_backend_cuda_graph_compute(ggml_backend_t backend, 
                 if (properties_changed) {
                     // Properties changed - reset warmup, execute directly until stable again
                     graph->warmup_complete = false;
-                    GGML_LOG_DEBUG("%s: CUDA graph warmup reset\n", __func__);
+                    if (log_graph_warmup) {
+                        GGML_LOG_DEBUG("%s: CUDA graph warmup reset\n", __func__);
+                    }
                 } else {
                     use_cuda_graph = true;
                     cuda_graph_update_required = graph->instance == nullptr;
@@ -5992,8 +6064,14 @@ static ggml_backend_feature * ggml_backend_cuda_get_features(ggml_backend_reg_t 
 
 static void * ggml_backend_cuda_reg_get_proc_address(ggml_backend_reg_t reg, const char * name) {
     GGML_UNUSED(reg);
-    if (strcmp(name, "ggml_backend_allreduce_tensor") == 0) {
-        return (void *)ggml_backend_cuda_allreduce_tensor;
+    if (strcmp(name, "ggml_backend_comm_init") == 0) {
+        return (void *)ggml_backend_cuda_comm_init;
+    }
+    if (strcmp(name, "ggml_backend_comm_free") == 0) {
+        return (void *)ggml_backend_cuda_comm_free;
+    }
+    if (strcmp(name, "ggml_backend_comm_allreduce_tensor") == 0) {
+        return (void *)ggml_backend_cuda_comm_allreduce_tensor;
     }
     if (strcmp(name, "ggml_backend_split_buffer_type") == 0) {
         return (void *)ggml_backend_cuda_split_buffer_type;

--- a/server/deps/llama.cpp/ggml/src/ggml-impl.h
+++ b/server/deps/llama.cpp/ggml/src/ggml-impl.h
@@ -30,6 +30,8 @@ extern "C" {
 
 void ggml_print_backtrace(void);
 
+uint64_t ggml_graph_next_uid(void);
+
 #ifndef MIN
 #    define MIN(a, b) ((a) < (b) ? (a) : (b))
 #endif
@@ -338,6 +340,10 @@ struct ggml_cgraph {
     struct ggml_hash_set visited_hash_set;
 
     enum ggml_cgraph_eval_order order;
+
+    // an optional identifier that can be utilized to recognize same graphs if two non-zero values match
+    // a value of 0 means it is not set and should be ignored
+    uint64_t uid;
 };
 
 // returns a slice of cgraph with nodes [i0, i1)

--- a/server/deps/llama.cpp/ggml/src/ggml.c
+++ b/server/deps/llama.cpp/ggml/src/ggml.c
@@ -55,6 +55,16 @@
 
 #define UNUSED GGML_UNUSED
 
+uint64_t ggml_graph_next_uid(void) {
+#ifdef _MSC_VER
+    static volatile long long counter = 1;
+    return (uint64_t) _InterlockedIncrement64(&counter) - 1;
+#else
+    static uint64_t counter = 1;
+    return __atomic_fetch_add(&counter, 1, __ATOMIC_RELAXED);
+#endif
+}
+
 // Needed for ggml_fp32_to_bf16_row()
 #if defined(__AVX512BF16__)
 #if defined(_MSC_VER)
@@ -7450,6 +7460,7 @@ struct ggml_cgraph * ggml_new_graph_custom(struct ggml_context * ctx, size_t siz
         /*.use_counts   =*/ use_counts_ptr,
         /*.hash_table   =*/ { hash_size, hash_used, hash_keys_ptr },
         /*.order        =*/ GGML_CGRAPH_EVAL_ORDER_LEFT_TO_RIGHT,
+        /*.uid          =*/ 0,
     };
 
     ggml_hash_set_reset(&cgraph->visited_hash_set);
@@ -7477,6 +7488,7 @@ struct ggml_cgraph ggml_graph_view(struct ggml_cgraph * cgraph0, int i0, int i1)
         /*.use_counts       =*/ cgraph0->use_counts,
         /*.visited_hash_set =*/ cgraph0->visited_hash_set,
         /*.order            =*/ cgraph0->order,
+        /*.uid              =*/ 0
     };
 
     return cgraph;

--- a/server/src/common/feature_gate.cpp
+++ b/server/src/common/feature_gate.cpp
@@ -62,16 +62,44 @@ std::string check_feature_compatibility(
                std::string(placement_backend_name(target_backend)) +
                " draft=" + placement_backend_name(draft_backend) + ")";
     }
-    // ── target layer split structure and remote backend topology
+    // ── target split structure and remote backend topology
+    const bool tensor_mode =
+        args.device.split_mode == TargetSplitMode::Tensor;
     if (!args.device.is_layer_split() &&
         !args.device.layer_split_weights.empty()) {
-        return "--target-layer-split requires --target-devices";
+        return tensor_mode
+            ? "--target-layer-split is incompatible with tensor parallelism"
+            : "--target-layer-split requires --target-devices";
     }
-    if (args.device.is_layer_split()) {
+    if (args.device.is_multi_device() || tensor_mode) {
         const std::string placement_error =
             validate_device_placement(args.device, /*device_count=*/-1);
         if (!placement_error.empty()) {
-            return "bad target layer split: " + placement_error;
+            return "bad target placement: " + placement_error;
+        }
+    }
+
+    // The target-only implementation is deliberately narrow: every rank must
+    // be a local CUDA device and target-replacing features are unsupported.
+    if (tensor_mode) {
+        if (arch != "qwen35") {
+            return "tensor parallelism is currently supported only for dense qwen35";
+        }
+        if (target_backend != PlacementBackend::Cuda ||
+            compiled_backend != PlacementBackend::Cuda) {
+            return "tensor parallelism currently requires local CUDA devices";
+        }
+        if (args.device.is_mixed_layer_split()) {
+            return "tensor parallelism requires homogeneous local devices";
+        }
+        if (args.remote_target_shard.enabled()) {
+            return "tensor parallelism is incompatible with --target-shard-ipc-bin";
+        }
+        if (features.pflash_enabled) {
+            return "tensor parallelism does not yet support prefill compression";
+        }
+        if (args.draft_path) {
+            return "tensor parallelism does not yet support a DFlash draft";
         }
     }
 

--- a/server/src/placement/placement_config.cpp
+++ b/server/src/placement/placement_config.cpp
@@ -22,6 +22,11 @@ std::string validate_device_placement(
                     : "");
     }
 
+    if (dp.split_mode == TargetSplitMode::Tensor &&
+        dp.layer_split_gpus.size() < 2) {
+        return "tensor parallelism requires at least 2 target devices";
+    }
+
     if (!dp.layer_split_gpus.empty()) {
         if (dp.layer_split_gpus.size() < 2) {
             return "target device list must have at least 2 entries";

--- a/server/src/placement/placement_config.cpp
+++ b/server/src/placement/placement_config.cpp
@@ -24,7 +24,7 @@ std::string validate_device_placement(
 
     if (!dp.layer_split_gpus.empty()) {
         if (dp.layer_split_gpus.size() < 2) {
-            return "layer_split_gpus must have at least 2 entries";
+            return "target device list must have at least 2 entries";
         }
         if (!dp.layer_split_backends.empty() &&
             dp.layer_split_backends.size() != dp.layer_split_gpus.size()) {
@@ -47,10 +47,15 @@ std::string validate_device_placement(
                             : "");
             }
             if (!seen.insert({g, backend}).second) {
-                return "duplicate device " +
+                return "duplicate target device " +
                        std::string(placement_backend_name(backend)) + ":" +
                        std::to_string(g) + " in layer_split_gpus";
             }
+        }
+
+        if (dp.split_mode == TargetSplitMode::Tensor &&
+            !dp.layer_split_weights.empty()) {
+            return "target layer split weights are incompatible with tensor parallelism";
         }
 
         if (!dp.layer_split_weights.empty() &&

--- a/server/src/placement/placement_config.h
+++ b/server/src/placement/placement_config.h
@@ -15,9 +15,32 @@
 
 namespace dflash::common {
 
+enum class TargetSplitMode {
+    Layer,
+    Tensor,
+};
+
+inline const char * target_split_mode_name(TargetSplitMode mode) {
+    return mode == TargetSplitMode::Tensor ? "tensor" : "layer";
+}
+
+inline bool parse_target_split_mode(const std::string & value,
+                                    TargetSplitMode & out) {
+    if (value == "layer") {
+        out = TargetSplitMode::Layer;
+        return true;
+    }
+    if (value == "tensor") {
+        out = TargetSplitMode::Tensor;
+        return true;
+    }
+    return false;
+}
+
 struct DevicePlacement {
     PlacementBackend backend = PlacementBackend::Auto;
     int gpu = 0;                              // primary GPU (single-GPU mode)
+    TargetSplitMode split_mode = TargetSplitMode::Layer;
 
     // Multi-GPU layer-split. Empty = single GPU mode.
     std::vector<PlacementBackend> layer_split_backends; // backend for each shard
@@ -27,7 +50,13 @@ struct DevicePlacement {
     bool peer_access = false;                 // enable CUDA/HIP peer access between GPUs
     int  max_ctx     = 8192;                  // max KV cache context length
 
-    bool is_layer_split() const { return layer_split_gpus.size() > 1; }
+    bool is_multi_device() const { return layer_split_gpus.size() > 1; }
+    bool is_layer_split() const {
+        return is_multi_device() && split_mode == TargetSplitMode::Layer;
+    }
+    bool is_tensor_parallel() const {
+        return is_multi_device() && split_mode == TargetSplitMode::Tensor;
+    }
     bool is_mixed_layer_split() const {
         if (layer_split_backends.size() <= 1) return false;
         const PlacementBackend first = layer_split_backends[0];

--- a/server/src/qwen35/gguf_target_loader.cpp
+++ b/server/src/qwen35/gguf_target_loader.cpp
@@ -627,6 +627,72 @@ bool load_target_gguf_partial(const std::string & path,
         alloc_total += ggml_backend_buft_get_alloc_size(buft, t);
         allocs.push_back(a);
     }
+
+    // The generic meta buffer allocator must see all tensors together so it
+    // can allocate each device from its actual slices. The legacy loader's
+    // monolithic backing buffer would reserve alloc_total on every rank.
+    if (!plan.metadata_only && ggml_backend_buft_is_meta(buft)) {
+        ggml_init_params tip{};
+        tip.mem_size = (allocs.size() + 32) * ggml_tensor_overhead();
+        tip.mem_buffer = nullptr;
+        tip.no_alloc = true;
+        ggml_context * tp_ctx = ggml_init(tip);
+        if (!tp_ctx) {
+            set_last_error("target TP allocation context init failed");
+            gguf_free(gctx);
+            return false;
+        }
+
+        for (TargetTensorAlloc & a : allocs) {
+            ggml_tensor * clone = ggml_dup_tensor(tp_ctx, a.tensor);
+            ggml_set_name(clone, a.tensor->name);
+            a.tensor = clone;
+        }
+
+        auto remap = [&](ggml_tensor *& tensor) {
+            if (tensor) tensor = ggml_get_tensor(tp_ctx, tensor->name);
+        };
+        remap(out.out_norm);
+        remap(out.output);
+        for (TargetLayer & layer : out.layers) {
+            remap(layer.attn_norm);
+            remap(layer.attn_post_norm);
+            remap(layer.ffn_norm);
+            remap(layer.w_gate);
+            remap(layer.w_up);
+            remap(layer.w_down);
+            remap(layer.wq);
+            remap(layer.wk);
+            remap(layer.wv);
+            remap(layer.wo);
+            remap(layer.q_norm);
+            remap(layer.k_norm);
+            remap(layer.wqkv);
+            remap(layer.wqkv_gate);
+            remap(layer.ssm_conv1d);
+            remap(layer.ssm_beta);
+            remap(layer.ssm_alpha);
+            remap(layer.ssm_a);
+            remap(layer.ssm_dt_bias);
+            remap(layer.ssm_norm);
+            remap(layer.ssm_out);
+            remap(layer.ffn_gate_inp);
+            remap(layer.ffn_gate_exps);
+            remap(layer.ffn_up_exps);
+            remap(layer.ffn_down_exps);
+            remap(layer.ffn_gate_up_exps);
+            remap(layer.ffn_gate_inp_shexp);
+            remap(layer.ffn_gate_shexp);
+            remap(layer.ffn_up_shexp);
+            remap(layer.ffn_down_shexp);
+        }
+
+        ggml_free(meta_ctx);
+        meta_ctx = tp_ctx;
+        out.ctx = tp_ctx;
+        out.tok_embd = nullptr;
+    }
+
     auto release_out_buffer = [&]() {
         if (out.buf) {
             ggml_backend_buffer_free(out.buf);
@@ -639,6 +705,14 @@ bool load_target_gguf_partial(const std::string & path,
         set_last_error("target load plan selected no GPU tensors");
         gguf_free(gctx);
         return false;
+    } else if (ggml_backend_buft_is_meta(buft)) {
+        out.buf = ggml_backend_alloc_ctx_tensors(out.ctx, backend);
+        if (!out.buf) {
+            set_last_error("ggml_backend_alloc_ctx_tensors failed (target TP)");
+            gguf_free(gctx);
+            return false;
+        }
+        ggml_backend_buffer_set_usage(out.buf, GGML_BACKEND_BUFFER_USAGE_WEIGHTS);
     } else {
         out.buf = ggml_backend_alloc_buffer(backend, alloc_total);
         if (!out.buf) {
@@ -730,8 +804,6 @@ bool load_target_gguf_partial(const std::string & path,
     ggml_type tok_embd_type = GGML_TYPE_COUNT;
     for (int64_t tid = 0; tid < n_tensors; tid++) {
         const char * tname = gguf_get_tensor_name(gctx, tid);
-        ggml_tensor * t = ggml_get_tensor(meta_ctx, tname);
-        if (!t) continue;
         const size_t rel_off = gguf_get_tensor_offset(gctx, tid);
         const size_t off = data_start + rel_off;
         const size_t sz  = gguf_get_tensor_size(gctx, tid);
@@ -750,6 +822,8 @@ bool load_target_gguf_partial(const std::string & path,
             tok_embd_type = gguf_get_tensor_type(gctx, tid);
             continue;
         }
+        ggml_tensor * t = ggml_get_tensor(meta_ctx, tname);
+        if (!t) continue;
         if (!should_load_target_tensor(tname, plan.layer_begin, plan.layer_end, plan.load_output, plan.skip_expert_tensors)) {
             continue;
         }

--- a/server/src/qwen35/qwen35_backend.cpp
+++ b/server/src/qwen35/qwen35_backend.cpp
@@ -15,6 +15,7 @@
 #endif
 #include "common/io_utils.h"
 #include "common/restore_delta.h"
+#include "qwen35_tensor_parallel.h"
 #include "qwen3/qwen3_drafter.h"
 #include "qwen3/qwen3_kvflash_scorer.h"
 
@@ -176,14 +177,21 @@ KvFlashAutoBudget Qwen35Backend::make_kvflash_budget(const TargetWeights & w,
 
 bool Qwen35Backend::init() {
     const bool use_remote_draft = cfg_.remote_draft.enabled();
-    split_gpus_ = !use_remote_draft && (cfg_.device.gpu != cfg_.draft_gpu);
+    const bool tensor_parallel = cfg_.device.is_tensor_parallel();
+    split_gpus_ = !use_remote_draft && cfg_.draft_path &&
+                  (tensor_parallel || cfg_.device.gpu != cfg_.draft_gpu);
 
-    target_backend_ = ggml_backend_cuda_init(cfg_.device.gpu);
+    if (tensor_parallel) {
+        tensor_parallel_ = Qwen35TensorParallelContext::create(cfg_.device, w_);
+        target_backend_ = tensor_parallel_ ? tensor_parallel_->init_backend() : nullptr;
+    } else {
+        target_backend_ = ggml_backend_cuda_init(cfg_.device.gpu);
+    }
     if (!target_backend_) {
-        std::fprintf(stderr, "target cuda init failed\n");
+        std::fprintf(stderr, "target backend init failed\n");
         return false;
     }
-    draft_backend_ = use_remote_draft ? nullptr : target_backend_;
+    draft_backend_ = use_remote_draft || !cfg_.draft_path ? nullptr : target_backend_;
     if (split_gpus_) {
         draft_backend_ = ggml_backend_cuda_init(cfg_.draft_gpu);
         if (!draft_backend_) {
@@ -747,6 +755,7 @@ void Qwen35Backend::shutdown() {
         ggml_backend_free(target_backend_);
         target_backend_ = nullptr;
     }
+    tensor_parallel_.reset();
     if (snap_backend_) {
         free_snapshot_backend(snap_backend_, target_backend_);
         snap_backend_ = nullptr;
@@ -1600,7 +1609,9 @@ bool Qwen35Backend::do_ar_decode(int committed, int n_gen,
             // for greedy). Falls back to the CPU chain on -1.
             int g_tok = -1;
             if (gpu_sampler_enabled() && gpu_sampler_supports(sampler_) &&
-                sg_.logits && sg_.logits->data) {
+                sg_.logits && sg_.logits->data &&
+                !ggml_backend_buft_is_meta(
+                    ggml_backend_get_default_buffer_type(target_backend_))) {
                 // Draw the uniform from a copy of the RNG so the real stream is
                 // not advanced yet; we only commit that single draw if the GPU
                 // path succeeds (below). On fallback the stream is untouched and

--- a/server/src/qwen35/qwen35_backend.h
+++ b/server/src/qwen35/qwen35_backend.h
@@ -36,6 +36,8 @@
 
 namespace dflash::common {
 
+class Qwen35TensorParallelContext;
+
 // ── Configuration passed at construction ────────────────────────────────
 
 struct Qwen35Config {
@@ -220,6 +222,7 @@ private:
     ggml_backend_t target_backend_ = nullptr;
     ggml_backend_t draft_backend_  = nullptr;
     ggml_backend_t snap_backend_   = nullptr;  // snapshot storage (CPU or unified)
+    std::unique_ptr<Qwen35TensorParallelContext> tensor_parallel_;
     bool           split_gpus_     = false;
 
     // ── Model weights + caches ───────────────────────────────────────

--- a/server/src/qwen35/qwen35_target_graph.cpp
+++ b/server/src/qwen35/qwen35_target_graph.cpp
@@ -293,19 +293,26 @@ bool create_target_cache_partial(const TargetWeights & w,
     }
 
     // ── Zero-initialize all state tensors ─────────────────────────────
-    std::vector<uint8_t> zeros(1 * 1024 * 1024, 0);
-    ggml_context * ctx_list[] = { out.base_ctx, out.rollback_ctx };
-    for (int ci = 0; ci < 2; ci++) {
-        ggml_context * c = ctx_list[ci];
-        if (!c) continue;
-        for (ggml_tensor * t = ggml_get_first_tensor(c); t != nullptr;
-             t = ggml_get_next_tensor(c, t)) {
-            size_t nb = ggml_nbytes(t);
-            size_t off = 0;
-            while (off < nb) {
-                size_t chunk = std::min(nb - off, zeros.size());
-                ggml_backend_tensor_set(t, zeros.data(), off, chunk);
-                off += chunk;
+    const bool meta_backend = ggml_backend_buft_is_meta(
+        ggml_backend_get_default_buffer_type(backend));
+    if (meta_backend) {
+        ggml_backend_buffer_clear(out.base_buf, 0);
+        if (out.rollback_buf) ggml_backend_buffer_clear(out.rollback_buf, 0);
+    } else {
+        std::vector<uint8_t> zeros(1 * 1024 * 1024, 0);
+        ggml_context * ctx_list[] = { out.base_ctx, out.rollback_ctx };
+        for (int ci = 0; ci < 2; ci++) {
+            ggml_context * c = ctx_list[ci];
+            if (!c) continue;
+            for (ggml_tensor * t = ggml_get_first_tensor(c); t != nullptr;
+                 t = ggml_get_next_tensor(c, t)) {
+                size_t nb = ggml_nbytes(t);
+                size_t off = 0;
+                while (off < nb) {
+                    size_t chunk = std::min(nb - off, zeros.size());
+                    ggml_backend_tensor_set(t, zeros.data(), off, chunk);
+                    off += chunk;
+                }
             }
         }
     }
@@ -333,6 +340,12 @@ void free_target_cache(TargetCache & c) {
 
 void reset_target_cache(TargetCache & c) {
     c.cur_pos = 0;
+    if (c.backend && ggml_backend_buft_is_meta(
+            ggml_backend_get_default_buffer_type(c.backend))) {
+        if (c.base_buf) ggml_backend_buffer_clear(c.base_buf, 0);
+        if (c.rollback_buf) ggml_backend_buffer_clear(c.rollback_buf, 0);
+        return;
+    }
     std::vector<uint8_t> zeros(1 * 1024 * 1024, 0);
     ggml_context * ctx_list[] = { c.base_ctx, c.rollback_ctx };
     for (int ci = 0; ci < 2; ci++) {
@@ -459,16 +472,21 @@ bool migrate_prefill_cache(const TargetWeights & w,
         return false;
     }
 
-    // Zero-initialize rollback tensors
-    std::vector<uint8_t> zeros(1 * 1024 * 1024, 0);
-    for (ggml_tensor * t = ggml_get_first_tensor(cache.rollback_ctx); t != nullptr;
-         t = ggml_get_next_tensor(cache.rollback_ctx, t)) {
-        size_t nb = ggml_nbytes(t);
-        size_t off = 0;
-        while (off < nb) {
-            size_t chunk = std::min(nb - off, zeros.size());
-            ggml_backend_tensor_set(t, zeros.data(), off, chunk);
-            off += chunk;
+    // Zero-initialize rollback tensors. Meta buffers must be cleared per rank;
+    // fixed-size host chunks can cut through an axis-2 split row.
+    if (ggml_backend_buft_is_meta(ggml_backend_get_default_buffer_type(backend))) {
+        ggml_backend_buffer_clear(cache.rollback_buf, 0);
+    } else {
+        std::vector<uint8_t> zeros(1 * 1024 * 1024, 0);
+        for (ggml_tensor * t = ggml_get_first_tensor(cache.rollback_ctx); t != nullptr;
+             t = ggml_get_next_tensor(cache.rollback_ctx, t)) {
+            size_t nb = ggml_nbytes(t);
+            size_t off = 0;
+            while (off < nb) {
+                size_t chunk = std::min(nb - off, zeros.size());
+                ggml_backend_tensor_set(t, zeros.data(), off, chunk);
+                off += chunk;
+            }
         }
     }
 

--- a/server/src/qwen35/qwen35_tensor_parallel.cpp
+++ b/server/src/qwen35/qwen35_tensor_parallel.cpp
@@ -1,0 +1,265 @@
+#include "qwen35_tensor_parallel.h"
+
+#include "ggml-cuda.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
+#include <numeric>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace dflash::common {
+namespace {
+
+using SplitState = ggml_backend_meta_split_state;
+using SplitAxis = ggml_backend_meta_split_axis;
+
+struct TensorSplit {
+    SplitAxis axis = GGML_BACKEND_SPLIT_AXIS_MIRRORED;
+    int layer = 0;
+    std::vector<std::pair<int64_t, uint32_t>> segments;
+    std::vector<int64_t> granularities;
+};
+
+bool starts_with(const std::string & value, const char * prefix) {
+    return value.rfind(prefix, 0) == 0;
+}
+
+bool ends_with(const std::string & value, const char * suffix) {
+    const std::size_t n = std::strlen(suffix);
+    return value.size() >= n && value.compare(value.size() - n, n, suffix) == 0;
+}
+
+int parse_layer(const std::string & name) {
+    if (starts_with(name, "blk.")) {
+        const std::size_t end = name.find('.', 4);
+        return end == std::string::npos ? 0 : std::atoi(name.substr(4, end - 4).c_str());
+    }
+    const std::size_t end = name.find_last_not_of("0123456789");
+    return end == std::string::npos || end + 1 == name.size()
+        ? 0
+        : std::atoi(name.c_str() + end + 1);
+}
+
+bool is_delta_layer(const TargetWeights & w, int layer) {
+    return ((layer + 1) % w.full_attention_interval) != 0;
+}
+
+int effective_layer(const TargetWeights & w, int layer) {
+    int result = 0;
+    const bool delta = is_delta_layer(w, layer);
+    for (int i = 0; i < layer; ++i) {
+        result += is_delta_layer(w, i) == delta;
+    }
+    return result;
+}
+
+SplitState mirrored_state() {
+    SplitState state{};
+    state.axis = GGML_BACKEND_SPLIT_AXIS_MIRRORED;
+    state.nr[0] = 1;
+    state.n_segments = 1;
+    return state;
+}
+
+TensorSplit classify_tensor(const ggml_tensor * tensor,
+                            const TargetWeights & w) {
+    const std::string name = tensor->name;
+    TensorSplit result;
+    result.layer = parse_layer(name);
+
+    auto one_segment = [&](SplitAxis axis, int64_t granularity) {
+        result.axis = axis;
+        result.segments = {{tensor->ne[axis], 1}};
+        result.granularities = {granularity};
+    };
+
+    const int64_t block = ggml_blck_size(tensor->type);
+    const int64_t perf_block = std::lcm<int64_t>(block, 128);
+    const int64_t n_gqa = w.n_head / w.n_head_kv;
+    const int64_t group_q_dim = n_gqa * w.n_embd_head_k;
+    const int64_t q_granularity = std::lcm<int64_t>(group_q_dim, perf_block);
+    const int64_t kv_granularity = q_granularity / n_gqa;
+    const int64_t key_dim = (int64_t) w.ssm_d_state * w.ssm_n_group;
+    const int64_t value_head_ratio = w.ssm_dt_rank / w.ssm_n_group;
+
+    // Lucebox builds ARGMAX into the target graph. Keep the LM head mirrored
+    // until the meta backend has a distributed max-with-index reduction.
+    if (ends_with(name, ".attn_q.weight")) {
+        one_segment(GGML_BACKEND_SPLIT_AXIS_1,
+                    std::lcm<int64_t>(2 * group_q_dim, perf_block));
+    } else if (ends_with(name, ".attn_k.weight") ||
+               ends_with(name, ".attn_v.weight")) {
+        one_segment(GGML_BACKEND_SPLIT_AXIS_1, kv_granularity);
+    } else if (ends_with(name, ".attn_output.weight")) {
+        one_segment(GGML_BACKEND_SPLIT_AXIS_0, q_granularity);
+    } else if (ends_with(name, ".attn_qkv.weight") ||
+               ends_with(name, ".ssm_conv1d.weight")) {
+        result.axis = GGML_BACKEND_SPLIT_AXIS_1;
+        result.segments = {{key_dim, (uint32_t) (2 + value_head_ratio)}};
+        result.granularities = {std::lcm<int64_t>(perf_block, w.ssm_d_state)};
+    } else if (ends_with(name, ".attn_gate.weight")) {
+        result.axis = GGML_BACKEND_SPLIT_AXIS_1;
+        result.segments = {{key_dim, (uint32_t) value_head_ratio}};
+        result.granularities = {std::lcm<int64_t>(perf_block, w.ssm_d_state)};
+    } else if (ends_with(name, ".ssm_out.weight")) {
+        result.axis = GGML_BACKEND_SPLIT_AXIS_0;
+        result.segments = {{key_dim, (uint32_t) value_head_ratio}};
+        result.granularities = {std::lcm<int64_t>(perf_block, w.ssm_d_state)};
+    } else if (ends_with(name, ".ssm_alpha.weight") ||
+               ends_with(name, ".ssm_beta.weight")) {
+        result.axis = GGML_BACKEND_SPLIT_AXIS_1;
+        result.segments = {{w.ssm_n_group, (uint32_t) value_head_ratio}};
+        result.granularities = {1};
+    } else if (ends_with(name, ".ssm_a") || ends_with(name, ".ssm_dt.bias")) {
+        result.axis = GGML_BACKEND_SPLIT_AXIS_0;
+        result.segments = {{w.ssm_n_group, (uint32_t) value_head_ratio}};
+        result.granularities = {1};
+    } else if (ends_with(name, ".ffn_gate.weight") ||
+               ends_with(name, ".ffn_up.weight")) {
+        one_segment(GGML_BACKEND_SPLIT_AXIS_1, perf_block);
+    } else if (ends_with(name, ".ffn_down.weight")) {
+        one_segment(GGML_BACKEND_SPLIT_AXIS_0, perf_block);
+    } else if (starts_with(name, "cache_k_") || starts_with(name, "cache_v_") ||
+               starts_with(name, "snap_cache_k_") || starts_with(name, "snap_cache_v_")) {
+        one_segment(GGML_BACKEND_SPLIT_AXIS_2, 1);
+    } else if (starts_with(name, "ssm_state_") ||
+               starts_with(name, "ssm_state_snap_") ||
+               starts_with(name, "ssm_intermediate_") ||
+               starts_with(name, "snap_ssm_state_")) {
+        result.axis = GGML_BACKEND_SPLIT_AXIS_2;
+        result.segments = {{w.ssm_n_group, (uint32_t) value_head_ratio}};
+        result.granularities = {1};
+    } else if (starts_with(name, "conv_state_") ||
+               starts_with(name, "conv_state_snap_") ||
+               starts_with(name, "conv_input_cache_") ||
+               starts_with(name, "snap_conv_state_")) {
+        result.axis = GGML_BACKEND_SPLIT_AXIS_1;
+        result.segments = {{key_dim, (uint32_t) (2 + value_head_ratio)}};
+        result.granularities = {w.ssm_d_state};
+    } else if (name == "q_cap") {
+        one_segment(GGML_BACKEND_SPLIT_AXIS_1, n_gqa);
+    }
+
+    return result;
+}
+
+SplitState build_split_state(const ggml_tensor * tensor,
+                             const TargetWeights & w,
+                             std::size_t n_devices) {
+    const TensorSplit split = classify_tensor(tensor, w);
+    if (split.axis < 0 || split.axis >= GGML_MAX_DIMS) {
+        return mirrored_state();
+    }
+
+    SplitState state{};
+    state.axis = split.axis;
+    state.n_segments = (uint32_t) split.segments.size();
+    const std::size_t rotation =
+        (std::size_t) effective_layer(w, split.layer) % n_devices;
+
+    int64_t expected = 0;
+    for (std::size_t s = 0; s < split.segments.size(); ++s) {
+        const int64_t segment_size = split.segments[s].first;
+        const uint32_t repeat = split.segments[s].second;
+        const int64_t granularity = split.granularities[s];
+        int64_t low = 0;
+        for (std::size_t j = 0; j < n_devices; ++j) {
+            int64_t high = j + 1 == n_devices
+                ? segment_size
+                : segment_size * (int64_t) (j + 1) / (int64_t) n_devices;
+            high -= high % granularity;
+            state.ne[s * n_devices + (j + rotation) % n_devices] = high - low;
+            low = high;
+        }
+        state.nr[s] = repeat;
+        expected += segment_size * repeat;
+    }
+
+    if (expected != tensor->ne[split.axis]) {
+        std::fprintf(stderr,
+            "[tp] split layout mismatch tensor=%s axis=%d expected=%lld actual=%lld\n",
+            tensor->name, (int) split.axis,
+            (long long) expected, (long long) tensor->ne[split.axis]);
+        return mirrored_state();
+    }
+    return state;
+}
+
+}  // namespace
+
+ggml_backend_meta_split_state qwen35_tensor_parallel_split_state(
+        const ggml_tensor * tensor,
+        const TargetWeights & weights,
+        std::size_t device_count) {
+    return build_split_state(tensor, weights, device_count);
+}
+
+Qwen35TensorParallelContext::Qwen35TensorParallelContext(
+        TargetWeights & weights,
+        std::vector<ggml_backend_dev_t> devices)
+    : weights_(&weights), devices_(std::move(devices)) {
+    meta_device_ = ggml_backend_meta_device(
+        devices_.data(), devices_.size(), split_state, this);
+}
+
+std::unique_ptr<Qwen35TensorParallelContext>
+Qwen35TensorParallelContext::create(const DevicePlacement & placement,
+                                    TargetWeights & weights) {
+#if !defined(DFLASH27B_BACKEND_CUDA)
+    (void) placement;
+    (void) weights;
+    std::fprintf(stderr, "[tp] tensor parallelism requires a CUDA build\n");
+    return nullptr;
+#else
+    ggml_backend_reg_t cuda_reg = ggml_backend_cuda_reg();
+    if (!cuda_reg) {
+        std::fprintf(stderr, "[tp] CUDA backend registry is unavailable\n");
+        return nullptr;
+    }
+
+    std::vector<ggml_backend_dev_t> devices;
+    devices.reserve(placement.layer_split_gpus.size());
+    const std::size_t available = ggml_backend_reg_dev_count(cuda_reg);
+    for (int gpu : placement.layer_split_gpus) {
+        if (gpu < 0 || (std::size_t) gpu >= available) {
+            std::fprintf(stderr, "[tp] CUDA device %d is unavailable\n", gpu);
+            return nullptr;
+        }
+        ggml_backend_dev_t device = ggml_backend_reg_dev_get(cuda_reg, (std::size_t) gpu);
+        if (!device) {
+            std::fprintf(stderr, "[tp] failed to resolve CUDA device %d\n", gpu);
+            return nullptr;
+        }
+        devices.push_back(device);
+    }
+
+    auto result = std::unique_ptr<Qwen35TensorParallelContext>(
+        new Qwen35TensorParallelContext(weights, std::move(devices)));
+    if (!result->meta_device_) {
+        std::fprintf(stderr, "[tp] failed to create GGML meta device\n");
+        return nullptr;
+    }
+    return result;
+#endif
+}
+
+ggml_backend_t Qwen35TensorParallelContext::init_backend() const {
+    return meta_device_ ? ggml_backend_dev_init(meta_device_, nullptr) : nullptr;
+}
+
+ggml_backend_meta_split_state Qwen35TensorParallelContext::split_state(
+        const ggml_tensor * tensor,
+        void * userdata) {
+    auto * context = static_cast<Qwen35TensorParallelContext *>(userdata);
+    if (!context || !context->weights_ || context->devices_.empty()) {
+        return mirrored_state();
+    }
+    return qwen35_tensor_parallel_split_state(
+        tensor, *context->weights_, context->devices_.size());
+}
+
+}  // namespace dflash::common

--- a/server/src/qwen35/qwen35_tensor_parallel.cpp
+++ b/server/src/qwen35/qwen35_tensor_parallel.cpp
@@ -195,6 +195,9 @@ ggml_backend_meta_split_state qwen35_tensor_parallel_split_state(
         const ggml_tensor * tensor,
         const TargetWeights & weights,
         std::size_t device_count) {
+    if (device_count == 0) {
+        return mirrored_state();
+    }
     return build_split_state(tensor, weights, device_count);
 }
 
@@ -215,6 +218,14 @@ Qwen35TensorParallelContext::create(const DevicePlacement & placement,
     std::fprintf(stderr, "[tp] tensor parallelism requires a CUDA build\n");
     return nullptr;
 #else
+    const std::size_t device_count = placement.layer_split_gpus.size();
+    if (device_count < 2 || device_count > GGML_BACKEND_META_MAX_DEVICES) {
+        std::fprintf(stderr,
+            "[tp] tensor parallelism requires between 2 and %d devices (got %zu)\n",
+            GGML_BACKEND_META_MAX_DEVICES, device_count);
+        return nullptr;
+    }
+
     ggml_backend_reg_t cuda_reg = ggml_backend_cuda_reg();
     if (!cuda_reg) {
         std::fprintf(stderr, "[tp] CUDA backend registry is unavailable\n");

--- a/server/src/qwen35/qwen35_tensor_parallel.h
+++ b/server/src/qwen35/qwen35_tensor_parallel.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "internal.h"
+#include "placement/placement_config.h"
+
+#include "ggml-backend.h"
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+namespace dflash::common {
+
+ggml_backend_meta_split_state qwen35_tensor_parallel_split_state(
+    const ggml_tensor * tensor,
+    const TargetWeights & weights,
+    std::size_t device_count);
+
+class Qwen35TensorParallelContext {
+public:
+    static std::unique_ptr<Qwen35TensorParallelContext> create(
+        const DevicePlacement & placement,
+        TargetWeights & weights);
+
+    ggml_backend_t init_backend() const;
+    std::size_t device_count() const { return devices_.size(); }
+
+private:
+    Qwen35TensorParallelContext(TargetWeights & weights,
+                                std::vector<ggml_backend_dev_t> devices);
+
+    static ggml_backend_meta_split_state split_state(
+        const ggml_tensor * tensor,
+        void * userdata);
+
+    TargetWeights * weights_ = nullptr;
+    std::vector<ggml_backend_dev_t> devices_;
+    ggml_backend_dev_t meta_device_ = nullptr;
+};
+
+}  // namespace dflash::common

--- a/server/src/server/server_main.cpp
+++ b/server/src/server/server_main.cpp
@@ -86,7 +86,8 @@ static void print_usage(const char * prog) {
         "                                 Env: DFLASH27B_DRAFT_SWA)\n"
         "  --target-shard-ipc-bin <path>  Remote target shard IPC daemon for mixed target split\n"
         "  --target-shard-ipc-work-dir <path>  Remote target shard IPC scratch directory\n"
-        "  --target-devices <list>        Reserved layer-split devices, e.g. cuda:0,cuda:1\n"
+        "  --target-devices <list>        Target devices, e.g. cuda:0,cuda:1\n"
+        "  --target-split-mode <mode>     Multi-GPU mode: layer (default) or tensor\n"
         "  --target-layer-split <weights>  Reserved layer-split weights\n"
         "  --target-split-fast-rollback   Opt in to exact F32 checkpoints for local\n"
         "                                 qwen35 layer splits (extra VRAM; env:\n"
@@ -305,6 +306,12 @@ int main(int argc, char ** argv) {
             target_devices_seen = true;
             if (!parse_placement_device_list(argv[++i], bargs.device)) {
                 std::fprintf(stderr, "[server] bad --target-devices value (expected backend:gpu[,backend:gpu...])\n");
+                return 2;
+            }
+        } else if (std::strcmp(argv[i], "--target-split-mode") == 0 && i + 1 < argc) {
+            if (!parse_target_split_mode(argv[++i], bargs.device.split_mode)) {
+                std::fprintf(stderr,
+                    "[server] bad --target-split-mode value (expected layer or tensor)\n");
                 return 2;
             }
         } else if (std::strcmp(argv[i], "--target-layer-split") == 0 && i + 1 < argc) {
@@ -968,8 +975,10 @@ int main(int argc, char ** argv) {
                  sconfig.effort_tiers.max, src_of(cli_set.effort_max));
     std::fprintf(stderr, "[server] │  target_device   = %s\n",
                  placement_device_name(bargs.device).c_str());
-    if (bargs.device.is_layer_split()) {
-        std::fprintf(stderr, "[server] │  target_shards   =");
+    std::fprintf(stderr, "[server] │  target_split    = %s\n",
+                 target_split_mode_name(bargs.device.split_mode));
+    if (bargs.device.is_multi_device()) {
+        std::fprintf(stderr, "[server] │  target_devices  =");
         for (size_t i = 0; i < bargs.device.layer_split_gpus.size(); ++i) {
             std::fprintf(stderr, " %s:%d",
                          placement_backend_name(bargs.device.layer_split_backend(i)),

--- a/server/test/test_cuda_comm_api.cpp
+++ b/server/test/test_cuda_comm_api.cpp
@@ -1,0 +1,31 @@
+#include "ggml-backend.h"
+#include "ggml-cuda.h"
+
+#include <cstdio>
+
+int main() {
+    if (ggml_backend_cuda_get_device_count() == 0) {
+        std::puts("CUDA device unavailable; skipping communicator API test");
+        return 0;
+    }
+
+    ggml_backend_t backend = ggml_backend_cuda_init(0);
+    if (backend == nullptr) {
+        std::fputs("failed to initialize CUDA backend 0\n", stderr);
+        return 1;
+    }
+
+    ggml_backend_t backends[] = {backend, backend};
+    ggml_tensor * tensors[] = {nullptr, nullptr};
+    const bool result =
+        ggml_backend_cuda_allreduce_tensor(backends, tensors, 2);
+    ggml_backend_free(backend);
+
+    if (result) {
+        std::fputs("duplicate CUDA devices unexpectedly initialized a communicator\n", stderr);
+        return 1;
+    }
+
+    std::puts("CUDA communicator API compatibility test passed");
+    return 0;
+}

--- a/server/test/test_cuda_comm_api.cpp
+++ b/server/test/test_cuda_comm_api.cpp
@@ -1,7 +1,104 @@
 #include "ggml-backend.h"
 #include "ggml-cuda.h"
+#include "ggml.h"
 
+#include <array>
+#include <cmath>
 #include <cstdio>
+#include <cstdlib>
+
+static bool parse_test_devices(const char * value, int & first, int & second) {
+    char trailing = '\0';
+    return value != nullptr &&
+        std::sscanf(value, "%d,%d%c", &first, &second, &trailing) == 2;
+}
+
+static bool run_allreduce_test(int first, int second) {
+    const int device_count = ggml_backend_cuda_get_device_count();
+    if (first < 0 || second < 0 || first >= device_count ||
+        second >= device_count || first == second) {
+        std::fprintf(stderr,
+            "DFLASH_TP_TEST_DEVICES must name two distinct visible CUDA devices "
+            "(got %d,%d; visible=%d)\n",
+            first, second, device_count);
+        return false;
+    }
+
+    ggml_backend_t backends[2] = {
+        ggml_backend_cuda_init(first),
+        ggml_backend_cuda_init(second),
+    };
+    ggml_context * contexts[2] = {nullptr, nullptr};
+    ggml_backend_buffer_t buffers[2] = {nullptr, nullptr};
+    ggml_tensor * tensors[2] = {nullptr, nullptr};
+
+    auto cleanup = [&]() {
+        for (int i = 0; i < 2; ++i) {
+            if (buffers[i]) ggml_backend_buffer_free(buffers[i]);
+            if (contexts[i]) ggml_free(contexts[i]);
+            if (backends[i]) ggml_backend_free(backends[i]);
+        }
+    };
+
+    if (!backends[0] || !backends[1]) {
+        std::fputs("failed to initialize selected CUDA backends\n", stderr);
+        cleanup();
+        return false;
+    }
+
+    const std::array<std::array<float, 4>, 2> input = {{
+        {{1.0f, 2.0f, 3.0f, 4.0f}},
+        {{10.0f, 20.0f, 30.0f, 40.0f}},
+    }};
+    const std::array<float, 4> expected = {{11.0f, 22.0f, 33.0f, 44.0f}};
+
+    for (int i = 0; i < 2; ++i) {
+        ggml_init_params params{};
+        params.mem_size = 16 * 1024;
+        params.no_alloc = true;
+        contexts[i] = ggml_init(params);
+        if (!contexts[i]) {
+            std::fputs("failed to initialize GGML test context\n", stderr);
+            cleanup();
+            return false;
+        }
+        tensors[i] = ggml_new_tensor_1d(contexts[i], GGML_TYPE_F32, 4);
+        tensors[i]->flags |= GGML_TENSOR_FLAG_COMPUTE;
+        buffers[i] = ggml_backend_alloc_ctx_tensors(contexts[i], backends[i]);
+        if (!buffers[i]) {
+            std::fputs("failed to allocate CUDA all-reduce tensor\n", stderr);
+            cleanup();
+            return false;
+        }
+        ggml_backend_tensor_set(
+            tensors[i], input[i].data(), 0, sizeof(input[i]));
+    }
+
+    if (!ggml_backend_cuda_allreduce_tensor(backends, tensors, 2)) {
+        std::fputs(
+            "selected-device all-reduce failed (ensure this build has NCCL)\n",
+            stderr);
+        cleanup();
+        return false;
+    }
+
+    bool ok = true;
+    for (int i = 0; i < 2; ++i) {
+        ggml_backend_synchronize(backends[i]);
+        std::array<float, 4> output{};
+        ggml_backend_tensor_get(tensors[i], output.data(), 0, sizeof(output));
+        for (size_t j = 0; j < output.size(); ++j) {
+            if (std::fabs(output[j] - expected[j]) > 1e-6f) {
+                std::fprintf(stderr,
+                    "all-reduce mismatch on CUDA%d[%zu]: got %.8g expected %.8g\n",
+                    i == 0 ? first : second, j, output[j], expected[j]);
+                ok = false;
+            }
+        }
+    }
+    cleanup();
+    return ok;
+}
 
 int main() {
     if (ggml_backend_cuda_get_device_count() == 0) {
@@ -27,5 +124,24 @@ int main() {
     }
 
     std::puts("CUDA communicator API compatibility test passed");
+
+    const char * selected = std::getenv("DFLASH_TP_TEST_DEVICES");
+    if (!selected || !selected[0]) {
+        std::puts(
+            "DFLASH_TP_TEST_DEVICES is unset; skipping two-GPU NCCL all-reduce");
+        return 0;
+    }
+
+    int first = -1;
+    int second = -1;
+    if (!parse_test_devices(selected, first, second)) {
+        std::fprintf(stderr,
+            "bad DFLASH_TP_TEST_DEVICES=%s (expected e.g. 1,2)\n", selected);
+        return 1;
+    }
+    if (!run_allreduce_test(first, second)) return 1;
+
+    std::printf("selected-device NCCL all-reduce passed on CUDA%d,CUDA%d\n",
+                first, second);
     return 0;
 }

--- a/server/test/test_feature_gate.cpp
+++ b/server/test/test_feature_gate.cpp
@@ -176,6 +176,60 @@ static void test_feature_gate_validates_target_split_topology() {
         two_boundaries, "qwen35", PlacementBackend::Cuda).empty());
 }
 
+static void test_feature_gate_tensor_parallel_requirements() {
+    BackendArgs valid;
+    valid.model_path = "/nonexistent/model.gguf";
+    TEST_ASSERT(parse_placement_device_list(
+        "cuda:0,cuda:1", valid.device));
+    valid.device.split_mode = TargetSplitMode::Tensor;
+    TEST_ASSERT(gate_result(
+        valid, "qwen35", PlacementBackend::Cuda).empty());
+
+    BackendArgs missing_devices;
+    missing_devices.model_path = "/nonexistent/model.gguf";
+    missing_devices.device.split_mode = TargetSplitMode::Tensor;
+    TEST_ASSERT(!gate_result(
+        missing_devices, "qwen35", PlacementBackend::Cuda).empty());
+
+    TEST_ASSERT(!gate_result(
+        valid, "laguna", PlacementBackend::Cuda).empty());
+
+    BackendArgs hip;
+    hip.model_path = "/nonexistent/model.gguf";
+    TEST_ASSERT(parse_placement_device_list("hip:0,hip:1", hip.device));
+    hip.device.split_mode = TargetSplitMode::Tensor;
+    TEST_ASSERT(!gate_result(
+        hip, "qwen35", PlacementBackend::Hip).empty());
+
+    BackendArgs mixed = valid;
+    TEST_ASSERT(parse_placement_device_list(
+        "cuda:0,hip:0", mixed.device));
+    mixed.device.split_mode = TargetSplitMode::Tensor;
+    TEST_ASSERT(!gate_result(
+        mixed, "qwen35", PlacementBackend::Cuda).empty());
+
+    BackendArgs weighted = valid;
+    weighted.device.layer_split_weights = {1.0, 1.0};
+    TEST_ASSERT(!gate_result(
+        weighted, "qwen35", PlacementBackend::Cuda).empty());
+
+    BackendArgs remote = valid;
+    remote.remote_target_shard.ipc_bin = "/usr/bin/target-shard";
+    TEST_ASSERT(!gate_result(
+        remote, "qwen35", PlacementBackend::Cuda).empty());
+
+    BackendFeatureConfig pflash;
+    pflash.pflash_enabled = true;
+    pflash.pflash_drafter_configured = true;
+    TEST_ASSERT(!gate_result(
+        valid, "qwen35", PlacementBackend::Cuda, pflash).empty());
+
+    BackendArgs draft = valid;
+    draft.draft_path = "/nonexistent/draft.gguf";
+    TEST_ASSERT(!gate_result(
+        draft, "qwen35", PlacementBackend::Cuda).empty());
+}
+
 static void test_feature_gate_ds4_prefill_requires_deepseek4() {
     BackendArgs args = gate_args_hip_deepseek4();
     args.ds4_prefill_mode_set = true;
@@ -414,6 +468,7 @@ int main() {
     RUN_TEST(test_feature_gate_mixed_draft_placement_requires_ipc);
     RUN_TEST(test_feature_gate_pflash_requires_drafter_and_supported_arch);
     RUN_TEST(test_feature_gate_validates_target_split_topology);
+    RUN_TEST(test_feature_gate_tensor_parallel_requirements);
     RUN_TEST(test_feature_gate_ds4_prefill_requires_deepseek4);
     RUN_TEST(test_feature_gate_approximate_ds4_prefill_requires_local_hip);
     RUN_TEST(test_feature_gate_ds4_decode_options_require_monolithic_hip);

--- a/server/test/test_qwen35_tensor_parallel.cpp
+++ b/server/test/test_qwen35_tensor_parallel.cpp
@@ -42,6 +42,14 @@ int main() {
 
     TargetWeights weights;
 
+    ggml_tensor * zero_device_tensor =
+        ggml_new_tensor_2d(ctx, GGML_TYPE_F32, 5120, 10240);
+    ggml_set_name(zero_device_tensor, "blk.0.attn_qkv.weight");
+    const auto zero_device_state =
+        qwen35_tensor_parallel_split_state(zero_device_tensor, weights, 0);
+    CHECK(zero_device_state.axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED);
+    CHECK(zero_device_state.n_segments == 1);
+
     expect_split(weights,
         ggml_new_tensor_2d(ctx, GGML_TYPE_F32, 5120, 10240),
         "blk.0.attn_qkv.weight", GGML_BACKEND_SPLIT_AXIS_1, 1024, 5);
@@ -87,6 +95,24 @@ int main() {
     CHECK(validate_device_placement(placement, 3).empty());
     placement.layer_split_weights = {1.0, 1.0};
     CHECK(!validate_device_placement(placement, 3).empty());
+
+    DevicePlacement missing_tensor_devices;
+    missing_tensor_devices.split_mode = TargetSplitMode::Tensor;
+    CHECK(!validate_device_placement(missing_tensor_devices, 3).empty());
+    missing_tensor_devices.layer_split_gpus = {0};
+    missing_tensor_devices.layer_split_backends = {PlacementBackend::Cuda};
+    CHECK(!validate_device_placement(missing_tensor_devices, 3).empty());
+
+    DevicePlacement too_many_devices;
+    too_many_devices.split_mode = TargetSplitMode::Tensor;
+    too_many_devices.layer_split_gpus.resize(
+        GGML_BACKEND_META_MAX_DEVICES + 1);
+    too_many_devices.layer_split_backends.resize(
+        GGML_BACKEND_META_MAX_DEVICES + 1, PlacementBackend::Cuda);
+    for (size_t i = 0; i < too_many_devices.layer_split_gpus.size(); ++i) {
+        too_many_devices.layer_split_gpus[i] = (int) i;
+    }
+    CHECK(!Qwen35TensorParallelContext::create(too_many_devices, weights));
 
     ggml_free(ctx);
     std::puts("qwen35 tensor-parallel split tests passed");

--- a/server/test/test_qwen35_tensor_parallel.cpp
+++ b/server/test/test_qwen35_tensor_parallel.cpp
@@ -1,0 +1,94 @@
+#include "qwen35/qwen35_tensor_parallel.h"
+
+#include "ggml.h"
+
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+
+using namespace dflash::common;
+
+#define CHECK(condition) do {                                               \
+    if (!(condition)) {                                                     \
+        std::fprintf(stderr, "CHECK failed: %s (%s:%d)\n",                 \
+                     #condition, __FILE__, __LINE__);                       \
+        std::abort();                                                       \
+    }                                                                       \
+} while (0)
+
+static void expect_split(const TargetWeights & weights,
+                         ggml_tensor * tensor,
+                         const char * name,
+                         ggml_backend_meta_split_axis axis,
+                         int64_t per_device,
+                         uint32_t repeat) {
+    ggml_set_name(tensor, name);
+    const auto state = qwen35_tensor_parallel_split_state(tensor, weights, 2);
+    CHECK(state.axis == axis);
+    CHECK(state.n_segments == 1);
+    CHECK(state.ne[0] == per_device);
+    CHECK(state.ne[1] == per_device);
+    CHECK(state.nr[0] == repeat);
+    CHECK((state.ne[0] + state.ne[1]) * state.nr[0] == tensor->ne[axis]);
+}
+
+int main() {
+    ggml_init_params params{};
+    params.mem_size = 32 * ggml_tensor_overhead();
+    params.no_alloc = true;
+    ggml_context * ctx = ggml_init(params);
+    CHECK(ctx);
+
+    TargetWeights weights;
+
+    expect_split(weights,
+        ggml_new_tensor_2d(ctx, GGML_TYPE_F32, 5120, 10240),
+        "blk.0.attn_qkv.weight", GGML_BACKEND_SPLIT_AXIS_1, 1024, 5);
+    expect_split(weights,
+        ggml_new_tensor_2d(ctx, GGML_TYPE_F32, 4, 10240),
+        "blk.0.ssm_conv1d.weight", GGML_BACKEND_SPLIT_AXIS_1, 1024, 5);
+    expect_split(weights,
+        ggml_new_tensor_2d(ctx, GGML_TYPE_F32, 6144, 5120),
+        "blk.0.ssm_out.weight", GGML_BACKEND_SPLIT_AXIS_0, 1024, 3);
+    expect_split(weights,
+        ggml_new_tensor_2d(ctx, GGML_TYPE_F32, 5120, 12288),
+        "blk.3.attn_q.weight", GGML_BACKEND_SPLIT_AXIS_1, 6144, 1);
+    expect_split(weights,
+        ggml_new_tensor_2d(ctx, GGML_TYPE_F32, 6144, 5120),
+        "blk.3.attn_output.weight", GGML_BACKEND_SPLIT_AXIS_0, 3072, 1);
+    expect_split(weights,
+        ggml_new_tensor_3d(ctx, GGML_TYPE_F32, 256, 4096, 4),
+        "cache_k_3", GGML_BACKEND_SPLIT_AXIS_2, 2, 1);
+    expect_split(weights,
+        ggml_new_tensor_3d(ctx, GGML_TYPE_F32, 128, 128, 48),
+        "ssm_state_0", GGML_BACKEND_SPLIT_AXIS_2, 8, 3);
+    expect_split(weights,
+        ggml_new_tensor_2d(ctx, GGML_TYPE_F32, 3, 10240),
+        "conv_state_0", GGML_BACKEND_SPLIT_AXIS_1, 1024, 5);
+
+    ggml_tensor * norm = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 5120);
+    ggml_set_name(norm, "blk.0.attn_norm.weight");
+    const auto mirrored = qwen35_tensor_parallel_split_state(norm, weights, 2);
+    CHECK(mirrored.axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED);
+
+    ggml_tensor * output = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, 5120, 248320);
+    ggml_set_name(output, "output.weight");
+    const auto output_state =
+        qwen35_tensor_parallel_split_state(output, weights, 2);
+    CHECK(output_state.axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED);
+
+    DevicePlacement placement;
+    placement.layer_split_gpus = {1, 2};
+    placement.layer_split_backends = {PlacementBackend::Cuda, PlacementBackend::Cuda};
+    CHECK(placement.is_layer_split());
+    placement.split_mode = TargetSplitMode::Tensor;
+    CHECK(placement.is_tensor_parallel());
+    CHECK(validate_device_placement(placement, 3).empty());
+    placement.layer_split_weights = {1.0, 1.0};
+    CHECK(!validate_device_placement(placement, 3).empty());
+
+    ggml_free(ctx);
+    std::puts("qwen35 tensor-parallel split tests passed");
+    return 0;
+}


### PR DESCRIPTION
Add target-only tensor parallelism for dense Qwen3.5/Qwen3.6 models through
the GGML meta backend.

The public interface is:

```text
--target-devices cuda:1,cuda:2 --target-split-mode tensor
```

`layer` remains the default. Tensor mode validates homogeneous local CUDA
devices and rejects incompatible weighted placement, IPC, PFlash, and draft
configurations. The implementation splits attention, fused projections,
DeltaNet, FFN, KV cache, and recurrent state tensors. The LM head remains
mirrored because Lucebox performs argmax inside the target graph.

## Verification

- Full native build passes.
- All 15 CTest targets pass.
- Qwen3.6 split-layout unit tests cover dimensions, segments, reconstruction,
  and placement validation.
- Target-only streaming and non-streaming generation pass.
- Q5 and Q6 long-context runs pass at 98,304 context with Q8 KV.
- The branch explicitly rejects `--draft` in tensor mode; DFlash support is in
  the stacked follow-up.

## Sustained stock-power results

Each configuration processed the same 26,758-token OpenClaw payload and
generated all 1,024 requested tokens with Q8 KV, no cache, and 98,304 context.
The RTX 5090 used its 600 W limit and each RTX 3090 used its stock 350 W limit.

| Model / configuration | PP | TG | Prefill | Decode | Total |
|---|---:|---:|---:|---:|---:|
| Q5, RTX 5090 | 2,816 tok/s | 59.5 tok/s | 9.5 s | 17.2 s | 26.7 s |
| Q5, RTX 3090 | 980 tok/s | 32.4 tok/s | 27.3 s | 31.6 s | 58.9 s |
| Q5, 2x3090 layer split | 611 tok/s | 20.6 tok/s | 43.8 s | 49.7 s | 94.2 s |
| Q5, 2x3090 TP + NVLink | 1,423 tok/s | 40.4 tok/s | 18.8 s | 25.4 s | 44.2 s |
| Q5, 2x3090 TP, P2P disabled | 977 tok/s | 38.9 tok/s | 27.4 s | 26.3 s | 53.7 s |
| Q6, RTX 5090 | 2,478 tok/s | 48.7 tok/s | 10.8 s | 21.0 s | 31.9 s |
| Q6, 2x3090 layer split | 591 tok/s | 17.7 tok/s | 45.3 s | 58.0 s | 103.9 s |
| Q6, 2x3090 TP + NVLink | 1,372 tok/s | 34.8 tok/s | 19.5 s | 29.4 s | 48.9 s |
| Q6, 2x3090 TP, P2P disabled | 966 tok/s | 34.3 tok/s | 27.7 s | 29.9 s | 57.6 s |

These are single sustained runs per configuration. Peak sampled power was
552.9 W on the RTX 5090 and 349.8 W on the single RTX 3090. Q6 on the 5090
peaked at 31,441 MiB VRAM. 

This requires this PR: https://github.com/Luce-Org/lucebox-ggml/pull/39

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

