### PR TITLE
feat(server): harden HTTP exposure and admission

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -265,6 +265,8 @@ RUN chmod -R a+rX /opt/lucebox-hub/.venv /opt/lucebox-hub /opt/uv
 # Models live in server/models/ — bind-mount or volume them in.
 # Example:
 #   docker run --rm --gpus all -p 8080:8080 \
+#       -v "$PWD/dflash-api-key:/run/secrets/dflash-api-key:ro" \
+#       -e DFLASH_API_KEY_FILE=/run/secrets/dflash-api-key \
 #       -v "$PWD/server/models:/opt/lucebox-hub/server/models" \
 #       lucebox-hub
 # The VOLUME declaration keeps the path out of the image layer cache; the
@@ -275,6 +277,10 @@ ENV DFLASH_HOST=0.0.0.0 \
     DFLASH_PORT=8080 \
     DFLASH_BIN=/opt/lucebox-hub/server/build/test_dflash \
     DFLASH_SERVER_BIN=/opt/lucebox-hub/server/build/dflash_server
+
+# The public container bind fails closed unless DFLASH_API_KEY or the
+# entrypoint's DFLASH_API_KEY_FILE is configured. Trusted networks can opt in
+# explicitly with DFLASH_ALLOW_UNAUTHENTICATED_NONLOOPBACK=1.
 
 EXPOSE 8080
 

--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -203,6 +203,8 @@ RUN chmod -R a+rX /opt/lucebox-hub/.venv /opt/lucebox-hub /opt/uv
 #   docker run --rm --device /dev/kfd --device /dev/dri \
 #       --group-add video --group-add render \
 #       --security-opt seccomp=unconfined -p 8080:8080 \
+#       -v "$PWD/dflash-api-key:/run/secrets/dflash-api-key:ro" \
+#       -e DFLASH_API_KEY_FILE=/run/secrets/dflash-api-key \
 #       -v "$PWD/server/models:/opt/lucebox-hub/server/models" \
 #       ghcr.io/luce-org/lucebox-hub:rocm
 VOLUME ["/opt/lucebox-hub/server/models"]
@@ -211,6 +213,10 @@ ENV DFLASH_HOST=0.0.0.0 \
     DFLASH_PORT=8080 \
     DFLASH_BIN=/opt/lucebox-hub/server/build/test_dflash \
     DFLASH_SERVER_BIN=/opt/lucebox-hub/server/build/dflash_server
+
+# The public container bind fails closed unless DFLASH_API_KEY or the
+# entrypoint's DFLASH_API_KEY_FILE is configured. Trusted networks can opt in
+# explicitly with DFLASH_ALLOW_UNAUTHENTICATED_NONLOOPBACK=1.
 
 EXPOSE 8080
 

--- a/README.md
+++ b/README.md
@@ -201,16 +201,25 @@ hf download Lucebox/Qwen3.6-27B-DFlash-GGUF dflash-draft-3.6-q4_k_m.gguf \
 # 3a. NVIDIA (CUDA 12+)
 docker run --rm --gpus all -p 8000:8080 \
   -v "$PWD/server/models:/opt/lucebox-hub/server/models" \
+  -v "$PWD/dflash-api-key:/run/secrets/dflash-api-key:ro" \
+  -e DFLASH_API_KEY_FILE=/run/secrets/dflash-api-key \
   ghcr.io/luce-org/lucebox-hub:cuda12
 
 # 3b. AMD (ROCm 6+, Strix Halo / RX 7900)
 docker run --rm --device /dev/kfd --device /dev/dri \
   --group-add video --group-add render --security-opt seccomp=unconfined \
   -p 8000:8080 -v "$PWD/server/models:/opt/lucebox-hub/server/models" \
+  -v "$PWD/dflash-api-key:/run/secrets/dflash-api-key:ro" \
+  -e DFLASH_API_KEY_FILE=/run/secrets/dflash-api-key \
   ghcr.io/luce-org/lucebox-hub:rocm
 ```
 
-Then hit `:8000/v1/chat/completions` (OpenAI-compatible).
+Before starting the container, create `dflash-api-key` as a non-empty,
+single-line file, set its mode to `0600`, and keep it out of version control.
+Then hit `:8000/v1/chat/completions` with that value as a Bearer token. Public
+container binds fail closed without `DFLASH_API_KEY` or `DFLASH_API_KEY_FILE`;
+the explicit trusted-network escape hatch is
+`DFLASH_ALLOW_UNAUTHENTICATED_NONLOOPBACK=1`.
 
 ## Run the Server
 
@@ -378,7 +387,13 @@ Pages the attention KV cache through a fixed pool of GPU slots; cold 64-token ch
 | `--draft-ipc-bin <path>` | — | Out-of-process draft binary (mixed CUDA/HIP) |
 | `--peer-access` | off | Enable P2P between target GPUs |
 | `--chunk N` | backend default | Prefill ubatch size |
-| `--no-cors` | CORS on | Disable CORS headers |
+| `--host <addr>` | `127.0.0.1` | Bind address; unauthenticated non-loopback binds are refused by default |
+| `DFLASH_API_KEY` / `--api-key-file <path>` | off | Require `Authorization: Bearer …` except on `/health` and `/ready` |
+| `--cors-allow-origin <origin>` | none | Allow one exact browser origin; repeat for multiple origins |
+| `--no-cors` | CORS already off | Deprecated compatibility alias |
+| `--allow-unauthenticated-nonloopback` | off | Explicit unsafe escape hatch for trusted network setups |
+| `--max-header-bytes N` / `--max-body-bytes N` | 32 KiB / 16 MiB | Reject oversized requests with HTTP 413 |
+| `--max-active-connections N` / `--max-queued-requests N` | 64 / 16 | Reject excess load with HTTP 429 |
 | `DFLASH_TARGET_GPU=N` | `0` | Env var equivalent of `--target-gpu` |
 | `DFLASH_DRAFT_GPU=N` | same as target | Env var equivalent of `--draft-gpu` |
 | `DFLASH_MODEL_NAME=<name>` | `dflash` | Env var equivalent of `--model-name`; sets the `/v1/models` id and selects the matching `share/model_cards/<name>.json` |

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -1070,10 +1070,17 @@ if(DFLASH27B_TESTS)
     # ─── Unit tests (no GPU, no model files) ────────────────────────────
     enable_testing()
 
+    add_executable(test_server_security
+        test/test_server_security.cpp
+        src/server/server_security.cpp)
+    target_include_directories(test_server_security PRIVATE ${DFLASH27B_SRC_INCLUDE_DIRS})
+    add_test(NAME server_security COMMAND test_server_security)
+
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_server_unit.cpp")
         add_executable(test_server_unit test/test_server_unit.cpp)
         target_sources(test_server_unit PRIVATE
             src/server/http_server.cpp
+            src/server/server_security.cpp
             src/server/model_card.cpp
             src/server/prompt_normalize.cpp)
         target_include_directories(test_server_unit PRIVATE ${DFLASH27B_SRC_INCLUDE_DIRS})
@@ -1102,7 +1109,7 @@ if(DFLASH27B_TESTS)
 
     # 'make check' — builds test targets then runs ctest
     if(TARGET test_server_unit)
-        set(_check_deps test_server_unit)
+        set(_check_deps test_server_unit test_server_security)
         if(TARGET test_deepseek4_unit)
             list(APPEND _check_deps test_deepseek4_unit)
         endif()
@@ -1168,6 +1175,7 @@ if(DFLASH27B_SERVER)
         add_executable(dflash_server
             src/server/server_main.cpp
             src/server/http_server.cpp
+            src/server/server_security.cpp
             src/server/model_card.cpp
             src/server/prompt_normalize.cpp
         )

--- a/server/CODEX.md
+++ b/server/CODEX.md
@@ -34,7 +34,7 @@ cd dflash
 Wait until you see:
 
 ```
-[server] listening on 0.0.0.0:8080
+[server] listening on 127.0.0.1:8080
 ```
 
 ### Quick smoke test
@@ -147,7 +147,9 @@ requests reuse the loaded model and are much faster.
 ./build/dflash_server <model.gguf> [OPTIONS]
 
 Options:
-  --host HOST           Bind address (default: 0.0.0.0)
+  --host HOST           Bind address (default: 127.0.0.1)
+  --api-key-file PATH   Read the inbound Bearer key from a file
+  --cors-allow-origin ORIGIN  Allow an exact browser origin (repeatable)
   --port PORT           Bind port (default: 8080)
   --draft PATH          Draft model for speculative decoding
   --ddtree-budget N     Speculation budget (default: 64)

--- a/server/DEVELOPER.md
+++ b/server/DEVELOPER.md
@@ -120,7 +120,9 @@ cd dflash
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--host` | `0.0.0.0` | Bind address |
+| `--host` | `127.0.0.1` | Bind address; non-loopback requires auth or the explicit unsafe escape hatch |
+| `--api-key-file` / `DFLASH_API_KEY` | off | Require Bearer authentication outside health/readiness probes |
+| `--cors-allow-origin` | none | Exact browser origin allowlist; repeatable |
 | `--port` | `8080` | Port |
 | `--target` | `models/Qwen3.6-27B-Q4_K_M.gguf` | Target GGUF model |
 | `--draft` | `models/draft` | Draft model directory |

--- a/server/README.md
+++ b/server/README.md
@@ -146,7 +146,7 @@ The default draft path is discovered under `models/draft/`. Scripts prefer `dfla
 ## Native C++ HTTP server
 
 `dflash_server` serves the same client-facing local API surface used by the
-harnesses. It supports `/health`,
+harnesses. It listens on `127.0.0.1` by default and supports `/health`, `/ready`,
 `/v1/models`, OpenAI Chat Completions including streaming and tool metadata,
 OpenAI Responses for Codex, Anthropic Messages for Claude Code, and Open WebUI
 model metadata.
@@ -209,6 +209,34 @@ python3 ../harness/client_test_runner.py probe \
   --url http://127.0.0.1:18080 \
   --clients all
 ```
+
+### Network and API security
+
+The server is local-only by default: it binds `127.0.0.1`, sends no CORS
+headers, and bounds request headers, bodies, active connections, and the
+pending inference queue. `/health` and `/ready` remain unauthenticated for
+orchestrator probes. Every other endpoint requires the configured Bearer key.
+
+For authenticated LAN exposure, prefer a key file with restrictive filesystem
+permissions:
+
+```bash
+./build/dflash_server models/Qwen3.6-27B-Q4_K_M.gguf \
+  --host 0.0.0.0 --api-key-file /run/secrets/dflash-api-key \
+  --cors-allow-origin https://console.example.net
+```
+
+`DFLASH_API_KEY` is also supported when no `--api-key-file` is passed. Key
+values are never printed in the startup banner or request logs. Browser origins
+must be allowlisted exactly; wildcard CORS is not supported. For an isolated,
+trusted network that cannot use authentication,
+`--allow-unauthenticated-nonloopback` is the explicit escape hatch and prints a
+startup warning.
+
+Admission defaults can be adjusted with `--max-header-bytes`,
+`--max-body-bytes`, `--max-active-connections`, and `--max-queued-requests`.
+Passing zero disables the corresponding bound. Oversized requests receive 413;
+connection and queue saturation receive 429.
 
 On fragile external RTX links, use the same conservative NVIDIA profile as the
 RTX mixed-hardware notes before running long prompts.

--- a/server/docs/API.md
+++ b/server/docs/API.md
@@ -10,7 +10,9 @@ backend (qwen35, qwen3, gemma4, laguna).
 
 | Method | Path | Description | Status |
 |--------|------|-------------|--------|
-| GET | `/health`, `/` | Health check | ✅ |
+| GET | `/health` | Unauthenticated liveness check | ✅ |
+| GET | `/ready` | Unauthenticated readiness check | ✅ |
+| GET | `/` | Backwards-compatible authenticated health alias | ✅ |
 | GET | `/v1/models` | List available models | ✅ |
 | POST | `/v1/chat/completions` | OpenAI Chat Completions | ✅ |
 | POST | `/v1/messages` | Anthropic Messages | ✅ |
@@ -174,7 +176,9 @@ When `temperature = 0`:
 | Prefix cache (disk) | ✅ | Persistent across restarts |
 | PFlash (speculative prefill) | ✅ | Compresses long prompts |
 | Client disconnect detection | ✅ | Aborts generation on disconnect |
-| CORS | ✅ | Enabled by default |
+| Bearer authentication | ✅ | Optional via `DFLASH_API_KEY` or `--api-key-file`; `/health` and `/ready` are exempt |
+| CORS | ✅ | Disabled by default; exact origins via repeatable `--cors-allow-origin` |
+| Admission limits | ✅ | Bounded headers, bodies, active connections, and pending inference queue |
 | Tool memory | ✅ | Caches tool call results |
 
 ---

--- a/server/scripts/entrypoint.sh
+++ b/server/scripts/entrypoint.sh
@@ -274,7 +274,7 @@ fi
 
 : "${DFLASH_BIN:=$DFLASH_DIR/build/test_dflash}"
 : "${DFLASH_SERVER_BIN:=$DFLASH_DIR/build/dflash_server}"
-: "${DFLASH_HOST:=0.0.0.0}"
+: "${DFLASH_HOST:=127.0.0.1}"
 : "${DFLASH_PORT:=8080}"
 : "${DFLASH_BUDGET:=22}"
 : "${DFLASH_MAX_CTX:=16384}"
@@ -297,6 +297,9 @@ fi
 # share/model_cards/<name>.json). When unset, the C++ server uses its default
 # ("dflash"). Lets an operator surface the real model id without a wrapper.
 : "${DFLASH_MODEL_NAME:=}"
+: "${DFLASH_API_KEY_FILE:=}"
+: "${DFLASH_CORS_ALLOW_ORIGIN:=}"
+: "${DFLASH_ALLOW_UNAUTHENTICATED_NONLOOPBACK:=0}"
 # Phase-1 (thinking) cap when a request opts into thinking. Default mirrors
 # antirez/ds4 ds4_eval.c: think_max_tokens = max_tokens(16000) - hard_limit
 # reply budget(512) = 15488. The server's own hardcoded default is 10000;
@@ -500,6 +503,9 @@ CMD=("$DFLASH_SERVER_BIN" "$DFLASH_TARGET"
 [ -n "$DRAFT_ARG" ]                && CMD+=(--ddtree --ddtree-budget "$DFLASH_BUDGET")
 [ -n "$DFLASH_DEFAULT_MAX_TOKENS" ] && CMD+=(--default-max-tokens "$DFLASH_DEFAULT_MAX_TOKENS")
 [ -n "$DFLASH_MODEL_NAME" ]         && CMD+=(--model-name "$DFLASH_MODEL_NAME")
+[ -n "$DFLASH_API_KEY_FILE" ]       && CMD+=(--api-key-file "$DFLASH_API_KEY_FILE")
+[ -n "$DFLASH_CORS_ALLOW_ORIGIN" ]  && CMD+=(--cors-allow-origin "$DFLASH_CORS_ALLOW_ORIGIN")
+[ "$DFLASH_ALLOW_UNAUTHENTICATED_NONLOOPBACK" = "1" ] && CMD+=(--allow-unauthenticated-nonloopback)
 # `--lazy-draft` is silently dropped by the C++ server unless both
 # `--prefill-drafter` and `--draft` are present (look for the runtime
 # warning `--lazy-draft ignored: requires both --prefill-drafter and

--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -17,6 +17,7 @@
 #endif
 
 #include "http_server.h"
+#include "server_security.h"
 #include "admission.h"
 #include "sse_emitter.h"
 #include "prompt_normalize.h"
@@ -136,13 +137,36 @@ struct CurlWriteCtx {
     std::string buffer;  // accumulates non-streaming response
     std::string response_id;
     std::string model;
+    const std::atomic<bool> * cancelled;
 };
+
+static int curl_cancelled(void * userdata,
+                          curl_off_t, curl_off_t, curl_off_t, curl_off_t) {
+    const auto * cancelled = static_cast<const std::atomic<bool> *>(userdata);
+    return cancelled && cancelled->load() ? 1 : 0;
+}
+
+static bool curl_client_send(int fd, const void * data, size_t len) {
+    const char * bytes = static_cast<const char *>(data);
+    size_t sent = 0;
+    while (sent < len) {
+        struct pollfd pfd{SOCK_FD(fd), POLLOUT, 0};
+        const int ready = poll(&pfd, 1, 1000);
+        if (ready <= 0 || (pfd.revents & (POLLERR | POLLHUP | POLLNVAL))) return false;
+        const ssize_t n = ::send(fd, bytes + sent, len - sent, MSG_NOSIGNAL);
+        if (n < 0 && (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK)) continue;
+        if (n <= 0) return false;
+        sent += static_cast<size_t>(n);
+    }
+    return true;
+}
 
 static size_t curl_write_passthrough(char * ptr, size_t size, size_t nmemb, void * userdata) {
     size_t total = size * nmemb;
     auto * ctx = static_cast<CurlWriteCtx *>(userdata);
+    if (ctx->cancelled && ctx->cancelled->load()) return 0;
     if (ctx->streaming) {
-        ::send(ctx->client_fd, ptr, total, MSG_NOSIGNAL);
+        if (!curl_client_send(ctx->client_fd, ptr, total)) return 0;
     } else {
         ctx->buffer.append(ptr, total);
     }
@@ -152,6 +176,7 @@ static size_t curl_write_passthrough(char * ptr, size_t size, size_t nmemb, void
 static size_t curl_write_rewrite(char * ptr, size_t size, size_t nmemb, void * userdata) {
     size_t total = size * nmemb;
     auto * ctx = static_cast<CurlWriteCtx *>(userdata);
+    if (ctx->cancelled && ctx->cancelled->load()) return 0;
 
     if (!ctx->streaming) {
         ctx->buffer.append(ptr, total);
@@ -169,19 +194,19 @@ static size_t curl_write_rewrite(char * ptr, size_t size, size_t nmemb, void * u
         pos = nl + 1;
         if (line.empty() || line == "\r") {
             std::string out = "\n";
-            ::send(ctx->client_fd, out.data(), out.size(), MSG_NOSIGNAL);
+            if (!curl_client_send(ctx->client_fd, out.data(), out.size())) return 0;
             continue;
         }
         if (line.size() > 0 && line.back() == '\r') line.pop_back();
         if (line.rfind("data: ", 0) != 0) {
             line += "\n";
-            ::send(ctx->client_fd, line.data(), line.size(), MSG_NOSIGNAL);
+            if (!curl_client_send(ctx->client_fd, line.data(), line.size())) return 0;
             continue;
         }
         std::string payload = line.substr(6);
         if (payload == "[DONE]") {
             std::string out = "data: [DONE]\n\n";
-            ::send(ctx->client_fd, out.data(), out.size(), MSG_NOSIGNAL);
+            if (!curl_client_send(ctx->client_fd, out.data(), out.size())) return 0;
             continue;
         }
         try {
@@ -204,10 +229,10 @@ static size_t curl_write_rewrite(char * ptr, size_t size, size_t nmemb, void * u
                 }
             }
             std::string out = "data: " + j.dump() + "\n\n";
-            ::send(ctx->client_fd, out.data(), out.size(), MSG_NOSIGNAL);
+            if (!curl_client_send(ctx->client_fd, out.data(), out.size())) return 0;
         } catch (...) {
             std::string out = line + "\n";
-            ::send(ctx->client_fd, out.data(), out.size(), MSG_NOSIGNAL);
+            if (!curl_client_send(ctx->client_fd, out.data(), out.size())) return 0;
         }
     }
     buf.erase(0, pos);
@@ -240,7 +265,9 @@ static bool curl_forward(int client_fd, const std::string & url,
                          const std::string & api_key, const json & body,
                          bool streaming, bool rewrite_to_chat,
                          const std::string & response_id,
-                         const std::string & model) {
+                         const std::string & model,
+                         const std::string & cors_origin,
+                         const std::atomic<bool> * cancelled) {
     CURL * curl = curl_easy_init();
     if (!curl) return false;
 
@@ -260,6 +287,7 @@ static bool curl_forward(int client_fd, const std::string & url,
     ctx.chat_rewrite = rewrite_to_chat;
     ctx.response_id = response_id;
     ctx.model = model;
+    ctx.cancelled = cancelled;
 
     curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body_str.c_str());
@@ -267,6 +295,9 @@ static bool curl_forward(int client_fd, const std::string & url,
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, 600L);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &ctx);
+    curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
+    curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, curl_cancelled);
+    curl_easy_setopt(curl, CURLOPT_XFERINFODATA, cancelled);
 
     if (rewrite_to_chat) {
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curl_write_rewrite);
@@ -279,9 +310,17 @@ static bool curl_forward(int client_fd, const std::string & url,
             "HTTP/1.1 200 OK\r\n"
             "Content-Type: text/event-stream\r\n"
             "Cache-Control: no-cache\r\n"
-            "Connection: keep-alive\r\n"
-            "\r\n";
-        ::send(client_fd, sse_header.data(), sse_header.size(), MSG_NOSIGNAL);
+            "Connection: keep-alive\r\n";
+        if (!cors_origin.empty()) {
+            sse_header += "Access-Control-Allow-Origin: " + cors_origin + "\r\n"
+                          "Vary: Origin\r\n";
+        }
+        sse_header += "\r\n";
+        if (!curl_client_send(client_fd, sse_header.data(), sse_header.size())) {
+            curl_slist_free_all(headers);
+            curl_easy_cleanup(curl);
+            return false;
+        }
     }
 
     CURLcode res = curl_easy_perform(curl);
@@ -295,24 +334,32 @@ static bool curl_forward(int client_fd, const std::string & url,
                 std::string out = chat_resp.dump();
                 std::string http =
                     "HTTP/1.1 200 OK\r\n"
-                    "Content-Type: application/json\r\n"
-                    "Content-Length: " + std::to_string(out.size()) + "\r\n"
-                    "\r\n" + out;
-                ::send(client_fd, http.data(), http.size(), MSG_NOSIGNAL);
+                    "Content-Type: application/json\r\n";
+                if (!cors_origin.empty()) {
+                    http += "Access-Control-Allow-Origin: " + cors_origin + "\r\n"
+                            "Vary: Origin\r\n";
+                }
+                http += "Content-Length: " + std::to_string(out.size()) + "\r\n"
+                        "\r\n" + out;
+                curl_client_send(client_fd, http.data(), http.size());
             } catch (...) {
                 std::string http =
                     "HTTP/1.1 502 Bad Gateway\r\n"
                     "Content-Type: application/json\r\n"
                     "\r\n{\"error\":\"upstream response parse failed\"}";
-                ::send(client_fd, http.data(), http.size(), MSG_NOSIGNAL);
+                curl_client_send(client_fd, http.data(), http.size());
             }
         } else {
             std::string http =
                 "HTTP/1.1 200 OK\r\n"
-                "Content-Type: application/json\r\n"
-                "Content-Length: " + std::to_string(ctx.buffer.size()) + "\r\n"
-                "\r\n" + ctx.buffer;
-            ::send(client_fd, http.data(), http.size(), MSG_NOSIGNAL);
+                "Content-Type: application/json\r\n";
+            if (!cors_origin.empty()) {
+                http += "Access-Control-Allow-Origin: " + cors_origin + "\r\n"
+                        "Vary: Origin\r\n";
+            }
+            http += "Content-Length: " + std::to_string(ctx.buffer.size()) + "\r\n"
+                    "\r\n" + ctx.buffer;
+            curl_client_send(client_fd, http.data(), http.size());
         }
     }
 
@@ -341,6 +388,7 @@ static constexpr char kServerName[] = "luce-dflash";
 // handlers in handle_client() and route_request().
 static const std::vector<std::string> kApiEndpoints = {
     "GET /health",
+    "GET /ready",
     "GET /props",
     "GET /status",
     "GET /status/events",
@@ -982,7 +1030,7 @@ void HttpServer::broadcast_status() {
         }
     }
     for (int fd : dead) {
-        socket_close(fd);
+        ::shutdown(SOCK_FD(fd), SHUT_RDWR);
         sse_fds_.erase(std::remove(sse_fds_.begin(), sse_fds_.end(), fd),
                        sse_fds_.end());
     }
@@ -1005,7 +1053,7 @@ void HttpServer::broadcast_token(const std::string & text) {
         }
     }
     for (int fd : dead) {
-        socket_close(fd);
+        ::shutdown(SOCK_FD(fd), SHUT_RDWR);
         sse_fds_.erase(std::remove(sse_fds_.begin(), sse_fds_.end(), fd),
                        sse_fds_.end());
     }
@@ -1026,7 +1074,7 @@ void HttpServer::sse_heartbeat() {
         }
     }
     for (int fd : dead) {
-        socket_close(fd);
+        ::shutdown(SOCK_FD(fd), SHUT_RDWR);
         sse_fds_.erase(std::remove(sse_fds_.begin(), sse_fds_.end(), fd),
                        sse_fds_.end());
     }
@@ -1047,29 +1095,24 @@ void HttpServer::shutdown() {
         socket_close(listen_fd_);
         listen_fd_ = -1;
     }
+    {
+        std::lock_guard<std::mutex> lk(clients_mu_);
+        for (int fd : client_fds_) ::shutdown(SOCK_FD(fd), SHUT_RDWR);
+    }
+    cancel_pending_jobs();
     if (worker_thread_.joinable()) {
         worker_thread_.join();
+    }
+    {
+        std::unique_lock<std::mutex> lk(clients_mu_);
+        clients_cv_.wait(lk, [this]() { return active_clients_.load() == 0; });
     }
 
     // Close SSE client connections.
     {
         std::lock_guard<std::mutex> lk(sse_mu_);
-        for (int fd : sse_fds_) socket_close(fd);
+        for (int fd : sse_fds_) ::shutdown(SOCK_FD(fd), SHUT_RDWR);
         sse_fds_.clear();
-    }
-
-    // Drain any pending jobs.
-    {
-        std::lock_guard<std::mutex> lk(queue_mu_);
-        while (queue_head_) {
-            ServerJob * j = queue_head_;
-            queue_head_ = j->next;
-            j->next = nullptr;
-            std::lock_guard<std::mutex> jlk(j->mu);
-            j->done = true;
-            j->cv.notify_one();
-        }
-        queue_tail_ = nullptr;
     }
 
     // Shutdown save: persist all tracked snapshot slots to disk.
@@ -1175,10 +1218,26 @@ int HttpServer::run() {
         int flag = 1;
         setsockopt(SOCK_FD(client_fd), IPPROTO_TCP, TCP_NODELAY, SETSOCKOPT_CAST &flag, sizeof(flag));
 
+        const int previous_clients = active_clients_.fetch_add(1);
+        if (config_.max_active_connections > 0 &&
+            previous_clients >= config_.max_active_connections) {
+            active_clients_.fetch_sub(1);
+            send_error(client_fd, 429, "too many active connections");
+            socket_close(client_fd);
+            continue;
+        }
+        {
+            std::lock_guard<std::mutex> lk(clients_mu_);
+            client_fds_.insert(client_fd);
+        }
+
         // Spawn client thread (detached — client_main owns the fd).
-        active_clients_.fetch_add(1);
         std::thread([this, client_fd]() {
             handle_client(client_fd);
+            {
+                std::lock_guard<std::mutex> lk(clients_mu_);
+                client_fds_.erase(client_fd);
+            }
             if (active_clients_.fetch_sub(1) == 1) {
                 std::lock_guard<std::mutex> lk(clients_mu_);
                 clients_cv_.notify_all();
@@ -1189,9 +1248,23 @@ int HttpServer::run() {
     // Wake the worker thread so it can observe stopping_ and exit.
     queue_cv_.notify_all();
 
-    // Wait for client threads to drain, but bound it: a client mid-stream (long
-    // SSE generation) must not hold the process resident on shutdown. After the
-    // grace period we proceed — detached client threads are torn down on exit.
+    // Wake blocked readers and queued-request waiters. Client threads retain
+    // ownership of the descriptors and perform the final close.
+    {
+        std::lock_guard<std::mutex> lk(clients_mu_);
+        for (int fd : client_fds_) {
+            ::shutdown(SOCK_FD(fd), SHUT_RDWR);
+        }
+    }
+    {
+        std::lock_guard<std::mutex> lk(sse_mu_);
+        for (int fd : sse_fds_) ::shutdown(SOCK_FD(fd), SHUT_RDWR);
+    }
+    cancel_pending_jobs();
+
+    // Give client threads a short grace period to drain before joining the
+    // worker. A timeout is diagnostic only; after worker cancellation completes
+    // below, run() still waits for every detached thread to release its members.
     {
         std::unique_lock<std::mutex> lk(clients_mu_);
         bool drained = clients_cv_.wait_for(
@@ -1200,7 +1273,7 @@ int HttpServer::run() {
         if (!drained) {
             std::fprintf(stderr,
                          "[server] shutdown: %d client thread(s) still active "
-                         "after grace period, exiting anyway\n",
+                         "after grace period; waiting for worker cancellation\n",
                          active_clients_.load());
         }
     }
@@ -1208,6 +1281,14 @@ int HttpServer::run() {
     // Wait for worker to finish.
     if (worker_thread_.joinable()) {
         worker_thread_.join();
+    }
+
+    // The worker is now unable to retain any stack-owned ServerJob. Wait for
+    // the corresponding detached client threads to observe completion and
+    // release their descriptors before run() returns and members can teardown.
+    {
+        std::unique_lock<std::mutex> lk(clients_mu_);
+        clients_cv_.wait(lk, [this]() { return active_clients_.load() == 0; });
     }
 
     // Persist disk cache (worker joined — no race on slot_tokens_).
@@ -1230,22 +1311,59 @@ int HttpServer::run() {
 
 void HttpServer::handle_client(int fd) {
     HttpRequest hr;
-    if (!read_http_request(fd, hr)) {
-        send_error(fd, 400, "bad HTTP request");
+    const HttpReadResult read_result = read_http_request(fd, hr);
+    if (read_result != HttpReadResult::OK) {
+        const bool too_large = read_result == HttpReadResult::HEADER_TOO_LARGE ||
+                               read_result == HttpReadResult::BODY_TOO_LARGE;
+        send_error(fd, too_large ? 413 : 400,
+                   too_large ? "HTTP request exceeds configured size limit"
+                             : "bad HTTP request");
         socket_close(fd);
         return;
     }
 
     // CORS preflight.
     if (hr.method == "OPTIONS") {
-        send_response(fd, 204, "", "");
+        if (!cors_origin_allowed(hr.origin, config_.cors_allowed_origins)) {
+            send_error(fd, 403, "origin is not allowed");
+        } else {
+            send_response(fd, 204, "", "", hr.origin);
+        }
         socket_close(fd);
         return;
     }
 
-    // Health check.
-    if (hr.method == "GET" && (hr.path == "/health" || hr.path == "/")) {
-        send_response(fd, 200, "application/json", "{\"status\":\"ok\"}\n");
+    if (!cors_origin_allowed(hr.origin, config_.cors_allowed_origins)) {
+        send_error(fd, 403, "origin is not allowed");
+        socket_close(fd);
+        return;
+    }
+
+    // Health and readiness remain unauthenticated for local orchestrators.
+    if (hr.method == "GET" && hr.path == "/health") {
+        send_response(fd, 200, "application/json", "{\"status\":\"ok\"}\n", hr.origin);
+        socket_close(fd);
+        return;
+    }
+    if (hr.method == "GET" && hr.path == "/ready") {
+        send_response(fd, stopping_.load() ? 503 : 200, "application/json",
+                      stopping_.load() ? "{\"status\":\"stopping\"}\n"
+                                       : "{\"status\":\"ready\"}\n",
+                      hr.origin);
+        socket_close(fd);
+        return;
+    }
+
+    if (!bearer_authorized(hr.authorization, config_.api_key)) {
+        send_error(fd, 401, "authentication required", hr.origin);
+        socket_close(fd);
+        return;
+    }
+
+    // Backwards-compatible root probe. Unlike /health and /ready, it follows
+    // the normal authentication boundary when auth is enabled.
+    if (hr.method == "GET" && hr.path == "/") {
+        send_response(fd, 200, "application/json", "{\"status\":\"ok\"}\n", hr.origin);
         socket_close(fd);
         return;
     }
@@ -1253,7 +1371,7 @@ void HttpServer::handle_client(int fd) {
     // Introspection: server config + cache stats + arch + capabilities.
     if (hr.method == "GET" && hr.path == "/props") {
         json body = build_props_body(config_, prefix_cache_, tool_memory_);
-        send_response(fd, 200, "application/json", body.dump() + "\n");
+        send_response(fd, 200, "application/json", body.dump() + "\n", hr.origin);
         socket_close(fd);
         return;
     }
@@ -1262,19 +1380,20 @@ void HttpServer::handle_client(int fd) {
     if (hr.method == "GET" && hr.path == "/status") {
         if (status_html_path_.empty()) {
             send_error(fd, 404,
-                "status.html not found. Set DFLASH_SHARE_DIR or place it in share/status.html");
+                "status.html not found. Set DFLASH_SHARE_DIR or place it in share/status.html",
+                hr.origin);
             socket_close(fd);
             return;
         }
         std::ifstream ifs(status_html_path_);
         if (!ifs.is_open()) {
-            send_error(fd, 500, "failed to open status.html");
+            send_error(fd, 500, "failed to open status.html", hr.origin);
             socket_close(fd);
             return;
         }
         std::ostringstream oss;
         oss << ifs.rdbuf();
-        send_response(fd, 200, "text/html; charset=utf-8", oss.str());
+        send_response(fd, 200, "text/html; charset=utf-8", oss.str(), hr.origin);
         socket_close(fd);
         return;
     }
@@ -1282,22 +1401,15 @@ void HttpServer::handle_client(int fd) {
     // Status JSON snapshot (for non-SSE clients / debugging).
     if (hr.method == "GET" && hr.path == "/status/json") {
         send_response(fd, 200, "application/json",
-            status_.to_json().dump(-1, ' ', false, json::error_handler_t::replace) + "\n");
+            status_.to_json().dump(-1, ' ', false, json::error_handler_t::replace) + "\n",
+            hr.origin);
         socket_close(fd);
         return;
     }
 
     // Status SSE stream: hold connection open and push updates.
     if (hr.method == "GET" && hr.path == "/status/events") {
-        // Send SSE headers.
-        const char * headers =
-            "HTTP/1.1 200 OK\r\n"
-            "Content-Type: text/event-stream\r\n"
-            "Cache-Control: no-cache\r\n"
-            "Connection: keep-alive\r\n"
-            "Access-Control-Allow-Origin: *\r\n"
-            "\r\n";
-        if (!send_all(fd, headers, std::strlen(headers))) {
+        if (!send_sse_headers(fd, hr.origin)) {
             socket_close(fd);
             return;
         }
@@ -1310,7 +1422,24 @@ void HttpServer::handle_client(int fd) {
             std::lock_guard<std::mutex> lk(sse_mu_);
             sse_fds_.push_back(fd);
         }
-        return;  // Do NOT close fd — it's now owned by the SSE broadcast loop.
+        // Keep this client thread alive so the active-connection limit includes
+        // long-lived status streams. Broadcasts only signal dead sockets; this
+        // owner performs the final close.
+        while (!stopping_.load() && !peer_disconnected(fd)) {
+            struct pollfd pfd{SOCK_FD(fd), POLLIN, 0};
+            const int ready = poll(&pfd, 1, 500);
+            // This HTTP/1.1 implementation does not support pipelining on an
+            // SSE connection. Close on any client input instead of spinning
+            // forever around unread bytes.
+            if (ready > 0 && (pfd.revents & POLLIN)) break;
+        }
+        {
+            std::lock_guard<std::mutex> lk(sse_mu_);
+            sse_fds_.erase(std::remove(sse_fds_.begin(), sse_fds_.end(), fd),
+                           sse_fds_.end());
+        }
+        socket_close(fd);
+        return;
     }
 
     // Models endpoint.
@@ -1358,7 +1487,7 @@ void HttpServer::handle_client(int fd) {
                      {"supports_parallel_tool_calls", false}}
                 })}
             };
-            send_response(fd, 200, "application/json", codex_models.dump() + "\n");
+            send_response(fd, 200, "application/json", codex_models.dump() + "\n", hr.origin);
             socket_close(fd);
             return;
         }
@@ -1373,14 +1502,14 @@ void HttpServer::handle_client(int fd) {
                  {"max_context_length", config_.max_ctx}}
             })}
         };
-        send_response(fd, 200, "application/json", models.dump() + "\n");
+        send_response(fd, 200, "application/json", models.dump() + "\n", hr.origin);
         socket_close(fd);
         return;
     }
 
     // Route POST endpoints.
     if (!route_request(fd, hr)) {
-        send_error(fd, 404, "unknown endpoint");
+        send_error(fd, 404, "unknown endpoint", hr.origin);
     }
     socket_close(fd);
 }
@@ -1392,6 +1521,7 @@ bool HttpServer::route_request(int fd, const HttpRequest & hr) {
                  hr.path.c_str(), hr.body.size());
 
     ParsedRequest req;
+    req.cors_origin = hr.origin;
     std::string err;
 
     try {
@@ -1464,14 +1594,16 @@ bool HttpServer::route_request(int fd, const HttpRequest & hr) {
                 if (!apply_request_scope_override(req.disk_cache_policy,
                                                   pc["scope"].get<std::string>())) {
                     send_error(fd, 400,
-                        "prefix_cache.scope must be off, full, auto, auto:<window>, or a positive token count");
+                        "prefix_cache.scope must be off, full, auto, auto:<window>, or a positive token count",
+                        hr.origin);
                     return true;
                 }
             }
             if (pc.contains("window") && pc["window"].is_number_integer()) {
                 const int window = pc["window"].get<int>();
                 if (window <= 0 || window > 1000000) {
-                    send_error(fd, 400, "prefix_cache.window must be a positive integer");
+                    send_error(fd, 400, "prefix_cache.window must be a positive integer",
+                               hr.origin);
                     return true;
                 }
                 req.disk_cache_policy.auto_window = window;
@@ -1722,7 +1854,8 @@ bool HttpServer::route_request(int fd, const HttpRequest & hr) {
                     tools_json);
             } catch (const std::exception & e) {
                 send_error(fd, 500,
-                    std::string("chat template (jinja) render failed: ") + e.what());
+                    std::string("chat template (jinja) render failed: ") + e.what(),
+                    hr.origin);
                 return true;
             }
         } else {
@@ -1737,12 +1870,12 @@ bool HttpServer::route_request(int fd, const HttpRequest & hr) {
         // entirely — Anthropic's contract is just `{"input_tokens": N}`.
         if (count_tokens_only) {
             json resp = {{"input_tokens", (int)req.prompt_tokens.size()}};
-            send_response(fd, 200, "application/json", resp.dump() + "\n");
+            send_response(fd, 200, "application/json", resp.dump() + "\n", hr.origin);
             return true;
         }
 
     } catch (const std::exception & e) {
-        send_error(fd, 400, std::string("JSON parse error: ") + e.what());
+        send_error(fd, 400, std::string("JSON parse error: ") + e.what(), hr.origin);
         return true;  // handled (with error)
     }
 
@@ -1758,7 +1891,8 @@ bool HttpServer::route_request(int fd, const HttpRequest & hr) {
                                     config_.max_ctx, pflash_will_run)) {
             send_error(fd, 400,
                        context_overflow_message(config_.max_ctx, n_prompt,
-                                                req.max_output));
+                                                req.max_output),
+                       hr.origin);
             return true;
         }
     }
@@ -1788,12 +1922,26 @@ bool HttpServer::route_request(int fd, const HttpRequest & hr) {
     job.fd = fd;
     job.req = std::move(req);
 
-    enqueue(&job);
+    if (!enqueue(&job)) {
+        send_error(fd, 429, "request queue is full", hr.origin);
+        return true;
+    }
 
-    // Wait for the worker to signal completion.
+    // Wait for the worker while monitoring the peer. A queued request whose
+    // caller has gone away is removed before it consumes inference time. If
+    // it is already executing, the cancellation flag reaches token callbacks.
     {
         std::unique_lock<std::mutex> lk(job.mu);
-        job.cv.wait(lk, [&]() { return job.done; });
+        while (!job.done) {
+            job.cv.wait_for(lk, std::chrono::milliseconds(100));
+            if (job.done) break;
+            if (stopping_.load() || peer_disconnected(fd)) {
+                job.cancelled.store(true);
+                lk.unlock();
+                cancel_queued(&job);
+                lk.lock();
+            }
+        }
     }
 
     return true;
@@ -1809,6 +1957,13 @@ void HttpServer::worker_loop() {
         int fd = job->fd;
         const auto & req = job->req;
         auto started_at = std::chrono::steady_clock::now();
+
+        if (job->cancelled.load()) {
+            std::lock_guard<std::mutex> lk(job->mu);
+            job->done = true;
+            job->cv.notify_one();
+            continue;
+        }
 
         // Track live status for /status page. RAII guard ensures idle on all paths.
         std::string prompt_excerpt;
@@ -1855,7 +2010,7 @@ void HttpServer::worker_loop() {
                 const char done[] = "data: [DONE]\n\n";
                 send_all(fd, done, sizeof(done) - 1);
             } else {
-                send_error(fd, status, message);
+                send_error(fd, status, message, req.cors_origin);
             }
             finish_job();
         };
@@ -1872,7 +2027,7 @@ void HttpServer::worker_loop() {
 
         // Send SSE headers (skip when proxying — curl_forward handles its own headers).
         if (req.stream && config_.pflash_upstream_base.empty()) {
-            if (!send_sse_headers(fd)) {
+            if (!send_sse_headers(fd, req.cors_origin)) {
                 finish_job();
                 continue;
             }
@@ -2304,6 +2459,10 @@ void HttpServer::worker_loop() {
 
         // ── Upstream proxy: forward to remote server if configured ────
 #ifdef DFLASH_HAS_CURL
+        if (job->cancelled.load()) {
+            finish_job();
+            continue;
+        }
         if (!config_.pflash_upstream_base.empty()) {
             const std::string & upstream = config_.pflash_upstream_base;
             const std::string & upstream_key = config_.pflash_upstream_key;
@@ -2335,7 +2494,8 @@ void HttpServer::worker_loop() {
                 curl_forward(fd, upstream + "/completions",
                              upstream_key, comp_body,
                              req.stream, /*rewrite_to_chat=*/true,
-                             req.response_id, upstream_model);
+                             req.response_id, upstream_model, req.cors_origin,
+                             &job->cancelled);
             } else {
                 json fwd_body = req.raw_body;
                 fwd_body["model"] = upstream_model;
@@ -2347,7 +2507,8 @@ void HttpServer::worker_loop() {
                 curl_forward(fd, upstream + "/chat/completions",
                              upstream_key, fwd_body,
                              req.stream, /*rewrite_to_chat=*/false,
-                             req.response_id, upstream_model);
+                             req.response_id, upstream_model, req.cors_origin,
+                             &job->cancelled);
             }
             finish_job();
             continue;
@@ -2757,6 +2918,10 @@ void HttpServer::worker_loop() {
         bool client_disconnected = false;
 
         io.on_token = [&](int32_t token) -> bool {
+            if (job->cancelled.load()) {
+                client_disconnected = true;
+                return false;
+            }
             if (client_disconnected) return false;
             completion_tokens++;
 
@@ -2866,7 +3031,9 @@ void HttpServer::worker_loop() {
         broadcast_status();
 
         GenerateResult result;
-        if (using_restore) {
+        if (job->cancelled.load()) {
+            client_disconnected = true;
+        } else if (using_restore) {
             result = backend_.restore_and_generate(cache_slot, gen_req, io);
         } else {
             result = backend_.generate(gen_req, io);
@@ -3279,7 +3446,8 @@ void HttpServer::worker_loop() {
             // Set socket back to blocking for the final send.
             int flags = sock_get_flags(fd);
             if (flags >= 0) sock_set_block(fd);
-            send_response(fd, 200, "application/json", resp.dump() + "\n");
+            send_response(fd, 200, "application/json", resp.dump() + "\n",
+                          req.cors_origin);
         }
 
         if (client_disconnected) {
@@ -3328,20 +3496,64 @@ void HttpServer::worker_loop() {
 
 // ─── Job queue ──────────────────────────────────────────────────────────
 
-void HttpServer::enqueue(ServerJob * job) {
+bool HttpServer::enqueue(ServerJob * job) {
     std::lock_guard<std::mutex> lk(queue_mu_);
     if (stopping_.load()) {
         // Server is shutting down — immediately signal job as done.
         std::lock_guard<std::mutex> jlk(job->mu);
         job->done = true;
         job->cv.notify_one();
-        return;
+        return true;
+    }
+    if (config_.max_queued_requests > 0 &&
+        queue_size_ >= static_cast<size_t>(config_.max_queued_requests)) {
+        return false;
     }
     job->next = nullptr;
     if (queue_tail_) queue_tail_->next = job;
     else queue_head_ = job;
     queue_tail_ = job;
+    ++queue_size_;
     queue_cv_.notify_one();
+    return true;
+}
+
+bool HttpServer::cancel_queued(ServerJob * job) {
+    std::lock_guard<std::mutex> lk(queue_mu_);
+    ServerJob * previous = nullptr;
+    ServerJob * current = queue_head_;
+    while (current && current != job) {
+        previous = current;
+        current = current->next;
+    }
+    if (!current) return false;
+
+    if (previous) previous->next = current->next;
+    else queue_head_ = current->next;
+    if (queue_tail_ == current) queue_tail_ = previous;
+    current->next = nullptr;
+    if (queue_size_ > 0) --queue_size_;
+    {
+        std::lock_guard<std::mutex> jlk(current->mu);
+        current->done = true;
+        current->cv.notify_one();
+    }
+    return true;
+}
+
+void HttpServer::cancel_pending_jobs() {
+    std::lock_guard<std::mutex> lk(queue_mu_);
+    while (queue_head_) {
+        ServerJob * job = queue_head_;
+        queue_head_ = job->next;
+        job->next = nullptr;
+        job->cancelled.store(true);
+        std::lock_guard<std::mutex> jlk(job->mu);
+        job->done = true;
+        job->cv.notify_one();
+    }
+    queue_tail_ = nullptr;
+    queue_size_ = 0;
 }
 
 ServerJob * HttpServer::dequeue() {
@@ -3355,27 +3567,41 @@ ServerJob * HttpServer::dequeue() {
             lk.lock();
         }
     }
-    if (!queue_head_) return nullptr;
+    if (stopping_.load() || !queue_head_) return nullptr;
     ServerJob * j = queue_head_;
     queue_head_ = j->next;
     if (!queue_head_) queue_tail_ = nullptr;
     j->next = nullptr;
+    if (queue_size_ > 0) --queue_size_;
     return j;
+}
+
+bool HttpServer::peer_disconnected(int fd) {
+    struct pollfd pfd{SOCK_FD(fd), POLLIN, 0};
+    const int pr = poll(&pfd, 1, 0);
+    if (pr < 0) return errno != EINTR;
+    if (pr == 0) return false;
+    if (pfd.revents & (POLLERR | POLLHUP | POLLNVAL)) return true;
+    if (!(pfd.revents & POLLIN)) return false;
+
+    char byte;
+    const ssize_t n = recv(fd, &byte, 1, MSG_PEEK | MSG_DONTWAIT);
+    return n == 0 || (n < 0 && errno != EINTR && errno != EAGAIN && errno != EWOULDBLOCK);
 }
 
 // ─── HTTP I/O ───────────────────────────────────────────────────────────
 
-bool HttpServer::read_http_request(int fd, HttpRequest & out) {
+HttpServer::HttpReadResult HttpServer::read_http_request(int fd, HttpRequest & out) {
     std::string buf;
     buf.reserve(8192);
     char tmp[4096];
 
     // Read until we find the header/body boundary (\r\n\r\n or \n\n).
     ssize_t hend = -1;
-    while (hend < 0 && buf.size() < 65536) {
+    while (hend < 0) {
         ssize_t n = recv(fd, tmp, sizeof(tmp), 0);
         if (n < 0 && errno == EINTR) continue;
-        if (n <= 0) return false;
+        if (n <= 0) return HttpReadResult::BAD_REQUEST;
         buf.append(tmp, n);
 
         // Look for end of headers.
@@ -3394,21 +3620,36 @@ bool HttpServer::read_http_request(int fd, HttpRequest & out) {
                 }
             }
         }
+        if (hend < 0 && config_.max_header_bytes > 0 &&
+            buf.size() > config_.max_header_bytes) {
+            return HttpReadResult::HEADER_TOO_LARGE;
+        }
     }
-    if (hend < 0) return false;
+    if (hend < 0) return HttpReadResult::BAD_REQUEST;
+    if (config_.max_header_bytes > 0 &&
+        static_cast<size_t>(hend) > config_.max_header_bytes) {
+        return HttpReadResult::HEADER_TOO_LARGE;
+    }
 
     // Parse request line.
     size_t line_end = buf.find('\n');
-    if (line_end == std::string::npos) return false;
+    if (line_end == std::string::npos) return HttpReadResult::BAD_REQUEST;
     std::string line = buf.substr(0, line_end);
     if (!line.empty() && line.back() == '\r') line.pop_back();
 
     // "METHOD /path HTTP/1.1"
     size_t sp1 = line.find(' ');
     size_t sp2 = line.find(' ', sp1 + 1);
-    if (sp1 == std::string::npos || sp2 == std::string::npos) return false;
+    if (sp1 == std::string::npos || sp2 == std::string::npos) {
+        return HttpReadResult::BAD_REQUEST;
+    }
     out.method = line.substr(0, sp1);
     out.path = line.substr(sp1 + 1, sp2 - sp1 - 1);
+    const std::string version = line.substr(sp2 + 1);
+    if (out.method.empty() || out.path.empty() || out.path[0] != '/' ||
+        (version != "HTTP/1.1" && version != "HTTP/1.0")) {
+        return HttpReadResult::BAD_REQUEST;
+    }
 
     // Separate query string from path.
     std::string query_string;
@@ -3419,34 +3660,81 @@ bool HttpServer::read_http_request(int fd, HttpRequest & out) {
     }
     out.query = std::move(query_string);
 
-    // Find Content-Length.
-    long content_length = 0;
-    {
-        std::string headers = buf.substr(0, hend);
-        std::string lower_headers = headers;
-        std::transform(lower_headers.begin(), lower_headers.end(),
-                       lower_headers.begin(), ::tolower);
-        size_t cl_pos = lower_headers.find("content-length:");
-        if (cl_pos != std::string::npos) {
-            size_t val_start = cl_pos + 15;
-            while (val_start < lower_headers.size() &&
-                   lower_headers[val_start] == ' ') val_start++;
-            content_length = std::strtol(headers.c_str() + val_start, nullptr, 10);
+    // Parse the small header subset used by the security boundary. Duplicate
+    // Content-Length/Authorization fields are rejected to avoid ambiguity.
+    size_t content_length = 0;
+    bool saw_content_length = false;
+    bool saw_authorization = false;
+    bool saw_origin = false;
+    size_t cursor = line_end + 1;
+    while (cursor < static_cast<size_t>(hend)) {
+        size_t end = buf.find('\n', cursor);
+        if (end == std::string::npos || end > static_cast<size_t>(hend)) {
+            end = static_cast<size_t>(hend);
+        }
+        std::string header = buf.substr(cursor, end - cursor);
+        if (!header.empty() && header.back() == '\r') header.pop_back();
+        cursor = end + 1;
+        if (header.empty()) break;
+
+        const size_t colon = header.find(':');
+        if (colon == std::string::npos || colon == 0) {
+            return HttpReadResult::BAD_REQUEST;
+        }
+        std::string name = header.substr(0, colon);
+        if (name.find_first_of(" \t") != std::string::npos) {
+            return HttpReadResult::BAD_REQUEST;
+        }
+        std::transform(name.begin(), name.end(), name.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        std::string value = header.substr(colon + 1);
+        const size_t first = value.find_first_not_of(" \t");
+        const size_t last = value.find_last_not_of(" \t");
+        value = first == std::string::npos ? std::string() : value.substr(first, last - first + 1);
+
+        if (name == "content-length") {
+            if (saw_content_length || value.empty() || value[0] == '-') {
+                return HttpReadResult::BAD_REQUEST;
+            }
+            char * parse_end = nullptr;
+            errno = 0;
+            const unsigned long long parsed = std::strtoull(value.c_str(), &parse_end, 10);
+            if (errno == ERANGE || !parse_end || *parse_end != '\0' ||
+                parsed > static_cast<unsigned long long>(SIZE_MAX)) {
+                return HttpReadResult::BAD_REQUEST;
+            }
+            content_length = static_cast<size_t>(parsed);
+            saw_content_length = true;
+        } else if (name == "authorization") {
+            if (saw_authorization) return HttpReadResult::BAD_REQUEST;
+            saw_authorization = true;
+            out.authorization = std::move(value);
+        } else if (name == "origin") {
+            if (saw_origin) return HttpReadResult::BAD_REQUEST;
+            saw_origin = true;
+            out.origin = std::move(value);
+        } else if (name == "transfer-encoding") {
+            // Chunked request parsing is intentionally unsupported.
+            return HttpReadResult::BAD_REQUEST;
         }
     }
 
-    if (content_length < 0 || content_length > 64 * 1024 * 1024) return false;
+    if (config_.max_body_bytes > 0 && content_length > config_.max_body_bytes) {
+        return HttpReadResult::BODY_TOO_LARGE;
+    }
 
     // Read body.
-    while ((ssize_t)buf.size() < hend + content_length) {
+    const size_t body_end = static_cast<size_t>(hend) + content_length;
+    if (body_end < static_cast<size_t>(hend)) return HttpReadResult::BODY_TOO_LARGE;
+    while (buf.size() < body_end) {
         ssize_t n = recv(fd, tmp, sizeof(tmp), 0);
         if (n < 0 && errno == EINTR) continue;
-        if (n <= 0) return false;
+        if (n <= 0) return HttpReadResult::BAD_REQUEST;
         buf.append(tmp, n);
     }
 
     out.body = buf.substr(hend, content_length);
-    return true;
+    return HttpReadResult::OK;
 }
 
 bool HttpServer::send_all(int fd, const void * data, size_t len) {
@@ -3481,24 +3769,32 @@ bool HttpServer::send_all(int fd, const void * data, size_t len) {
 }
 
 bool HttpServer::send_response(int fd, int status, const std::string & content_type,
-                               const std::string & body) {
+                               const std::string & body,
+                               const std::string & cors_origin) {
     const char * reason = "OK";
     switch (status) {
         case 200: reason = "OK"; break;
         case 204: reason = "No Content"; break;
         case 400: reason = "Bad Request"; break;
+        case 401: reason = "Unauthorized"; break;
+        case 403: reason = "Forbidden"; break;
         case 404: reason = "Not Found"; break;
         case 405: reason = "Method Not Allowed"; break;
         case 413: reason = "Payload Too Large"; break;
+        case 429: reason = "Too Many Requests"; break;
         case 500: reason = "Internal Server Error"; break;
         case 503: reason = "Service Unavailable"; break;
     }
     std::string header = "HTTP/1.1 " + std::to_string(status) + " " + reason + "\r\n";
-    if (config_.enable_cors) {
-        header += "Access-Control-Allow-Origin: *\r\n"
+    if (!cors_origin.empty() &&
+        cors_origin_allowed(cors_origin, config_.cors_allowed_origins)) {
+        header += "Access-Control-Allow-Origin: " + cors_origin + "\r\n"
                   "Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n"
-                  "Access-Control-Allow-Headers: *\r\n";
+                  "Access-Control-Allow-Headers: Authorization, Content-Type\r\n"
+                  "Vary: Origin\r\n";
     }
+    if (status == 401) header += "WWW-Authenticate: Bearer\r\n";
+    if (status == 429) header += "Retry-After: 1\r\n";
     if (!content_type.empty()) {
         header += "Content-Type: " + content_type + "\r\n";
     }
@@ -3508,15 +3804,18 @@ bool HttpServer::send_response(int fd, int status, const std::string & content_t
     return send_all(fd, header.data(), header.size());
 }
 
-bool HttpServer::send_error(int fd, int status, const std::string & message) {
+bool HttpServer::send_error(int fd, int status, const std::string & message,
+                            const std::string & cors_origin) {
     json err = {{"error", {{"message", message}, {"type", "invalid_request_error"}}}};
-    return send_response(fd, status, "application/json", err.dump() + "\n");
+    return send_response(fd, status, "application/json", err.dump() + "\n", cors_origin);
 }
 
-bool HttpServer::send_sse_headers(int fd) {
+bool HttpServer::send_sse_headers(int fd, const std::string & cors_origin) {
     std::string header = "HTTP/1.1 200 OK\r\n";
-    if (config_.enable_cors) {
-        header += "Access-Control-Allow-Origin: *\r\n";
+    if (!cors_origin.empty() &&
+        cors_origin_allowed(cors_origin, config_.cors_allowed_origins)) {
+        header += "Access-Control-Allow-Origin: " + cors_origin + "\r\n"
+                  "Vary: Origin\r\n";
     }
     header += "Content-Type: text/event-stream\r\n"
               "Cache-Control: no-cache\r\n"

--- a/server/src/server/http_server.h
+++ b/server/src/server/http_server.h
@@ -28,6 +28,7 @@
 #include <nlohmann/json.hpp>
 
 #include <atomic>
+#include <cstddef>
 #include <condition_variable>
 #include <cstdint>
 #include <functional>
@@ -39,6 +40,7 @@
 #include <unistd.h>
 #endif
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace dflash::common {
@@ -50,11 +52,26 @@ struct ServerJob;
 
 // ─── Server configuration ───────────────────────────────────────────────
 struct ServerConfig {
-    std::string host        = "0.0.0.0";
+    std::string host        = "127.0.0.1";
     int         port        = 8080;
     int         max_tokens  = 4096;     // default max output tokens (legacy alias for default_max_tokens)
     int         max_ctx     = 0;        // 0 = use backend's DevicePlacement default (8192)
-    bool        enable_cors = true;
+    // Browser access is disabled unless an exact origin is allowlisted.
+    // --no-cors remains accepted as a backwards-compatible no-op.
+    std::vector<std::string> cors_allowed_origins;
+
+    // Empty means authentication is disabled. server_main refuses an
+    // unauthenticated non-loopback bind unless the operator opts into the
+    // explicit escape hatch.
+    std::string api_key;
+    bool        allow_unauthenticated_nonloopback = false;
+
+    // HTTP/admission bounds. Zero disables a particular bound, but CLI
+    // defaults are intentionally finite for safe unattended operation.
+    size_t      max_header_bytes = 32 * 1024;
+    size_t      max_body_bytes   = 16 * 1024 * 1024;
+    int         max_active_connections = 64;
+    int         max_queued_requests     = 16;
     std::string model_name  = "dflash";
     int         prefix_cache_cap = 32;  // prefix cache slots (0 disables)
     int         prefill_cache_cap = 0;  // full-prompt/prefill cache slots (0 disables)
@@ -204,6 +221,8 @@ struct ParsedRequest {
     json                      messages;
     // Original request body (for upstream proxy forwarding)
     json                      raw_body;
+    // Echoed only when it exactly matches an operator allowlist entry.
+    std::string               cors_origin;
     // Response ID
     std::string               response_id;
     // Thinking/reasoning state
@@ -280,24 +299,32 @@ private:
         std::string path;
         std::string query;  // raw query string (after '?')
         std::string body;
+        std::string authorization;
+        std::string origin;
     };
-    bool read_http_request(int fd, HttpRequest & out);
+    enum class HttpReadResult { OK, BAD_REQUEST, HEADER_TOO_LARGE, BODY_TOO_LARGE };
+    HttpReadResult read_http_request(int fd, HttpRequest & out);
 
     // Route request to appropriate parser.
     bool route_request(int fd, const HttpRequest & hr);
 
     // Send HTTP response helpers.
     bool send_response(int fd, int status, const std::string & content_type,
-                       const std::string & body);
-    bool send_error(int fd, int status, const std::string & message);
-    bool send_sse_headers(int fd);
+                       const std::string & body,
+                       const std::string & cors_origin = {});
+    bool send_error(int fd, int status, const std::string & message,
+                    const std::string & cors_origin = {});
+    bool send_sse_headers(int fd, const std::string & cors_origin = {});
 
     // Send raw bytes with stall detection.
     bool send_all(int fd, const void * data, size_t len);
 
     // Job queue.
-    void enqueue(ServerJob * job);
+    bool enqueue(ServerJob * job);
+    bool cancel_queued(ServerJob * job);
+    void cancel_pending_jobs();
     ServerJob * dequeue();
+    static bool peer_disconnected(int fd);
 
     // Members.
     ModelBackend &   backend_;
@@ -362,12 +389,14 @@ private:
     std::condition_variable         queue_cv_;
     ServerJob *                     queue_head_ = nullptr;
     ServerJob *                     queue_tail_ = nullptr;
+    size_t                          queue_size_ = 0;
     std::atomic<bool>               stopping_{false};
 
     // Active client thread tracking.
     std::atomic<int>                active_clients_{0};
     std::mutex                      clients_mu_;
     std::condition_variable         clients_cv_;
+    std::unordered_set<int>         client_fds_;
 
     // Listen socket.
     int listen_fd_ = -1;
@@ -381,6 +410,7 @@ struct ServerJob {
     std::mutex    mu;
     std::condition_variable cv;
     ServerJob *   next = nullptr;
+    std::atomic<bool> cancelled{false};
 };
 
 // ─── Parse session_id from a chat-completion JSON body ──────────────────

--- a/server/src/server/server_main.cpp
+++ b/server/src/server/server_main.cpp
@@ -8,10 +8,11 @@
 //
 // Usage:
 //   dflash_server <model.gguf> [--draft <draft.gguf>] [--port 8080]
-//                              [--host 0.0.0.0] [--max-ctx 131072]
+//                              [--host 127.0.0.1] [--max-ctx 131072]
 //                              [--max-tokens 4096] [--target-device auto:0]
 
 #include "http_server.h"
+#include "server_security.h"
 #include "chat_template.h"
 #include "model_card.h"
 #include "common/backend_factory.h"
@@ -27,10 +28,15 @@
 #include "gguf.h"
 
 #include <algorithm>
+#include <cerrno>
+#include <climits>
 #include <csignal>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <fstream>
+#include <iterator>
+#include <limits>
 #include <memory>
 #include <string>
 #include <utility>
@@ -51,6 +57,36 @@ static void signal_handler(int sig) {
     if (g_server) {
         g_server->request_stop();
     }
+}
+
+static bool parse_size_limit(const char * value, size_t & out) {
+    if (!value || !*value || value[0] == '-') return false;
+    char * end = nullptr;
+    errno = 0;
+    const unsigned long long parsed = std::strtoull(value, &end, 10);
+    if (errno == ERANGE || !end || *end != '\0' ||
+        parsed > static_cast<unsigned long long>((std::numeric_limits<size_t>::max)())) {
+        return false;
+    }
+    out = static_cast<size_t>(parsed);
+    return true;
+}
+
+static bool load_api_key_file(const char * path, std::string & out) {
+    std::ifstream input(path, std::ios::binary);
+    if (!input) return false;
+    std::string value((std::istreambuf_iterator<char>(input)),
+                      std::istreambuf_iterator<char>());
+    if (value.size() > 64 * 1024) return false;
+    while (!value.empty() && (value.back() == '\n' || value.back() == '\r')) {
+        value.pop_back();
+    }
+    if (value.empty() || value.find('\n') != std::string::npos ||
+        value.find('\r') != std::string::npos) {
+        return false;
+    }
+    out = std::move(value);
+    return true;
 }
 
 static bool parse_double_list(const char * value, std::vector<double> & out) {
@@ -198,7 +234,7 @@ static void print_usage(const char * prog) {
         "Options:\n"
         "  --draft <path>       Draft model for speculative decode\n"
         "  --port <N>           Listen port (default: 8080)\n"
-        "  --host <addr>        Bind address (default: 0.0.0.0)\n"
+        "  --host <addr>        Bind address (default: 127.0.0.1)\n"
         "  --max-ctx <N>        Max context length (default: 131072)\n"
         "  --max-tokens <N>     Default max output tokens (legacy alias for\n"
         "                       --default-max-tokens; loses to --default-max-tokens\n"
@@ -235,7 +271,17 @@ static void print_usage(const char * prog) {
         "                       trimmed per step by drafter confidence; N = fixed base)\n"
         "  --adaptive-experts [tau]  MoE expert-count gating on verify batches\n"
         "                       (near-lossless; default tau 0.80 when passed)\n"
-        "  --no-cors            Disable CORS headers\n"
+        "  --cors-allow-origin <origin>\n"
+        "                       Allow one exact browser origin (repeatable; default: none)\n"
+        "  --no-cors            Deprecated compatibility alias; CORS is off by default\n"
+        "  --api-key-file <path> Read the inbound Bearer key from a file\n"
+        "                       (DFLASH_API_KEY is used when no file is passed)\n"
+        "  --allow-unauthenticated-nonloopback\n"
+        "                       Explicitly allow an unauthenticated non-loopback bind\n"
+        "  --max-header-bytes <N>       HTTP header limit (default: 32768; 0=unlimited)\n"
+        "  --max-body-bytes <N>         HTTP body limit (default: 16777216; 0=unlimited)\n"
+        "  --max-active-connections <N> Active connection limit (default: 64; 0=unlimited)\n"
+        "  --max-queued-requests <N>    Pending inference limit (default: 16; 0=unlimited)\n"
         "  --think-max-tokens <N>     Phase-1 reasoning cap when a request opts in\n"
         "                             via thinking:{type:enabled} (default: 15488 =\n"
         "                             default_max_tokens - hard_limit_reply_budget;\n"
@@ -326,6 +372,9 @@ int main(int argc, char ** argv) {
     // Parse arguments.
     BackendArgs bargs;
     ServerConfig sconfig;
+    if (const char * env_key = std::getenv("DFLASH_API_KEY")) {
+        if (*env_key) sconfig.api_key = env_key;
+    }
     bargs.model_path = argv[1];
     bool   spark_autotune = false; // --spark: self-tuning hot/cold MoE residency
     int    spark_slots = -1;       // --spark-slots: explicit cache slots/layer (-1=auto)
@@ -366,6 +415,44 @@ int main(int argc, char ** argv) {
             sconfig.port = std::atoi(argv[++i]);
         } else if (std::strcmp(argv[i], "--host") == 0 && i + 1 < argc) {
             sconfig.host = argv[++i];
+        } else if (std::strcmp(argv[i], "--api-key-file") == 0 && i + 1 < argc) {
+            if (!load_api_key_file(argv[++i], sconfig.api_key)) {
+                std::fprintf(stderr, "[server] --api-key-file must name a readable, non-empty single-line file\n");
+                return 2;
+            }
+        } else if (std::strcmp(argv[i], "--allow-unauthenticated-nonloopback") == 0) {
+            sconfig.allow_unauthenticated_nonloopback = true;
+        } else if (std::strcmp(argv[i], "--cors-allow-origin") == 0 && i + 1 < argc) {
+            std::string origin = argv[++i];
+            if (!cors_origin_valid(origin)) {
+                std::fprintf(stderr, "[server] --cors-allow-origin requires an exact http(s) origin; wildcard is not allowed\n");
+                return 2;
+            }
+            sconfig.cors_allowed_origins.push_back(std::move(origin));
+        } else if (std::strcmp(argv[i], "--max-header-bytes") == 0 && i + 1 < argc) {
+            if (!parse_size_limit(argv[++i], sconfig.max_header_bytes)) {
+                std::fprintf(stderr, "[server] bad --max-header-bytes value\n");
+                return 2;
+            }
+        } else if (std::strcmp(argv[i], "--max-body-bytes") == 0 && i + 1 < argc) {
+            if (!parse_size_limit(argv[++i], sconfig.max_body_bytes)) {
+                std::fprintf(stderr, "[server] bad --max-body-bytes value\n");
+                return 2;
+            }
+        } else if (std::strcmp(argv[i], "--max-active-connections") == 0 && i + 1 < argc) {
+            size_t value = 0;
+            if (!parse_size_limit(argv[++i], value) || value > static_cast<size_t>(INT_MAX)) {
+                std::fprintf(stderr, "[server] bad --max-active-connections value\n");
+                return 2;
+            }
+            sconfig.max_active_connections = static_cast<int>(value);
+        } else if (std::strcmp(argv[i], "--max-queued-requests") == 0 && i + 1 < argc) {
+            size_t value = 0;
+            if (!parse_size_limit(argv[++i], value) || value > static_cast<size_t>(INT_MAX)) {
+                std::fprintf(stderr, "[server] bad --max-queued-requests value\n");
+                return 2;
+            }
+            sconfig.max_queued_requests = static_cast<int>(value);
         } else if (std::strcmp(argv[i], "--max-ctx") == 0 && i + 1 < argc) {
             int v = std::atoi(argv[++i]);
             sconfig.max_ctx = v;
@@ -503,7 +590,7 @@ int main(int argc, char ** argv) {
         } else if (std::strcmp(argv[i], "--spark-vram") == 0 && i + 1 < argc) {
             spark_vram_gib = std::atof(argv[++i]);
         } else if (std::strcmp(argv[i], "--no-cors") == 0) {
-            sconfig.enable_cors = false;
+            sconfig.cors_allowed_origins.clear();
         } else if (std::strcmp(argv[i], "--think-max-tokens") == 0 && i + 1 < argc) {
             sconfig.think_max_tokens = std::atoi(argv[++i]);
             cli_set.think_max_tokens = true;
@@ -654,6 +741,27 @@ int main(int argc, char ** argv) {
         }
     }
     if (fast_rollback_forced_off) bargs.fast_rollback = false;
+
+    if (sconfig.api_key.size() > 64 * 1024 ||
+        sconfig.api_key.find('\r') != std::string::npos ||
+        sconfig.api_key.find('\n') != std::string::npos) {
+        std::fprintf(stderr, "[server] inbound API key must be a single line no larger than 64 KiB\n");
+        return 2;
+    }
+
+    if (!is_loopback_host(sconfig.host) && sconfig.api_key.empty() &&
+        !sconfig.allow_unauthenticated_nonloopback) {
+        std::fprintf(stderr,
+            "[server] refusing unauthenticated non-loopback bind to %s; configure "
+            "DFLASH_API_KEY/--api-key-file or pass "
+            "--allow-unauthenticated-nonloopback explicitly\n",
+            sconfig.host.c_str());
+        return 2;
+    }
+    if (!is_loopback_host(sconfig.host) && sconfig.api_key.empty()) {
+        std::fprintf(stderr,
+            "[server] WARNING: unauthenticated non-loopback exposure explicitly enabled\n");
+    }
 
     if (!validate_server_placement(bargs, sconfig)) return 2;
 
@@ -1121,7 +1229,11 @@ int main(int argc, char ** argv) {
     std::fprintf(stderr, "[server] │  ddtree_budget   = %d\n", bargs.ddtree_budget);
     std::fprintf(stderr, "[server] │  prefix_cache    = %d slots\n", sconfig.prefix_cache_cap);
     std::fprintf(stderr, "[server] │  prefill_cache   = %d slots\n", sconfig.prefill_cache_cap);
-    std::fprintf(stderr, "[server] │  cors            = %s\n", sconfig.enable_cors ? "ON" : "off");
+    std::fprintf(stderr, "[server] │  auth            = %s\n", sconfig.api_key.empty() ? "off" : "Bearer enabled");
+    std::fprintf(stderr, "[server] │  cors_origins    = %zu\n", sconfig.cors_allowed_origins.size());
+    std::fprintf(stderr, "[server] │  http_limits     = headers=%zu body=%zu active=%d queue=%d\n",
+                 sconfig.max_header_bytes, sconfig.max_body_bytes,
+                 sconfig.max_active_connections, sconfig.max_queued_requests);
     std::fprintf(stderr, "[server] │  cache_type_k    = %s\n",
 #ifdef GGML_USE_HIP
         cache_type_k.empty() ? "q4_0 (default, HIP)" : cache_type_k.c_str());

--- a/server/src/server/server_security.cpp
+++ b/server/src/server/server_security.cpp
@@ -1,0 +1,72 @@
+#include "server_security.h"
+
+#include <cctype>
+#include <cstdint>
+
+namespace dflash::common {
+
+bool is_loopback_host(const std::string & host) {
+    if (host == "localhost") return true;
+    if (host.rfind("127.", 0) != 0) return false;
+
+    // inet_pton() performs the final address validation in HttpServer::run().
+    // Here, require only the conventional IPv4 loopback prefix and reject an
+    // empty suffix so malformed values cannot bypass the startup boundary.
+    return host.size() > 4;
+}
+
+static bool ascii_iequal_prefix(const std::string & value, const char * prefix) {
+    size_t i = 0;
+    for (; prefix[i] != '\0'; ++i) {
+        if (i >= value.size()) return false;
+        const auto lhs = static_cast<unsigned char>(value[i]);
+        const auto rhs = static_cast<unsigned char>(prefix[i]);
+        if (std::tolower(lhs) != std::tolower(rhs)) return false;
+    }
+    return true;
+}
+
+bool bearer_authorized(const std::string & authorization,
+                       const std::string & api_key) {
+    if (api_key.empty()) return true;
+
+    static constexpr char kScheme[] = "Bearer ";
+    if (!ascii_iequal_prefix(authorization, kScheme)) return false;
+    const std::string supplied = authorization.substr(sizeof(kScheme) - 1);
+
+    // Include the length mismatch in the accumulated result and always scan
+    // the configured-key length. This avoids an early exit on matching bytes.
+    size_t diff = supplied.size() ^ api_key.size();
+    for (size_t i = 0; i < api_key.size(); ++i) {
+        const uint8_t got = i < supplied.size()
+            ? static_cast<uint8_t>(supplied[i])
+            : 0;
+        diff |= static_cast<size_t>(got ^ static_cast<uint8_t>(api_key[i]));
+    }
+    return diff == 0;
+}
+
+bool cors_origin_valid(const std::string & origin) {
+    if (origin == "*" || origin.find('\r') != std::string::npos ||
+        origin.find('\n') != std::string::npos) {
+        return false;
+    }
+    size_t authority = std::string::npos;
+    if (origin.rfind("http://", 0) == 0) authority = 7;
+    if (origin.rfind("https://", 0) == 0) authority = 8;
+    return authority != std::string::npos && authority < origin.size() &&
+           origin.find_first_of("/?#", authority) == std::string::npos &&
+           origin.find_first_of(" \t@", authority) == std::string::npos;
+}
+
+bool cors_origin_allowed(const std::string & origin,
+                         const std::vector<std::string> & allowlist) {
+    if (origin.empty()) return true;
+    if (!cors_origin_valid(origin)) return false;
+    for (const auto & allowed : allowlist) {
+        if (origin == allowed) return true;
+    }
+    return false;
+}
+
+} // namespace dflash::common

--- a/server/src/server/server_security.h
+++ b/server/src/server/server_security.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace dflash::common {
+
+// The native server is IPv4-only today. Keep the exposure check aligned with
+// the addresses accepted by HttpServer::run().
+bool is_loopback_host(const std::string & host);
+
+// Authenticate a complete Authorization header against the configured key.
+// The comparison is constant-time with respect to matching key bytes.
+bool bearer_authorized(const std::string & authorization,
+                       const std::string & api_key);
+
+bool cors_origin_valid(const std::string & origin);
+
+// Empty origins are non-browser requests and do not require CORS headers.
+bool cors_origin_allowed(const std::string & origin,
+                         const std::vector<std::string> & allowlist);
+
+} // namespace dflash::common

--- a/server/test/test_server_security.cpp
+++ b/server/test/test_server_security.cpp
@@ -1,0 +1,48 @@
+#include "server/server_security.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace dflash::common;
+
+#define CHECK(expr) do { \
+    if (!(expr)) { \
+        std::fprintf(stderr, "check failed at %s:%d: %s\n", __FILE__, __LINE__, #expr); \
+        return 1; \
+    } \
+} while (0)
+
+int main() {
+    CHECK(is_loopback_host("127.0.0.1"));
+    CHECK(is_loopback_host("127.42.0.9"));
+    CHECK(is_loopback_host("localhost"));
+    CHECK(!is_loopback_host("0.0.0.0"));
+    CHECK(!is_loopback_host("192.168.1.10"));
+    CHECK(!is_loopback_host("127."));
+
+    const std::string key = "unit-test-key";
+    CHECK(bearer_authorized("", ""));
+    CHECK(!bearer_authorized("", key));
+    CHECK(!bearer_authorized("Basic unit-test-key", key));
+    CHECK(bearer_authorized("Bearer unit-test-key", key));
+    CHECK(bearer_authorized("bearer unit-test-key", key));
+    CHECK(!bearer_authorized("Bearer unit-test-kez", key));
+    CHECK(!bearer_authorized("Bearer " + key + std::string(256, 'x'), key));
+
+    const std::vector<std::string> origins = {
+        "https://console.example.test",
+        "http://127.0.0.1:3000",
+    };
+    CHECK(cors_origin_valid("https://console.example.test"));
+    CHECK(cors_origin_valid("http://127.0.0.1:3000"));
+    CHECK(!cors_origin_valid("*"));
+    CHECK(!cors_origin_valid("https://console.example.test/path"));
+    CHECK(!cors_origin_valid("https://console.example.test\r\nInjected: yes"));
+    CHECK(cors_origin_allowed("", origins));
+    CHECK(cors_origin_allowed("https://console.example.test", origins));
+    CHECK(!cors_origin_allowed("https://evil.example.test", origins));
+    CHECK(!cors_origin_allowed("https://console.example.test/", origins));
+    CHECK(!cors_origin_allowed("https://console.example.test", {}));
+    return 0;
+}

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -16,6 +16,7 @@
 #include "server/utf8_utils.h"
 #include "server/api_types.h"
 #include "server/http_server.h"
+#include "server/server_security.h"
 #include "server/chat_template.h"
 #include "common/sampler.h"
 #include "common/backend_precision.h"
@@ -1433,6 +1434,57 @@ static void test_pflash_config_defaults() {
     TEST_ASSERT(cfg.pflash_drafter_path.empty());
     TEST_ASSERT(!cfg.pflash_skip_park);
     TEST_ASSERT(cfg.draft_residency == DraftResidencyPolicy::Auto);
+}
+
+static void test_server_security_defaults() {
+    ServerConfig cfg;
+    TEST_ASSERT(cfg.host == "127.0.0.1");
+    TEST_ASSERT(cfg.cors_allowed_origins.empty());
+    TEST_ASSERT(cfg.api_key.empty());
+    TEST_ASSERT(cfg.max_header_bytes == 32 * 1024);
+    TEST_ASSERT(cfg.max_body_bytes == 16 * 1024 * 1024);
+    TEST_ASSERT(cfg.max_active_connections == 64);
+    TEST_ASSERT(cfg.max_queued_requests == 16);
+}
+
+static void test_server_loopback_detection() {
+    TEST_ASSERT(is_loopback_host("127.0.0.1"));
+    TEST_ASSERT(is_loopback_host("127.1.2.3"));
+    TEST_ASSERT(is_loopback_host("localhost"));
+    TEST_ASSERT(!is_loopback_host("0.0.0.0"));
+    TEST_ASSERT(!is_loopback_host("192.168.1.10"));
+    TEST_ASSERT(!is_loopback_host("127."));
+}
+
+static void test_server_bearer_auth() {
+    const std::string configured = "unit-test-key";
+    TEST_ASSERT(bearer_authorized("", ""));
+    TEST_ASSERT(!bearer_authorized("", configured));
+    TEST_ASSERT(!bearer_authorized("Basic unit-test-key", configured));
+    TEST_ASSERT(bearer_authorized("Bearer unit-test-key", configured));
+    TEST_ASSERT(bearer_authorized("bearer unit-test-key", configured));
+    TEST_ASSERT(!bearer_authorized("Bearer unit-test-kez", configured));
+    TEST_ASSERT(!bearer_authorized("Bearer unit-test-key-extra", configured));
+
+    // A length difference larger than one byte must never wrap into equality.
+    TEST_ASSERT(!bearer_authorized("Bearer " + configured + std::string(256, 'x'),
+                                   configured));
+}
+
+static void test_server_cors_allowlist() {
+    const std::vector<std::string> origins = {
+        "https://console.example.test",
+        "http://127.0.0.1:3000",
+    };
+    TEST_ASSERT(cors_origin_valid("https://console.example.test"));
+    TEST_ASSERT(!cors_origin_valid("*"));
+    TEST_ASSERT(!cors_origin_valid("https://console.example.test/path"));
+    TEST_ASSERT(cors_origin_allowed("", origins));
+    TEST_ASSERT(cors_origin_allowed("https://console.example.test", origins));
+    TEST_ASSERT(cors_origin_allowed("http://127.0.0.1:3000", origins));
+    TEST_ASSERT(!cors_origin_allowed("https://evil.example.test", origins));
+    TEST_ASSERT(!cors_origin_allowed("https://console.example.test/", origins));
+    TEST_ASSERT(!cors_origin_allowed("https://console.example.test", {}));
 }
 
 static void test_pflash_config_modes() {
@@ -4543,6 +4595,10 @@ int main() {
 
     std::fprintf(stderr, "\n── PFlash config ──\n");
     RUN_TEST(test_pflash_config_defaults);
+    RUN_TEST(test_server_security_defaults);
+    RUN_TEST(test_server_loopback_detection);
+    RUN_TEST(test_server_bearer_auth);
+    RUN_TEST(test_server_cors_allowlist);
     RUN_TEST(test_pflash_config_modes);
     RUN_TEST(test_pflash_compress_request_struct);
     RUN_TEST(test_pflash_compress_result_defaults);

--- a/server/tests/test_server_comprehensive.py
+++ b/server/tests/test_server_comprehensive.py
@@ -867,8 +867,8 @@ class TestSuite:
             self._check("invalid JSON body", False, str(e))
 
     def test_options_cors(self):
-        """OPTIONS request should return CORS headers."""
-        print("\n[EC-6] Edge case — CORS OPTIONS preflight")
+        """CORS is disabled unless the server was given an allowlist."""
+        print("\n[EC-6] Edge case — CORS disabled by default")
         try:
             req = urllib.request.Request(
                 self.base + "/v1/chat/completions",
@@ -878,8 +878,8 @@ class TestSuite:
             headers = dict(resp.headers)
             self._check("returns 200",
                          resp.status == 200 or resp.status == 204)
-            self._check("has Access-Control-Allow-Origin",
-                         "Access-Control-Allow-Origin" in headers,
+            self._check("does not emit Access-Control-Allow-Origin",
+                         "Access-Control-Allow-Origin" not in headers,
                          f"headers: {list(headers.keys())}")
         except Exception as e:
             self._check("CORS OPTIONS", False, str(e))

--- a/variables.md
+++ b/variables.md
@@ -29,6 +29,10 @@ Untagged variables are operational tuning knobs.
 |---|---|
 | `DFLASH_HOST` | Server bind host. |
 | `DFLASH_PORT` | Server bind port. |
+| `DFLASH_API_KEY` | Inbound Bearer key. Prefer a mounted key file for containers. |
+| `DFLASH_API_KEY_FILE` | Entrypoint mapping for `--api-key-file`. |
+| `DFLASH_CORS_ALLOW_ORIGIN` | Entrypoint mapping for one exact browser origin. |
+| `DFLASH_ALLOW_UNAUTHENTICATED_NONLOOPBACK` | Entrypoint mapping for the explicit unsafe non-loopback escape hatch. |
 | `DFLASH_BIN` / `DFLASH_SERVER_BIN` | Path to the server binary (harness/scripts). |
 | `DFLASH_BIN_AR` | Alternate/AR binary path for benchmarks. |
 | `DFLASH_DIR` | Base working directory. |


### PR DESCRIPTION
Hardens the native server deployment boundary: loopback/no-CORS defaults, exact CORS allowlists, environment/file Bearer authentication, fail-closed unauthenticated non-loopback binding with an explicit escape hatch, body/header/active/queue admission limits, disconnect cancellation, and complete shutdown draining. Health/readiness remain unauthenticated. Docker public binds require credentials or the explicit unsafe override.

Validation:
- focused strict C++ security tests pass
- combined SM70 build and full server unit suite pass on dual Tesla V100S
- live unauthenticated non-loopback startup exits 2 before model loading
- live authenticated server returns 200 for unauthenticated /health and /ready, 401 for unauthenticated /props, /v1/models, and generation, and 200 for authenticated /props

CLI, API, Docker, and operational documentation are updated.