### PR TITLE
build(rocm): declare hipCUB and rocPRIM headers

### DIFF
--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -42,7 +42,10 @@ ENV PATH=/opt/rocm/bin:/opt/rocm/lib/llvm/bin:${PATH}
 # Unlike the CUDA image there is NO driver-stub symlink step: the ROCm base
 # ships the real HIP runtime libs (libamdhip64.so etc.) and the host kernel
 # driver (/dev/kfd, /dev/dri) is wired in at run time via --device.
-# hipblas/rocblas: ggml's HIP backend hard-requires them
+# hipblas/rocblas: ggml's HIP backend hard-requires them.
+# hipCUB/rocPRIM: ggml's ROCm argsort/top-k kernels use their headers for the
+# large-N device-sort path; the ROCm apt repository ships them separately from
+# the base HIP toolchain.
 # (deps/llama.cpp/ggml/src/ggml-hip/CMakeLists.txt does find_package(hipblas)
 # for its BLAS matmul path). The rocm/dev-ubuntu base ships the HIP toolchain
 # but NOT the math libs, so they are installed explicitly from the ROCm apt
@@ -55,11 +58,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         git \
         git-lfs \
         hipblas-dev \
+        hipcub-dev \
         libcurl4-openssl-dev \
         ninja-build \
         pkg-config \
         python3 \
         rocblas-dev \
+        rocprim-dev \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /src

--- a/server/README.md
+++ b/server/README.md
@@ -518,6 +518,10 @@ Same DFlash + PFlash stack on AMD GPUs. PR #119 ports the Phase 2 rocWMMA flashp
 ```bash
 git clone --recurse-submodules https://github.com/Luce-Org/lucebox-hub && cd lucebox-hub/server
 
+# Ubuntu/ROCm build dependencies used by ggml's HIP backend.
+sudo apt-get update
+sudo apt-get install hipblas-dev hipcub-dev rocblas-dev rocprim-dev
+
 # Build for gfx1151 (Strix Halo). Swap arch for gfx1100 / gfx1201.
 cmake -B build -S . \
   -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
Prerequisite packaging for #504.\n\n- Install `hipcub-dev` and `rocprim-dev` in the ROCm Docker builder.\n- Document the same packages for native Ubuntu/ROCm builds.\n\nValidated on Lucebox6 with ROCm 7.2.4: a fresh #496 + #504 gfx1151 build compiled all 346 targets and linked `dflash_server` using only system headers (no temporary include path).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

