### PR TITLE
bench(harness): add fail-closed validation v2 tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Lint Python surfaces touched by lucebox tooling
         run: uv run --frozen --extra dev ruff check .
 
+      - name: Run validation-v2 model-free contract tests
+        run: uv run --frozen --extra dev pytest -q harness/validation_v2/tests
+
   build:
     name: Build (cmake + uv sync --extra megakernel)
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ fix-plan.md
 
 # Harness test artifacts
 .harness-work/
+.validation-v2/
 health
 
 # lucebox host-side generated config + benchmark output

--- a/harness/README.md
+++ b/harness/README.md
@@ -139,3 +139,5 @@ backends.
 - `clients/`: real client launchers
 - `clients/prompts/`: short prompts used by the launchers
 - `benchmarks/`: direct generation benchmark against OpenAI-compatible servers
+- `validation_v2/`: fail-closed matrix lifecycle, exact scoring, provenance, and
+  prompt-clustered statistical analysis for publication campaigns

--- a/harness/validation_v2/README.md
+++ b/harness/validation_v2/README.md
@@ -1,0 +1,72 @@
+# Validation v2
+
+This package is the fail-closed preparation and analysis layer for the July 2026
+Lucebox validation campaign. It does not contain a benchmark headline and does
+not treat a failed GPU process as a completed experiment.
+
+Key contracts:
+
+- A matrix cell is complete only when its newest attempt is `success`, hashes
+  match the plan, and every required metric exists.
+- Prompt or benchmark case is the independent statistical unit. Repetitions are
+  nested technical replicates.
+- NIAH uses protocol-native final content and exact normalized equality. The
+  expected string appearing inside a longer response is a failure.
+- Publication provenance refuses dirty trees and hashes every executable input.
+- Raw outputs remain available for rescoring; task-specific answer recovery is
+  not part of a primary quality score.
+
+Generate the deterministic 100-case design plus 20 controls:
+
+```bash
+python -m harness.validation_v2.cli niah-generate \
+  --context-tokens 32768 \
+  --tokenizer-revision <immutable-hub-commit> \
+  --controls \
+  --out .validation-v2/niah-32k.jsonl
+```
+
+Validate that every planned matrix cell succeeded:
+
+```bash
+python -m harness.validation_v2.cli validate-matrix \
+  --plan .validation-v2/matrix.jsonl \
+  --results .validation-v2/results.jsonl \
+  --require-metric decode_tok_s \
+  --require-metric ttft_ms
+```
+
+Create the prompt-clustered comparison:
+
+```bash
+python -m harness.validation_v2.cli summarize-paired \
+  --results .validation-v2/flat-results.jsonl \
+  --baseline target-ar --candidate local-approx-ddtree \
+  --metric decode_tok_s --out .validation-v2/summary.json
+```
+
+Official RULER and LongBench runners remain external pinned inputs. Their commit,
+dataset revision, prompts, generation settings, and official scorer hashes must
+be recorded in the campaign manifest rather than copied or silently modified.
+
+`protocol.json` freezes the campaign-wide revisions and measurement contract.
+`matrix.py` expands a sealed prompt corpus and configuration list into stable,
+append-only experiment cells before any GPU output is inspected.
+
+Build the independent tuning and held-out decode corpora from hash-verified,
+commit-pinned public sources:
+
+```bash
+python -m harness.validation_v2.corpora
+```
+
+This produces the external V100 study's CC0 40-prompt set for tuning and a
+balanced ten-family, 100-prompt held-out set from the Apache-2.0 Stanford
+Alpaca corpus. The source output/labels are deliberately excluded: these files
+measure deterministic decode behavior and latency, not task accuracy.
+
+`http_runner.py` executes a pre-generated matrix against an OpenAI-compatible
+endpoint. It appends every failure/timeout, retries non-success cells on resume,
+requires authoritative server token counts, retains rescorable raw responses,
+and reads any bearer credential from an environment variable without recording
+it in the request artifact.

--- a/harness/validation_v2/README.md
+++ b/harness/validation_v2/README.md
@@ -110,3 +110,16 @@ never overwrite a failed attempt. Run concurrency is explicit with
 `--concurrency`; every cell must declare the same planned `concurrency` value.
 `fixed_work` cells must request `ignore_eos` and still produce exactly
 `max_tokens`, while `natural_stop` cells preserve the model's stop behavior.
+Parity hashes cover the canonical assistant `reasoning_content` and final
+`content` fields together; hashing visible final content alone is forbidden.
+Quality scorers still receive final content as a separate field.
+
+Upstream llama.cpp cells set `runtime_family` to `llama.cpp` and must pin the
+exact `/props` `build_info`, model alias, and planned speculative type. Because
+upstream `/props` does not expose the active speculative route, target-only
+cells must report zero draft tokens and DFlash/MTP cells must report positive,
+internally consistent `draft_n` and `draft_n_accepted` response timings. These
+routes are recorded as `external-unverified`; output parity is evaluated from
+the independently retained response bytes and is never inferred from draft
+activity alone. Lucebox cells retain the stronger nested launch/response
+contract checks described above.

--- a/harness/validation_v2/README.md
+++ b/harness/validation_v2/README.md
@@ -67,6 +67,13 @@ be recorded in the campaign manifest rather than copied or silently modified.
 `matrix.py` expands a sealed prompt corpus and configuration list into stable,
 append-only experiment cells before any GPU output is inspected.
 
+The local Lucebox and upstream llama.cpp DFlash draft GGUFs are separate pinned
+inputs. They advertise different architecture identifiers and are not
+interchangeable. The MTP comparator likewise uses the pinned MTP-bearing target
+GGUF; a target without embedded MTP layers must fail that cell rather than fall
+back to ordinary autoregressive decoding. SHA-256 values for all three model
+families are part of the protocol.
+
 Build the independent tuning and held-out decode corpora from hash-verified,
 commit-pinned public sources:
 

--- a/harness/validation_v2/README.md
+++ b/harness/validation_v2/README.md
@@ -77,3 +77,10 @@ it in the request artifact. Each configuration must also declare
 `expected_draft_loaded`. The runner authenticates to `/props`, verifies those
 launch facts against the nested `usage.speculative` response, and refuses to
 mark a row complete if any exactness evidence is absent or inconsistent.
+Decode throughput comes from `usage.timings.decode_tokens_per_sec`, not total
+HTTP wall time. Streaming cells require both a terminal finish reason and the
+`[DONE]` sentinel. Raw response artifacts are attempt-qualified, so a retry can
+never overwrite a failed attempt. Run concurrency is explicit with
+`--concurrency`; every cell must declare the same planned `concurrency` value.
+`fixed_work` cells must request `ignore_eos` and still produce exactly
+`max_tokens`, while `natural_stop` cells preserve the model's stop behavior.

--- a/harness/validation_v2/README.md
+++ b/harness/validation_v2/README.md
@@ -21,10 +21,24 @@ Generate the deterministic 100-case design plus 20 controls:
 ```bash
 python -m harness.validation_v2.cli niah-generate \
   --context-tokens 32768 \
+  --tokenizer <immutable-hub-tokenizer-repo> \
   --tokenizer-revision <immutable-hub-commit> \
   --controls \
   --out .validation-v2/niah-32k.jsonl
 ```
+
+Strictly join and score one hash-bound final response per generated case:
+
+```bash
+python -m harness.validation_v2.cli score-niah \
+  --cases .validation-v2/niah-32k.jsonl \
+  --responses .validation-v2/niah-32k-responses.jsonl \
+  --out .validation-v2/niah-32k-scores.json
+```
+
+Each response row must contain `prompt_id`, the matrix `prompt_hash`, and
+protocol-native `final_content`. Missing, duplicate, unplanned, or hash-mismatched
+responses abort scoring; longer strings containing the expected answer still fail.
 
 Validate that every planned matrix cell succeeded:
 
@@ -61,11 +75,16 @@ python -m harness.validation_v2.corpora
 ```
 
 This produces the external V100 study's CC0 40-prompt set for tuning and a
-balanced ten-family, 100-prompt held-out set from the Apache-2.0 Stanford
+balanced ten-family, 100-prompt held-out set from the CC-BY-NC-4.0 Stanford
 Alpaca corpus. The source output/labels are deliberately excluded: these files
 measure deterministic decode behavior and latency, not task accuracy.
 The expected generated hashes are frozen in `protocol.json`; a different hash
 is a new campaign, not a resumable continuation of this one.
+
+NIAH generation loads the tokenizer at the supplied immutable Hub revision and
+uses its chat template for every count; character-count estimates are rejected
+for publication cases. Generated rows record both the requested and actual token
+count and the tokenizer-measured needle depth.
 
 `http_runner.py` executes a pre-generated matrix against an OpenAI-compatible
 endpoint. It appends every failure/timeout, retries non-success cells on resume,

--- a/harness/validation_v2/README.md
+++ b/harness/validation_v2/README.md
@@ -71,4 +71,9 @@ is a new campaign, not a resumable continuation of this one.
 endpoint. It appends every failure/timeout, retries non-success cells on resume,
 requires authoritative server token counts, retains rescorable raw responses,
 and reads any bearer credential from an environment variable without recording
-it in the request artifact.
+it in the request artifact. Each configuration must also declare
+`expected_configured_contract`, `expected_effective_decode_mode`,
+`expected_fallback_reason`, `expected_draft_attached`, and
+`expected_draft_loaded`. The runner authenticates to `/props`, verifies those
+launch facts against the nested `usage.speculative` response, and refuses to
+mark a row complete if any exactness evidence is absent or inconsistent.

--- a/harness/validation_v2/README.md
+++ b/harness/validation_v2/README.md
@@ -64,6 +64,8 @@ This produces the external V100 study's CC0 40-prompt set for tuning and a
 balanced ten-family, 100-prompt held-out set from the Apache-2.0 Stanford
 Alpaca corpus. The source output/labels are deliberately excluded: these files
 measure deterministic decode behavior and latency, not task accuracy.
+The expected generated hashes are frozen in `protocol.json`; a different hash
+is a new campaign, not a resumable continuation of this one.
 
 `http_runner.py` executes a pre-generated matrix against an OpenAI-compatible
 endpoint. It appends every failure/timeout, retries non-success cells on resume,

--- a/harness/validation_v2/__init__.py
+++ b/harness/validation_v2/__init__.py
@@ -1,0 +1,12 @@
+"""Publication-grade validation helpers for Lucebox validation-v2."""
+
+from .records import ResultStore, RunStatus, validate_complete_matrix
+from .scoring import ExactScore, score_exact_final_content
+
+__all__ = [
+    "ExactScore",
+    "ResultStore",
+    "RunStatus",
+    "score_exact_final_content",
+    "validate_complete_matrix",
+]

--- a/harness/validation_v2/cli.py
+++ b/harness/validation_v2/cli.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Command-line entry point for validation-v2 preparation and analysis."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .niah import generate_control_cases, generate_primary_cases, write_cases
+from .records import ResultStore, canonical_json, validate_complete_matrix
+from .statistics import paired_prompt_values, summarize_paired
+
+
+def _jsonl(path: Path) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    with path.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, 1):
+            if not line.strip():
+                continue
+            try:
+                raw = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"invalid JSON at {path}:{line_number}: {exc}") from exc
+            if not isinstance(raw, dict):
+                raise ValueError(f"expected object at {path}:{line_number}")
+            rows.append(raw)
+    return rows
+
+
+def command_niah(args: argparse.Namespace) -> None:
+    cases = generate_primary_cases(
+        context_tokens=args.context_tokens,
+        tokenizer_revision=args.tokenizer_revision,
+        seed_base=args.seed_base,
+    )
+    if args.controls:
+        cases.extend(
+            generate_control_cases(
+                context_tokens=args.context_tokens,
+                tokenizer_revision=args.tokenizer_revision,
+                seed_base=args.seed_base,
+            )
+        )
+    digest = write_cases(args.out, cases)
+    print(canonical_json({"cases": len(cases), "path": str(args.out), "sha256": digest}))
+
+
+def command_validate_matrix(args: argparse.Namespace) -> None:
+    planned = _jsonl(args.plan)
+    rows = ResultStore(args.results).rows()
+    counts = validate_complete_matrix(planned, rows, required_metrics=args.require_metric)
+    print(canonical_json({"complete": True, "counts": counts}))
+
+
+def command_summarize(args: argparse.Namespace) -> None:
+    rows = _jsonl(args.results)
+    pairs = paired_prompt_values(
+        rows,
+        baseline=args.baseline,
+        candidate=args.candidate,
+        metric=args.metric,
+    )
+    summary = summarize_paired(
+        pairs,
+        bootstrap_samples=args.bootstrap_samples,
+        seed=args.seed,
+    )
+    rendered = json.dumps(summary, ensure_ascii=False, sort_keys=True, indent=2) + "\n"
+    if args.out:
+        args.out.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser(description=__doc__)
+    commands = root.add_subparsers(dest="command", required=True)
+
+    niah = commands.add_parser("niah-generate", help="generate a sealed NIAH-v2 case set")
+    niah.add_argument("--context-tokens", type=int, required=True, choices=(32768, 65536, 131072))
+    niah.add_argument("--tokenizer-revision", required=True)
+    niah.add_argument("--seed-base", type=int, default=20260718)
+    niah.add_argument("--controls", action="store_true")
+    niah.add_argument("--out", type=Path, required=True)
+    niah.set_defaults(function=command_niah)
+
+    matrix = commands.add_parser("validate-matrix", help="fail unless every planned cell succeeded")
+    matrix.add_argument("--plan", type=Path, required=True)
+    matrix.add_argument("--results", type=Path, required=True)
+    matrix.add_argument("--require-metric", action="append", default=[])
+    matrix.set_defaults(function=command_validate_matrix)
+
+    summary = commands.add_parser("summarize-paired", help="paired prompt-level bootstrap summary")
+    summary.add_argument("--results", type=Path, required=True)
+    summary.add_argument("--baseline", required=True)
+    summary.add_argument("--candidate", required=True)
+    summary.add_argument("--metric", required=True)
+    summary.add_argument("--bootstrap-samples", type=int, default=10_000)
+    summary.add_argument("--seed", type=int, default=20260718)
+    summary.add_argument("--out", type=Path)
+    summary.set_defaults(function=command_summarize)
+    return root
+
+
+def main() -> None:
+    args = parser().parse_args()
+    args.function(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/harness/validation_v2/cli.py
+++ b/harness/validation_v2/cli.py
@@ -9,7 +9,35 @@ from pathlib import Path
 
 from .niah import generate_control_cases, generate_primary_cases, write_cases
 from .records import ResultStore, canonical_json, validate_complete_matrix
+from .scoring import score_niah_records
 from .statistics import paired_prompt_values, summarize_paired
+
+
+def _pinned_tokenizer_counter(identifier: str, revision: str):
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        identifier,
+        revision=revision,
+        trust_remote_code=False,
+    )
+    resolved = tokenizer.init_kwargs.get("_commit_hash")
+    if resolved != revision:
+        raise ValueError(
+            f"tokenizer resolved revision {resolved!r}, expected immutable {revision!r}"
+        )
+
+    def count(prompt: str) -> int:
+        token_ids = tokenizer.apply_chat_template(
+            [{"role": "user", "content": prompt}],
+            tokenize=True,
+            add_generation_prompt=True,
+        )
+        if not isinstance(token_ids, list) or not token_ids:
+            raise ValueError("pinned tokenizer returned no token IDs")
+        return len(token_ids)
+
+    return count
 
 
 def _jsonl(path: Path) -> list[dict[str, object]]:
@@ -29,10 +57,12 @@ def _jsonl(path: Path) -> list[dict[str, object]]:
 
 
 def command_niah(args: argparse.Namespace) -> None:
+    token_counter = _pinned_tokenizer_counter(args.tokenizer, args.tokenizer_revision)
     cases = generate_primary_cases(
         context_tokens=args.context_tokens,
         tokenizer_revision=args.tokenizer_revision,
         seed_base=args.seed_base,
+        token_counter=token_counter,
     )
     if args.controls:
         cases.extend(
@@ -40,6 +70,7 @@ def command_niah(args: argparse.Namespace) -> None:
                 context_tokens=args.context_tokens,
                 tokenizer_revision=args.tokenizer_revision,
                 seed_base=args.seed_base,
+                token_counter=token_counter,
             )
         )
     digest = write_cases(args.out, cases)
@@ -53,6 +84,16 @@ def command_validate_matrix(args: argparse.Namespace) -> None:
     print(canonical_json({"complete": True, "counts": counts}))
 
 
+def command_score_niah(args: argparse.Namespace) -> None:
+    summary = score_niah_records(_jsonl(args.cases), _jsonl(args.responses))
+    rendered = json.dumps(summary, ensure_ascii=False, sort_keys=True, indent=2) + "\n"
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+
+
 def command_summarize(args: argparse.Namespace) -> None:
     rows = _jsonl(args.results)
     pairs = paired_prompt_values(
@@ -60,6 +101,7 @@ def command_summarize(args: argparse.Namespace) -> None:
         baseline=args.baseline,
         candidate=args.candidate,
         metric=args.metric,
+        expected_repetitions=args.expected_repetitions,
     )
     summary = summarize_paired(
         pairs,
@@ -80,6 +122,7 @@ def parser() -> argparse.ArgumentParser:
     niah = commands.add_parser("niah-generate", help="generate a sealed NIAH-v2 case set")
     niah.add_argument("--context-tokens", type=int, required=True, choices=(32768, 65536, 131072))
     niah.add_argument("--tokenizer-revision", required=True)
+    niah.add_argument("--tokenizer", required=True)
     niah.add_argument("--seed-base", type=int, default=20260718)
     niah.add_argument("--controls", action="store_true")
     niah.add_argument("--out", type=Path, required=True)
@@ -91,11 +134,18 @@ def parser() -> argparse.ArgumentParser:
     matrix.add_argument("--require-metric", action="append", default=[])
     matrix.set_defaults(function=command_validate_matrix)
 
+    score = commands.add_parser("score-niah", help="strictly score a complete NIAH response set")
+    score.add_argument("--cases", type=Path, required=True)
+    score.add_argument("--responses", type=Path, required=True)
+    score.add_argument("--out", type=Path)
+    score.set_defaults(function=command_score_niah)
+
     summary = commands.add_parser("summarize-paired", help="paired prompt-level bootstrap summary")
     summary.add_argument("--results", type=Path, required=True)
     summary.add_argument("--baseline", required=True)
     summary.add_argument("--candidate", required=True)
     summary.add_argument("--metric", required=True)
+    summary.add_argument("--expected-repetitions", type=int, default=5)
     summary.add_argument("--bootstrap-samples", type=int, default=10_000)
     summary.add_argument("--seed", type=int, default=20260718)
     summary.add_argument("--out", type=Path)

--- a/harness/validation_v2/corpora.py
+++ b/harness/validation_v2/corpora.py
@@ -31,7 +31,7 @@ VALIDATION_SOURCE = {
     ),
     "sha256": "2eddafc6b977608d778aaab8dfc7e50e547b3af9826dfb9e909d9fc362e4a419",
     "revision": "761dc5bfbdeeffa89b8bff5d038781a4055f796a",
-    "license": "Apache-2.0",
+    "license": "CC-BY-NC-4.0",
     "source": "tatsu-lab/stanford_alpaca",
 }
 
@@ -156,10 +156,33 @@ def write_jsonl(path: Path, rows: list[dict[str, str]]) -> str:
     return digest.hexdigest()
 
 
+def validate_frozen_hashes(result: Mapping[str, Mapping[str, str]], protocol_path: Path) -> None:
+    protocol = json.loads(protocol_path.read_text(encoding="utf-8"))
+    frozen = protocol.get("decode_corpora")
+    if not isinstance(frozen, Mapping):
+        raise ValueError("protocol lacks decode_corpora hashes")
+    expected = {
+        "tuning40": frozen.get("tuning40_sha256"),
+        "validation100": frozen.get("validation100_sha256"),
+    }
+    mismatches = [
+        name
+        for name, digest in expected.items()
+        if not isinstance(digest, str) or result[name]["sha256"] != digest
+    ]
+    if mismatches:
+        raise ValueError(f"generated corpora differ from frozen protocol: {mismatches}")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--cache", type=Path, default=Path(".validation-v2/cache"))
     parser.add_argument("--out-dir", type=Path, default=Path(".validation-v2/corpora"))
+    parser.add_argument(
+        "--protocol",
+        type=Path,
+        default=Path(__file__).with_name("protocol.json"),
+    )
     args = parser.parse_args()
     tuning = build_tuning40(fetch_pinned(TUNING_SOURCE, args.cache))
     validation = build_validation100(fetch_pinned(VALIDATION_SOURCE, args.cache))
@@ -173,6 +196,7 @@ def main() -> None:
             "sha256": write_jsonl(args.out_dir / "validation100.jsonl", validation),
         },
     }
+    validate_frozen_hashes(result, args.protocol)
     print(canonical_json(result))
 
 

--- a/harness/validation_v2/corpora.py
+++ b/harness/validation_v2/corpora.py
@@ -1,0 +1,180 @@
+"""Build sealed tuning and held-out decode corpora from pinned public sources."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import urllib.request
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from .records import canonical_json
+
+TUNING_SOURCE = {
+    "url": (
+        "https://raw.githubusercontent.com/thc1006/qwen3.6-speculative-decoding-v100/"
+        "e9894887828fc7b9c15d7af170b4da36ce0758fa/prompts/prompts40.json"
+    ),
+    "sha256": "61d04afa8243989ee7ec951973fd9143f7818bc890fc6fee1fe3d307467bb197",
+    "revision": "e9894887828fc7b9c15d7af170b4da36ce0758fa",
+    "license": "CC0-1.0",
+    "source": "thc1006/qwen3.6-speculative-decoding-v100",
+}
+
+VALIDATION_SOURCE = {
+    "url": (
+        "https://raw.githubusercontent.com/tatsu-lab/stanford_alpaca/"
+        "761dc5bfbdeeffa89b8bff5d038781a4055f796a/alpaca_data.json"
+    ),
+    "sha256": "2eddafc6b977608d778aaab8dfc7e50e547b3af9826dfb9e909d9fc362e4a419",
+    "revision": "761dc5bfbdeeffa89b8bff5d038781a4055f796a",
+    "license": "Apache-2.0",
+    "source": "tatsu-lab/stanford_alpaca",
+}
+
+FAMILY_PATTERNS: tuple[tuple[str, str], ...] = (
+    ("code", r"\b(code|program|function|algorithm|python|javascript|java|sql)\b"),
+    ("math", r"\b(calculate|solve|equation|mathematical|arithmetic|probability|percentage)\b"),
+    ("summarization", r"\b(summarize|summary|summarise)\b"),
+    ("classification", r"\b(classify|classification|categorize|category|label)\b"),
+    ("extraction", r"\b(extract|identify|find)\b.*\b(from|in the)\b"),
+    ("rewriting", r"\b(rewrite|rephrase|paraphrase|edit|correct the grammar)\b"),
+    ("brainstorming", r"\b(brainstorm|ideas|suggest|recommend)\b"),
+    ("question-answering", r"^(what|who|when|where|why|how)\b|answer the following question"),
+    ("reasoning", r"\b(reason|logic|infer|analyze|analyse|compare|evaluate)\b"),
+    ("creative", r"\b(story|poem|creative|dialogue|slogan|song|fiction)\b"),
+)
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def fetch_pinned(source: Mapping[str, str], cache: Path) -> bytes:
+    cache.mkdir(parents=True, exist_ok=True)
+    target = cache / f"{source['revision']}-{Path(source['url']).name}"
+    if target.is_file():
+        value = target.read_bytes()
+    else:
+        with urllib.request.urlopen(source["url"], timeout=120) as response:  # noqa: S310
+            value = response.read()
+        target.write_bytes(value)
+    actual = sha256_bytes(value)
+    if actual != source["sha256"]:
+        raise ValueError(
+            f"pinned corpus hash mismatch for {source['source']}: "
+            f"expected {source['sha256']}, got {actual}"
+        )
+    return value
+
+
+def _record(*, case_id: str, family: str, prompt: str, source: Mapping[str, str]) -> dict[str, str]:
+    return {
+        "id": case_id,
+        "family": family,
+        "prompt": prompt,
+        "prompt_sha256": sha256_bytes(prompt.encode()),
+        "source": source["source"],
+        "source_revision": source["revision"],
+        "source_license": source["license"],
+    }
+
+
+def build_tuning40(raw: bytes) -> list[dict[str, str]]:
+    source_rows = json.loads(raw)
+    if not isinstance(source_rows, list) or len(source_rows) != 40:
+        raise ValueError("pinned tuning source must contain exactly 40 prompts")
+    rows: list[dict[str, str]] = []
+    for index, item in enumerate(source_rows):
+        if not isinstance(item, list) or len(item) != 2:
+            raise ValueError(f"invalid tuning prompt at index {index}")
+        family, prompt = map(str, item)
+        rows.append(
+            _record(
+                case_id=f"tuning-{index:03d}", family=family, prompt=prompt, source=TUNING_SOURCE
+            )
+        )
+    return rows
+
+
+def _render_alpaca(item: Mapping[str, Any]) -> str:
+    instruction = str(item.get("instruction", "")).strip()
+    context = str(item.get("input", "")).strip()
+    if not instruction:
+        raise ValueError("Alpaca row has an empty instruction")
+    if context:
+        return f"{instruction}\n\nInput:\n{context}"
+    return instruction
+
+
+def build_validation100(raw: bytes) -> list[dict[str, str]]:
+    source_rows = json.loads(raw)
+    if not isinstance(source_rows, list):
+        raise ValueError("validation source must be a JSON list")
+    used: set[int] = set()
+    rows: list[dict[str, str]] = []
+    for family, pattern in FAMILY_PATTERNS:
+        selected = 0
+        compiled = re.compile(pattern)
+        for index, item in enumerate(source_rows):
+            if index in used or not isinstance(item, Mapping):
+                continue
+            instruction = str(item.get("instruction", "")).lower()
+            if not compiled.search(instruction):
+                continue
+            prompt = _render_alpaca(item)
+            rows.append(
+                _record(
+                    case_id=f"validation-{family}-{selected:02d}",
+                    family=family,
+                    prompt=prompt,
+                    source=VALIDATION_SOURCE,
+                )
+            )
+            used.add(index)
+            selected += 1
+            if selected == 10:
+                break
+        if selected != 10:
+            raise ValueError(f"validation source supplied only {selected}/10 prompts for {family}")
+    if len(rows) != 100 or len({row["prompt_sha256"] for row in rows}) != 100:
+        raise ValueError("validation corpus is not 100 unique prompts")
+    return rows
+
+
+def write_jsonl(path: Path, rows: list[dict[str, str]]) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    digest = hashlib.sha256()
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            line = canonical_json(row) + "\n"
+            handle.write(line)
+            digest.update(line.encode())
+    return digest.hexdigest()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cache", type=Path, default=Path(".validation-v2/cache"))
+    parser.add_argument("--out-dir", type=Path, default=Path(".validation-v2/corpora"))
+    args = parser.parse_args()
+    tuning = build_tuning40(fetch_pinned(TUNING_SOURCE, args.cache))
+    validation = build_validation100(fetch_pinned(VALIDATION_SOURCE, args.cache))
+    result = {
+        "tuning40": {
+            "path": str(args.out_dir / "tuning40.jsonl"),
+            "sha256": write_jsonl(args.out_dir / "tuning40.jsonl", tuning),
+        },
+        "validation100": {
+            "path": str(args.out_dir / "validation100.jsonl"),
+            "sha256": write_jsonl(args.out_dir / "validation100.jsonl", validation),
+        },
+    }
+    print(canonical_json(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/harness/validation_v2/http_runner.py
+++ b/harness/validation_v2/http_runner.py
@@ -203,6 +203,9 @@ def execute_cell(
     attempt: int,
 ) -> RunRow:
     config = dict(cell["config"])
+    prompt_hash = hashlib.sha256(canonical_json(prompt).encode()).hexdigest()
+    if prompt_hash != cell.get("prompt_hash"):
+        raise ValueError("prompt row does not match the matrix prompt hash")
     endpoint = str(config["endpoint_url"]).rstrip("/") + "/chat/completions"
     payload: dict[str, Any] = {
         "model": config["model"],
@@ -273,6 +276,7 @@ def execute_cell(
         artifact = {
             "config_id": cell["config_id"],
             "prompt_id": cell["prompt_id"],
+            "prompt_hash": prompt_hash,
             "request": payload,
             "response": raw_response,
             "props": props,
@@ -308,6 +312,9 @@ def execute_cell(
         metrics=metrics,
         artifacts=artifacts,
         error=error,
+        prompt_hash=str(cell["prompt_hash"]),
+        protocol_hash=str(cell["protocol_hash"]),
+        cell_hash=str(cell["cell_hash"]),
     )
 
 
@@ -346,6 +353,9 @@ def main() -> None:
             config_id,
             config_hash=str(cell["config_hash"]),
             environment_hash=str(cell["environment_hash"]),
+            prompt_hash=str(cell["prompt_hash"]),
+            protocol_hash=str(cell["protocol_hash"]),
+            cell_hash=str(cell["cell_hash"]),
             required_metrics=required,
         ):
             continue

--- a/harness/validation_v2/http_runner.py
+++ b/harness/validation_v2/http_runner.py
@@ -9,6 +9,7 @@ import json
 import os
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 from typing import Any
@@ -103,6 +104,79 @@ def request_chat(
     return _content(parsed), dict(parsed.get("usage") or {}), parsed, None, elapsed
 
 
+def request_props(*, endpoint_url: str, api_key: str, timeout: float) -> dict[str, Any]:
+    """Fetch authenticated launch evidence from the server's root /props route."""
+
+    parsed_url = urllib.parse.urlsplit(endpoint_url)
+    if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
+        raise ValueError("endpoint_url must be an absolute HTTP(S) URL")
+    props_url = urllib.parse.urlunsplit(
+        (parsed_url.scheme, parsed_url.netloc, "/props", "", "")
+    )
+    headers: dict[str, str] = {}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    request = urllib.request.Request(props_url, headers=headers, method="GET")
+    with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+        props = json.loads(response.read().decode("utf-8"))
+    if not isinstance(props, dict):
+        raise ValueError("/props response is not a JSON object")
+    return props
+
+
+def validate_speculative_evidence(
+    *, usage: dict[str, Any], props: dict[str, Any], config: dict[str, Any]
+) -> dict[str, str]:
+    """Fail closed unless response and launch evidence prove the planned route."""
+
+    expected_fields = (
+        "expected_configured_contract",
+        "expected_effective_decode_mode",
+        "expected_fallback_reason",
+        "expected_draft_attached",
+        "expected_draft_loaded",
+    )
+    missing_expectations = [field for field in expected_fields if field not in config]
+    if missing_expectations:
+        raise ValueError(
+            "configuration lacks speculative evidence expectations: "
+            + ", ".join(missing_expectations)
+        )
+
+    speculative = usage.get("speculative")
+    if not isinstance(speculative, dict):
+        raise ValueError("response usage lacks nested speculative evidence")
+    props_speculative = props.get("speculative")
+    if not isinstance(props_speculative, dict):
+        raise ValueError("/props lacks speculative launch evidence")
+
+    evidence: dict[str, str] = {}
+    for field in ("configured_contract", "effective_decode_mode", "fallback_reason"):
+        value = speculative.get(field)
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"response usage.speculative lacks {field}")
+        evidence[field] = value
+
+    expected_contract = str(config["expected_configured_contract"])
+    expected_mode = str(config["expected_effective_decode_mode"])
+    expected_fallback = str(config["expected_fallback_reason"])
+    if evidence["configured_contract"] != expected_contract:
+        raise ValueError("response configured contract does not match the matrix")
+    if evidence["effective_decode_mode"] != expected_mode:
+        raise ValueError("response effective decode mode does not match the matrix")
+    if evidence["fallback_reason"] != expected_fallback:
+        raise ValueError("response fallback reason does not match the matrix")
+    if props_speculative.get("configured_contract") != expected_contract:
+        raise ValueError("/props configured contract does not match the matrix")
+    for field in ("draft_attached", "draft_loaded"):
+        expected = config[f"expected_{field}"]
+        if not isinstance(expected, bool):
+            raise ValueError(f"expected_{field} must be a boolean")
+        if props_speculative.get(field) is not expected:
+            raise ValueError(f"/props {field} does not match the matrix")
+    return evidence
+
+
 def _artifact_name(config_id: str) -> str:
     safe = "".join(character if character.isalnum() or character in "-_." else "_" for character in config_id)
     return safe[:220] + ".json"
@@ -138,8 +212,14 @@ def execute_cell(
     artifacts: dict[str, str] = {}
     error: str | None = None
     try:
+        props = request_props(
+            endpoint_url=str(config["endpoint_url"]), api_key=api_key, timeout=timeout
+        )
         text, usage, raw_response, ttft_s, elapsed_s = request_chat(
             url=endpoint, api_key=api_key, payload=payload, timeout=timeout
+        )
+        speculative = validate_speculative_evidence(
+            usage=usage, props=props, config=config
         )
         completion_tokens = usage.get("completion_tokens")
         if not isinstance(completion_tokens, int) or completion_tokens <= 0:
@@ -152,9 +232,10 @@ def execute_cell(
             "decode_tok_s": completion_tokens / elapsed_s,
             "output_sha256": hashlib.sha256(text.encode()).hexdigest(),
             "output_bytes": len(text.encode()),
-            "effective_decode_mode": usage.get("effective_decode_mode"),
-            "configured_contract": usage.get("configured_contract"),
-            "fallback_reason": usage.get("fallback_reason"),
+            "effective_decode_mode": speculative["effective_decode_mode"],
+            "configured_contract": speculative["configured_contract"],
+            "fallback_reason": speculative["fallback_reason"],
+            "props_sha256": hashlib.sha256(canonical_json(props).encode()).hexdigest(),
         }
         artifact_path = artifacts_dir / _artifact_name(str(cell["config_id"]))
         artifact_path.parent.mkdir(parents=True, exist_ok=True)
@@ -163,6 +244,7 @@ def execute_cell(
             "prompt_id": cell["prompt_id"],
             "request": payload,
             "response": raw_response,
+            "props": props,
             "final_content": text,
         }
         artifact_path.write_text(canonical_json(artifact) + "\n", encoding="utf-8")
@@ -216,7 +298,15 @@ def main() -> None:
     for cell in cells:
         config_id = str(cell["config_id"])
         previous = latest.get(config_id)
-        required = ("decode_tok_s", "completion_tokens", "output_sha256")
+        required = (
+            "decode_tok_s",
+            "completion_tokens",
+            "output_sha256",
+            "configured_contract",
+            "effective_decode_mode",
+            "fallback_reason",
+            "props_sha256",
+        )
         if store.is_complete(
             config_id,
             config_hash=str(cell["config_hash"]),

--- a/harness/validation_v2/http_runner.py
+++ b/harness/validation_v2/http_runner.py
@@ -79,6 +79,48 @@ def _content(response: dict[str, Any]) -> str:
     return content
 
 
+def _assistant_output(raw_response: Any) -> dict[str, str]:
+    """Reconstruct the assistant fields that carry generated model text.
+
+    Output parity must include reasoning text as well as final content.  Quality
+    scorers continue to consume final content separately.
+    """
+
+    if isinstance(raw_response, dict):
+        choices = raw_response.get("choices") or []
+        if len(choices) != 1:
+            raise ValueError("response must contain exactly one choice")
+        message = choices[0].get("message") or {}
+        content = message.get("content")
+        reasoning = message.get("reasoning_content", "")
+        if not isinstance(content, str) or not isinstance(reasoning, str):
+            raise ValueError("response assistant text fields must be strings")
+        return {"reasoning_content": reasoning, "content": content}
+    if isinstance(raw_response, list):
+        content_parts: list[str] = []
+        reasoning_parts: list[str] = []
+        for chunk in raw_response:
+            if not isinstance(chunk, dict):
+                raise ValueError("stream chunk is not a JSON object")
+            for choice in chunk.get("choices") or []:
+                delta = choice.get("delta") or {}
+                content = delta.get("content")
+                reasoning = delta.get("reasoning_content")
+                if content is not None:
+                    if not isinstance(content, str):
+                        raise ValueError("stream content delta is not a string")
+                    content_parts.append(content)
+                if reasoning is not None:
+                    if not isinstance(reasoning, str):
+                        raise ValueError("stream reasoning delta is not a string")
+                    reasoning_parts.append(reasoning)
+        return {
+            "reasoning_content": "".join(reasoning_parts),
+            "content": "".join(content_parts),
+        }
+    raise ValueError("response is neither a JSON object nor SSE chunks")
+
+
 def request_chat(
     *,
     url: str,
@@ -188,6 +230,96 @@ def validate_speculative_evidence(
     return evidence
 
 
+def _response_timings(raw_response: Any) -> dict[str, Any]:
+    """Return the server timing object from a JSON response or final SSE chunk."""
+
+    candidates = (
+        [raw_response]
+        if isinstance(raw_response, dict)
+        else list(reversed(raw_response))
+        if isinstance(raw_response, list)
+        else []
+    )
+    for candidate in candidates:
+        if isinstance(candidate, dict) and isinstance(candidate.get("timings"), dict):
+            return dict(candidate["timings"])
+    raise ValueError("response lacks authoritative server timings")
+
+
+def validate_llama_cpp_evidence(
+    *, props: dict[str, Any], raw_response: Any, config: dict[str, Any]
+) -> dict[str, Any]:
+    """Validate observable upstream llama.cpp identity and speculative activity.
+
+    llama.cpp does not currently expose the configured speculative route in
+    ``/props``.  We therefore require an exact build/model identity match and
+    prove speculative execution from per-response draft counters.  This is
+    deliberately labelled externally unverified rather than exact.
+    """
+
+    expected_fields = (
+        "expected_build_info",
+        "expected_model_alias",
+        "expected_speculative_type",
+        "expected_configured_contract",
+        "expected_effective_decode_mode",
+        "expected_fallback_reason",
+    )
+    missing = [field for field in expected_fields if field not in config]
+    if missing:
+        raise ValueError(
+            "llama.cpp configuration lacks evidence expectations: "
+            + ", ".join(missing)
+        )
+    if props.get("build_info") != config["expected_build_info"]:
+        raise ValueError("/props build_info does not match the matrix")
+    if props.get("model_alias") != config["expected_model_alias"]:
+        raise ValueError("/props model_alias does not match the matrix")
+
+    speculative_type = str(config["expected_speculative_type"])
+    allowed_types = {"none", "draft-dflash", "draft-mtp"}
+    if speculative_type not in allowed_types:
+        raise ValueError("unsupported expected_speculative_type")
+    timings = _response_timings(raw_response)
+    draft_n = timings.get("draft_n", 0)
+    draft_n_accepted = timings.get("draft_n_accepted", 0)
+    if not isinstance(draft_n, int) or not isinstance(draft_n_accepted, int):
+        raise ValueError("llama.cpp draft counters must be integers")
+    if draft_n < 0 or draft_n_accepted < 0 or draft_n_accepted > draft_n:
+        raise ValueError("llama.cpp draft counters are inconsistent")
+
+    if speculative_type == "none":
+        if draft_n != 0:
+            raise ValueError("target-only llama.cpp cell unexpectedly drafted tokens")
+        configured_contract = "autoregressive"
+        effective_mode = "autoregressive"
+    else:
+        if draft_n <= 0:
+            raise ValueError("llama.cpp speculative cell produced no draft evidence")
+        configured_contract = "external-unverified"
+        effective_mode = "llama_cpp_" + speculative_type.removeprefix("draft-")
+    fallback_reason = "none"
+
+    expected = {
+        "configured_contract": str(config["expected_configured_contract"]),
+        "effective_decode_mode": str(config["expected_effective_decode_mode"]),
+        "fallback_reason": str(config["expected_fallback_reason"]),
+    }
+    observed = {
+        "configured_contract": configured_contract,
+        "effective_decode_mode": effective_mode,
+        "fallback_reason": fallback_reason,
+    }
+    for field, value in observed.items():
+        if value != expected[field]:
+            raise ValueError(f"llama.cpp {field} does not match the matrix")
+    return {
+        **observed,
+        "draft_n": draft_n,
+        "draft_n_accepted": draft_n_accepted,
+    }
+
+
 def _artifact_name(config_id: str, attempt: int) -> str:
     safe = "".join(character if character.isalnum() or character in "-_." else "_" for character in config_id)
     return safe[:210] + f".attempt-{attempt}.json"
@@ -239,23 +371,38 @@ def execute_cell(
         text, usage, raw_response, ttft_s, elapsed_s = request_chat(
             url=endpoint, api_key=api_key, payload=payload, timeout=timeout
         )
-        speculative = validate_speculative_evidence(
-            usage=usage, props=props, config=config
-        )
+        assistant_output = _assistant_output(raw_response)
+        if assistant_output["content"] != text:
+            raise ValueError("reconstructed final content does not match the response")
+        runtime_family = str(config.get("runtime_family", "lucebox"))
+        if runtime_family == "lucebox":
+            speculative: dict[str, Any] = validate_speculative_evidence(
+                usage=usage, props=props, config=config
+            )
+            timings = usage.get("timings")
+            if not isinstance(timings, dict):
+                raise ValueError("response usage lacks authoritative server timings")
+            decode_tok_s = timings.get("decode_tokens_per_sec")
+            decode_ms = timings.get("decode_ms")
+        elif runtime_family == "llama.cpp":
+            speculative = validate_llama_cpp_evidence(
+                props=props, raw_response=raw_response, config=config
+            )
+            timings = _response_timings(raw_response)
+            decode_tok_s = timings.get("predicted_per_second")
+            decode_ms = timings.get("predicted_ms")
+        else:
+            raise ValueError("runtime_family must be lucebox or llama.cpp")
         completion_tokens = usage.get("completion_tokens")
         if not isinstance(completion_tokens, int) or completion_tokens <= 0:
             raise ValueError("response lacks an authoritative positive completion token count")
         if measurement_kind == "fixed_work" and completion_tokens != payload["max_tokens"]:
             raise ValueError("fixed_work response stopped before the requested token count")
-        timings = usage.get("timings")
-        if not isinstance(timings, dict):
-            raise ValueError("response usage lacks authoritative server timings")
-        decode_tok_s = timings.get("decode_tokens_per_sec")
-        decode_ms = timings.get("decode_ms")
         if not isinstance(decode_tok_s, (int, float)) or decode_tok_s <= 0:
             raise ValueError("response lacks a positive server decode rate")
         if not isinstance(decode_ms, (int, float)) or decode_ms <= 0:
             raise ValueError("response lacks a positive server decode duration")
+        generated_bytes = canonical_json(assistant_output).encode()
         metrics = {
             "elapsed_s": elapsed_s,
             "ttft_ms": None if ttft_s is None else ttft_s * 1000.0,
@@ -264,13 +411,26 @@ def execute_cell(
             "decode_tok_s": float(decode_tok_s),
             "decode_ms": float(decode_ms),
             "measurement_kind": measurement_kind,
-            "output_sha256": hashlib.sha256(text.encode()).hexdigest(),
-            "output_bytes": len(text.encode()),
+            "output_sha256": hashlib.sha256(generated_bytes).hexdigest(),
+            "output_bytes": len(generated_bytes),
             "effective_decode_mode": speculative["effective_decode_mode"],
             "configured_contract": speculative["configured_contract"],
             "fallback_reason": speculative["fallback_reason"],
+            "runtime_family": runtime_family,
             "props_sha256": hashlib.sha256(canonical_json(props).encode()).hexdigest(),
         }
+        if "draft_n" in speculative:
+            draft_n = int(speculative["draft_n"])
+            draft_n_accepted = int(speculative["draft_n_accepted"])
+            metrics.update(
+                {
+                    "draft_n": draft_n,
+                    "draft_n_accepted": draft_n_accepted,
+                    "draft_acceptance_rate": draft_n_accepted / draft_n
+                    if draft_n
+                    else None,
+                }
+            )
         artifact_path = artifacts_dir / _artifact_name(str(cell["config_id"]), attempt)
         artifact_path.parent.mkdir(parents=True, exist_ok=True)
         artifact = {
@@ -280,6 +440,7 @@ def execute_cell(
             "request": payload,
             "response": raw_response,
             "props": props,
+            "assistant_output": assistant_output,
             "final_content": text,
         }
         artifact_path.write_text(canonical_json(artifact) + "\n", encoding="utf-8")

--- a/harness/validation_v2/http_runner.py
+++ b/harness/validation_v2/http_runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import concurrent.futures
 import datetime as dt
 import hashlib
 import json
@@ -34,6 +35,8 @@ def parse_sse_lines(lines: list[bytes]) -> tuple[str, dict[str, Any], list[dict[
     text_parts: list[str] = []
     usage: dict[str, Any] = {}
     chunks: list[dict[str, Any]] = []
+    saw_done = False
+    saw_finish_reason = False
     for raw_line in lines:
         line = raw_line.decode("utf-8", errors="strict").strip()
         if not line or line.startswith(":"):
@@ -42,11 +45,15 @@ def parse_sse_lines(lines: list[bytes]) -> tuple[str, dict[str, Any], list[dict[
             raise ValueError("stream returned a non-SSE data line")
         payload = line.removeprefix("data:").strip()
         if payload == "[DONE]":
+            saw_done = True
             break
         chunk = json.loads(payload)
         if not isinstance(chunk, dict):
             raise ValueError("stream chunk is not a JSON object")
         chunks.append(chunk)
+        for choice in chunk.get("choices") or []:
+            if choice.get("finish_reason") is not None:
+                saw_finish_reason = True
         if isinstance(chunk.get("usage"), dict):
             usage.update(chunk["usage"])
         for choice in chunk.get("choices") or []:
@@ -54,6 +61,10 @@ def parse_sse_lines(lines: list[bytes]) -> tuple[str, dict[str, Any], list[dict[
             content = delta.get("content")
             if isinstance(content, str):
                 text_parts.append(content)
+    if not saw_done:
+        raise ValueError("stream ended without [DONE]")
+    if not saw_finish_reason:
+        raise ValueError("stream ended without a finish reason")
     return "".join(text_parts), usage, chunks
 
 
@@ -177,9 +188,9 @@ def validate_speculative_evidence(
     return evidence
 
 
-def _artifact_name(config_id: str) -> str:
+def _artifact_name(config_id: str, attempt: int) -> str:
     safe = "".join(character if character.isalnum() or character in "-_." else "_" for character in config_id)
-    return safe[:220] + ".json"
+    return safe[:210] + f".attempt-{attempt}.json"
 
 
 def execute_cell(
@@ -201,6 +212,13 @@ def execute_cell(
         "temperature": float(config.get("temperature", 0.0)),
         "stream": bool(config.get("stream", False)),
     }
+    measurement_kind = str(config.get("measurement_kind", "natural_stop"))
+    if measurement_kind not in {"fixed_work", "natural_stop"}:
+        raise ValueError("measurement_kind must be fixed_work or natural_stop")
+    if measurement_kind == "fixed_work":
+        if config.get("ignore_eos") is not True:
+            raise ValueError("fixed_work cells must explicitly request ignore_eos")
+        payload["ignore_eos"] = True
     for key in ("seed", "top_p", "top_k", "min_p", "stop"):
         if key in config:
             payload[key] = config[key]
@@ -224,12 +242,25 @@ def execute_cell(
         completion_tokens = usage.get("completion_tokens")
         if not isinstance(completion_tokens, int) or completion_tokens <= 0:
             raise ValueError("response lacks an authoritative positive completion token count")
+        if measurement_kind == "fixed_work" and completion_tokens != payload["max_tokens"]:
+            raise ValueError("fixed_work response stopped before the requested token count")
+        timings = usage.get("timings")
+        if not isinstance(timings, dict):
+            raise ValueError("response usage lacks authoritative server timings")
+        decode_tok_s = timings.get("decode_tokens_per_sec")
+        decode_ms = timings.get("decode_ms")
+        if not isinstance(decode_tok_s, (int, float)) or decode_tok_s <= 0:
+            raise ValueError("response lacks a positive server decode rate")
+        if not isinstance(decode_ms, (int, float)) or decode_ms <= 0:
+            raise ValueError("response lacks a positive server decode duration")
         metrics = {
             "elapsed_s": elapsed_s,
             "ttft_ms": None if ttft_s is None else ttft_s * 1000.0,
             "completion_tokens": completion_tokens,
             "prompt_tokens": usage.get("prompt_tokens"),
-            "decode_tok_s": completion_tokens / elapsed_s,
+            "decode_tok_s": float(decode_tok_s),
+            "decode_ms": float(decode_ms),
+            "measurement_kind": measurement_kind,
             "output_sha256": hashlib.sha256(text.encode()).hexdigest(),
             "output_bytes": len(text.encode()),
             "effective_decode_mode": speculative["effective_decode_mode"],
@@ -237,7 +268,7 @@ def execute_cell(
             "fallback_reason": speculative["fallback_reason"],
             "props_sha256": hashlib.sha256(canonical_json(props).encode()).hexdigest(),
         }
-        artifact_path = artifacts_dir / _artifact_name(str(cell["config_id"]))
+        artifact_path = artifacts_dir / _artifact_name(str(cell["config_id"]), attempt)
         artifact_path.parent.mkdir(parents=True, exist_ok=True)
         artifact = {
             "config_id": cell["config_id"],
@@ -288,6 +319,7 @@ def main() -> None:
     parser.add_argument("--artifacts-dir", type=Path, required=True)
     parser.add_argument("--api-key-env", default="VALIDATION_API_KEY")
     parser.add_argument("--timeout", type=float, default=1200.0)
+    parser.add_argument("--concurrency", type=int, default=1)
     args = parser.parse_args()
 
     cells = _jsonl(args.matrix)
@@ -295,6 +327,9 @@ def main() -> None:
     store = ResultStore(args.results)
     latest = store.latest()
     api_key = os.environ.get(args.api_key_env, "")
+    if args.concurrency < 1:
+        raise ValueError("concurrency must be >= 1")
+    pending: list[tuple[dict[str, Any], dict[str, Any], int]] = []
     for cell in cells:
         config_id = str(cell["config_id"])
         previous = latest.get(config_id)
@@ -317,18 +352,38 @@ def main() -> None:
         prompt_id = str(cell["prompt_id"])
         if prompt_id not in prompts:
             raise ValueError(f"matrix references missing prompt: {prompt_id}")
+        planned_concurrency = int(cell["config"].get("concurrency", 1))
+        if planned_concurrency != args.concurrency:
+            raise ValueError(
+                f"cell {config_id} requires concurrency={planned_concurrency}, "
+                f"runner was started with {args.concurrency}"
+            )
         attempt = 1 if previous is None else previous.attempt + 1
-        row = execute_cell(
-            cell,
-            prompt=prompts[prompt_id],
-            api_key=api_key,
-            timeout=args.timeout,
-            artifacts_dir=args.artifacts_dir,
-            attempt=attempt,
-        )
-        store.append(row)
-        latest[config_id] = row
-        print(canonical_json({"config_id": config_id, "attempt": attempt, "status": row.status.value}))
+        pending.append((cell, prompts[prompt_id], attempt))
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.concurrency) as executor:
+        futures = [
+            executor.submit(
+                execute_cell,
+                cell,
+                prompt=prompt,
+                api_key=api_key,
+                timeout=args.timeout,
+                artifacts_dir=args.artifacts_dir,
+                attempt=attempt,
+            )
+            for cell, prompt, attempt in pending
+        ]
+        for (cell, _, attempt), future in zip(pending, futures, strict=True):
+            row = future.result()
+            store.append(row)
+            config_id = str(cell["config_id"])
+            latest[config_id] = row
+            print(
+                canonical_json(
+                    {"config_id": config_id, "attempt": attempt, "status": row.status.value}
+                )
+            )
 
 
 if __name__ == "__main__":

--- a/harness/validation_v2/http_runner.py
+++ b/harness/validation_v2/http_runner.py
@@ -1,0 +1,245 @@
+"""Execute pre-generated validation cells against an OpenAI-compatible endpoint."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from .records import ResultStore, RunRow, RunStatus, canonical_json
+
+
+def _jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with path.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, 1):
+            if not line.strip():
+                continue
+            raw = json.loads(line)
+            if not isinstance(raw, dict):
+                raise ValueError(f"expected object at {path}:{line_number}")
+            rows.append(raw)
+    return rows
+
+
+def parse_sse_lines(lines: list[bytes]) -> tuple[str, dict[str, Any], list[dict[str, Any]]]:
+    text_parts: list[str] = []
+    usage: dict[str, Any] = {}
+    chunks: list[dict[str, Any]] = []
+    for raw_line in lines:
+        line = raw_line.decode("utf-8", errors="strict").strip()
+        if not line or line.startswith(":"):
+            continue
+        if not line.startswith("data:"):
+            raise ValueError("stream returned a non-SSE data line")
+        payload = line.removeprefix("data:").strip()
+        if payload == "[DONE]":
+            break
+        chunk = json.loads(payload)
+        if not isinstance(chunk, dict):
+            raise ValueError("stream chunk is not a JSON object")
+        chunks.append(chunk)
+        if isinstance(chunk.get("usage"), dict):
+            usage.update(chunk["usage"])
+        for choice in chunk.get("choices") or []:
+            delta = choice.get("delta") or {}
+            content = delta.get("content")
+            if isinstance(content, str):
+                text_parts.append(content)
+    return "".join(text_parts), usage, chunks
+
+
+def _content(response: dict[str, Any]) -> str:
+    choices = response.get("choices") or []
+    if len(choices) != 1:
+        raise ValueError("non-streaming response must contain exactly one choice")
+    message = choices[0].get("message") or {}
+    content = message.get("content")
+    if not isinstance(content, str):
+        raise ValueError("response has no string final content")
+    return content
+
+
+def request_chat(
+    *,
+    url: str,
+    api_key: str,
+    payload: dict[str, Any],
+    timeout: float,
+) -> tuple[str, dict[str, Any], Any, float | None, float]:
+    body = json.dumps(payload, ensure_ascii=False).encode()
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    request = urllib.request.Request(url, data=body, headers=headers, method="POST")
+    started = time.perf_counter()
+    if payload.get("stream"):
+        chunks: list[bytes] = []
+        first_content_at: float | None = None
+        with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+            while True:
+                line = response.readline()
+                if not line:
+                    break
+                chunks.append(line)
+                if first_content_at is None and b'"content"' in line and b'"content":""' not in line:
+                    first_content_at = time.perf_counter()
+        text, usage, parsed = parse_sse_lines(chunks)
+        elapsed = time.perf_counter() - started
+        ttft = None if first_content_at is None else first_content_at - started
+        return text, usage, parsed, ttft, elapsed
+    with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+        parsed = json.loads(response.read().decode("utf-8"))
+    elapsed = time.perf_counter() - started
+    if not isinstance(parsed, dict):
+        raise ValueError("response is not a JSON object")
+    return _content(parsed), dict(parsed.get("usage") or {}), parsed, None, elapsed
+
+
+def _artifact_name(config_id: str) -> str:
+    safe = "".join(character if character.isalnum() or character in "-_." else "_" for character in config_id)
+    return safe[:220] + ".json"
+
+
+def execute_cell(
+    cell: dict[str, Any],
+    *,
+    prompt: dict[str, Any],
+    api_key: str,
+    timeout: float,
+    artifacts_dir: Path,
+    attempt: int,
+) -> RunRow:
+    config = dict(cell["config"])
+    endpoint = str(config["endpoint_url"]).rstrip("/") + "/chat/completions"
+    payload: dict[str, Any] = {
+        "model": config["model"],
+        "messages": prompt.get("messages")
+        or [{"role": "user", "content": str(prompt["prompt"])}],
+        "max_tokens": int(config.get("max_tokens", 384)),
+        "temperature": float(config.get("temperature", 0.0)),
+        "stream": bool(config.get("stream", False)),
+    }
+    for key in ("seed", "top_p", "top_k", "min_p", "stop"):
+        if key in config:
+            payload[key] = config[key]
+
+    started_at = dt.datetime.now(dt.UTC)
+    status = RunStatus.SUCCESS
+    return_code: int | None = 0
+    metrics: dict[str, Any] = {}
+    artifacts: dict[str, str] = {}
+    error: str | None = None
+    try:
+        text, usage, raw_response, ttft_s, elapsed_s = request_chat(
+            url=endpoint, api_key=api_key, payload=payload, timeout=timeout
+        )
+        completion_tokens = usage.get("completion_tokens")
+        if not isinstance(completion_tokens, int) or completion_tokens <= 0:
+            raise ValueError("response lacks an authoritative positive completion token count")
+        metrics = {
+            "elapsed_s": elapsed_s,
+            "ttft_ms": None if ttft_s is None else ttft_s * 1000.0,
+            "completion_tokens": completion_tokens,
+            "prompt_tokens": usage.get("prompt_tokens"),
+            "decode_tok_s": completion_tokens / elapsed_s,
+            "output_sha256": hashlib.sha256(text.encode()).hexdigest(),
+            "output_bytes": len(text.encode()),
+            "effective_decode_mode": usage.get("effective_decode_mode"),
+            "configured_contract": usage.get("configured_contract"),
+            "fallback_reason": usage.get("fallback_reason"),
+        }
+        artifact_path = artifacts_dir / _artifact_name(str(cell["config_id"]))
+        artifact_path.parent.mkdir(parents=True, exist_ok=True)
+        artifact = {
+            "config_id": cell["config_id"],
+            "prompt_id": cell["prompt_id"],
+            "request": payload,
+            "response": raw_response,
+            "final_content": text,
+        }
+        artifact_path.write_text(canonical_json(artifact) + "\n", encoding="utf-8")
+        artifacts = {
+            "response": str(artifact_path),
+            "response_sha256": hashlib.sha256(artifact_path.read_bytes()).hexdigest(),
+        }
+    except TimeoutError as exc:
+        status = RunStatus.TIMEOUT
+        return_code = None
+        error = type(exc).__name__
+    except urllib.error.HTTPError as exc:
+        status = RunStatus.FAILED
+        return_code = exc.code
+        error = f"HTTPError:{exc.code}"
+    except Exception as exc:  # noqa: BLE001 - failures are append-only evidence
+        status = RunStatus.FAILED
+        return_code = 1
+        error = type(exc).__name__
+    finished_at = dt.datetime.now(dt.UTC)
+    return RunRow(
+        config_id=str(cell["config_id"]),
+        attempt=attempt,
+        status=status,
+        config_hash=str(cell["config_hash"]),
+        environment_hash=str(cell["environment_hash"]),
+        started_at=started_at.isoformat(),
+        finished_at=finished_at.isoformat(),
+        return_code=return_code,
+        metrics=metrics,
+        artifacts=artifacts,
+        error=error,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--matrix", type=Path, required=True)
+    parser.add_argument("--prompts", type=Path, required=True)
+    parser.add_argument("--results", type=Path, required=True)
+    parser.add_argument("--artifacts-dir", type=Path, required=True)
+    parser.add_argument("--api-key-env", default="VALIDATION_API_KEY")
+    parser.add_argument("--timeout", type=float, default=1200.0)
+    args = parser.parse_args()
+
+    cells = _jsonl(args.matrix)
+    prompts = {str(row["id"]): row for row in _jsonl(args.prompts)}
+    store = ResultStore(args.results)
+    latest = store.latest()
+    api_key = os.environ.get(args.api_key_env, "")
+    for cell in cells:
+        config_id = str(cell["config_id"])
+        previous = latest.get(config_id)
+        required = ("decode_tok_s", "completion_tokens", "output_sha256")
+        if store.is_complete(
+            config_id,
+            config_hash=str(cell["config_hash"]),
+            environment_hash=str(cell["environment_hash"]),
+            required_metrics=required,
+        ):
+            continue
+        prompt_id = str(cell["prompt_id"])
+        if prompt_id not in prompts:
+            raise ValueError(f"matrix references missing prompt: {prompt_id}")
+        attempt = 1 if previous is None else previous.attempt + 1
+        row = execute_cell(
+            cell,
+            prompt=prompts[prompt_id],
+            api_key=api_key,
+            timeout=args.timeout,
+            artifacts_dir=args.artifacts_dir,
+            attempt=attempt,
+        )
+        store.append(row)
+        latest[config_id] = row
+        print(canonical_json({"config_id": config_id, "attempt": attempt, "status": row.status.value}))
+
+
+if __name__ == "__main__":
+    main()

--- a/harness/validation_v2/matrix.py
+++ b/harness/validation_v2/matrix.py
@@ -1,0 +1,102 @@
+"""Pre-generate stable validation-v2 experiment cells."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any
+
+from .records import canonical_json, sha256_json
+
+
+def load_prompt_ids(path: Path) -> list[str]:
+    prompt_ids: list[str] = []
+    with path.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, 1):
+            if not line.strip():
+                continue
+            raw = json.loads(line)
+            prompt_id = str(raw.get("id") or raw.get("name") or "")
+            if not prompt_id:
+                raise ValueError(f"prompt at {path}:{line_number} has no id/name")
+            prompt_ids.append(prompt_id)
+    if len(prompt_ids) != len(set(prompt_ids)):
+        raise ValueError("prompt IDs must be unique")
+    if not prompt_ids:
+        raise ValueError("prompt corpus is empty")
+    return prompt_ids
+
+
+def build_cells(
+    *,
+    prompt_ids: Iterable[str],
+    platform: str,
+    environment_hash: str,
+    configurations: Iterable[Mapping[str, Any]],
+    repetitions: int,
+    phase: str,
+) -> list[dict[str, Any]]:
+    cells: list[dict[str, Any]] = []
+    for raw_config in configurations:
+        config = dict(raw_config)
+        config_name = str(config["name"])
+        config_hash = sha256_json(config)
+        for prompt_id in prompt_ids:
+            for repetition in range(1, repetitions + 1):
+                config_id = f"{phase}:{platform}:{config_name}:{prompt_id}:r{repetition}"
+                cells.append(
+                    {
+                        "config_id": config_id,
+                        "config": config,
+                        "config_hash": config_hash,
+                        "environment_hash": environment_hash,
+                        "phase": phase,
+                        "platform": platform,
+                        "prompt_id": prompt_id,
+                        "repetition": repetition,
+                    }
+                )
+    return cells
+
+
+def write_cells(path: Path, cells: Iterable[Mapping[str, Any]]) -> str:
+    rows = list(cells)
+    config_ids = [str(row["config_id"]) for row in rows]
+    if len(config_ids) != len(set(config_ids)):
+        raise ValueError("generated matrix has duplicate config IDs")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(canonical_json(row) + "\n")
+    return sha256_json(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--prompts", type=Path, required=True)
+    parser.add_argument("--configurations", type=Path, required=True)
+    parser.add_argument("--platform", required=True, choices=("dual-v100s", "rtx3090"))
+    parser.add_argument("--environment-hash", required=True)
+    parser.add_argument("--phase", required=True, choices=("tuning", "publication"))
+    parser.add_argument("--repetitions", type=int, default=5)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+    configurations = json.loads(args.configurations.read_text(encoding="utf-8"))
+    if not isinstance(configurations, list):
+        raise ValueError("configurations must be a JSON list")
+    cells = build_cells(
+        prompt_ids=load_prompt_ids(args.prompts),
+        platform=args.platform,
+        environment_hash=args.environment_hash,
+        configurations=configurations,
+        repetitions=args.repetitions,
+        phase=args.phase,
+    )
+    digest = write_cells(args.out, cells)
+    print(canonical_json({"cells": len(cells), "path": str(args.out), "sha256": digest}))
+
+
+if __name__ == "__main__":
+    main()

--- a/harness/validation_v2/matrix.py
+++ b/harness/validation_v2/matrix.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 from collections.abc import Iterable, Mapping
 from pathlib import Path
@@ -11,61 +12,114 @@ from typing import Any
 from .records import canonical_json, sha256_json
 
 
-def load_prompt_ids(path: Path) -> list[str]:
-    prompt_ids: list[str] = []
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def load_prompt_hashes(path: Path) -> dict[str, str]:
+    """Load unique prompt IDs and bind each ID to its complete source row."""
+
+    prompts: dict[str, str] = {}
     with path.open(encoding="utf-8") as handle:
         for line_number, line in enumerate(handle, 1):
             if not line.strip():
                 continue
             raw = json.loads(line)
-            prompt_id = str(raw.get("id") or raw.get("name") or "")
+            prompt_id = str(raw.get("id") or raw.get("case_id") or raw.get("name") or "")
             if not prompt_id:
                 raise ValueError(f"prompt at {path}:{line_number} has no id/name")
-            prompt_ids.append(prompt_id)
-    if len(prompt_ids) != len(set(prompt_ids)):
-        raise ValueError("prompt IDs must be unique")
-    if not prompt_ids:
+            if prompt_id in prompts:
+                raise ValueError("prompt IDs must be unique")
+            declared = raw.get("prompt_sha256")
+            if declared is not None:
+                prompt = raw.get("prompt")
+                if not isinstance(prompt, str):
+                    raise ValueError(
+                        f"prompt at {path}:{line_number} declares prompt_sha256 "
+                        "without string prompt content"
+                    )
+                actual = hashlib.sha256(prompt.encode()).hexdigest()
+                if declared != actual:
+                    raise ValueError(f"prompt hash mismatch at {path}:{line_number}")
+            prompts[prompt_id] = sha256_json(raw)
+    if not prompts:
         raise ValueError("prompt corpus is empty")
-    return prompt_ids
+    return prompts
 
 
 def build_cells(
     *,
-    prompt_ids: Iterable[str],
+    prompt_hashes: Mapping[str, str],
     platform: str,
     environment_hash: str,
+    protocol_hash: str,
     configurations: Iterable[Mapping[str, Any]],
     repetitions: int,
     phase: str,
 ) -> list[dict[str, Any]]:
+    if repetitions < 1:
+        raise ValueError("repetitions must be >= 1")
+    if not prompt_hashes:
+        raise ValueError("prompt corpus is empty")
+    if platform not in {"dual-v100s", "rtx3090"}:
+        raise ValueError(f"unsupported platform: {platform}")
+    if phase not in {"tuning", "publication"}:
+        raise ValueError(f"unsupported phase: {phase}")
+    for label, digest in {
+        "environment_hash": environment_hash,
+        "protocol_hash": protocol_hash,
+        **{f"prompt_hash[{key}]": value for key, value in prompt_hashes.items()},
+    }.items():
+        if len(digest) != 64 or any(ch not in "0123456789abcdef" for ch in digest):
+            raise ValueError(f"{label} must be a lowercase SHA-256 digest")
+
+    configs = [dict(raw) for raw in configurations]
+    if not configs:
+        raise ValueError("configuration list is empty")
+    names = [str(config.get("name", "")).strip() for config in configs]
+    if any(not name for name in names):
+        raise ValueError("every configuration needs a non-empty name")
+    if len(names) != len(set(names)):
+        raise ValueError("configuration names must be unique")
+
     cells: list[dict[str, Any]] = []
-    for raw_config in configurations:
-        config = dict(raw_config)
+    for config in configs:
         config_name = str(config["name"])
         config_hash = sha256_json(config)
-        for prompt_id in prompt_ids:
+        for prompt_id, prompt_hash in prompt_hashes.items():
             for repetition in range(1, repetitions + 1):
                 config_id = f"{phase}:{platform}:{config_name}:{prompt_id}:r{repetition}"
-                cells.append(
-                    {
-                        "config_id": config_id,
-                        "config": config,
-                        "config_hash": config_hash,
-                        "environment_hash": environment_hash,
-                        "phase": phase,
-                        "platform": platform,
-                        "prompt_id": prompt_id,
-                        "repetition": repetition,
-                    }
-                )
+                cell = {
+                    "config_id": config_id,
+                    "config": config,
+                    "config_hash": config_hash,
+                    "environment_hash": environment_hash,
+                    "phase": phase,
+                    "platform": platform,
+                    "prompt_id": prompt_id,
+                    "prompt_hash": prompt_hash,
+                    "protocol_hash": protocol_hash,
+                    "repetition": repetition,
+                }
+                cell["cell_hash"] = sha256_json(cell)
+                cells.append(cell)
     return cells
 
 
 def write_cells(path: Path, cells: Iterable[Mapping[str, Any]]) -> str:
     rows = list(cells)
+    if not rows:
+        raise ValueError("generated matrix is empty")
     config_ids = [str(row["config_id"]) for row in rows]
     if len(config_ids) != len(set(config_ids)):
         raise ValueError("generated matrix has duplicate config IDs")
+    for row in rows:
+        if row.get("config_hash") != sha256_json(row.get("config", {})):
+            raise ValueError(f"matrix config hash mismatch: {row['config_id']}")
+        content = dict(row)
+        declared_cell_hash = content.pop("cell_hash", None)
+        if declared_cell_hash != sha256_json(content):
+            raise ValueError(f"matrix cell hash mismatch: {row['config_id']}")
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8") as handle:
         for row in rows:
@@ -79,6 +133,11 @@ def main() -> None:
     parser.add_argument("--configurations", type=Path, required=True)
     parser.add_argument("--platform", required=True, choices=("dual-v100s", "rtx3090"))
     parser.add_argument("--environment-hash", required=True)
+    parser.add_argument(
+        "--protocol",
+        type=Path,
+        default=Path(__file__).with_name("protocol.json"),
+    )
     parser.add_argument("--phase", required=True, choices=("tuning", "publication"))
     parser.add_argument("--repetitions", type=int, default=5)
     parser.add_argument("--out", type=Path, required=True)
@@ -87,9 +146,10 @@ def main() -> None:
     if not isinstance(configurations, list):
         raise ValueError("configurations must be a JSON list")
     cells = build_cells(
-        prompt_ids=load_prompt_ids(args.prompts),
+        prompt_hashes=load_prompt_hashes(args.prompts),
         platform=args.platform,
         environment_hash=args.environment_hash,
+        protocol_hash=_sha256_file(args.protocol),
         configurations=configurations,
         repetitions=args.repetitions,
         phase=args.phase,

--- a/harness/validation_v2/niah.py
+++ b/harness/validation_v2/niah.py
@@ -7,7 +7,7 @@ import hashlib
 import json
 import random
 import uuid
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from pathlib import Path
 
 DEPTHS = (0.05, 0.25, 0.50, 0.75, 0.95)
@@ -80,6 +80,8 @@ class NiahCase:
     prompt: str
     prompt_sha256: str
     tokenizer_revision: str
+    actual_context_tokens: int
+    actual_depth_fraction: float
     control: str | None = None
 
     def as_dict(self) -> dict[str, object]:
@@ -103,13 +105,88 @@ def _answer(answer_type: str, rng: random.Random) -> str:
 def _filler(target_characters: int, family: tuple[str, str], rng: random.Random) -> str:
     name, template = family
     records: list[str] = []
+    characters = 0
     index = 0
-    while sum(map(len, records)) < target_characters:
+    while characters < target_characters:
         unrelated = rng.randrange(1_000_000, 10_000_000)
-        records.append(template.format(index=f"{index}-{unrelated}"))
+        record = template.format(index=f"{index}-{unrelated}")
+        records.append(record)
+        characters += len(record)
         index += 1
     rng.shuffle(records)
     return "".join(records), name
+
+
+def _validate_revision(revision: str) -> None:
+    if len(revision) not in {40, 64} or any(ch not in "0123456789abcdef" for ch in revision):
+        raise ValueError("tokenizer_revision must be an immutable lowercase SHA")
+
+
+def _sized_prompt(
+    *,
+    context_tokens: int,
+    depth_fraction: float,
+    body: str,
+    question: str,
+    family: tuple[str, str],
+    rng: random.Random,
+    token_counter: Callable[[str], int],
+    chars_per_token: float,
+    token_tolerance: int,
+) -> tuple[str, str, int, float]:
+    """Size and place a case using the campaign tokenizer, never a char proxy."""
+
+    if context_tokens < 1:
+        raise ValueError("context_tokens must be positive")
+    if chars_per_token <= 0:
+        raise ValueError("chars_per_token must be positive")
+    if token_tolerance < 0:
+        raise ValueError("token_tolerance must be non-negative")
+    filler, filler_id = _filler(
+        round(context_tokens * chars_per_token * 2.0), family, rng
+    )
+
+    def render(filler_characters: int) -> tuple[str, int]:
+        selected = filler[:filler_characters]
+        insertion = min(len(selected), round(len(selected) * depth_fraction))
+        prompt = selected[:insertion] + "\n" + body + "\n" + selected[insertion:] + "\n" + question
+        return prompt, insertion
+
+    filler_characters = min(len(filler), round(context_tokens * chars_per_token))
+    best: tuple[int, str, int] | None = None
+    for _ in range(16):
+        prompt, insertion = render(filler_characters)
+        actual = token_counter(prompt)
+        if not isinstance(actual, int) or isinstance(actual, bool) or actual <= 0:
+            raise ValueError("token counter must return a positive integer")
+        if actual <= context_tokens and (best is None or actual > best[0]):
+            best = (actual, prompt, insertion)
+        if actual <= context_tokens and context_tokens - actual <= token_tolerance:
+            break
+        observed_chars_per_token = len(prompt) / actual
+        adjustment = round((context_tokens - actual) * observed_chars_per_token)
+        if adjustment == 0:
+            adjustment = 1 if actual < context_tokens else -1
+        next_characters = max(0, min(len(filler), filler_characters + adjustment))
+        if next_characters == filler_characters:
+            break
+        filler_characters = next_characters
+
+    if best is None or context_tokens - best[0] > token_tolerance:
+        observed = None if best is None else best[0]
+        raise ValueError(
+            f"tokenizer-sized prompt missed target {context_tokens} by more than "
+            f"{token_tolerance} tokens (best={observed})"
+        )
+    actual, prompt, insertion = best
+    prefix_tokens = token_counter(prompt[:insertion]) if insertion else 0
+    actual_depth = prefix_tokens / actual
+    if abs(actual_depth - depth_fraction) > 0.02:
+        raise ValueError(
+            f"tokenizer-sized needle depth {actual_depth:.4f} differs from "
+            f"planned {depth_fraction:.4f}"
+        )
+    return prompt, filler_id, actual, actual_depth
 
 
 def generate_primary_cases(
@@ -118,11 +195,15 @@ def generate_primary_cases(
     tokenizer_revision: str,
     seed_base: int = 20260718,
     chars_per_token: float = 4.0,
+    token_counter: Callable[[str], int] | None = None,
+    token_tolerance: int = 8,
 ) -> list[NiahCase]:
     """Generate the 5 depths x 5 seed families x 4 answer types design."""
 
+    _validate_revision(tokenizer_revision)
+    if token_counter is None:
+        raise ValueError("publication NIAH generation requires an actual tokenizer counter")
     cases: list[NiahCase] = []
-    target_characters = round(context_tokens * chars_per_token)
     for depth_index, depth in enumerate(DEPTHS):
         for seed_family in range(5):
             for answer_index, answer_type in enumerate(ANSWER_TYPES):
@@ -133,10 +214,17 @@ def generate_primary_cases(
                     (depth_index + seed_family) % len(HELD_OUT_TEMPLATES)
                 ]
                 answer = _answer(answer_type, rng)
-                filler, filler_id = _filler(target_characters, family, rng)
-                insertion = min(len(filler), round(len(filler) * depth))
-                needle = "\n" + needle_template.format(answer=answer) + "\n"
-                prompt = filler[:insertion] + needle + filler[insertion:] + "\n" + question
+                prompt, filler_id, actual_tokens, actual_depth = _sized_prompt(
+                    context_tokens=context_tokens,
+                    depth_fraction=depth,
+                    body=needle_template.format(answer=answer),
+                    question=question,
+                    family=family,
+                    rng=rng,
+                    token_counter=token_counter,
+                    chars_per_token=chars_per_token,
+                    token_tolerance=token_tolerance,
+                )
                 case_id = (
                     f"niah-{context_tokens}-d{depth_index}-s{seed_family}-a{answer_index}"
                 )
@@ -153,6 +241,8 @@ def generate_primary_cases(
                         prompt=prompt,
                         prompt_sha256=hashlib.sha256(prompt.encode()).hexdigest(),
                         tokenizer_revision=tokenizer_revision,
+                        actual_context_tokens=actual_tokens,
+                        actual_depth_fraction=actual_depth,
                     )
                 )
     if len(cases) != 100:
@@ -165,7 +255,13 @@ def generate_control_cases(
     context_tokens: int,
     tokenizer_revision: str,
     seed_base: int = 20260718,
+    chars_per_token: float = 4.0,
+    token_counter: Callable[[str], int] | None = None,
+    token_tolerance: int = 8,
 ) -> list[NiahCase]:
+    _validate_revision(tokenizer_revision)
+    if token_counter is None:
+        raise ValueError("publication NIAH generation requires an actual tokenizer counter")
     controls = ("answer-absent", "misleading", "multiple", "prefix", "prompt-echo")
     cases: list[NiahCase] = []
     for control_index, control in enumerate(controls):
@@ -184,20 +280,34 @@ def generate_control_cases(
                 body = f"An invalid longer identifier is {answer}{rng.randrange(10, 99)}."
             else:
                 body = f"The question text mentions a placeholder such as {distractor}."
-            prompt = body + "\nReturn the authoritative value only, or NONE if it is unavailable."
+            question = "Return the authoritative value only, or NONE if it is unavailable."
+            family = FILLER_FAMILIES[(control_index + repetition) % len(FILLER_FAMILIES)]
+            prompt, filler_id, actual_tokens, actual_depth = _sized_prompt(
+                context_tokens=context_tokens,
+                depth_fraction=0.5,
+                body=body,
+                question=question,
+                family=family,
+                rng=rng,
+                token_counter=token_counter,
+                chars_per_token=chars_per_token,
+                token_tolerance=token_tolerance,
+            )
             cases.append(
                 NiahCase(
                     case_id=f"niah-control-{context_tokens}-{control}-{repetition}",
                     seed=seed,
                     context_tokens=context_tokens,
                     depth_fraction=0.5,
-                    filler_id="control",
+                    filler_id=filler_id,
                     template_id="control",
                     answer_type=ANSWER_TYPES[repetition],
-                    answer="NONE" if control in {"answer-absent", "misleading", "prompt-echo"} else answer,
+                    answer="NONE",
                     prompt=prompt,
                     prompt_sha256=hashlib.sha256(prompt.encode()).hexdigest(),
                     tokenizer_revision=tokenizer_revision,
+                    actual_context_tokens=actual_tokens,
+                    actual_depth_fraction=actual_depth,
                     control=control,
                 )
             )

--- a/harness/validation_v2/niah.py
+++ b/harness/validation_v2/niah.py
@@ -1,0 +1,215 @@
+"""Deterministic held-out NIAH-v2 case generation."""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+import random
+import uuid
+from collections.abc import Iterable
+from pathlib import Path
+
+DEPTHS = (0.05, 0.25, 0.50, 0.75, 0.95)
+ANSWER_TYPES = ("seven-digit", "uuid", "word-pair", "short-phrase")
+
+FILLER_FAMILIES = (
+    (
+        "field-notes",
+        "Field note {index}: the archive records routine observations about weather, "
+        "equipment checks, and ordinary travel arrangements. No instruction in this "
+        "note changes the requested response format.\n",
+    ),
+    (
+        "catalog",
+        "Catalog record {index}: item descriptions, shelf locations, and unrelated numeric "
+        "inventory references are listed for background context only.\n",
+    ),
+    (
+        "meeting-minutes",
+        "Meeting minute {index}: participants reviewed schedules, maintenance, documentation, "
+        "and several unrelated identifiers before moving to the next agenda item.\n",
+    ),
+)
+
+HELD_OUT_TEMPLATES = (
+    (
+        "archive-key",
+        "The authoritative archive key is {answer}. Preserve it exactly.",
+        "Return only the authoritative archive key.",
+    ),
+    (
+        "verification-token",
+        "For the final audit, the verification token is {answer}. This statement supersedes "
+        "all unrelated identifiers.",
+        "Return only the final audit verification token.",
+    ),
+    (
+        "reference-label",
+        "The reference label requested by the operator is {answer}. Keep its spelling and case.",
+        "Return only the operator's requested reference label.",
+    ),
+)
+
+WORD_BANK = (
+    "amber",
+    "birch",
+    "cobalt",
+    "delta",
+    "ember",
+    "fjord",
+    "granite",
+    "harbor",
+    "indigo",
+    "juniper",
+    "kepler",
+    "lumen",
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class NiahCase:
+    case_id: str
+    seed: int
+    context_tokens: int
+    depth_fraction: float
+    filler_id: str
+    template_id: str
+    answer_type: str
+    answer: str
+    prompt: str
+    prompt_sha256: str
+    tokenizer_revision: str
+    control: str | None = None
+
+    def as_dict(self) -> dict[str, object]:
+        return dataclasses.asdict(self)
+
+
+def _answer(answer_type: str, rng: random.Random) -> str:
+    if answer_type == "seven-digit":
+        return f"{rng.randrange(1_000_000, 10_000_000)}"
+    if answer_type == "uuid":
+        return str(uuid.UUID(int=rng.getrandbits(128)))
+    if answer_type == "word-pair":
+        left, right = rng.sample(WORD_BANK, 2)
+        return f"{left}-{right}"
+    if answer_type == "short-phrase":
+        words = rng.sample(WORD_BANK, 3)
+        return " ".join(words)
+    raise ValueError(f"unknown answer type: {answer_type}")
+
+
+def _filler(target_characters: int, family: tuple[str, str], rng: random.Random) -> str:
+    name, template = family
+    records: list[str] = []
+    index = 0
+    while sum(map(len, records)) < target_characters:
+        unrelated = rng.randrange(1_000_000, 10_000_000)
+        records.append(template.format(index=f"{index}-{unrelated}"))
+        index += 1
+    rng.shuffle(records)
+    return "".join(records), name
+
+
+def generate_primary_cases(
+    *,
+    context_tokens: int,
+    tokenizer_revision: str,
+    seed_base: int = 20260718,
+    chars_per_token: float = 4.0,
+) -> list[NiahCase]:
+    """Generate the 5 depths x 5 seed families x 4 answer types design."""
+
+    cases: list[NiahCase] = []
+    target_characters = round(context_tokens * chars_per_token)
+    for depth_index, depth in enumerate(DEPTHS):
+        for seed_family in range(5):
+            for answer_index, answer_type in enumerate(ANSWER_TYPES):
+                seed = seed_base + depth_index * 10_000 + seed_family * 100 + answer_index
+                rng = random.Random(seed)
+                family = FILLER_FAMILIES[(seed_family + answer_index) % len(FILLER_FAMILIES)]
+                template_id, needle_template, question = HELD_OUT_TEMPLATES[
+                    (depth_index + seed_family) % len(HELD_OUT_TEMPLATES)
+                ]
+                answer = _answer(answer_type, rng)
+                filler, filler_id = _filler(target_characters, family, rng)
+                insertion = min(len(filler), round(len(filler) * depth))
+                needle = "\n" + needle_template.format(answer=answer) + "\n"
+                prompt = filler[:insertion] + needle + filler[insertion:] + "\n" + question
+                case_id = (
+                    f"niah-{context_tokens}-d{depth_index}-s{seed_family}-a{answer_index}"
+                )
+                cases.append(
+                    NiahCase(
+                        case_id=case_id,
+                        seed=seed,
+                        context_tokens=context_tokens,
+                        depth_fraction=depth,
+                        filler_id=filler_id,
+                        template_id=template_id,
+                        answer_type=answer_type,
+                        answer=answer,
+                        prompt=prompt,
+                        prompt_sha256=hashlib.sha256(prompt.encode()).hexdigest(),
+                        tokenizer_revision=tokenizer_revision,
+                    )
+                )
+    if len(cases) != 100:
+        raise AssertionError(f"primary NIAH design produced {len(cases)} cases")
+    return cases
+
+
+def generate_control_cases(
+    *,
+    context_tokens: int,
+    tokenizer_revision: str,
+    seed_base: int = 20260718,
+) -> list[NiahCase]:
+    controls = ("answer-absent", "misleading", "multiple", "prefix", "prompt-echo")
+    cases: list[NiahCase] = []
+    for control_index, control in enumerate(controls):
+        for repetition in range(4):
+            seed = seed_base + 900_000 + control_index * 100 + repetition
+            rng = random.Random(seed)
+            answer = _answer(ANSWER_TYPES[repetition], rng)
+            distractor = _answer(ANSWER_TYPES[repetition], rng)
+            if control == "answer-absent":
+                body = "No authoritative value is present in this control context."
+            elif control == "misleading":
+                body = f"A superseded record contains {distractor}; it is not authoritative."
+            elif control == "multiple":
+                body = f"Two conflicting unverified records contain {answer} and {distractor}."
+            elif control == "prefix":
+                body = f"An invalid longer identifier is {answer}{rng.randrange(10, 99)}."
+            else:
+                body = f"The question text mentions a placeholder such as {distractor}."
+            prompt = body + "\nReturn the authoritative value only, or NONE if it is unavailable."
+            cases.append(
+                NiahCase(
+                    case_id=f"niah-control-{context_tokens}-{control}-{repetition}",
+                    seed=seed,
+                    context_tokens=context_tokens,
+                    depth_fraction=0.5,
+                    filler_id="control",
+                    template_id="control",
+                    answer_type=ANSWER_TYPES[repetition],
+                    answer="NONE" if control in {"answer-absent", "misleading", "prompt-echo"} else answer,
+                    prompt=prompt,
+                    prompt_sha256=hashlib.sha256(prompt.encode()).hexdigest(),
+                    tokenizer_revision=tokenizer_revision,
+                    control=control,
+                )
+            )
+    return cases
+
+
+def write_cases(path: Path, cases: Iterable[NiahCase]) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    digest = hashlib.sha256()
+    with path.open("w", encoding="utf-8") as handle:
+        for case in cases:
+            line = json.dumps(case.as_dict(), ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+            handle.write(line + "\n")
+            digest.update((line + "\n").encode())
+    return digest.hexdigest()

--- a/harness/validation_v2/protocol.json
+++ b/harness/validation_v2/protocol.json
@@ -9,7 +9,15 @@
   },
   "models": {
     "official_qwen36_gguf_revision": "8a7ee08e8b9bfb857107ecc25a5599d2f38b76f8",
-    "local_dflash_draft_revision": "fca10ba135c9d834988e15b7d7f5aee8ebc562a7"
+    "official_qwen36_q4_k_m_sha256": "5ed60d0af4650a854b1755bd392f9aef4872643dc25a254bc68043fa638392a0",
+    "local_dflash_draft_revision": "fca10ba135c9d834988e15b7d7f5aee8ebc562a7",
+    "local_dflash_draft_q4_k_m_sha256": "e2500e90165a0f8e7b52c9882c29ed1fa391c60b300ff11b817bf10e31fa092e",
+    "llama_cpp_dflash_repo": "Alittlehammmer/Qwen3.6-27B-DFlash-GGUF-llama.cpp",
+    "llama_cpp_dflash_revision": "5f2ed671305fb1fd8de023d6b335cef4d2663888",
+    "llama_cpp_dflash_q4_k_m_sha256": "71362369a3428a9e93436a869b1131f63e04b88efbc92dacacb18c419d8de95c",
+    "llama_cpp_mtp_repo": "unsloth/Qwen3.6-27B-MTP-GGUF",
+    "llama_cpp_mtp_revision": "5cb35eb3dcbf52dbce5f87dbc64df6aaffadcace",
+    "llama_cpp_mtp_q4_k_m_sha256": "a7cbd3ecc0e3f9b333edee61ae66bc87ed713c5d49587a8355814722ed329e0f"
   },
   "decode_corpora": {
     "tuning40_sha256": "7cd4dba3f443361e17760687893f6d019d6a37d580457ea23b6cbd370a0c752a",

--- a/harness/validation_v2/protocol.json
+++ b/harness/validation_v2/protocol.json
@@ -28,7 +28,7 @@
     {"id": "dual-v100s", "compute_capability": "70", "gpu_count": 2},
     {"id": "rtx3090", "compute_capability": "86", "gpu_count": 1}
   ],
-  "contracts": ["autoregressive", "exact", "approximate"],
+  "contracts": ["autoregressive", "exact", "approximate", "external-unverified"],
   "local_modes": [
     "target-ar",
     "exact-chain",

--- a/harness/validation_v2/protocol.json
+++ b/harness/validation_v2/protocol.json
@@ -13,7 +13,7 @@
   },
   "decode_corpora": {
     "tuning40_sha256": "7cd4dba3f443361e17760687893f6d019d6a37d580457ea23b6cbd370a0c752a",
-    "validation100_sha256": "d25db478ada08bf7ddd647eb2fc2a35e22ed6028b78d9b98bbed1b70086d9374",
+    "validation100_sha256": "d994509830a32136012359db5b334126b521168523bd67cc543cf61b58643e9d",
     "publication_corpus_used_for_tuning": false
   },
   "platforms": [

--- a/harness/validation_v2/protocol.json
+++ b/harness/validation_v2/protocol.json
@@ -1,0 +1,68 @@
+{
+  "schema": "lucebox.validation-v2.protocol/1",
+  "frozen_at": "2026-07-18",
+  "source": {
+    "lucebox": "a8465ccac803d591097b50973aaa6333a39a900f",
+    "llama_cpp": "571d0d540df04f25298d0e159e520d9fc62ed121",
+    "ruler": "e8bbff677ca2c239640dc90f93310dcf32408c93",
+    "longbench": "2e00731f8d0bff23dc4325161044d0ed8af94c1e"
+  },
+  "models": {
+    "official_qwen36_gguf_revision": "8a7ee08e8b9bfb857107ecc25a5599d2f38b76f8",
+    "local_dflash_draft_revision": "fca10ba135c9d834988e15b7d7f5aee8ebc562a7"
+  },
+  "decode_corpora": {
+    "tuning40_sha256": "7cd4dba3f443361e17760687893f6d019d6a37d580457ea23b6cbd370a0c752a",
+    "validation100_sha256": "d25db478ada08bf7ddd647eb2fc2a35e22ed6028b78d9b98bbed1b70086d9374",
+    "publication_corpus_used_for_tuning": false
+  },
+  "platforms": [
+    {"id": "dual-v100s", "compute_capability": "70", "gpu_count": 2},
+    {"id": "rtx3090", "compute_capability": "86", "gpu_count": 1}
+  ],
+  "contracts": ["autoregressive", "exact", "approximate"],
+  "local_modes": [
+    "target-ar",
+    "exact-chain",
+    "exact-ddtree",
+    "approximate-chain",
+    "approximate-ddtree"
+  ],
+  "external_validation_sweeps": {
+    "llama-dflash": [1, 2, 3, 4, 6],
+    "mtp": [1, 2, 3, 4]
+  },
+  "performance": {
+    "warmups": 2,
+    "repetitions": 5,
+    "fixed_work_tokens": 384,
+    "fixed_work_ignore_eos": true,
+    "natural_stop_token_cap": 384,
+    "concurrency": [1, 4],
+    "bootstrap_samples": 10000,
+    "bootstrap_seed": 20260718,
+    "independent_unit": "prompt"
+  },
+  "niah": {
+    "context_tokens": [32768, 65536, 131072],
+    "primary_cases_per_length": 100,
+    "control_cases_per_length": 20,
+    "depth_fractions": [0.05, 0.25, 0.5, 0.75, 0.95],
+    "scorer": "unicode-nfc-trimmed-complete-final-content-exact-equality"
+  },
+  "ruler": {
+    "suite": "rulerv1-ns",
+    "tasks": 13,
+    "cases_per_task_per_length": 20,
+    "context_tokens": [32768, 65536, 131072],
+    "official_scorers_only": true
+  },
+  "longbench": {
+    "label": "pinned six-task LongBench subset",
+    "tasks": ["qasper", "multifieldqa_en", "hotpotqa", "2wikimqa", "gov_report", "qmsum"],
+    "cases_per_task": 50,
+    "official_scorers_only": true
+  },
+  "row_statuses": ["success", "failed", "timeout", "skipped"],
+  "primary_quality_uses_postprocessing": false
+}

--- a/harness/validation_v2/provenance.py
+++ b/harness/validation_v2/provenance.py
@@ -1,0 +1,103 @@
+"""Content-addressed experiment provenance collection and validation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from .records import canonical_json, sha256_json
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _run(args: list[str], cwd: Path) -> str:
+    result = subprocess.run(args, cwd=cwd, capture_output=True, text=True, check=True)
+    return result.stdout.strip()
+
+
+def repository_identity(root: Path) -> dict[str, Any]:
+    status = _run(["git", "status", "--porcelain"], root)
+    if status:
+        raise ValueError("publication provenance refuses a dirty git tree")
+    submodules = _run(["git", "submodule", "status", "--recursive"], root)
+    return {
+        "commit": _run(["git", "rev-parse", "HEAD"], root),
+        "tree": _run(["git", "rev-parse", "HEAD^{tree}"], root),
+        "branch": _run(["git", "branch", "--show-current"], root),
+        "submodules": submodules.splitlines() if submodules else [],
+        "clean": True,
+    }
+
+
+def build_manifest(
+    *,
+    root: Path,
+    files: dict[str, Path],
+    immutable_inputs: dict[str, str],
+    build: dict[str, Any],
+    command: list[str],
+) -> dict[str, Any]:
+    missing = [name for name, path in files.items() if not path.is_file()]
+    if missing:
+        raise ValueError(f"missing manifest files: {missing}")
+    mutable = [name for name, revision in immutable_inputs.items() if len(revision) < 12]
+    if mutable:
+        raise ValueError(f"immutable inputs need commit-like revisions: {mutable}")
+    manifest = {
+        "schema": "lucebox.validation-v2.provenance/1",
+        "repository": repository_identity(root),
+        "files": {
+            name: {"path": str(path.resolve()), "sha256": sha256_file(path), "bytes": path.stat().st_size}
+            for name, path in sorted(files.items())
+        },
+        "immutable_inputs": dict(sorted(immutable_inputs.items())),
+        "build": build,
+        "command": command,
+        "environment": {
+            "platform": platform.platform(),
+            "python": platform.python_version(),
+            "machine": platform.machine(),
+        },
+    }
+    manifest["manifest_hash"] = sha256_json(manifest)
+    return manifest
+
+
+def write_manifest(path: Path, manifest: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(canonical_json(manifest) + "\n", encoding="utf-8")
+
+
+def verify_manifest(path: Path) -> dict[str, Any]:
+    manifest = json.loads(path.read_text(encoding="utf-8"))
+    expected_hash = manifest.pop("manifest_hash", None)
+    actual_hash = sha256_json(manifest)
+    if expected_hash != actual_hash:
+        raise ValueError("manifest content hash mismatch")
+    for name, record in manifest["files"].items():
+        file_path = Path(record["path"])
+        if not file_path.is_file():
+            raise ValueError(f"manifest input disappeared: {name}")
+        if sha256_file(file_path) != record["sha256"]:
+            raise ValueError(f"manifest input hash mismatch: {name}")
+    manifest["manifest_hash"] = expected_hash
+    return manifest
+
+
+def redact_environment(environment: dict[str, str] | None = None) -> dict[str, str]:
+    """Return only explicitly non-secret execution metadata."""
+
+    source = os.environ if environment is None else environment
+    allowed = ("CUDA_VISIBLE_DEVICES", "CMAKE_BUILD_TYPE", "TZ", "LANG")
+    return {name: source[name] for name in allowed if name in source}

--- a/harness/validation_v2/provenance.py
+++ b/harness/validation_v2/provenance.py
@@ -6,7 +6,10 @@ import hashlib
 import json
 import os
 import platform
+import re
 import subprocess
+import urllib.parse
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -23,7 +26,7 @@ def sha256_file(path: Path) -> str:
 
 def _run(args: list[str], cwd: Path) -> str:
     result = subprocess.run(args, cwd=cwd, capture_output=True, text=True, check=True)
-    return result.stdout.strip()
+    return result.stdout.rstrip()
 
 
 def repository_identity(root: Path) -> dict[str, Any]:
@@ -31,13 +34,74 @@ def repository_identity(root: Path) -> dict[str, Any]:
     if status:
         raise ValueError("publication provenance refuses a dirty git tree")
     submodules = _run(["git", "submodule", "status", "--recursive"], root)
+    submodule_rows = submodules.splitlines() if submodules else []
+    invalid_submodules = [row for row in submodule_rows if not row.startswith(" ")]
+    if invalid_submodules:
+        raise ValueError(
+            "publication provenance requires initialized, pinned submodules: "
+            + "; ".join(invalid_submodules)
+        )
     return {
         "commit": _run(["git", "rev-parse", "HEAD"], root),
         "tree": _run(["git", "rev-parse", "HEAD^{tree}"], root),
         "branch": _run(["git", "branch", "--show-current"], root),
-        "submodules": submodules.splitlines() if submodules else [],
+        "submodules": [row.strip() for row in submodule_rows],
         "clean": True,
     }
+
+
+_SECRET_KEY = re.compile(
+    r"(?:api[-_]?key|access[-_]?token|auth[-_]?token|bearer[-_]?token|"
+    r"(?:^|[-_])token(?:$|[-_=])|password|passwd|secret|authorization|credential)",
+    re.I,
+)
+_IMMUTABLE_SHA = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})")
+
+
+def redact_command(command: list[str]) -> list[str]:
+    """Redact common secret-bearing flags, assignments, and URL credentials."""
+
+    redacted: list[str] = []
+    hide_next = False
+    for argument in command:
+        if hide_next:
+            redacted.append("[REDACTED]")
+            hide_next = False
+            continue
+        parsed = urllib.parse.urlsplit(argument)
+        if parsed.scheme in {"http", "https"} and parsed.netloc:
+            hostname = parsed.hostname or ""
+            if parsed.port is not None:
+                hostname += f":{parsed.port}"
+            redacted.append(
+                urllib.parse.urlunsplit((parsed.scheme, hostname, parsed.path, "", ""))
+            )
+            continue
+        if argument.startswith("-") and "=" in argument:
+            name, _ = argument.split("=", 1)
+            if _SECRET_KEY.search(name):
+                redacted.append(f"{name}=[REDACTED]")
+                continue
+        if argument.startswith("-") and _SECRET_KEY.search(argument):
+            redacted.append(argument)
+            hide_next = True
+            continue
+        if "=" in argument and _SECRET_KEY.search(argument.split("=", 1)[0]):
+            redacted.append(f"{argument.split('=', 1)[0]}=[REDACTED]")
+            continue
+        redacted.append(argument)
+    return redacted
+
+
+def redact_mapping(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            str(key): "[REDACTED]" if _SECRET_KEY.search(str(key)) else redact_mapping(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [redact_mapping(item) for item in value]
+    return value
 
 
 def build_manifest(
@@ -51,7 +115,9 @@ def build_manifest(
     missing = [name for name, path in files.items() if not path.is_file()]
     if missing:
         raise ValueError(f"missing manifest files: {missing}")
-    mutable = [name for name, revision in immutable_inputs.items() if len(revision) < 12]
+    mutable = [
+        name for name, revision in immutable_inputs.items() if not _IMMUTABLE_SHA.fullmatch(revision)
+    ]
     if mutable:
         raise ValueError(f"immutable inputs need commit-like revisions: {mutable}")
     manifest = {
@@ -62,8 +128,8 @@ def build_manifest(
             for name, path in sorted(files.items())
         },
         "immutable_inputs": dict(sorted(immutable_inputs.items())),
-        "build": build,
-        "command": command,
+        "build": redact_mapping(build),
+        "command": redact_command(command),
         "environment": {
             "platform": platform.platform(),
             "python": platform.python_version(),

--- a/harness/validation_v2/records.py
+++ b/harness/validation_v2/records.py
@@ -1,0 +1,203 @@
+"""Append-only result rows and strict matrix-completeness validation."""
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+import hashlib
+import json
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any
+
+
+class RunStatus(enum.StrEnum):
+    SUCCESS = "success"
+    FAILED = "failed"
+    TIMEOUT = "timeout"
+    SKIPPED = "skipped"
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def sha256_json(value: Any) -> str:
+    return hashlib.sha256(canonical_json(value).encode()).hexdigest()
+
+
+@dataclasses.dataclass(frozen=True)
+class RunRow:
+    config_id: str
+    attempt: int
+    status: RunStatus
+    config_hash: str
+    environment_hash: str
+    started_at: str
+    finished_at: str
+    return_code: int | None
+    metrics: Mapping[str, Any]
+    artifacts: Mapping[str, str]
+    error: str | None = None
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, Any]) -> RunRow:
+        required = {
+            "config_id",
+            "attempt",
+            "status",
+            "config_hash",
+            "environment_hash",
+            "started_at",
+            "finished_at",
+            "return_code",
+            "metrics",
+            "artifacts",
+        }
+        missing = required - raw.keys()
+        if missing:
+            raise ValueError(f"result row missing fields: {sorted(missing)}")
+        row = cls(
+            config_id=str(raw["config_id"]),
+            attempt=int(raw["attempt"]),
+            status=RunStatus(str(raw["status"])),
+            config_hash=str(raw["config_hash"]),
+            environment_hash=str(raw["environment_hash"]),
+            started_at=str(raw["started_at"]),
+            finished_at=str(raw["finished_at"]),
+            return_code=None if raw["return_code"] is None else int(raw["return_code"]),
+            metrics=dict(raw["metrics"]),
+            artifacts={str(key): str(value) for key, value in dict(raw["artifacts"]).items()},
+            error=None if raw.get("error") is None else str(raw["error"]),
+        )
+        if row.attempt < 1:
+            raise ValueError("attempt must be >= 1")
+        if row.status is RunStatus.SUCCESS and row.return_code != 0:
+            raise ValueError("success row must have return_code=0")
+        if row.status is RunStatus.SUCCESS and row.error:
+            raise ValueError("success row cannot carry an error")
+        return row
+
+    def as_dict(self) -> dict[str, Any]:
+        raw = dataclasses.asdict(self)
+        raw["status"] = self.status.value
+        return raw
+
+
+class ResultStore:
+    """Append-only JSONL store.
+
+    A cell is resumable only when its newest row is a complete success whose
+    configuration and environment hashes match the planned matrix.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def rows(self) -> list[RunRow]:
+        if not self.path.exists():
+            return []
+        rows: list[RunRow] = []
+        with self.path.open(encoding="utf-8") as handle:
+            for line_number, line in enumerate(handle, 1):
+                if not line.strip():
+                    continue
+                try:
+                    rows.append(RunRow.from_mapping(json.loads(line)))
+                except (json.JSONDecodeError, TypeError, ValueError) as exc:
+                    raise ValueError(f"invalid result row at {self.path}:{line_number}: {exc}") from exc
+        self._validate_attempts(rows)
+        return rows
+
+    @staticmethod
+    def _validate_attempts(rows: Iterable[RunRow]) -> None:
+        seen: set[tuple[str, int]] = set()
+        latest: dict[str, int] = {}
+        for row in rows:
+            key = (row.config_id, row.attempt)
+            if key in seen:
+                raise ValueError(f"duplicate result attempt: {row.config_id}#{row.attempt}")
+            seen.add(key)
+            if row.attempt <= latest.get(row.config_id, 0):
+                raise ValueError(f"attempts are not append-ordered for {row.config_id}")
+            latest[row.config_id] = row.attempt
+
+    def append(self, row: RunRow) -> None:
+        existing = self.rows()
+        previous = max((item.attempt for item in existing if item.config_id == row.config_id), default=0)
+        if row.attempt != previous + 1:
+            raise ValueError(
+                f"attempt for {row.config_id} must be {previous + 1}, got {row.attempt}"
+            )
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(canonical_json(row.as_dict()) + "\n")
+
+    def latest(self) -> dict[str, RunRow]:
+        latest: dict[str, RunRow] = {}
+        for row in self.rows():
+            latest[row.config_id] = row
+        return latest
+
+    def is_complete(
+        self,
+        config_id: str,
+        *,
+        config_hash: str,
+        environment_hash: str,
+        required_metrics: Iterable[str],
+    ) -> bool:
+        row = self.latest().get(config_id)
+        if row is None or row.status is not RunStatus.SUCCESS:
+            return False
+        if row.config_hash != config_hash or row.environment_hash != environment_hash:
+            return False
+        return all(metric in row.metrics and row.metrics[metric] is not None for metric in required_metrics)
+
+
+def validate_complete_matrix(
+    planned: Iterable[Mapping[str, Any]],
+    rows: Iterable[RunRow],
+    *,
+    required_metrics: Iterable[str],
+) -> dict[str, int]:
+    plans = list(planned)
+    plan_by_id: dict[str, Mapping[str, Any]] = {}
+    for plan in plans:
+        config_id = str(plan["config_id"])
+        if config_id in plan_by_id:
+            raise ValueError(f"duplicate planned config_id: {config_id}")
+        plan_by_id[config_id] = plan
+
+    latest: dict[str, RunRow] = {}
+    for row in rows:
+        if row.config_id not in plan_by_id:
+            raise ValueError(f"unplanned result row: {row.config_id}")
+        latest[row.config_id] = row
+
+    counts = {status.value: 0 for status in RunStatus}
+    counts["missing"] = 0
+    incomplete: list[str] = []
+    required = tuple(required_metrics)
+    for config_id, plan in plan_by_id.items():
+        row = latest.get(config_id)
+        if row is None:
+            counts["missing"] += 1
+            incomplete.append(f"{config_id}: missing")
+            continue
+        counts[row.status.value] += 1
+        expected_config = str(plan.get("config_hash") or sha256_json(plan.get("config", {})))
+        expected_environment = str(plan["environment_hash"])
+        missing_metrics = [metric for metric in required if row.metrics.get(metric) is None]
+        if row.status is not RunStatus.SUCCESS:
+            incomplete.append(f"{config_id}: {row.status.value}")
+        elif row.config_hash != expected_config:
+            incomplete.append(f"{config_id}: config hash mismatch")
+        elif row.environment_hash != expected_environment:
+            incomplete.append(f"{config_id}: environment hash mismatch")
+        elif missing_metrics:
+            incomplete.append(f"{config_id}: missing metrics {missing_metrics}")
+
+    if incomplete:
+        raise ValueError("matrix is incomplete:\n" + "\n".join(incomplete))
+    return counts

--- a/harness/validation_v2/records.py
+++ b/harness/validation_v2/records.py
@@ -39,6 +39,9 @@ class RunRow:
     metrics: Mapping[str, Any]
     artifacts: Mapping[str, str]
     error: str | None = None
+    prompt_hash: str = ""
+    protocol_hash: str = ""
+    cell_hash: str = ""
 
     @classmethod
     def from_mapping(cls, raw: Mapping[str, Any]) -> RunRow:
@@ -53,6 +56,9 @@ class RunRow:
             "return_code",
             "metrics",
             "artifacts",
+            "prompt_hash",
+            "protocol_hash",
+            "cell_hash",
         }
         missing = required - raw.keys()
         if missing:
@@ -69,6 +75,9 @@ class RunRow:
             metrics=dict(raw["metrics"]),
             artifacts={str(key): str(value) for key, value in dict(raw["artifacts"]).items()},
             error=None if raw.get("error") is None else str(raw["error"]),
+            prompt_hash=str(raw["prompt_hash"]),
+            protocol_hash=str(raw["protocol_hash"]),
+            cell_hash=str(raw["cell_hash"]),
         )
         if row.attempt < 1:
             raise ValueError("attempt must be >= 1")
@@ -76,6 +85,10 @@ class RunRow:
             raise ValueError("success row must have return_code=0")
         if row.status is RunStatus.SUCCESS and row.error:
             raise ValueError("success row cannot carry an error")
+        for name in ("config_hash", "environment_hash", "prompt_hash", "protocol_hash", "cell_hash"):
+            value = getattr(row, name)
+            if len(value) != 64 or any(ch not in "0123456789abcdef" for ch in value):
+                raise ValueError(f"{name} must be a lowercase SHA-256 digest")
         return row
 
     def as_dict(self) -> dict[str, Any]:
@@ -123,6 +136,7 @@ class ResultStore:
             latest[row.config_id] = row.attempt
 
     def append(self, row: RunRow) -> None:
+        RunRow.from_mapping(row.as_dict())
         existing = self.rows()
         previous = max((item.attempt for item in existing if item.config_id == row.config_id), default=0)
         if row.attempt != previous + 1:
@@ -145,12 +159,21 @@ class ResultStore:
         *,
         config_hash: str,
         environment_hash: str,
+        prompt_hash: str,
+        protocol_hash: str,
+        cell_hash: str,
         required_metrics: Iterable[str],
     ) -> bool:
         row = self.latest().get(config_id)
         if row is None or row.status is not RunStatus.SUCCESS:
             return False
-        if row.config_hash != config_hash or row.environment_hash != environment_hash:
+        if (
+            row.config_hash != config_hash
+            or row.environment_hash != environment_hash
+            or row.prompt_hash != prompt_hash
+            or row.protocol_hash != protocol_hash
+            or row.cell_hash != cell_hash
+        ):
             return False
         return all(metric in row.metrics and row.metrics[metric] is not None for metric in required_metrics)
 
@@ -162,11 +185,24 @@ def validate_complete_matrix(
     required_metrics: Iterable[str],
 ) -> dict[str, int]:
     plans = list(planned)
+    if not plans:
+        raise ValueError("planned matrix is empty")
     plan_by_id: dict[str, Mapping[str, Any]] = {}
     for plan in plans:
         config_id = str(plan["config_id"])
         if config_id in plan_by_id:
             raise ValueError(f"duplicate planned config_id: {config_id}")
+        expected_config = sha256_json(plan.get("config", {}))
+        if plan.get("config_hash") != expected_config:
+            raise ValueError(f"planned config hash mismatch: {config_id}")
+        cell_content = dict(plan)
+        declared_cell_hash = cell_content.pop("cell_hash", None)
+        if declared_cell_hash != sha256_json(cell_content):
+            raise ValueError(f"planned cell hash mismatch: {config_id}")
+        for name in ("environment_hash", "prompt_hash", "protocol_hash"):
+            value = str(plan.get(name, ""))
+            if len(value) != 64 or any(ch not in "0123456789abcdef" for ch in value):
+                raise ValueError(f"planned {name} is not a lowercase SHA-256: {config_id}")
         plan_by_id[config_id] = plan
 
     latest: dict[str, RunRow] = {}
@@ -186,7 +222,7 @@ def validate_complete_matrix(
             incomplete.append(f"{config_id}: missing")
             continue
         counts[row.status.value] += 1
-        expected_config = str(plan.get("config_hash") or sha256_json(plan.get("config", {})))
+        expected_config = str(plan["config_hash"])
         expected_environment = str(plan["environment_hash"])
         missing_metrics = [metric for metric in required if row.metrics.get(metric) is None]
         if row.status is not RunStatus.SUCCESS:
@@ -195,6 +231,12 @@ def validate_complete_matrix(
             incomplete.append(f"{config_id}: config hash mismatch")
         elif row.environment_hash != expected_environment:
             incomplete.append(f"{config_id}: environment hash mismatch")
+        elif row.prompt_hash != str(plan["prompt_hash"]):
+            incomplete.append(f"{config_id}: prompt hash mismatch")
+        elif row.protocol_hash != str(plan["protocol_hash"]):
+            incomplete.append(f"{config_id}: protocol hash mismatch")
+        elif row.cell_hash != str(plan["cell_hash"]):
+            incomplete.append(f"{config_id}: cell hash mismatch")
         elif missing_metrics:
             incomplete.append(f"{config_id}: missing metrics {missing_metrics}")
 

--- a/harness/validation_v2/scoring.py
+++ b/harness/validation_v2/scoring.py
@@ -1,0 +1,80 @@
+"""Strict final-content scoring without benchmark-specific recovery."""
+
+from __future__ import annotations
+
+import dataclasses
+import re
+import unicodedata
+from collections.abc import Mapping
+from typing import Any
+
+
+@dataclasses.dataclass(frozen=True)
+class ExactScore:
+    passed: bool
+    expected: str
+    observed: str | None
+    reason: str
+
+
+def normalize_final_content(value: str) -> str:
+    return unicodedata.normalize("NFC", value).strip()
+
+
+def extract_final_content(response: str | Mapping[str, Any]) -> str | None:
+    """Extract only a protocol-native final content field.
+
+    Plain strings are treated as the complete final field. Structured inputs
+    may use ``content`` directly or an OpenAI-compatible first choice. This
+    intentionally does not search reasoning text, prompts, or arbitrary nested
+    fields for the expected answer.
+    """
+
+    if isinstance(response, str):
+        return response
+    direct = response.get("content")
+    if isinstance(direct, str):
+        return direct
+    choices = response.get("choices")
+    if not isinstance(choices, list) or len(choices) != 1:
+        return None
+    choice = choices[0]
+    if not isinstance(choice, Mapping):
+        return None
+    message = choice.get("message")
+    if isinstance(message, Mapping) and isinstance(message.get("content"), str):
+        return str(message["content"])
+    if isinstance(choice.get("text"), str):
+        return str(choice["text"])
+    return None
+
+
+def score_exact_final_content(expected: str, response: str | Mapping[str, Any]) -> ExactScore:
+    wanted = normalize_final_content(expected)
+    raw = extract_final_content(response)
+    if raw is None:
+        return ExactScore(False, wanted, None, "missing-or-ambiguous-final-content")
+    observed = normalize_final_content(raw)
+    if not observed:
+        return ExactScore(False, wanted, observed, "empty-final-content")
+    if observed == wanted:
+        return ExactScore(True, wanted, observed, "exact-match")
+    return ExactScore(False, wanted, observed, "not-exact")
+
+
+def contains_expected_string(expected: str, response: str | Mapping[str, Any]) -> bool:
+    """Diagnostic only; this must never be used as the publication scorer."""
+
+    raw = extract_final_content(response)
+    if raw is None:
+        return False
+    return normalize_final_content(expected) in normalize_final_content(raw)
+
+
+def looks_like_prompt_echo(prompt: str, response: str | Mapping[str, Any]) -> bool:
+    raw = extract_final_content(response)
+    if raw is None:
+        return False
+    compact_prompt = re.sub(r"\s+", " ", normalize_final_content(prompt))
+    compact_response = re.sub(r"\s+", " ", normalize_final_content(raw))
+    return bool(compact_prompt and compact_prompt in compact_response)

--- a/harness/validation_v2/scoring.py
+++ b/harness/validation_v2/scoring.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import dataclasses
 import re
 import unicodedata
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from typing import Any
+
+from .records import sha256_json
 
 
 @dataclasses.dataclass(frozen=True)
@@ -78,3 +80,77 @@ def looks_like_prompt_echo(prompt: str, response: str | Mapping[str, Any]) -> bo
     compact_prompt = re.sub(r"\s+", " ", normalize_final_content(prompt))
     compact_response = re.sub(r"\s+", " ", normalize_final_content(raw))
     return bool(compact_prompt and compact_prompt in compact_response)
+
+
+def score_niah_records(
+    cases: Iterable[Mapping[str, Any]], responses: Iterable[Mapping[str, Any]]
+) -> dict[str, Any]:
+    """Strictly join one hash-bound final response to every generated NIAH case."""
+
+    case_by_id: dict[str, Mapping[str, Any]] = {}
+    for case in cases:
+        case_id = str(case.get("case_id") or "")
+        if not case_id:
+            raise ValueError("NIAH case lacks case_id")
+        if case_id in case_by_id:
+            raise ValueError(f"duplicate NIAH case: {case_id}")
+        if not isinstance(case.get("answer"), str):
+            raise ValueError(f"NIAH case lacks string answer: {case_id}")
+        case_by_id[case_id] = case
+    if not case_by_id:
+        raise ValueError("NIAH case set is empty")
+
+    response_by_id: dict[str, Mapping[str, Any]] = {}
+    for response in responses:
+        case_id = str(response.get("case_id") or response.get("prompt_id") or "")
+        if not case_id:
+            raise ValueError("NIAH response lacks case_id/prompt_id")
+        if case_id not in case_by_id:
+            raise ValueError(f"unplanned NIAH response: {case_id}")
+        if case_id in response_by_id:
+            raise ValueError(f"duplicate NIAH response: {case_id}")
+        expected_hash = sha256_json(case_by_id[case_id])
+        if response.get("prompt_hash") != expected_hash:
+            raise ValueError(f"NIAH response prompt hash mismatch: {case_id}")
+        if not isinstance(response.get("final_content"), str):
+            raise ValueError(f"NIAH response lacks final_content: {case_id}")
+        response_by_id[case_id] = response
+    missing = sorted(set(case_by_id) - set(response_by_id))
+    if missing:
+        raise ValueError(f"NIAH responses are incomplete: {missing}")
+
+    scores: list[dict[str, Any]] = []
+    for case_id, case in case_by_id.items():
+        exact = score_exact_final_content(str(case["answer"]), response_by_id[case_id]["final_content"])
+        scores.append(
+            {
+                "case_id": case_id,
+                "context_tokens": case.get("context_tokens"),
+                "depth_fraction": case.get("depth_fraction"),
+                "control": case.get("control"),
+                "passed": exact.passed,
+                "expected": exact.expected,
+                "observed": exact.observed,
+                "reason": exact.reason,
+            }
+        )
+    primary = [score for score in scores if score["control"] is None]
+    controls = [score for score in scores if score["control"] is not None]
+
+    def aggregate(rows: list[dict[str, Any]]) -> dict[str, Any]:
+        count = len(rows)
+        passed_count = sum(bool(row["passed"]) for row in rows)
+        return {
+            "cases": count,
+            "passed": passed_count,
+            "failed": count - passed_count,
+            "exact_match_rate": passed_count / count if count else None,
+        }
+
+    return {
+        "schema": "lucebox.validation-v2.niah-scores/1",
+        "summary": aggregate(scores),
+        "primary": aggregate(primary),
+        "controls": aggregate(controls),
+        "scores": scores,
+    }

--- a/harness/validation_v2/statistics.py
+++ b/harness/validation_v2/statistics.py
@@ -29,29 +29,89 @@ def paired_prompt_values(
     baseline: str,
     candidate: str,
     metric: str,
+    expected_repetitions: int | None = None,
+    expected_prompt_ids: Iterable[str] | None = None,
 ) -> dict[str, tuple[list[float], list[float]]]:
-    grouped: dict[tuple[str, str], list[float]] = defaultdict(list)
-    failed: set[tuple[str, str]] = set()
+    if expected_repetitions is not None and expected_repetitions < 1:
+        raise ValueError("expected_repetitions must be >= 1")
+
+    latest: dict[str, Mapping[str, Any]] = {}
+    legacy_rows: list[Mapping[str, Any]] = []
     for row in rows:
+        config_id = row.get("config_id")
+        attempt = row.get("attempt")
+        if config_id is None and attempt is None:
+            legacy_rows.append(row)
+            continue
+        if config_id is None or attempt is None:
+            raise ValueError("retry-aware rows require both config_id and attempt")
+        attempt_number = int(attempt)
+        if attempt_number < 1:
+            raise ValueError("attempt must be >= 1")
+        key = str(config_id)
+        previous = latest.get(key)
+        if previous is not None and int(previous["attempt"]) == attempt_number:
+            raise ValueError(f"duplicate result attempt: {key}#{attempt_number}")
+        if previous is None or int(previous["attempt"]) < attempt_number:
+            latest[key] = row
+
+    current_rows = [*legacy_rows, *latest.values()]
+    grouped: dict[tuple[str, str], dict[int, float]] = defaultdict(dict)
+    failed: set[tuple[str, str]] = set()
+    for row in current_rows:
         prompt_id = str(row["prompt_id"])
         config = str(row["config"])
         if config not in {baseline, candidate}:
             continue
+        repetition = row.get("repetition")
+        if repetition is None:
+            raise ValueError("paired analysis rows require repetition")
+        repetition_number = int(repetition)
+        if repetition_number < 1:
+            raise ValueError("repetition must be >= 1")
         if row.get("status") != "success" or row.get(metric) is None:
             failed.add((prompt_id, config))
             continue
-        grouped[(prompt_id, config)].append(float(row[metric]))
+        value = float(row[metric])
+        if not math.isfinite(value) or value <= 0:
+            raise ValueError(f"{metric} must be finite and positive for {prompt_id}/{config}")
+        values = grouped[(prompt_id, config)]
+        if repetition_number in values:
+            raise ValueError(
+                f"duplicate repetition for {prompt_id}/{config}: {repetition_number}"
+            )
+        values[repetition_number] = value
 
-    prompts = sorted({prompt for prompt, _ in grouped} | {prompt for prompt, _ in failed})
+    observed_prompts = {prompt for prompt, _ in grouped} | {prompt for prompt, _ in failed}
+    prompts = sorted(observed_prompts | set(expected_prompt_ids or ()))
     result: dict[str, tuple[list[float], list[float]]] = {}
     incomplete: list[str] = []
     for prompt_id in prompts:
-        base = grouped.get((prompt_id, baseline), [])
-        cand = grouped.get((prompt_id, candidate), [])
-        if (prompt_id, baseline) in failed or (prompt_id, candidate) in failed or not base or not cand:
+        base_by_rep = grouped.get((prompt_id, baseline), {})
+        cand_by_rep = grouped.get((prompt_id, candidate), {})
+        base_reps = set(base_by_rep)
+        cand_reps = set(cand_by_rep)
+        if (
+            (prompt_id, baseline) in failed
+            or (prompt_id, candidate) in failed
+            or not base_by_rep
+            or not cand_by_rep
+        ):
             incomplete.append(prompt_id)
             continue
-        result[prompt_id] = (base, cand)
+        if base_reps != cand_reps:
+            incomplete.append(prompt_id)
+            continue
+        if expected_repetitions is not None and base_reps != set(
+            range(1, expected_repetitions + 1)
+        ):
+            incomplete.append(prompt_id)
+            continue
+        repetitions = sorted(base_reps)
+        result[prompt_id] = (
+            [base_by_rep[index] for index in repetitions],
+            [cand_by_rep[index] for index in repetitions],
+        )
     if incomplete:
         raise ValueError(f"paired analysis has failed/incomplete prompts: {incomplete}")
     if not result:
@@ -65,6 +125,8 @@ def summarize_paired(
     bootstrap_samples: int = 10_000,
     seed: int = 20260718,
 ) -> dict[str, Any]:
+    if bootstrap_samples < 1:
+        raise ValueError("bootstrap_samples must be >= 1")
     prompt_ids = sorted(pairs)
     ratios: dict[str, float] = {}
     differences: dict[str, float] = {}
@@ -85,12 +147,15 @@ def summarize_paired(
         sampled_diffs: list[float] = []
         for prompt_id in sampled_prompts:
             baseline, candidate = pairs[prompt_id]
-            base_rep = rng.choice(list(baseline))
-            candidate_rep = rng.choice(list(candidate))
-            if base_rep <= 0:
-                raise ValueError(f"baseline repetition must be positive for {prompt_id}")
-            sampled_ratios.append(candidate_rep / base_rep)
-            sampled_diffs.append(candidate_rep - base_rep)
+            if len(baseline) != len(candidate):
+                raise ValueError(f"paired repetitions differ for {prompt_id}")
+            sampled_indices = [rng.randrange(len(baseline)) for _ in baseline]
+            base_mean = statistics.fmean(baseline[index] for index in sampled_indices)
+            candidate_mean = statistics.fmean(candidate[index] for index in sampled_indices)
+            if base_mean <= 0 or candidate_mean <= 0:
+                raise ValueError(f"repetition means must be positive for {prompt_id}")
+            sampled_ratios.append(candidate_mean / base_mean)
+            sampled_diffs.append(candidate_mean - base_mean)
         bootstrap_geomeans.append(math.exp(statistics.fmean(math.log(x) for x in sampled_ratios)))
         bootstrap_differences.append(statistics.fmean(sampled_diffs))
 

--- a/harness/validation_v2/statistics.py
+++ b/harness/validation_v2/statistics.py
@@ -1,0 +1,121 @@
+"""Paired prompt-level summaries with nested technical repetitions."""
+
+from __future__ import annotations
+
+import math
+import random
+import statistics
+from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
+
+
+def _quantile(values: Sequence[float], probability: float) -> float:
+    if not values:
+        raise ValueError("cannot take a quantile of an empty sequence")
+    ordered = sorted(values)
+    position = probability * (len(ordered) - 1)
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    weight = position - lower
+    return ordered[lower] * (1.0 - weight) + ordered[upper] * weight
+
+
+def paired_prompt_values(
+    rows: Iterable[Mapping[str, Any]],
+    *,
+    baseline: str,
+    candidate: str,
+    metric: str,
+) -> dict[str, tuple[list[float], list[float]]]:
+    grouped: dict[tuple[str, str], list[float]] = defaultdict(list)
+    failed: set[tuple[str, str]] = set()
+    for row in rows:
+        prompt_id = str(row["prompt_id"])
+        config = str(row["config"])
+        if config not in {baseline, candidate}:
+            continue
+        if row.get("status") != "success" or row.get(metric) is None:
+            failed.add((prompt_id, config))
+            continue
+        grouped[(prompt_id, config)].append(float(row[metric]))
+
+    prompts = sorted({prompt for prompt, _ in grouped} | {prompt for prompt, _ in failed})
+    result: dict[str, tuple[list[float], list[float]]] = {}
+    incomplete: list[str] = []
+    for prompt_id in prompts:
+        base = grouped.get((prompt_id, baseline), [])
+        cand = grouped.get((prompt_id, candidate), [])
+        if (prompt_id, baseline) in failed or (prompt_id, candidate) in failed or not base or not cand:
+            incomplete.append(prompt_id)
+            continue
+        result[prompt_id] = (base, cand)
+    if incomplete:
+        raise ValueError(f"paired analysis has failed/incomplete prompts: {incomplete}")
+    if not result:
+        raise ValueError("paired analysis has no complete prompts")
+    return result
+
+
+def summarize_paired(
+    pairs: Mapping[str, tuple[Sequence[float], Sequence[float]]],
+    *,
+    bootstrap_samples: int = 10_000,
+    seed: int = 20260718,
+) -> dict[str, Any]:
+    prompt_ids = sorted(pairs)
+    ratios: dict[str, float] = {}
+    differences: dict[str, float] = {}
+    for prompt_id, (baseline, candidate) in pairs.items():
+        base_mean = statistics.fmean(baseline)
+        candidate_mean = statistics.fmean(candidate)
+        if base_mean <= 0:
+            raise ValueError(f"baseline mean must be positive for {prompt_id}")
+        ratios[prompt_id] = candidate_mean / base_mean
+        differences[prompt_id] = candidate_mean - base_mean
+
+    rng = random.Random(seed)
+    bootstrap_geomeans: list[float] = []
+    bootstrap_differences: list[float] = []
+    for _ in range(bootstrap_samples):
+        sampled_prompts = [rng.choice(prompt_ids) for _ in prompt_ids]
+        sampled_ratios: list[float] = []
+        sampled_diffs: list[float] = []
+        for prompt_id in sampled_prompts:
+            baseline, candidate = pairs[prompt_id]
+            base_rep = rng.choice(list(baseline))
+            candidate_rep = rng.choice(list(candidate))
+            if base_rep <= 0:
+                raise ValueError(f"baseline repetition must be positive for {prompt_id}")
+            sampled_ratios.append(candidate_rep / base_rep)
+            sampled_diffs.append(candidate_rep - base_rep)
+        bootstrap_geomeans.append(math.exp(statistics.fmean(math.log(x) for x in sampled_ratios)))
+        bootstrap_differences.append(statistics.fmean(sampled_diffs))
+
+    ratio_values = list(ratios.values())
+    difference_values = list(differences.values())
+    return {
+        "independent_unit": "prompt",
+        "prompt_count": len(prompt_ids),
+        "technical_repetitions": {
+            prompt_id: {"baseline": len(pairs[prompt_id][0]), "candidate": len(pairs[prompt_id][1])}
+            for prompt_id in prompt_ids
+        },
+        "geometric_mean_ratio": math.exp(statistics.fmean(math.log(x) for x in ratio_values)),
+        "median_ratio": statistics.median(ratio_values),
+        "mean_difference": statistics.fmean(difference_values),
+        "slower_prompt_count": sum(value < 1.0 for value in ratio_values),
+        "ratio_ci95": [
+            _quantile(bootstrap_geomeans, 0.025),
+            _quantile(bootstrap_geomeans, 0.975),
+        ],
+        "difference_ci95": [
+            _quantile(bootstrap_differences, 0.025),
+            _quantile(bootstrap_differences, 0.975),
+        ],
+        "per_prompt_ratio": ratios,
+        "per_prompt_difference": differences,
+        "bootstrap": {"samples": bootstrap_samples, "seed": seed, "nested_repetitions": True},
+    }

--- a/harness/validation_v2/tests/test_corpora.py
+++ b/harness/validation_v2/tests/test_corpora.py
@@ -1,6 +1,13 @@
 import json
+from pathlib import Path
 
-from harness.validation_v2.corpora import build_tuning40, build_validation100
+import pytest
+
+from harness.validation_v2.corpora import (
+    build_tuning40,
+    build_validation100,
+    validate_frozen_hashes,
+)
 
 
 def test_tuning_builder_requires_exactly_40_unique_source_rows() -> None:
@@ -30,3 +37,27 @@ def test_validation_builder_balances_ten_declared_families() -> None:
     assert len(rows) == 100
     assert {row["family"] for row in rows} == set(examples)
     assert all(row["source_revision"] for row in rows)
+    assert {row["source_license"] for row in rows} == {"CC-BY-NC-4.0"}
+
+
+def test_generated_hashes_must_match_protocol(tmp_path: Path) -> None:
+    protocol = tmp_path / "protocol.json"
+    protocol.write_text(
+        json.dumps(
+            {
+                "decode_corpora": {
+                    "tuning40_sha256": "a" * 64,
+                    "validation100_sha256": "b" * 64,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    result = {
+        "tuning40": {"sha256": "a" * 64},
+        "validation100": {"sha256": "b" * 64},
+    }
+    validate_frozen_hashes(result, protocol)
+    result["validation100"]["sha256"] = "c" * 64
+    with pytest.raises(ValueError, match="frozen protocol"):
+        validate_frozen_hashes(result, protocol)

--- a/harness/validation_v2/tests/test_corpora.py
+++ b/harness/validation_v2/tests/test_corpora.py
@@ -1,0 +1,32 @@
+import json
+
+from harness.validation_v2.corpora import build_tuning40, build_validation100
+
+
+def test_tuning_builder_requires_exactly_40_unique_source_rows() -> None:
+    raw = json.dumps([["family", f"prompt {index}"] for index in range(40)]).encode()
+    rows = build_tuning40(raw)
+    assert len(rows) == 40
+    assert len({row["id"] for row in rows}) == 40
+
+
+def test_validation_builder_balances_ten_declared_families() -> None:
+    examples = {
+        "code": "Write a Python function for this task",
+        "math": "Calculate the probability in this problem",
+        "summarization": "Summarize the following passage",
+        "classification": "Classify the following document",
+        "extraction": "Extract the names from the text",
+        "rewriting": "Rewrite the following paragraph",
+        "brainstorming": "Brainstorm ideas for a workshop",
+        "question-answering": "What is the purpose of the device?",
+        "reasoning": "Analyze the evidence and infer the result",
+        "creative": "Write a creative short story",
+    }
+    source = []
+    for instruction in examples.values():
+        source.extend({"instruction": f"{instruction} #{index}", "input": ""} for index in range(10))
+    rows = build_validation100(json.dumps(source).encode())
+    assert len(rows) == 100
+    assert {row["family"] for row in rows} == set(examples)
+    assert all(row["source_revision"] for row in rows)

--- a/harness/validation_v2/tests/test_http_runner.py
+++ b/harness/validation_v2/tests/test_http_runner.py
@@ -42,7 +42,7 @@ def _usage() -> dict[str, object]:
 def test_sse_parser_reconstructs_content_and_usage() -> None:
     chunks = [
         b'data: {"choices":[{"delta":{"content":"hello "}}]}\n',
-        b'data: {"choices":[{"delta":{"content":"world"}}],"usage":{"completion_tokens":2}}\n',
+        b'data: {"choices":[{"delta":{"content":"world"},"finish_reason":"stop"}],"usage":{"completion_tokens":2}}\n',
         b"data: [DONE]\n",
     ]
     text, usage, parsed = parse_sse_lines(chunks)
@@ -56,7 +56,12 @@ def test_sse_parser_preserves_nested_speculative_evidence() -> None:
         b'data: {"choices":[{"delta":{"content":"ok"}}]}\n',
         (
             "data: "
-            + json.dumps({"choices": [], "usage": _usage()})
+            + json.dumps(
+                {
+                    "choices": [{"delta": {}, "finish_reason": "stop"}],
+                    "usage": _usage(),
+                }
+            )
             + "\n"
         ).encode(),
         b"data: [DONE]\n",
@@ -111,3 +116,17 @@ def test_sse_parser_rejects_non_data_lines() -> None:
 def test_sse_parser_rejects_non_object_chunks() -> None:
     with pytest.raises(ValueError, match="not a JSON object"):
         parse_sse_lines([f"data: {json.dumps([1, 2])}\n".encode()])
+
+
+def test_sse_parser_rejects_truncated_or_unfinished_streams() -> None:
+    with pytest.raises(ValueError, match=r"without \[DONE\]"):
+        parse_sse_lines(
+            [b'data: {"choices":[{"delta":{"content":"partial"}}]}\n']
+        )
+    with pytest.raises(ValueError, match="without a finish reason"):
+        parse_sse_lines(
+            [
+                b'data: {"choices":[{"delta":{"content":"partial"}}]}\n',
+                b"data: [DONE]\n",
+            ]
+        )

--- a/harness/validation_v2/tests/test_http_runner.py
+++ b/harness/validation_v2/tests/test_http_runner.py
@@ -2,7 +2,41 @@ import json
 
 import pytest
 
-from harness.validation_v2.http_runner import parse_sse_lines
+from harness.validation_v2.http_runner import (
+    parse_sse_lines,
+    validate_speculative_evidence,
+)
+
+
+def _config() -> dict[str, object]:
+    return {
+        "expected_configured_contract": "exact",
+        "expected_effective_decode_mode": "autoregressive",
+        "expected_fallback_reason": "exact_contract_requires_ar",
+        "expected_draft_attached": True,
+        "expected_draft_loaded": False,
+    }
+
+
+def _props() -> dict[str, object]:
+    return {
+        "speculative": {
+            "configured_contract": "exact",
+            "draft_attached": True,
+            "draft_loaded": False,
+        }
+    }
+
+
+def _usage() -> dict[str, object]:
+    return {
+        "completion_tokens": 2,
+        "speculative": {
+            "configured_contract": "exact",
+            "effective_decode_mode": "autoregressive",
+            "fallback_reason": "exact_contract_requires_ar",
+        },
+    }
 
 
 def test_sse_parser_reconstructs_content_and_usage() -> None:
@@ -15,6 +49,58 @@ def test_sse_parser_reconstructs_content_and_usage() -> None:
     assert text == "hello world"
     assert usage["completion_tokens"] == 2
     assert len(parsed) == 2
+
+
+def test_sse_parser_preserves_nested_speculative_evidence() -> None:
+    chunks = [
+        b'data: {"choices":[{"delta":{"content":"ok"}}]}\n',
+        (
+            "data: "
+            + json.dumps({"choices": [], "usage": _usage()})
+            + "\n"
+        ).encode(),
+        b"data: [DONE]\n",
+    ]
+    _, usage, _ = parse_sse_lines(chunks)
+    assert validate_speculative_evidence(
+        usage=usage, props=_props(), config=_config()
+    ) == {
+        "configured_contract": "exact",
+        "effective_decode_mode": "autoregressive",
+        "fallback_reason": "exact_contract_requires_ar",
+    }
+
+
+def test_nonstream_usage_requires_nested_speculative_evidence() -> None:
+    assert validate_speculative_evidence(
+        usage=_usage(), props=_props(), config=_config()
+    )["configured_contract"] == "exact"
+    flattened = {
+        "completion_tokens": 2,
+        "configured_contract": "exact",
+        "effective_decode_mode": "autoregressive",
+        "fallback_reason": "exact_contract_requires_ar",
+    }
+    with pytest.raises(ValueError, match="nested speculative"):
+        validate_speculative_evidence(
+            usage=flattened, props=_props(), config=_config()
+        )
+
+
+def test_speculative_evidence_must_match_props_and_matrix() -> None:
+    wrong_props = _props()
+    wrong_props["speculative"]["draft_loaded"] = True  # type: ignore[index]
+    with pytest.raises(ValueError, match="draft_loaded"):
+        validate_speculative_evidence(
+            usage=_usage(), props=wrong_props, config=_config()
+        )
+
+    missing_expectation = _config()
+    del missing_expectation["expected_fallback_reason"]
+    with pytest.raises(ValueError, match="lacks speculative evidence expectations"):
+        validate_speculative_evidence(
+            usage=_usage(), props=_props(), config=missing_expectation
+        )
 
 
 def test_sse_parser_rejects_non_data_lines() -> None:

--- a/harness/validation_v2/tests/test_http_runner.py
+++ b/harness/validation_v2/tests/test_http_runner.py
@@ -1,0 +1,27 @@
+import json
+
+import pytest
+
+from harness.validation_v2.http_runner import parse_sse_lines
+
+
+def test_sse_parser_reconstructs_content_and_usage() -> None:
+    chunks = [
+        b'data: {"choices":[{"delta":{"content":"hello "}}]}\n',
+        b'data: {"choices":[{"delta":{"content":"world"}}],"usage":{"completion_tokens":2}}\n',
+        b"data: [DONE]\n",
+    ]
+    text, usage, parsed = parse_sse_lines(chunks)
+    assert text == "hello world"
+    assert usage["completion_tokens"] == 2
+    assert len(parsed) == 2
+
+
+def test_sse_parser_rejects_non_data_lines() -> None:
+    with pytest.raises(ValueError, match="non-SSE"):
+        parse_sse_lines([b"not data\n"])
+
+
+def test_sse_parser_rejects_non_object_chunks() -> None:
+    with pytest.raises(ValueError, match="not a JSON object"):
+        parse_sse_lines([f"data: {json.dumps([1, 2])}\n".encode()])

--- a/harness/validation_v2/tests/test_http_runner.py
+++ b/harness/validation_v2/tests/test_http_runner.py
@@ -3,7 +3,10 @@ import json
 import pytest
 
 from harness.validation_v2.http_runner import (
+    _assistant_output,
+    _response_timings,
     parse_sse_lines,
+    validate_llama_cpp_evidence,
     validate_speculative_evidence,
 )
 
@@ -130,3 +133,105 @@ def test_sse_parser_rejects_truncated_or_unfinished_streams() -> None:
                 b"data: [DONE]\n",
             ]
         )
+
+
+def _llama_cpp_config(speculative_type: str) -> dict[str, object]:
+    speculative = speculative_type != "none"
+    return {
+        "expected_build_info": "b10068-571d0d54",
+        "expected_model_alias": "Qwen3.6-27B-Q4_K_M.gguf",
+        "expected_speculative_type": speculative_type,
+        "expected_configured_contract": "external-unverified"
+        if speculative
+        else "autoregressive",
+        "expected_effective_decode_mode": "llama_cpp_"
+        + speculative_type.removeprefix("draft-")
+        if speculative
+        else "autoregressive",
+        "expected_fallback_reason": "none",
+    }
+
+
+def test_llama_cpp_evidence_requires_matching_identity_and_draft_activity() -> None:
+    props = {
+        "build_info": "b10068-571d0d54",
+        "model_alias": "Qwen3.6-27B-Q4_K_M.gguf",
+    }
+    response = {
+        "timings": {
+            "predicted_ms": 1106.0,
+            "predicted_per_second": 57.8,
+            "draft_n": 55,
+            "draft_n_accepted": 44,
+        }
+    }
+    evidence = validate_llama_cpp_evidence(
+        props=props,
+        raw_response=response,
+        config=_llama_cpp_config("draft-mtp"),
+    )
+    assert evidence["effective_decode_mode"] == "llama_cpp_mtp"
+    assert evidence["draft_n_accepted"] == 44
+
+    no_drafts = {"timings": {"predicted_ms": 1.0, "predicted_per_second": 1.0}}
+    with pytest.raises(ValueError, match="no draft evidence"):
+        validate_llama_cpp_evidence(
+            props=props,
+            raw_response=no_drafts,
+            config=_llama_cpp_config("draft-dflash"),
+        )
+
+
+def test_llama_cpp_target_only_rejects_unexpected_drafts_and_wrong_build() -> None:
+    props = {
+        "build_info": "b10068-571d0d54",
+        "model_alias": "Qwen3.6-27B-Q4_K_M.gguf",
+    }
+    response = {"timings": {"predicted_ms": 1.0, "predicted_per_second": 1.0}}
+    evidence = validate_llama_cpp_evidence(
+        props=props, raw_response=response, config=_llama_cpp_config("none")
+    )
+    assert evidence["configured_contract"] == "autoregressive"
+
+    with pytest.raises(ValueError, match="unexpectedly drafted"):
+        validate_llama_cpp_evidence(
+            props=props,
+            raw_response={"timings": {"draft_n": 1, "draft_n_accepted": 1}},
+            config=_llama_cpp_config("none"),
+        )
+    with pytest.raises(ValueError, match="build_info"):
+        validate_llama_cpp_evidence(
+            props={**props, "build_info": "wrong"},
+            raw_response=response,
+            config=_llama_cpp_config("none"),
+        )
+
+
+def test_response_timings_reads_final_sse_chunk() -> None:
+    assert _response_timings(
+        [{"choices": []}, {"timings": {"predicted_per_second": 12.5}}]
+    )["predicted_per_second"] == 12.5
+
+
+def test_assistant_output_hash_material_includes_reasoning_and_final_content() -> None:
+    nonstream = {
+        "choices": [
+            {
+                "message": {
+                    "reasoning_content": "private trace",
+                    "content": "VOLTA",
+                }
+            }
+        ]
+    }
+    assert _assistant_output(nonstream) == {
+        "reasoning_content": "private trace",
+        "content": "VOLTA",
+    }
+    stream = [
+        {"choices": [{"delta": {"reasoning_content": "private "}}]},
+        {"choices": [{"delta": {"reasoning_content": "trace"}}]},
+        {"choices": [{"delta": {"content": "VOL"}}]},
+        {"choices": [{"delta": {"content": "TA"}, "finish_reason": "stop"}]},
+    ]
+    assert _assistant_output(stream) == _assistant_output(nonstream)

--- a/harness/validation_v2/tests/test_matrix.py
+++ b/harness/validation_v2/tests/test_matrix.py
@@ -1,11 +1,19 @@
-from harness.validation_v2.matrix import build_cells
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from harness.validation_v2.matrix import build_cells, load_prompt_hashes, write_cells
+from harness.validation_v2.records import sha256_json
 
 
 def test_matrix_ids_are_stable_and_unique() -> None:
     cells = build_cells(
-        prompt_ids=["p1", "p2"],
+        prompt_hashes={"p1": "a" * 64, "p2": "b" * 64},
         platform="dual-v100s",
         environment_hash="e" * 64,
+        protocol_hash="f" * 64,
         configurations=[{"name": "target-ar", "contract": "autoregressive"}],
         repetitions=2,
         phase="publication",
@@ -13,3 +21,39 @@ def test_matrix_ids_are_stable_and_unique() -> None:
     assert len(cells) == 4
     assert len({cell["config_id"] for cell in cells}) == 4
     assert cells[0]["config_hash"] == cells[-1]["config_hash"]
+    assert cells[0]["prompt_hash"] != cells[-1]["prompt_hash"]
+    assert all(cell["cell_hash"] for cell in cells)
+
+
+def test_prompt_rows_are_content_addressed(tmp_path: Path) -> None:
+    prompt = {"id": "p1", "prompt": "hello"}
+    prompt["prompt_sha256"] = hashlib.sha256(b"hello").hexdigest()
+    path = tmp_path / "prompts.jsonl"
+    path.write_text(json.dumps(prompt) + "\n", encoding="utf-8")
+    first = load_prompt_hashes(path)
+    prompt["prompt"] = "changed"
+    path.write_text(json.dumps(prompt) + "\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="prompt hash mismatch"):
+        load_prompt_hashes(path)
+    assert first == {"p1": sha256_json({**prompt, "prompt": "hello"})}
+
+
+def test_matrix_rejects_empty_zero_rep_and_stale_hashes(tmp_path: Path) -> None:
+    kwargs = {
+        "prompt_hashes": {"p": "a" * 64},
+        "platform": "rtx3090",
+        "environment_hash": "e" * 64,
+        "protocol_hash": "f" * 64,
+        "configurations": [{"name": "ar"}],
+        "phase": "publication",
+    }
+    with pytest.raises(ValueError, match="repetitions"):
+        build_cells(**kwargs, repetitions=0)
+    with pytest.raises(ValueError, match="configuration list is empty"):
+        build_cells(**{**kwargs, "configurations": []}, repetitions=1)
+    with pytest.raises(ValueError, match="prompt corpus is empty"):
+        build_cells(**{**kwargs, "prompt_hashes": {}}, repetitions=1)
+    cells = build_cells(**kwargs, repetitions=1)
+    cells[0]["config"]["mode"] = "changed"
+    with pytest.raises(ValueError, match="config hash mismatch"):
+        write_cells(tmp_path / "matrix.jsonl", cells)

--- a/harness/validation_v2/tests/test_matrix.py
+++ b/harness/validation_v2/tests/test_matrix.py
@@ -1,0 +1,15 @@
+from harness.validation_v2.matrix import build_cells
+
+
+def test_matrix_ids_are_stable_and_unique() -> None:
+    cells = build_cells(
+        prompt_ids=["p1", "p2"],
+        platform="dual-v100s",
+        environment_hash="e" * 64,
+        configurations=[{"name": "target-ar", "contract": "autoregressive"}],
+        repetitions=2,
+        phase="publication",
+    )
+    assert len(cells) == 4
+    assert len({cell["config_id"] for cell in cells}) == 4
+    assert cells[0]["config_hash"] == cells[-1]["config_hash"]

--- a/harness/validation_v2/tests/test_niah.py
+++ b/harness/validation_v2/tests/test_niah.py
@@ -1,18 +1,33 @@
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from harness.validation_v2.cli import _pinned_tokenizer_counter
 from harness.validation_v2.niah import generate_control_cases, generate_primary_cases
 
 
 def test_primary_design_is_balanced_and_deterministic() -> None:
-    first = generate_primary_cases(context_tokens=32768, tokenizer_revision="a" * 40)
-    second = generate_primary_cases(context_tokens=32768, tokenizer_revision="a" * 40)
+    counter = len
+    first = generate_primary_cases(
+        context_tokens=32768, tokenizer_revision="a" * 40, token_counter=counter
+    )
+    second = generate_primary_cases(
+        context_tokens=32768, tokenizer_revision="a" * 40, token_counter=counter
+    )
     assert len(first) == 100
     assert first == second
     assert len({case.case_id for case in first}) == 100
     assert {case.depth_fraction for case in first} == {0.05, 0.25, 0.5, 0.75, 0.95}
     assert len({case.prompt_sha256 for case in first}) == 100
+    assert all(case.actual_context_tokens == 32768 for case in first)
+    assert all(abs(case.actual_depth_fraction - case.depth_fraction) <= 0.02 for case in first)
 
 
 def test_controls_cover_all_adversarial_families() -> None:
-    controls = generate_control_cases(context_tokens=32768, tokenizer_revision="a" * 40)
+    controls = generate_control_cases(
+        context_tokens=32768, tokenizer_revision="a" * 40, token_counter=len
+    )
     assert len(controls) == 20
     assert {case.control for case in controls} == {
         "answer-absent",
@@ -21,3 +36,45 @@ def test_controls_cover_all_adversarial_families() -> None:
         "prefix",
         "prompt-echo",
     }
+    assert {case.answer for case in controls} == {"NONE"}
+    assert all(case.actual_context_tokens == 32768 for case in controls)
+
+
+def test_publication_generation_refuses_character_only_estimates() -> None:
+    with pytest.raises(ValueError, match="actual tokenizer counter"):
+        generate_primary_cases(context_tokens=32768, tokenizer_revision="a" * 40)
+    with pytest.raises(ValueError, match="immutable lowercase SHA"):
+        generate_primary_cases(
+            context_tokens=32768,
+            tokenizer_revision="latest",
+            token_counter=len,
+        )
+
+
+def test_cli_constructs_counter_from_exact_pinned_tokenizer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    revision = "a" * 40
+
+    class FakeTokenizer:
+        init_kwargs = {"_commit_hash": revision}
+
+        def apply_chat_template(self, messages, *, tokenize, add_generation_prompt):
+            assert messages == [{"role": "user", "content": "hello"}]
+            assert tokenize and add_generation_prompt
+            return [1, 2, 3]
+
+    class FakeAutoTokenizer:
+        @staticmethod
+        def from_pretrained(identifier, *, revision, trust_remote_code):
+            assert identifier == "repo/tokenizer"
+            assert revision == "a" * 40
+            assert trust_remote_code is False
+            return FakeTokenizer()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "transformers",
+        SimpleNamespace(AutoTokenizer=FakeAutoTokenizer),
+    )
+    assert _pinned_tokenizer_counter("repo/tokenizer", revision)("hello") == 3

--- a/harness/validation_v2/tests/test_niah.py
+++ b/harness/validation_v2/tests/test_niah.py
@@ -1,0 +1,23 @@
+from harness.validation_v2.niah import generate_control_cases, generate_primary_cases
+
+
+def test_primary_design_is_balanced_and_deterministic() -> None:
+    first = generate_primary_cases(context_tokens=32768, tokenizer_revision="a" * 40)
+    second = generate_primary_cases(context_tokens=32768, tokenizer_revision="a" * 40)
+    assert len(first) == 100
+    assert first == second
+    assert len({case.case_id for case in first}) == 100
+    assert {case.depth_fraction for case in first} == {0.05, 0.25, 0.5, 0.75, 0.95}
+    assert len({case.prompt_sha256 for case in first}) == 100
+
+
+def test_controls_cover_all_adversarial_families() -> None:
+    controls = generate_control_cases(context_tokens=32768, tokenizer_revision="a" * 40)
+    assert len(controls) == 20
+    assert {case.control for case in controls} == {
+        "answer-absent",
+        "misleading",
+        "multiple",
+        "prefix",
+        "prompt-echo",
+    }

--- a/harness/validation_v2/tests/test_provenance.py
+++ b/harness/validation_v2/tests/test_provenance.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+import pytest
+
+from harness.validation_v2.provenance import redact_environment, sha256_file
+
+
+def test_sha256_file_is_content_based(tmp_path: Path) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.write_bytes(b"same")
+    second.write_bytes(b"same")
+    assert sha256_file(first) == sha256_file(second)
+    second.write_bytes(b"changed")
+    assert sha256_file(first) != sha256_file(second)
+
+
+def test_environment_redaction_is_allowlist_only() -> None:
+    result = redact_environment(
+        {"CUDA_VISIBLE_DEVICES": "0", "LANG": "C.UTF-8", "API_KEY": "do-not-copy"}
+    )
+    assert result == {"CUDA_VISIBLE_DEVICES": "0", "LANG": "C.UTF-8"}
+
+
+def test_missing_file_hash_fails(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        sha256_file(tmp_path / "missing")

--- a/harness/validation_v2/tests/test_provenance.py
+++ b/harness/validation_v2/tests/test_provenance.py
@@ -2,7 +2,14 @@ from pathlib import Path
 
 import pytest
 
-from harness.validation_v2.provenance import redact_environment, sha256_file
+import harness.validation_v2.provenance as provenance
+from harness.validation_v2.provenance import (
+    build_manifest,
+    redact_command,
+    redact_environment,
+    repository_identity,
+    sha256_file,
+)
 
 
 def test_sha256_file_is_content_based(tmp_path: Path) -> None:
@@ -25,3 +32,70 @@ def test_environment_redaction_is_allowlist_only() -> None:
 def test_missing_file_hash_fails(tmp_path: Path) -> None:
     with pytest.raises(FileNotFoundError):
         sha256_file(tmp_path / "missing")
+
+
+def test_repository_rejects_uninitialized_or_mismatched_submodules(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fake_run(args: list[str], _cwd: Path) -> str:
+        if args[1:3] == ["status", "--porcelain"]:
+            return ""
+        if args[1:3] == ["submodule", "status"]:
+            return "-" + "a" * 40 + " deps/example"
+        return "a" * 40
+
+    monkeypatch.setattr(provenance, "_run", fake_run)
+    with pytest.raises(ValueError, match="initialized, pinned submodules"):
+        repository_identity(tmp_path)
+
+
+def test_manifest_requires_real_immutable_sha(tmp_path: Path) -> None:
+    source = tmp_path / "input"
+    source.write_text("data", encoding="utf-8")
+    with pytest.raises(ValueError, match="commit-like revisions"):
+        build_manifest(
+            root=tmp_path,
+            files={"input": source},
+            immutable_inputs={"model": "this-is-definitely-latest"},
+            build={},
+            command=[],
+        )
+
+
+def test_manifest_redacts_commands_urls_and_nested_build_secrets(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "input"
+    source.write_text("data", encoding="utf-8")
+    monkeypatch.setattr(
+        provenance,
+        "repository_identity",
+        lambda _root: {"commit": "a" * 40, "clean": True, "submodules": []},
+    )
+    manifest = build_manifest(
+        root=tmp_path,
+        files={"input": source},
+        immutable_inputs={"model": "a" * 40},
+        build={"flags": {"api_key": "secret", "max_tokens": 384}},
+        command=[
+            "runner",
+            "--api-key",
+            "secret",
+            "--max-tokens",
+            "384",
+            "https://user:password@example.com/run?token=secret",
+        ],
+    )
+    assert manifest["command"] == [
+        "runner",
+        "--api-key",
+        "[REDACTED]",
+        "--max-tokens",
+        "384",
+        "https://example.com/run",
+    ]
+    assert manifest["build"]["flags"] == {
+        "api_key": "[REDACTED]",
+        "max_tokens": 384,
+    }
+    assert redact_command(["HF_TOKEN=secret"]) == ["HF_TOKEN=[REDACTED]"]

--- a/harness/validation_v2/tests/test_records.py
+++ b/harness/validation_v2/tests/test_records.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import json
 from pathlib import Path
 
@@ -27,7 +28,32 @@ def row(*, status: RunStatus = RunStatus.SUCCESS, attempt: int = 1) -> RunRow:
         metrics={"decode_tok_s": 1.0} if status is RunStatus.SUCCESS else {},
         artifacts={},
         error=None if status is RunStatus.SUCCESS else "failed",
+        prompt_hash="a" * 64,
+        protocol_hash="f" * 64,
+        cell_hash=sha256_json(
+            {
+                "config_id": "cfg-1",
+                "config": {"mode": "exact"},
+                "config_hash": sha256_json({"mode": "exact"}),
+                "environment_hash": "e" * 64,
+                "prompt_hash": "a" * 64,
+                "protocol_hash": "f" * 64,
+            }
+        ),
     )
+
+
+def plan() -> dict[str, object]:
+    value: dict[str, object] = {
+        "config_id": "cfg-1",
+        "config": {"mode": "exact"},
+        "config_hash": sha256_json({"mode": "exact"}),
+        "environment_hash": "e" * 64,
+        "prompt_hash": "a" * 64,
+        "protocol_hash": "f" * 64,
+    }
+    value["cell_hash"] = sha256_json(value)
+    return value
 
 
 def test_failed_row_is_not_complete_and_is_retried(tmp_path: Path) -> None:
@@ -37,6 +63,9 @@ def test_failed_row_is_not_complete_and_is_retried(tmp_path: Path) -> None:
         "cfg-1",
         config_hash=sha256_json({"mode": "exact"}),
         environment_hash="e" * 64,
+        prompt_hash="a" * 64,
+        protocol_hash="f" * 64,
+        cell_hash=row().cell_hash,
         required_metrics=["decode_tok_s"],
     )
     store.append(row(attempt=2))
@@ -44,6 +73,9 @@ def test_failed_row_is_not_complete_and_is_retried(tmp_path: Path) -> None:
         "cfg-1",
         config_hash=sha256_json({"mode": "exact"}),
         environment_hash="e" * 64,
+        prompt_hash="a" * 64,
+        protocol_hash="f" * 64,
+        cell_hash=row().cell_hash,
         required_metrics=["decode_tok_s"],
     )
 
@@ -57,22 +89,34 @@ def test_duplicate_attempt_is_rejected(tmp_path: Path) -> None:
 
 
 def test_matrix_refuses_failed_or_missing_cells() -> None:
-    plan = {
-        "config_id": "cfg-1",
-        "config": {"mode": "exact"},
-        "environment_hash": "e" * 64,
-    }
     with pytest.raises(ValueError, match="matrix is incomplete"):
-        validate_complete_matrix([plan], [row(status=RunStatus.FAILED)], required_metrics=[])
+        validate_complete_matrix([plan()], [row(status=RunStatus.FAILED)], required_metrics=[])
     with pytest.raises(ValueError, match="matrix is incomplete"):
-        validate_complete_matrix([plan], [], required_metrics=[])
+        validate_complete_matrix([plan()], [], required_metrics=[])
 
 
 def test_success_requires_declared_metrics() -> None:
-    plan = {
-        "config_id": "cfg-1",
-        "config": {"mode": "exact"},
-        "environment_hash": "e" * 64,
-    }
     with pytest.raises(ValueError, match="missing metrics"):
-        validate_complete_matrix([plan], [row()], required_metrics=["ttft_ms"])
+        validate_complete_matrix([plan()], [row()], required_metrics=["ttft_ms"])
+
+
+def test_matrix_refuses_empty_plan_and_stale_declared_config() -> None:
+    with pytest.raises(ValueError, match="planned matrix is empty"):
+        validate_complete_matrix([], [], required_metrics=[])
+    stale = plan()
+    stale["config"] = {"mode": "changed"}
+    with pytest.raises(ValueError, match="planned config hash mismatch"):
+        validate_complete_matrix([stale], [], required_metrics=[])
+
+
+def test_matrix_binds_prompt_protocol_and_cell_hashes() -> None:
+    valid_plan = plan()
+    valid_row = dataclasses.replace(
+        row(),
+        cell_hash=str(valid_plan["cell_hash"]),
+    )
+    validate_complete_matrix([valid_plan], [valid_row], required_metrics=["decode_tok_s"])
+    for field in ("prompt_hash", "protocol_hash", "cell_hash"):
+        changed = dataclasses.replace(valid_row, **{field: "1" * 64})
+        with pytest.raises(ValueError, match=f"{field.replace('_', ' ')} mismatch"):
+            validate_complete_matrix([valid_plan], [changed], required_metrics=[])

--- a/harness/validation_v2/tests/test_records.py
+++ b/harness/validation_v2/tests/test_records.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from harness.validation_v2.records import (
+    ResultStore,
+    RunRow,
+    RunStatus,
+    sha256_json,
+    validate_complete_matrix,
+)
+
+
+def row(*, status: RunStatus = RunStatus.SUCCESS, attempt: int = 1) -> RunRow:
+    return RunRow(
+        config_id="cfg-1",
+        attempt=attempt,
+        status=status,
+        config_hash=sha256_json({"mode": "exact"}),
+        environment_hash="e" * 64,
+        started_at="2026-07-18T00:00:00Z",
+        finished_at="2026-07-18T00:00:01Z",
+        return_code=0 if status is RunStatus.SUCCESS else 1,
+        metrics={"decode_tok_s": 1.0} if status is RunStatus.SUCCESS else {},
+        artifacts={},
+        error=None if status is RunStatus.SUCCESS else "failed",
+    )
+
+
+def test_failed_row_is_not_complete_and_is_retried(tmp_path: Path) -> None:
+    store = ResultStore(tmp_path / "results.jsonl")
+    store.append(row(status=RunStatus.FAILED))
+    assert not store.is_complete(
+        "cfg-1",
+        config_hash=sha256_json({"mode": "exact"}),
+        environment_hash="e" * 64,
+        required_metrics=["decode_tok_s"],
+    )
+    store.append(row(attempt=2))
+    assert store.is_complete(
+        "cfg-1",
+        config_hash=sha256_json({"mode": "exact"}),
+        environment_hash="e" * 64,
+        required_metrics=["decode_tok_s"],
+    )
+
+
+def test_duplicate_attempt_is_rejected(tmp_path: Path) -> None:
+    path = tmp_path / "results.jsonl"
+    raw = json.dumps(row().as_dict())
+    path.write_text(raw + "\n" + raw + "\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="duplicate result attempt"):
+        ResultStore(path).rows()
+
+
+def test_matrix_refuses_failed_or_missing_cells() -> None:
+    plan = {
+        "config_id": "cfg-1",
+        "config": {"mode": "exact"},
+        "environment_hash": "e" * 64,
+    }
+    with pytest.raises(ValueError, match="matrix is incomplete"):
+        validate_complete_matrix([plan], [row(status=RunStatus.FAILED)], required_metrics=[])
+    with pytest.raises(ValueError, match="matrix is incomplete"):
+        validate_complete_matrix([plan], [], required_metrics=[])
+
+
+def test_success_requires_declared_metrics() -> None:
+    plan = {
+        "config_id": "cfg-1",
+        "config": {"mode": "exact"},
+        "environment_hash": "e" * 64,
+    }
+    with pytest.raises(ValueError, match="missing metrics"):
+        validate_complete_matrix([plan], [row()], required_metrics=["ttft_ms"])

--- a/harness/validation_v2/tests/test_scoring.py
+++ b/harness/validation_v2/tests/test_scoring.py
@@ -1,0 +1,25 @@
+from harness.validation_v2.scoring import score_exact_final_content
+
+
+def test_exact_match_normalizes_unicode_and_outer_whitespace() -> None:
+    score = score_exact_final_content("café", "  cafe\u0301\n")
+    assert score.passed
+
+
+def test_substring_prefix_superset_and_extra_prose_fail() -> None:
+    for response in ("12345670", "x1234567", "The answer is 1234567", "1234567 and 7654321"):
+        assert not score_exact_final_content("1234567", response).passed
+
+
+def test_only_native_final_content_is_considered() -> None:
+    response = {
+        "choices": [
+            {"message": {"content": "amber-birch", "reasoning_content": "wrong answer"}}
+        ]
+    }
+    assert score_exact_final_content("amber-birch", response).passed
+
+
+def test_ambiguous_or_missing_content_fails() -> None:
+    assert not score_exact_final_content("answer", {"choices": []}).passed
+    assert not score_exact_final_content("answer", {"choices": [{}, {}]}).passed

--- a/harness/validation_v2/tests/test_scoring.py
+++ b/harness/validation_v2/tests/test_scoring.py
@@ -1,4 +1,12 @@
-from harness.validation_v2.scoring import score_exact_final_content
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from harness.validation_v2.cli import command_score_niah
+from harness.validation_v2.records import sha256_json
+from harness.validation_v2.scoring import score_exact_final_content, score_niah_records
 
 
 def test_exact_match_normalizes_unicode_and_outer_whitespace() -> None:
@@ -23,3 +31,57 @@ def test_only_native_final_content_is_considered() -> None:
 def test_ambiguous_or_missing_content_fails() -> None:
     assert not score_exact_final_content("answer", {"choices": []}).passed
     assert not score_exact_final_content("answer", {"choices": [{}, {}]}).passed
+
+
+def test_niah_scoring_is_complete_hash_bound_and_exact() -> None:
+    cases = [
+        {"case_id": "p1", "answer": "amber", "context_tokens": 32, "control": None},
+        {"case_id": "p2", "answer": "NONE", "context_tokens": 32, "control": "prefix"},
+    ]
+    responses = [
+        {"prompt_id": "p1", "prompt_hash": sha256_json(cases[0]), "final_content": "amber"},
+        {
+            "prompt_id": "p2",
+            "prompt_hash": sha256_json(cases[1]),
+            "final_content": "NONE with explanation",
+        },
+    ]
+    result = score_niah_records(cases, responses)
+    assert result["summary"] == {
+        "cases": 2,
+        "passed": 1,
+        "failed": 1,
+        "exact_match_rate": 0.5,
+    }
+    assert result["primary"]["exact_match_rate"] == 1.0
+    assert result["controls"]["exact_match_rate"] == 0.0
+
+
+def test_niah_scoring_rejects_missing_or_unbound_responses() -> None:
+    case = {"case_id": "p1", "answer": "amber"}
+    with pytest.raises(ValueError, match="prompt hash mismatch"):
+        score_niah_records(
+            [case], [{"prompt_id": "p1", "prompt_hash": "x" * 64, "final_content": "amber"}]
+        )
+    with pytest.raises(ValueError, match="incomplete"):
+        score_niah_records([case], [])
+
+
+def test_score_niah_cli_writes_structured_output(tmp_path: Path) -> None:
+    case = {"case_id": "p1", "answer": "amber", "control": None}
+    response = {
+        "prompt_id": "p1",
+        "prompt_hash": sha256_json(case),
+        "final_content": "amber",
+    }
+    cases_path = tmp_path / "cases.jsonl"
+    responses_path = tmp_path / "responses.jsonl"
+    output_path = tmp_path / "scores.json"
+    cases_path.write_text(json.dumps(case) + "\n", encoding="utf-8")
+    responses_path.write_text(json.dumps(response) + "\n", encoding="utf-8")
+    command_score_niah(
+        argparse.Namespace(cases=cases_path, responses=responses_path, out=output_path)
+    )
+    output = json.loads(output_path.read_text(encoding="utf-8"))
+    assert output["schema"] == "lucebox.validation-v2.niah-scores/1"
+    assert output["summary"]["exact_match_rate"] == 1.0

--- a/harness/validation_v2/tests/test_statistics.py
+++ b/harness/validation_v2/tests/test_statistics.py
@@ -6,12 +6,30 @@ def test_paired_summary_uses_prompts_as_independent_units() -> None:
     for prompt in ("p1", "p2"):
         for repetition in range(5):
             rows.append(
-                {"prompt_id": prompt, "config": "ar", "status": "success", "tok_s": 10 + repetition}
+                {
+                    "prompt_id": prompt,
+                    "config": "ar",
+                    "repetition": repetition + 1,
+                    "status": "success",
+                    "tok_s": 10 + repetition,
+                }
             )
             rows.append(
-                {"prompt_id": prompt, "config": "spec", "status": "success", "tok_s": 15 + repetition}
+                {
+                    "prompt_id": prompt,
+                    "config": "spec",
+                    "repetition": repetition + 1,
+                    "status": "success",
+                    "tok_s": 15 + repetition,
+                }
             )
-    pairs = paired_prompt_values(rows, baseline="ar", candidate="spec", metric="tok_s")
+    pairs = paired_prompt_values(
+        rows,
+        baseline="ar",
+        candidate="spec",
+        metric="tok_s",
+        expected_repetitions=5,
+    )
     summary = summarize_paired(pairs, bootstrap_samples=100, seed=1)
     assert summary["independent_unit"] == "prompt"
     assert summary["prompt_count"] == 2
@@ -20,8 +38,20 @@ def test_paired_summary_uses_prompts_as_independent_units() -> None:
 
 def test_failed_prompt_is_not_silently_dropped() -> None:
     rows = [
-        {"prompt_id": "p1", "config": "ar", "status": "success", "tok_s": 10},
-        {"prompt_id": "p1", "config": "spec", "status": "failed", "tok_s": None},
+        {
+            "prompt_id": "p1",
+            "config": "ar",
+            "repetition": 1,
+            "status": "success",
+            "tok_s": 10,
+        },
+        {
+            "prompt_id": "p1",
+            "config": "spec",
+            "repetition": 1,
+            "status": "failed",
+            "tok_s": None,
+        },
     ]
     try:
         paired_prompt_values(rows, baseline="ar", candidate="spec", metric="tok_s")
@@ -29,3 +59,74 @@ def test_failed_prompt_is_not_silently_dropped() -> None:
         assert "failed/incomplete prompts" in str(exc)
     else:
         raise AssertionError("failed prompt was silently dropped")
+
+
+def test_latest_successful_retry_replaces_prior_failure() -> None:
+    rows = [
+        {
+            "config_id": "ar-p1-r1",
+            "attempt": 1,
+            "prompt_id": "p1",
+            "config": "ar",
+            "repetition": 1,
+            "status": "failed",
+            "tok_s": None,
+        },
+        {
+            "config_id": "ar-p1-r1",
+            "attempt": 2,
+            "prompt_id": "p1",
+            "config": "ar",
+            "repetition": 1,
+            "status": "success",
+            "tok_s": 10,
+        },
+        {
+            "config_id": "spec-p1-r1",
+            "attempt": 1,
+            "prompt_id": "p1",
+            "config": "spec",
+            "repetition": 1,
+            "status": "success",
+            "tok_s": 12,
+        },
+    ]
+    assert paired_prompt_values(
+        rows,
+        baseline="ar",
+        candidate="spec",
+        metric="tok_s",
+        expected_repetitions=1,
+    ) == {"p1": ([10.0], [12.0])}
+
+
+def test_paired_analysis_requires_same_complete_repetition_denominator() -> None:
+    rows = [
+        {
+            "prompt_id": "p1",
+            "config": "ar",
+            "repetition": 1,
+            "status": "success",
+            "tok_s": 10,
+        },
+        {
+            "prompt_id": "p1",
+            "config": "spec",
+            "repetition": 2,
+            "status": "success",
+            "tok_s": 12,
+        },
+    ]
+    try:
+        paired_prompt_values(rows, baseline="ar", candidate="spec", metric="tok_s")
+    except ValueError as exc:
+        assert "failed/incomplete prompts" in str(exc)
+    else:
+        raise AssertionError("mismatched paired repetitions were accepted")
+
+
+def test_nested_bootstrap_recomputes_ratio_of_means() -> None:
+    summary = summarize_paired({"p": ([1, 100], [2, 101])}, bootstrap_samples=1000, seed=1)
+    assert summary["geometric_mean_ratio"] == 103 / 101
+    assert summary["ratio_ci95"][0] >= 1.0
+    assert summary["ratio_ci95"][1] <= 2.0

--- a/harness/validation_v2/tests/test_statistics.py
+++ b/harness/validation_v2/tests/test_statistics.py
@@ -1,0 +1,31 @@
+from harness.validation_v2.statistics import paired_prompt_values, summarize_paired
+
+
+def test_paired_summary_uses_prompts_as_independent_units() -> None:
+    rows = []
+    for prompt in ("p1", "p2"):
+        for repetition in range(5):
+            rows.append(
+                {"prompt_id": prompt, "config": "ar", "status": "success", "tok_s": 10 + repetition}
+            )
+            rows.append(
+                {"prompt_id": prompt, "config": "spec", "status": "success", "tok_s": 15 + repetition}
+            )
+    pairs = paired_prompt_values(rows, baseline="ar", candidate="spec", metric="tok_s")
+    summary = summarize_paired(pairs, bootstrap_samples=100, seed=1)
+    assert summary["independent_unit"] == "prompt"
+    assert summary["prompt_count"] == 2
+    assert summary["slower_prompt_count"] == 0
+
+
+def test_failed_prompt_is_not_silently_dropped() -> None:
+    rows = [
+        {"prompt_id": "p1", "config": "ar", "status": "success", "tok_s": 10},
+        {"prompt_id": "p1", "config": "spec", "status": "failed", "tok_s": None},
+    ]
+    try:
+        paired_prompt_values(rows, baseline="ar", candidate="spec", metric="tok_s")
+    except ValueError as exc:
+        assert "failed/incomplete prompts" in str(exc)
+    else:
+        raise AssertionError("failed prompt was silently dropped")


### PR DESCRIPTION
Adds publication-oriented validation infrastructure without changing inference behavior.

Key properties:
- hash-pinned tuning and held-out corpora with corrected CC-BY-NC-4.0 Alpaca data licensing
- tokenizer-native NIAH-v2 sizing and hash-bound strict exact scoring
- append-only, attempt-qualified result lifecycle with retryable failures
- prompt/protocol/config/environment/cell identity binding
- retry-aware prompt-level ratio-of-means bootstrap statistics
- immutable provenance with initialized submodule checks and secret redaction
- authenticated Lucebox launch evidence from /props and required nested usage.speculative evidence
- separate fail-closed upstream llama.cpp adapter requiring exact build/model identity and positive, consistent response draft counters
- parity hashes over canonical reasoning_content plus final content; strict quality scoring remains final-content-only
- terminal SSE validation, server-native decode timings, explicit concurrency, and fixed-work completion checks
- pinned SHA-256 identities for Lucebox DFlash, upstream llama.cpp DFlash, and the MTP-bearing target GGUF

Validation: 45 model-free pytest tests, Ruff, and whitespace checks pass. Live dual-V100 adapter checks succeeded. Full GPU campaign results are intentionally not claimed by this PR.