### PR TITLE
build: drop Pascal (sm_60-62) from default CUDA arch list (no WMMA)

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -190,14 +190,20 @@ option(DFLASH27B_HIP_SM80_EQUIV
 # (defaulting to gfx1151 / Strix Halo) and pass it through to the HIP
 # toolchain and ggml backend.
 if(DFLASH27B_GPU_BACKEND STREQUAL "cuda")
-    # Pascal (60/61/62), Volta (70), Turing (75) and Ampere (86) always;
+    # Pascal (60–62) lacks tensor-core WMMA support and is excluded by default.
+    # Volta/Turing (70/75) support F16 WMMA (m16n8k16); Ampere (86)+ supports
+    # BF16 WMMA (m16n16k16). Add Pascal via -DDFLASH27B_USER_CUDA_ARCHITECTURES
+    # if needed (scalar fallback kernels compile for sm_60–69).
     # Blackwell consumer (120) and Thor
     # (110 on CUDA 13+) added when nvcc supports them. DGX Spark /
     # GB10 is compute capability 12.1 (121), added at CUDA 12.9+.
     if(DFLASH27B_USER_CUDA_ARCHITECTURES)
         set(_dflash_archs "${DFLASH27B_USER_CUDA_ARCHITECTURES}")
     else()
-        set(_dflash_archs "60;61;62;70;75;86")
+        # WMMA (warp matrix multiply) requires sm_70+. Pascal (60–62) lacks
+        # tensor cores and is excluded from the default arch list. Volta/Turing
+        # (70/75) support F16 WMMA; Ampere (86)+ supports BF16 WMMA.
+        set(_dflash_archs "70;75;86")
         if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "12.8")
             list(APPEND _dflash_archs "120")
         endif()


### PR DESCRIPTION
The CUDA WMMA (warp matrix multiply) API requires sm_70+. Pascal GPUs (sm_60/61/62) have no tensor cores and lack WMMA entirely. Volta/Turing (sm_70/75) support F16 WMMA (m16n8k16) and are retained. Ampere (sm_86) and later add BF16 WMMA (m16n16k16).

Default arch list changed:
  - Before: "60;61;62;70;75;86"
  - After:  "70;75;86" (+ 120 on CUDA 12.8+, 110 on 13.0+, 121 on 12.9+)

Pascal users can opt in via:
  -DDFLASH27B_USER_CUDA_ARCHITECTURES="60;61;62;70;75;86"

The scalar fallback kernel (flashprefill_scalar.cu) still compiles for sm_60–69 when Pascal arches are explicitly requested. F16 WMMA (flashprefill_f16.cu) covers Volta/Turing; BF16 WMMA (flashprefill_kernels.cu) covers sm_80+.

No functional change for Volta/Turing/Ampere+ users.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

