### PR TITLE
fix(ds4): make 16K graph eviction safe and parallelize index scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release
           cmake --build build \
             --target test_flash_attn_sparse test_deepseek4_mmid_grouped_cuda \
+              test_deepseek4_unit \
             -j"$(nproc)"
 
       - name: Run flash-attn sparse kernel test on the 3090
@@ -183,6 +184,9 @@ jobs:
 
       - name: Run grouped MMID dispatch and parity test on the 3090
         run: ./server/build/test_deepseek4_mmid_grouped_cuda
+
+      - name: Run DeepSeek4 graph-generation regression on the 3090
+        run: ./server/build/test_deepseek4_unit
 
       # Optional model-backed end-to-end smoke (real spec-decode on the 3090),
       # disabled by default because it builds dflash_server and lazy-loads the
@@ -290,11 +294,12 @@ jobs:
             -DCMAKE_HIP_FLAGS=-DDFLASH_WAVE_SIZE=32
           cmake --build "$RUNNER_TEMP/rocmfp-build" \
             --target test_rocmfp4 test_rocmfpx test_rocmfp4_hip_tail test_rocmfpx_mmq \
-              test_deepseek4_mmid_grouped_cuda test_recurrent_snapshot test_server_unit \
+              test_deepseek4_mmid_grouped_cuda test_deepseek4_unit \
+              test_recurrent_snapshot test_server_unit \
             --parallel 8
           ctest --test-dir "$RUNNER_TEMP/rocmfp-build" \
             --output-on-failure \
-            -R 'rocmfp4_reference|rocmfpx_reference|rocmfp4_hip_tail|rocmfpx_mmq|deepseek4_mmid_grouped_cuda|recurrent_snapshot|ChainRollbackPolicy'
+            -R 'rocmfp4_reference|rocmfpx_reference|rocmfp4_hip_tail|rocmfpx_mmq|deepseek4_mmid_grouped_cuda|deepseek4_unit|recurrent_snapshot|ChainRollbackPolicy'
 
   build-windows:
     name: Build Windows (MSVC + CUDA, library + server targets)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,6 +290,7 @@ jobs:
             -DDFLASH27B_HIP_ARCHITECTURES=gfx1151 \
             -DDFLASH27B_SERVER=OFF \
             -DDFLASH27B_TESTS=ON \
+            -DGGML_HIP_GRAPHS=ON \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_HIP_FLAGS=-DDFLASH_WAVE_SIZE=32
           cmake --build "$RUNNER_TEMP/rocmfp-build" \

--- a/server/deps/llama.cpp/ggml/include/ggml-cuda.h
+++ b/server/deps/llama.cpp/ggml/include/ggml-cuda.h
@@ -36,6 +36,15 @@ GGML_BACKEND_API bool ggml_backend_cuda_set_low_priority_stream(
 // not change; input contents may still be updated in place.
 GGML_BACKEND_API bool ggml_backend_cuda_set_skip_props_check(bool skip);
 
+// Retire CUDA/HIP graph-cache entries whose graph key points into a metadata
+// arena that is about to be rebuilt or released. The backend is synchronized
+// before native graph executables are destroyed. Returns the number of erased
+// entries. Non-CUDA/HIP backends and empty ranges return zero.
+GGML_BACKEND_API size_t ggml_backend_cuda_graph_invalidate_range(
+        ggml_backend_t backend,
+        const void *   begin,
+        size_t         size);
+
 // Disable CUDA/HIP graph capture and replay on the calling thread. Returns the
 // previous value so scoped callers can restore nested overrides correctly.
 GGML_BACKEND_API bool ggml_backend_cuda_set_graphs_disabled_override(bool disabled);

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/fattn.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/fattn.cu
@@ -368,6 +368,111 @@ __global__ static void ds4_fa_indexed_rows_kernel(
     }
 }
 
+// Long contexts used to compact the exact indexer mask on thread 0, scanning
+// every compressed row serially for every token and layer. Compact chunks in
+// physical-row order with warp ballots instead. The generated selected_rows
+// and per-owner rank lists are deliberately identical to the serial kernel so
+// the attention accumulation order and logits remain unchanged.
+template <typename Mask>
+__global__ static void ds4_fa_indexed_rows_parallel_kernel(
+        const Mask * mask,
+        int        * selected_rows,
+        int        * selected_counts,
+        int        * owner_offsets,
+        int        * owner_ranks,
+        int          n_tokens,
+        int          n_kv,
+        int          raw_rows,
+        int          capacity) {
+    const int t = (int) blockIdx.x;
+    const int tid = (int) threadIdx.x;
+    if (t >= n_tokens) return;
+
+    constexpr int N_THREADS = 256;
+    constexpr int MAX_WARPS = N_THREADS / 32;
+    __shared__ int warp_offsets[MAX_WARPS];
+    __shared__ int owner_counts[N_THREADS];
+    __shared__ int chunk_base;
+    __shared__ int total_selected;
+
+    const int n_comp_rows = n_kv - raw_rows;
+    const Mask * token_mask = mask + (size_t) t * n_kv;
+    int * token_rows = selected_rows + (size_t) t * capacity;
+    int * token_owner_offsets = owner_offsets + (size_t) t * (N_THREADS + 1);
+    int * token_owner_ranks = owner_ranks + (size_t) t * capacity;
+
+    owner_counts[tid] = 0;
+    if (tid == 0) total_selected = 0;
+    __syncthreads();
+
+    const int lane = tid % warpSize;
+    const int warp = tid / warpSize;
+    const int n_warps = N_THREADS / warpSize;
+    for (int base = 0; base < n_comp_rows; base += N_THREADS) {
+        const int c = base + tid;
+        const bool selected = c < n_comp_rows &&
+            ds4_fa_load<Mask, Mask>(token_mask + raw_rows + c) > -1.0e20f;
+        const unsigned long long selected_bits = __ballot(selected);
+        if (lane == 0) {
+            warp_offsets[warp] = __popcll(selected_bits);
+        }
+        __syncthreads();
+
+        if (tid == 0) {
+            int prefix = 0;
+            for (int w = 0; w < n_warps; ++w) {
+                const int count = warp_offsets[w];
+                warp_offsets[w] = prefix;
+                prefix += count;
+            }
+            chunk_base = total_selected;
+            total_selected += prefix;
+        }
+        __syncthreads();
+
+        const unsigned long long lower_lanes = lane == 0
+            ? 0ULL
+            : ((1ULL << lane) - 1ULL);
+        const int rank = chunk_base + warp_offsets[warp] +
+            __popcll(selected_bits & lower_lanes);
+        if (selected && rank < capacity) {
+            token_rows[rank] = raw_rows + c;
+        }
+        __syncthreads();
+    }
+
+    if (tid == 0) {
+        selected_counts[t] = min(total_selected, capacity);
+    }
+    __syncthreads();
+
+    const int count = selected_counts[t];
+    for (int rank = tid; rank < count; rank += N_THREADS) {
+        const int owner = token_rows[rank] & (N_THREADS - 1);
+        atomicAdd(owner_counts + owner, 1);
+    }
+    __syncthreads();
+
+    if (tid == 0) {
+        int prefix = 0;
+        for (int owner = 0; owner < N_THREADS; ++owner) {
+            token_owner_offsets[owner] = prefix;
+            prefix += owner_counts[owner];
+        }
+        token_owner_offsets[N_THREADS] = prefix;
+    }
+    __syncthreads();
+
+    // One thread owns each original attention reduction lane. Walking the
+    // already sorted rows preserves the serial kernel's rank order per owner.
+    int write = token_owner_offsets[tid];
+    for (int rank = 0; rank < count; ++rank) {
+        if ((token_rows[rank] & (N_THREADS - 1)) == tid) {
+            token_owner_ranks[write++] = rank;
+        }
+    }
+}
+
 template <typename KV, typename Mask>
 __global__ static void ds4_flash_attn_d512_shared_kv_kernel(
         float       * dst,
@@ -1748,18 +1853,36 @@ static bool ggml_cuda_ds4_flash_attn_d512_f32(
                 (size_t) n_tokens * 257);
             indexed_owner_ranks = indexed_owner_ranks_alloc.alloc(
                 (size_t) n_tokens * indexed_capacity);
+            const bool parallel_index_scan = n_comp_rows > 512 &&
+                getenv("GGML_DS4_FA_SERIAL_INDEX_SCAN") == nullptr;
             if (mask->type == GGML_TYPE_F16) {
-                ds4_fa_indexed_rows_kernel<half><<<n_tokens, 256, 0, stream>>>(
-                    (const half *) mask->data, indexed_rows, indexed_counts,
-                    indexed_owner_offsets, indexed_owner_ranks,
-                    n_tokens, n_kv, raw_rows,
-                    indexed_capacity);
+                if (parallel_index_scan) {
+                    ds4_fa_indexed_rows_parallel_kernel<half><<<n_tokens, 256, 0, stream>>>(
+                        (const half *) mask->data, indexed_rows, indexed_counts,
+                        indexed_owner_offsets, indexed_owner_ranks,
+                        n_tokens, n_kv, raw_rows,
+                        indexed_capacity);
+                } else {
+                    ds4_fa_indexed_rows_kernel<half><<<n_tokens, 256, 0, stream>>>(
+                        (const half *) mask->data, indexed_rows, indexed_counts,
+                        indexed_owner_offsets, indexed_owner_ranks,
+                        n_tokens, n_kv, raw_rows,
+                        indexed_capacity);
+                }
             } else {
-                ds4_fa_indexed_rows_kernel<float><<<n_tokens, 256, 0, stream>>>(
-                    (const float *) mask->data, indexed_rows, indexed_counts,
-                    indexed_owner_offsets, indexed_owner_ranks,
-                    n_tokens, n_kv, raw_rows,
-                    indexed_capacity);
+                if (parallel_index_scan) {
+                    ds4_fa_indexed_rows_parallel_kernel<float><<<n_tokens, 256, 0, stream>>>(
+                        (const float *) mask->data, indexed_rows, indexed_counts,
+                        indexed_owner_offsets, indexed_owner_ranks,
+                        n_tokens, n_kv, raw_rows,
+                        indexed_capacity);
+                } else {
+                    ds4_fa_indexed_rows_kernel<float><<<n_tokens, 256, 0, stream>>>(
+                        (const float *) mask->data, indexed_rows, indexed_counts,
+                        indexed_owner_offsets, indexed_owner_ranks,
+                        n_tokens, n_kv, raw_rows,
+                        indexed_capacity);
+                }
             }
             CUDA_CHECK(cudaGetLastError());
         }

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -4784,6 +4784,47 @@ extern "C" bool ggml_backend_cuda_set_skip_props_check(bool skip) {
     return previous;
 }
 
+extern "C" size_t ggml_backend_cuda_graph_invalidate_range(
+        ggml_backend_t backend,
+        const void * begin,
+        size_t size) {
+#ifdef USE_CUDA_GRAPH
+    if (backend == nullptr || begin == nullptr || size == 0 ||
+        !ggml_backend_is_cuda(backend)) {
+        return 0;
+    }
+
+    // Graph instances may still be queued even when their owning ggml graph
+    // is no longer reachable. Retiring one is only safe after all work on the
+    // backend has completed.
+    ggml_backend_synchronize(backend);
+    auto * cuda_ctx = static_cast<ggml_backend_cuda_context *>(backend->context);
+    ggml_cuda_set_device(cuda_ctx->device);
+
+    const uintptr_t first = reinterpret_cast<uintptr_t>(begin);
+    const uintptr_t last = size > std::numeric_limits<uintptr_t>::max() - first
+        ? std::numeric_limits<uintptr_t>::max()
+        : first + size;
+    size_t erased = 0;
+    for (auto it = cuda_ctx->cuda_graphs.begin();
+         it != cuda_ctx->cuda_graphs.end();) {
+        const uintptr_t key = reinterpret_cast<uintptr_t>(it->first);
+        if (key >= first && key < last) {
+            it = cuda_ctx->cuda_graphs.erase(it);
+            ++erased;
+        } else {
+            ++it;
+        }
+    }
+    return erased;
+#else
+    GGML_UNUSED(backend);
+    GGML_UNUSED(begin);
+    GGML_UNUSED(size);
+    return 0;
+#endif
+}
+
 static enum ggml_status ggml_backend_cuda_graph_compute(ggml_backend_t backend, ggml_cgraph * cgraph) {
     ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *) backend->context;
 
@@ -4817,9 +4858,20 @@ static enum ggml_status ggml_backend_cuda_graph_compute(ggml_backend_t backend, 
             getenv("GGML_CUDA_GRAPH_WARMUP_LOG") != nullptr;
         const bool graph_compatible = ggml_cuda_graph_check_compability(cgraph);
         if (graph_compatible) {
+            // A metadata arena can be rebuilt at the same address, producing
+            // the same pointer-derived graph key for a different graph. The
+            // scheduler assigns every split a new uid when that happens. A
+            // forced property-scan bypass is therefore valid only for the
+            // exact generation that populated this cache entry.
+            // Scheduler graphs carry a non-zero generation uid. Direct graphs
+            // retain uid=0 and therefore keep the existing caller-guaranteed
+            // immutable-topology fast path.
+            const bool same_graph_generation = cgraph->uid == 0 ||
+                                               cgraph->uid == graph->uid;
             const bool can_skip_props_check = ggml_cuda_skip_props_check
                                            && graph->warmup_complete
-                                           && graph->instance != nullptr;
+                                           && graph->instance != nullptr
+                                           && same_graph_generation;
             const bool properties_changed = can_skip_props_check
                                           ? false
                                           : ggml_cuda_graph_update_required(cuda_ctx, cgraph);

--- a/server/docs/DS4.md
+++ b/server/docs/DS4.md
@@ -248,6 +248,9 @@ The runtime logs the chosen split with a `[deepseek4-split] auto-split:` banner.
 | `DFLASH_EXPERT_BUDGET_MB` | Main-GPU memory budget for hot experts. |
 | `DFLASH_DS4_HOTNESS_CSV` | Optional per-layer routing profile for hot placement. |
 | `GGML_BATCH_PEER_COPIES` | Batch peer-runtime copies and unlike-runtime pinned-host staging with one source wait per split. The old `GGML_CUDA_BATCH_PEER_COPIES` spelling remains an alias. |
+| `DFLASH_DS4_TP_FUSED_CACHE_SLOTS` | Number of heterogeneous verifier graph slots. Defaults to `2`; each slot retains scheduler scratch on both GPUs. |
+| `DFLASH_DS4_VERIFY_FORCE_GRAPH_REPLAY` | Skip the expensive property scan only for a warmed verifier graph. Rebuilt scheduler generations are always validated. Leave unset for the conservative production profile. |
+| `GGML_DS4_FA_SERIAL_INDEX_SCAN` | Restore the serial compressed-row mask scan for an indexed-attention A/B. By default, HIP scans contexts above 512 compressed rows in parallel. |
 | `DFLASH_MOE_PREFILL_PERSISTENT_OWNER_ALLOC` | Long-prefill arena kill switch; set `0` to restore per-layer owner allocation. |
 
 `DFLASH_DS4_TIMING` enables the existing timing banners:
@@ -319,6 +322,24 @@ reported and falls back to normal autoregressive decode. The target cache and
 sampler stay on the main backend while routed target experts execute on their
 configured owners. `--ds4-expert-top-k 4` remains a separate approximate
 policy; omit it to retain the model's default six routed experts.
+
+### Verifier graph-cache safety
+
+Every heterogeneous verifier slot owns a scheduler and its per-backend scratch
+buffers. The production default is therefore two slots. Do not copy the old
+12-slot benchmark override into a long-lived service without measuring free
+VRAM across every intended context shape.
+
+Native CUDA/HIP graph executables are cached below the ggml scheduler. Before a
+DS4 slot is rebuilt, the runtime now synchronizes its backends and retires every
+native graph key that points into that slot's metadata arena. Forced replay is
+also generation-checked using the scheduler split uid. Consequently, an LRU
+slot rebuilt at the same address cannot replay the previous shape's executable.
+
+The required burn-in sequence is repeated requests at 2K, 4K, 8K, and 16K in
+one process, followed by another 2K request to force additional eviction. Run
+with `DFLASH_DS4_TP_FUSED_CACHE_SLOTS=2`; first qualify with forced replay
+unset, then repeat with it enabled as a separate performance A/B.
 
 On HIP `gfx1151`, enabling DSpark defaults `LUCE_MMVQ_MAX_NCOLS` to `4` when
 the variable is unset. This keeps the four-row verifier on MMVQ. On a 128 GiB

--- a/server/docs/ENVIRONMENT.md
+++ b/server/docs/ENVIRONMENT.md
@@ -40,6 +40,9 @@ consolidation of this list into CLI flags is tracked as follow-up work.
 | `DFLASH_CUDA_BACKEND_PATH` / `DFLASH_HIP_BACKEND_PATH` | auto-discovered beside the executable | Explicit peer module file path for a mixed CUDA+HIP build. |
 | `GGML_BATCH_PEER_COPIES` | unset | BURN-IN: batch peer-runtime copies and unlike-runtime host staging with one source wait per split. `GGML_CUDA_BATCH_PEER_COPIES` remains a compatibility alias. |
 | `GGML_SCHED_PROFILE` / `GGML_SCHED_PROFILE_MIN_SPLITS` | unset / 1 | DEBUG: report scheduler splits, copy volume, submission time, and source/destination synchronization time. |
+| `DFLASH_DS4_TP_FUSED_CACHE_SLOTS` | 2 | BURN-IN: number of heterogeneous verifier schedulers retained; higher values retain substantially more scratch on both GPUs. |
+| `DFLASH_DS4_VERIFY_FORCE_GRAPH_REPLAY` | unset | OPT-IN: bypass graph property scans only after warmup; scheduler-generation checks remain mandatory. |
+| `GGML_DS4_FA_SERIAL_INDEX_SCAN` | unset | DEBUG/A-B: restore the serial indexed-attention mask scan instead of the long-context HIP parallel scan. |
 | `DFLASH_MOE_PREFILL_PERSISTENT_OWNER_ALLOC` | 1 for qualified long heterogeneous prefill | KILL SWITCH: =0 restores per-layer route/owner scratch allocation. |
 | `DFLASH_MOE_TP_*` / `DFLASH_MOE_HYBRID_PREFILL_EAGER` | unset | BURN-IN: model-neutral names for common heterogeneous-MoE scheduling and kernel policy. Existing `DFLASH_DS4_*` names remain compatibility aliases. |
 | `DFLASH_MMID_TELEMETRY` | unset | DEBUG: report MUL_MAT_ID dispatch, MMVQ variant, and per-node graph compatibility. |
@@ -113,6 +116,7 @@ consolidation of this list into CLI flags is tracked as follow-up work.
 - `DFLASH_DS4_TP_FUSED_CACHE_SLOTS` - deepseek4_fused_verify.inc
 - `DFLASH_DS4_TP_SCHEDULE_BRANCHES` - deepseek4_fused_verify.inc
 - `DFLASH_DS4_TP_TARGETED_JOIN_SPLIT` - moe_hybrid_ffn_eval.cpp
+- `DFLASH_DS4_VERIFY_FORCE_GRAPH_REPLAY` - deepseek4_fused_verify.inc
 - `DFLASH_DS4_TOPK` - deepseek4_graph.cpp
 - `DFLASH_EXPERT_BUDGET_MB` - deepseek4_backend.cpp, laguna_backend.cpp, qwen35moe_backend.cpp
 - `DFLASH_EXPERT_BUDGET_PCT` - laguna_backend.cpp

--- a/server/src/deepseek4/deepseek4_fused_verify.inc
+++ b/server/src/deepseek4/deepseek4_fused_verify.inc
@@ -1126,7 +1126,7 @@ static int ds4_try_fused_verify_step(
         // buffers and HIP graph replay state still refers to those addresses.
         // Reinitializing the ggml context over the same metadata arena while
         // that state is live can replay kernels against stale allocations.
-        fg->destroy();
+        fg->destroy(vc.backend, vc.peer_backend);
         ex->reset();
 
         const auto build_t0 = Ds4TimingClock::now();
@@ -1135,7 +1135,7 @@ static int ds4_try_fused_verify_step(
                                           kv_start, q, token_ids != nullptr,
                                           *hooks->capture_layer_ids, hybrid,
                                           std::move(key))) {
-            fg->destroy();
+            fg->destroy(vc.backend, vc.peer_backend);
             ex->reset();
             vc.disabled = true;
             return 0;
@@ -1183,7 +1183,12 @@ static int ds4_try_fused_verify_step(
 
     // causal mask values
     {
-        std::vector<float> maskv((size_t) ggml_nelements(fg->mask_bundle), 0.0f);
+        const size_t mask_count = (size_t) ggml_nelements(fg->mask_bundle);
+        std::vector<float> & maskv = ex->mask_values;
+        if (maskv.size() != mask_count) {
+            maskv.resize(mask_count);
+        }
+        std::fill(maskv.begin(), maskv.end(), 0.0f);
         size_t off = 0;
         for (int il = 0; il < w.n_layer; ++il) {
             const int ratio = (int) w.compress_ratios[il];
@@ -1277,7 +1282,9 @@ static int ds4_try_fused_verify_step(
     // immutable until the slot is destroyed. The generic CUDA/HIP property
     // scan can nevertheless observe backend-mutated metadata and reset replay
     // at request boundaries. Mirror the qualified draft fast path behind an
-    // independent opt-in while retaining normal warmup/capture semantics.
+    // independent opt-in while retaining normal warmup/capture semantics. The
+    // backend additionally checks the scheduler graph uid, so a rebuilt slot
+    // can never bypass validation using the previous generation's executable.
     const bool force_verify_graph_replay = q > 1 &&
         ds4_env_flag("DFLASH_DS4_VERIFY_FORCE_GRAPH_REPLAY");
     ScopedCudaGraphOverrides graph_override_scope(

--- a/server/src/deepseek4/deepseek4_graph.cpp
+++ b/server/src/deepseek4/deepseek4_graph.cpp
@@ -4523,7 +4523,29 @@ struct DeepSeek4FusedDecodeGraph {
         return sg.ctx && sg.gf && logits;
     }
 
-    void destroy() {
+    void invalidate_native_graphs(ggml_backend_t main_backend,
+                                  ggml_backend_t peer_backend = nullptr) const {
+        if (sg.meta_arena.empty()) {
+            return;
+        }
+        auto invalidate = [&](ggml_backend_t candidate) {
+            if (candidate && ggml_backend_is_cuda(candidate)) {
+                ggml_backend_cuda_graph_invalidate_range(
+                    candidate, sg.meta_arena.data(), sg.meta_arena.size());
+            }
+        };
+        invalidate(main_backend);
+        if (peer_backend != main_backend) {
+            invalidate(peer_backend);
+        }
+    }
+
+    void destroy(ggml_backend_t main_backend,
+                 ggml_backend_t peer_backend = nullptr) {
+        // Native graph executables outlive ggml graph metadata in the backend
+        // cache. Retire them before either the scheduler or metadata arena is
+        // released, otherwise a rebuilt slot can inherit the same pointer key.
+        invalidate_native_graphs(main_backend, peer_backend);
         if (sched) {
             ggml_backend_sched_free(sched);
             sched = nullptr;
@@ -4550,7 +4572,7 @@ struct DeepSeek4FusedDecodeCache {
     ggml_tensor * fn_out_f16 = nullptr;
 
     void destroy() {
-        for (auto & s : slots) s.destroy();
+        for (auto & s : slots) s.destroy(backend);
         if (fn_buf) { ggml_backend_buffer_free(fn_buf); fn_buf = nullptr; }
         if (fn_ctx) { ggml_free(fn_ctx); fn_ctx = nullptr; }
         fn_attn_f16.clear();
@@ -4586,6 +4608,9 @@ struct Ds4FusedVerifyCache {
         ggml_tensor * st128 = nullptr;    // i64 [1,q]
         ggml_tensor * capture = nullptr;  // f32 [n_embd*ncap*q], order [ci][t]
         ggml_tensor * argmax = nullptr;   // i32 [q], optional greedy output
+        // Reused host staging for the context-sized additive attention mask.
+        // Keeping it per slot removes one allocation from every verify step.
+        std::vector<float> mask_values;
         int q = 0;
 
         void reset() { *this = Extra{}; }
@@ -4593,7 +4618,7 @@ struct Ds4FusedVerifyCache {
     std::array<Extra, kSlotCount> extra;
 
     void destroy() {
-        for (auto & slot : slots) slot.destroy();
+        for (auto & slot : slots) slot.destroy(backend, peer_backend);
         for (auto & value : extra) value.reset();
         owner_ctx = nullptr;
         backend = nullptr;
@@ -5250,6 +5275,11 @@ static int ds4_try_fused_decode_step(
                 if (s.last_use < fg->last_use) fg = &s;
             }
         }
+        // The backend's native graph cache is keyed by tensor metadata
+        // addresses. Retire the previous generation before rebuilding this
+        // slot over the same persistent arena; keep the gallocr itself so its
+        // device scratch can still be reused.
+        fg->invalidate_native_graphs(backend);
         const auto build_t0 = Ds4TimingClock::now();
         if (!ds4_build_fused_decode_graph(fc, *fg, backend, w, cache,
                                           hc_weights, hc_out_weights, hash_tables,

--- a/server/tests/test_deepseek4_unit.cpp
+++ b/server/tests/test_deepseek4_unit.cpp
@@ -3472,6 +3472,12 @@ static void test_cuda_graph_rebuild_generation_guard() {
         ggml_backend_t backends[] = {gpu, cpu};
         ggml_backend_sched_t sched = ggml_backend_sched_new(
             backends, nullptr, 2, 64, false, true);
+        if (sched) {
+            // Match the fused verifier: inputs and outputs are explicitly
+            // pinned to the main GPU before the scheduler allocates splits.
+            ggml_backend_sched_set_tensor_backend(sched, input, gpu);
+            ggml_backend_sched_set_tensor_backend(sched, output, gpu);
+        }
         bool ok = sched && ggml_backend_sched_alloc_graph(sched, graph);
         const float value = 3.0f;
         if (ok) {
@@ -3489,6 +3495,11 @@ static void test_cuda_graph_rebuild_generation_guard() {
         if (ok) {
             ggml_backend_tensor_get(output, &actual, 0, sizeof(actual));
             ok = nearly_equal(actual, expected, 1.0e-6f, 1.0e-6f);
+            if (!ok) {
+                std::fprintf(stderr,
+                             " graph output=%g expected=%g;", actual,
+                             expected);
+            }
         }
         if (retire_after) {
             ggml_backend_cuda_graph_invalidate_range(

--- a/server/tests/test_deepseek4_unit.cpp
+++ b/server/tests/test_deepseek4_unit.cpp
@@ -3430,6 +3430,13 @@ static void test_cuda_graph_rebuild_generation_guard() {
         std::fprintf(stderr, " skipped (no GPU backend)\n");
         return;
     }
+    ggml_backend_t cpu = ggml_backend_cpu_init();
+    TEST_ASSERT_MSG(cpu != nullptr, "CPU fallback backend init failed");
+    if (!cpu) {
+        ggml_backend_free(gpu);
+        std::fprintf(stderr, " FAIL\n");
+        return;
+    }
 
     std::vector<uint8_t> arena(1024 * 1024);
     const void * first_graph_key = nullptr;
@@ -3460,9 +3467,11 @@ static void test_cuda_graph_rebuild_generation_guard() {
             TEST_ASSERT(graph_key == first_graph_key);
         }
 
-        ggml_backend_t backends[] = {gpu};
+        // The generic scheduler contract requires a CPU fallback as its final
+        // backend even when every operation in this graph stays on the GPU.
+        ggml_backend_t backends[] = {gpu, cpu};
         ggml_backend_sched_t sched = ggml_backend_sched_new(
-            backends, nullptr, 1, 64, false, true);
+            backends, nullptr, 2, 64, false, true);
         bool ok = sched && ggml_backend_sched_alloc_graph(sched, graph);
         const float value = 3.0f;
         if (ok) {
@@ -3494,6 +3503,7 @@ static void test_cuda_graph_rebuild_generation_guard() {
                     "first graph generation failed");
     TEST_ASSERT_MSG(run_generation(false, -3.0f, true),
                     "rebuilt graph replayed stale executable");
+    ggml_backend_free(cpu);
     ggml_backend_free(gpu);
     std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
 }

--- a/server/tests/test_deepseek4_unit.cpp
+++ b/server/tests/test_deepseek4_unit.cpp
@@ -3481,8 +3481,11 @@ static void test_cuda_graph_rebuild_generation_guard() {
         bool ok = sched && ggml_backend_sched_alloc_graph(sched, graph);
         const float value = 3.0f;
         if (ok) {
-            ggml_backend_tensor_set(input, &value, 0, sizeof(value));
             for (int warm = 0; warm < 3 && ok; ++warm) {
+                // The scheduler allocator may legally reuse the input buffer
+                // for this unary output. Production uploads fresh inputs on
+                // every replay, so mirror that contract for each warmup.
+                ggml_backend_tensor_set(input, &value, 0, sizeof(value));
                 ScopedCudaGraphOverrides force_replay(
                     /*disable_graphs=*/false,
                     /*mmvq_max_ncols=*/0,

--- a/server/tests/test_deepseek4_unit.cpp
+++ b/server/tests/test_deepseek4_unit.cpp
@@ -3451,10 +3451,11 @@ static void test_cuda_graph_rebuild_generation_guard() {
 
         // Both generations intentionally reuse the exact metadata address,
         // which reproduces the verifier LRU slot's pointer-key collision.
+        ggml_tensor * graph_key = ggml_graph_node(graph, 0);
         if (!first_graph_key) {
-            first_graph_key = graph->nodes[0];
+            first_graph_key = graph_key;
         } else {
-            TEST_ASSERT(graph->nodes[0] == first_graph_key);
+            TEST_ASSERT(graph_key == first_graph_key);
         }
 
         ggml_backend_t backends[] = {gpu};

--- a/server/tests/test_deepseek4_unit.cpp
+++ b/server/tests/test_deepseek4_unit.cpp
@@ -2500,6 +2500,10 @@ static void test_ds4_flash_attention_keep_cap_gpu() {
 static void test_ds4_flash_attention_parallel_index_scan_gpu() {
     std::fprintf(stderr,
                  "  test_ds4_flash_attention_parallel_index_scan_gpu ...");
+#if !defined(GGML_USE_HIP)
+    std::fprintf(stderr, " skipped (HIP-only contract)\n");
+    return;
+#endif
     ggml_backend_t backend = ggml_backend_cuda_init(0);
     if (!backend) {
         std::fprintf(stderr, " skipped (no GPU backend)\n");
@@ -2535,7 +2539,7 @@ static void test_ds4_flash_attention_parallel_index_scan_gpu() {
         ctx, q, kv, kv, mask, 1.0f / std::sqrt((float) head_dim),
         0.0f, 0.0f);
     // Negative keep_rows marks an exact externally indexed mask. This shape
-    // enters the compact four-head GPU path and exceeds the parallel threshold.
+    // enters the compact four-head HIP path and exceeds the parallel threshold.
     ggml_flash_attn_ext_set_ds4_sparse(
         output, raw_rows, raw_window, -selected_rows, 1);
     ggml_set_output(output);

--- a/server/tests/test_deepseek4_unit.cpp
+++ b/server/tests/test_deepseek4_unit.cpp
@@ -2500,10 +2500,6 @@ static void test_ds4_flash_attention_keep_cap_gpu() {
 static void test_ds4_flash_attention_parallel_index_scan_gpu() {
     std::fprintf(stderr,
                  "  test_ds4_flash_attention_parallel_index_scan_gpu ...");
-#if !defined(GGML_USE_HIP)
-    std::fprintf(stderr, " skipped (HIP-only contract)\n");
-    return;
-#endif
     ggml_backend_t backend = ggml_backend_cuda_init(0);
     if (!backend) {
         std::fprintf(stderr, " skipped (no GPU backend)\n");
@@ -2539,7 +2535,7 @@ static void test_ds4_flash_attention_parallel_index_scan_gpu() {
         ctx, q, kv, kv, mask, 1.0f / std::sqrt((float) head_dim),
         0.0f, 0.0f);
     // Negative keep_rows marks an exact externally indexed mask. This shape
-    // enters the compact four-head HIP path and exceeds the parallel threshold.
+    // enters the compact four-head GPU path and exceeds the parallel threshold.
     ggml_flash_attn_ext_set_ds4_sparse(
         output, raw_rows, raw_window, -selected_rows, 1);
     ggml_set_output(output);

--- a/server/tests/test_deepseek4_unit.cpp
+++ b/server/tests/test_deepseek4_unit.cpp
@@ -2515,7 +2515,9 @@ static void test_ds4_flash_attention_parallel_index_scan_gpu() {
     constexpr int n_tokens = 2;
     constexpr int raw_rows = 256;
     constexpr int raw_window = 128;
-    constexpr int n_comp_rows = 1024;
+    // Keep the ordinary four-head shared-memory footprint above 24 KiB so
+    // this shape is forced through the compact indexed path under test.
+    constexpr int n_comp_rows = 1280;
     constexpr int n_kv = raw_rows + n_comp_rows;
     constexpr int selected_rows = 512;
 

--- a/server/tests/test_deepseek4_unit.cpp
+++ b/server/tests/test_deepseek4_unit.cpp
@@ -2497,6 +2497,138 @@ static void test_ds4_flash_attention_keep_cap_gpu() {
     std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
 }
 
+static void test_ds4_flash_attention_parallel_index_scan_gpu() {
+    std::fprintf(stderr,
+                 "  test_ds4_flash_attention_parallel_index_scan_gpu ...");
+#if !defined(GGML_USE_HIP)
+    std::fprintf(stderr, " skipped (HIP-only contract)\n");
+    return;
+#endif
+    ggml_backend_t backend = ggml_backend_cuda_init(0);
+    if (!backend) {
+        std::fprintf(stderr, " skipped (no GPU backend)\n");
+        return;
+    }
+
+    constexpr int head_dim = 512;
+    constexpr int n_heads = 4;
+    constexpr int n_tokens = 2;
+    constexpr int raw_rows = 256;
+    constexpr int raw_window = 128;
+    constexpr int n_comp_rows = 1024;
+    constexpr int n_kv = raw_rows + n_comp_rows;
+    constexpr int selected_rows = 512;
+
+    ggml_context * ctx = make_test_context(4u << 20);
+    TEST_ASSERT_MSG(ctx != nullptr, "ggml_init failed");
+    if (!ctx) {
+        ggml_backend_free(backend);
+        std::fprintf(stderr, " FAIL\n");
+        return;
+    }
+
+    ggml_tensor * q = ggml_new_tensor_3d(
+        ctx, GGML_TYPE_F32, head_dim, n_tokens, n_heads);
+    ggml_tensor * kv = ggml_new_tensor_3d(
+        ctx, GGML_TYPE_F32, head_dim, n_kv, 1);
+    ggml_tensor * mask = ggml_new_tensor_2d(
+        ctx, GGML_TYPE_F16, n_kv, n_tokens);
+    ggml_tensor * output = ggml_flash_attn_ext(
+        ctx, q, kv, kv, mask, 1.0f / std::sqrt((float) head_dim),
+        0.0f, 0.0f);
+    // Negative keep_rows marks an exact externally indexed mask. This shape
+    // enters the compact four-head HIP path and exceeds the parallel threshold.
+    ggml_flash_attn_ext_set_ds4_sparse(
+        output, raw_rows, raw_window, -selected_rows, 1);
+    ggml_set_output(output);
+    TEST_ASSERT_MSG(ggml_backend_supports_op(backend, output),
+                    "GPU rejected exact indexed DS4 attention");
+
+    ggml_cgraph * graph = ggml_new_graph_custom(ctx, 64, false);
+    ggml_build_forward_expand(graph, output);
+    ggml_gallocr_t alloc = ggml_gallocr_new(
+        ggml_backend_get_default_buffer_type(backend));
+    const bool allocated = ggml_gallocr_alloc_graph(alloc, graph);
+    TEST_ASSERT_MSG(allocated, "indexed attention graph allocation failed");
+    if (allocated) {
+        std::vector<float> q_data((size_t) head_dim * n_tokens * n_heads);
+        std::vector<float> kv_data((size_t) head_dim * n_kv);
+        std::vector<ggml_fp16_t> mask_data(
+            (size_t) n_kv * n_tokens, ggml_fp32_to_fp16(-1.0e30f));
+        for (size_t i = 0; i < q_data.size(); ++i) {
+            q_data[i] = ((int) (i % 31) - 15) * 0.001f;
+        }
+        for (size_t i = 0; i < kv_data.size(); ++i) {
+            kv_data[i] = ((int) (i % 37) - 18) * 0.001f;
+        }
+        for (int token = 0; token < n_tokens; ++token) {
+            ggml_fp16_t * token_mask =
+                mask_data.data() + (size_t) token * n_kv;
+            for (int row = raw_rows - raw_window; row < raw_rows; ++row) {
+                token_mask[row] = ggml_fp32_to_fp16(0.0f);
+            }
+            for (int row = token; row < n_comp_rows; row += 2) {
+                token_mask[raw_rows + row] = ggml_fp32_to_fp16(0.0f);
+            }
+        }
+        ggml_backend_tensor_set(q, q_data.data(), 0,
+                                q_data.size() * sizeof(float));
+        ggml_backend_tensor_set(kv, kv_data.data(), 0,
+                                kv_data.size() * sizeof(float));
+        ggml_backend_tensor_set(mask, mask_data.data(), 0,
+                                mask_data.size() * sizeof(ggml_fp16_t));
+
+        const char * previous_serial =
+            std::getenv("GGML_DS4_FA_SERIAL_INDEX_SCAN");
+        const std::string previous_value = previous_serial
+            ? previous_serial : "";
+        std::vector<float> serial((size_t) ggml_nelements(output));
+        std::vector<float> parallel(serial.size());
+        {
+            setenv("GGML_DS4_FA_SERIAL_INDEX_SCAN", "1", 1);
+            ScopedCudaGraphOverrides eager(
+                /*disable_graphs=*/true,
+                /*mmvq_max_ncols=*/0,
+                /*skip_property_check=*/false);
+            TEST_ASSERT_MSG(
+                ggml_backend_graph_compute(backend, graph) ==
+                    GGML_STATUS_SUCCESS,
+                "serial indexed attention failed");
+            ggml_backend_tensor_get(output, serial.data(), 0,
+                                    serial.size() * sizeof(float));
+        }
+        {
+            unsetenv("GGML_DS4_FA_SERIAL_INDEX_SCAN");
+            ScopedCudaGraphOverrides eager(
+                /*disable_graphs=*/true,
+                /*mmvq_max_ncols=*/0,
+                /*skip_property_check=*/false);
+            TEST_ASSERT_MSG(
+                ggml_backend_graph_compute(backend, graph) ==
+                    GGML_STATUS_SUCCESS,
+                "parallel indexed attention failed");
+            ggml_backend_tensor_get(output, parallel.data(), 0,
+                                    parallel.size() * sizeof(float));
+        }
+        if (previous_serial) {
+            setenv("GGML_DS4_FA_SERIAL_INDEX_SCAN",
+                   previous_value.c_str(), 1);
+        } else {
+            unsetenv("GGML_DS4_FA_SERIAL_INDEX_SCAN");
+        }
+        for (size_t i = 0; i < serial.size(); ++i) {
+            TEST_ASSERT_MSG(
+                nearly_equal(serial[i], parallel[i], 1.0e-6f, 1.0e-6f),
+                "parallel index scan changed attention output");
+        }
+    }
+
+    ggml_gallocr_free(alloc);
+    ggml_free(ctx);
+    ggml_backend_free(backend);
+    std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
+}
+
 static void test_ds4_flash_attention_inverse_rope_fallback_gpu() {
     std::fprintf(stderr,
                  "  test_ds4_flash_attention_inverse_rope_fallback_gpu ...");
@@ -3285,6 +3417,84 @@ static void test_cuda_graph_overrides_restore_nested_state() {
     std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
 }
 
+static void test_cuda_graph_rebuild_generation_guard() {
+    std::fprintf(stderr, "  test_cuda_graph_rebuild_generation_guard ...");
+    if (ggml_backend_cuda_get_device_count() <= 0) {
+        std::fprintf(stderr, " skipped (no GPU device)\n");
+        return;
+    }
+    ggml_backend_t gpu = ggml_backend_cuda_init(0);
+    if (!gpu) {
+        std::fprintf(stderr, " skipped (no GPU backend)\n");
+        return;
+    }
+
+    std::vector<uint8_t> arena(1024 * 1024);
+    const void * first_graph_key = nullptr;
+    auto run_generation = [&](bool square, float expected,
+                              bool retire_after) -> bool {
+        ggml_init_params params{};
+        params.mem_size = arena.size();
+        params.mem_buffer = arena.data();
+        params.no_alloc = true;
+        ggml_context * ctx = ggml_init(params);
+        if (!ctx) return false;
+
+        ggml_tensor * input = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 1);
+        ggml_set_input(input);
+        ggml_tensor * output = square
+            ? ggml_sqr(ctx, input)
+            : ggml_neg(ctx, input);
+        ggml_set_output(output);
+        ggml_cgraph * graph = ggml_new_graph_custom(ctx, 16, false);
+        ggml_build_forward_expand(graph, output);
+
+        // Both generations intentionally reuse the exact metadata address,
+        // which reproduces the verifier LRU slot's pointer-key collision.
+        if (!first_graph_key) {
+            first_graph_key = graph->nodes[0];
+        } else {
+            TEST_ASSERT(graph->nodes[0] == first_graph_key);
+        }
+
+        ggml_backend_t backends[] = {gpu};
+        ggml_backend_sched_t sched = ggml_backend_sched_new(
+            backends, nullptr, 1, 64, false, true);
+        bool ok = sched && ggml_backend_sched_alloc_graph(sched, graph);
+        const float value = 3.0f;
+        if (ok) {
+            ggml_backend_tensor_set(input, &value, 0, sizeof(value));
+            for (int warm = 0; warm < 3 && ok; ++warm) {
+                ScopedCudaGraphOverrides force_replay(
+                    /*disable_graphs=*/false,
+                    /*mmvq_max_ncols=*/0,
+                    /*skip_property_check=*/true);
+                ok = ggml_backend_sched_graph_compute(sched, graph) ==
+                    GGML_STATUS_SUCCESS;
+            }
+        }
+        float actual = 0.0f;
+        if (ok) {
+            ggml_backend_tensor_get(output, &actual, 0, sizeof(actual));
+            ok = nearly_equal(actual, expected, 1.0e-6f, 1.0e-6f);
+        }
+        if (retire_after) {
+            ggml_backend_cuda_graph_invalidate_range(
+                gpu, arena.data(), arena.size());
+        }
+        if (sched) ggml_backend_sched_free(sched);
+        ggml_free(ctx);
+        return ok;
+    };
+
+    TEST_ASSERT_MSG(run_generation(true, 9.0f, false),
+                    "first graph generation failed");
+    TEST_ASSERT_MSG(run_generation(false, -3.0f, true),
+                    "rebuilt graph replayed stale executable");
+    ggml_backend_free(gpu);
+    std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
+}
+
 static void test_hc_scratch_shape_capacity() {
     std::fprintf(stderr, "  test_hc_scratch_shape_capacity ...");
     if (!deepseek4_cuda_hc_set_device(0)) {
@@ -3427,6 +3637,7 @@ int main() {
     test_output_graph_reuse_microbench(backend);
 #if defined(GGML_USE_CUDA) || defined(GGML_USE_HIP)
     test_ds4_flash_attention_keep_cap_gpu();
+    test_ds4_flash_attention_parallel_index_scan_gpu();
     test_ds4_flash_attention_inverse_rope_fallback_gpu();
     test_hc_post_strided_split_gpu();
     test_hc_pre_kernel_gpu();
@@ -3434,6 +3645,7 @@ int main() {
     test_hc_scratch_per_device();
     test_hc_set_device_contract();
     test_cuda_graph_overrides_restore_nested_state();
+    test_cuda_graph_rebuild_generation_guard();
     test_hc_scratch_shape_capacity();
 #endif
 


### PR DESCRIPTION
Summary:
- retire native CUDA/HIP graph executables before DS4 metadata-arena reuse
- require matching scheduler generation before forced property-check bypass
- reuse verifier mask staging and parallelize long-context HIP indexed-row compaction
- add graph-rebuild and serial-versus-parallel parity regressions to CUDA/ROCm CI

Validation:
- final commit: `be202684a497f1d90f740665b115addee40c8129`
- self-hosted RTX 3090 CUDA suite: passed, including same-address graph-generation regression
- self-hosted Radeon 8060S gfx1151 ROCm suite: passed, including graph-generation regression and exact serial/parallel attention parity
- CI run: https://github.com/Luce-Org/lucebox/actions/runs/30658811391
- full 2K -> 4K -> 8K -> 16K -> 2K model burn-in remains required before deployment; Lucebox5 was intentionally not disturbed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
