### PR TITLE
fix(ds4): enable monolithic prefix cache

### DIFF
--- a/server/src/deepseek4/deepseek4_backend.cpp
+++ b/server/src/deepseek4/deepseek4_backend.cpp
@@ -22,6 +22,7 @@
 #include <cstring>
 #include <cinttypes>
 #include <limits>
+#include <new>
 
 namespace dflash::common {
 
@@ -774,6 +775,26 @@ void DeepSeek4Backend::release_spec_drafter(bool mark_parked) {
     spec_drafter_parked_ = mark_parked && !spec_draft_path_.empty();
 }
 
+void DeepSeek4Backend::keep_spec_feature_tail(
+        std::vector<float> & features, size_t max_rows) const {
+    if (!spec_drafter_) return;
+    const int feat_row = spec_drafter_->n_target_layers * w_.n_embd;
+    if (feat_row <= 0 || features.size() % (size_t) feat_row != 0) {
+        features.clear();
+        return;
+    }
+    const size_t rows = features.size() / (size_t) feat_row;
+    const size_t keep_rows = std::min(rows, max_rows);
+    if (rows == keep_rows) return;
+    const size_t keep_floats = keep_rows * (size_t) feat_row;
+    const size_t drop_floats = features.size() - keep_floats;
+    if (keep_floats > 0) {
+        std::memmove(features.data(), features.data() + drop_floats,
+                     keep_floats * sizeof(float));
+    }
+    features.resize(keep_floats);
+}
+
 bool DeepSeek4Backend::init() {
     // The shared MMVQ/MMQ crossover defaults to q=3 for NVIDIA. On gfx1151,
     // DSpark q=4 is faster through MMVQ. Keep AR and other devices unchanged,
@@ -1258,7 +1279,9 @@ bool DeepSeek4Backend::unpark(ParkTarget target) {
 
 int DeepSeek4Backend::do_prefill(const std::vector<int32_t> & tokens,
                                   const DaemonIO & io,
-                                  int kv_offset) {
+                                  int kv_offset,
+                                  int snap_slot,
+                                  int snap_pos) {
     // The all-hot layer-range path supports causal chunked prefill. The
     // optimized graph snapshots the previous raw SWA window, attends over
     // that snapshot plus the current ubatch, and commits only the final SWA
@@ -1284,6 +1307,9 @@ int DeepSeek4Backend::do_prefill(const std::vector<int32_t> & tokens,
         : std::max(1, std::min(requested_chunk,
                                layer_major_cap));
     int pos = kv_offset;
+    const bool save_snapshot =
+        snap_slot >= 0 && snap_slot < PREFIX_SLOTS &&
+        snap_pos > kv_offset && snap_pos <= kv_offset + n_total;
     // New sequence: clear the cache buffer so compressor state double-buffers
     // and compressed-KV rows start from zeros, exactly like a fresh server.
     // Without this, the first flush windows of a request pool over the
@@ -1293,19 +1319,33 @@ int DeepSeek4Backend::do_prefill(const std::vector<int32_t> & tokens,
         reset_deepseek4_cache(cache_);
     }
     last_logits_.clear();
-    int spec_capture_from = n_total;
+    int spec_final_from = n_total;
+    int spec_snap_from = n_total;
+    int spec_snap_to = 0;
+    int spec_old_rows_for_final = 0;
     if (spec_enabled_ && spec_drafter_) {
         const int feat_row = spec_drafter_->n_target_layers * w_.n_embd;
-        if (kv_offset == 0 || n_total >= w_.n_swa || feat_row <= 0 ||
+        const int snap_tokens = save_snapshot ? snap_pos - kv_offset : n_total;
+        spec_final_from = std::max(0, n_total - w_.n_swa);
+        if (save_snapshot) {
+            spec_snap_from = std::max(0, snap_tokens - w_.n_swa);
+            spec_snap_to = snap_tokens;
+        }
+        if (kv_offset == 0 || feat_row <= 0 ||
             spec_feat_window_.size() % (size_t) feat_row != 0) {
             spec_feat_window_.clear();
-            spec_capture_from = std::max(0, n_total - w_.n_swa);
         } else {
-            // Keep enough prior rows for the new prompt suffix, then append all
-            // new rows. This bounds host capture storage at n_swa without
-            // shifting a multi-megabyte feature window after every token.
+            // Preserve enough restored rows for both the requested checkpoint
+            // and the final prompt tail. The live vector is trimmed after
+            // prefill; the snapshot copy is independently trimmed at save.
             const size_t old_rows = spec_feat_window_.size() / (size_t) feat_row;
-            const size_t keep_rows = (size_t) std::max(0, w_.n_swa - n_total);
+            spec_old_rows_for_final = std::max(0, w_.n_swa - n_total);
+            const int old_rows_for_snap = save_snapshot
+                ? std::max(0, w_.n_swa - snap_tokens) : 0;
+            const size_t keep_rows = std::min(
+                old_rows,
+                (size_t) std::max(spec_old_rows_for_final,
+                                  old_rows_for_snap));
             if (old_rows > keep_rows) {
                 const size_t drop_floats = (old_rows - keep_rows) * (size_t) feat_row;
                 const size_t keep_floats = keep_rows * (size_t) feat_row;
@@ -1314,7 +1354,6 @@ int DeepSeek4Backend::do_prefill(const std::vector<int32_t> & tokens,
                              keep_floats * sizeof(float));
                 spec_feat_window_.resize(keep_floats);
             }
-            spec_capture_from = 0;
         }
     }
     const bool timing = env_flag_enabled("DFLASH_DS4_TIMING");
@@ -1322,10 +1361,17 @@ int DeepSeek4Backend::do_prefill(const std::vector<int32_t> & tokens,
     DeepSeek4StepTelemetry tel_acc;
     int steps = 0;
 
-    for (int i = 0; i < n_total; i += chunk) {
+    bool snapshot_saved = false;
+    for (int i = 0; i < n_total;) {
         if (io.cancelled) return pos;
 
-        const int n_tok = std::min(chunk, n_total - i);
+        int n_tok = std::min(chunk, n_total - i);
+        // A snapshot must represent an exact token boundary. Split a batched
+        // prefill chunk when the requested boundary falls inside it.
+        if (save_snapshot && !snapshot_saved &&
+            snap_pos > pos && snap_pos < pos + n_tok) {
+            n_tok = snap_pos - pos;
+        }
 
         // Embed tokens
         std::vector<float> embed(w_.n_embd * n_tok);
@@ -1340,7 +1386,12 @@ int DeepSeek4Backend::do_prefill(const std::vector<int32_t> & tokens,
         Ds4VerifyHooks spec_hooks;
         std::vector<float> spec_cap;
         Ds4VerifyHooks * hp = nullptr;
-        if (spec_enabled_ && spec_drafter_ && i + n_tok > spec_capture_from) {
+        const bool capture_final = i + n_tok > spec_final_from;
+        const bool capture_snapshot =
+            !snapshot_saved && i < spec_snap_to &&
+            i + n_tok > spec_snap_from;
+        if (spec_enabled_ && spec_drafter_ &&
+            (capture_final || capture_snapshot)) {
             spec_hooks.capture_layer_ids = &spec_drafter_->capture_layer_ids;
             spec_hooks.capture_out = &spec_cap;
             hp = &spec_hooks;
@@ -1374,8 +1425,13 @@ int DeepSeek4Backend::do_prefill(const std::vector<int32_t> & tokens,
         }
         if (ok && hp && !spec_cap.empty()) {
             const int feat_row = spec_drafter_->n_target_layers * w_.n_embd;
-            const int first_capture = std::max(0, spec_capture_from - i);
-            for (int t = first_capture; t < n_tok; ++t) {
+            for (int t = 0; t < n_tok; ++t) {
+                const int token_index = i + t;
+                const bool keep_for_final = token_index >= spec_final_from;
+                const bool keep_for_snapshot =
+                    !snapshot_saved && token_index >= spec_snap_from &&
+                    token_index < spec_snap_to;
+                if (!keep_for_final && !keep_for_snapshot) continue;
                 spec_feat_window_.insert(spec_feat_window_.end(),
                     spec_cap.begin() + (size_t) t * feat_row,
                     spec_cap.begin() + (size_t) (t + 1) * feat_row);
@@ -1391,7 +1447,30 @@ int DeepSeek4Backend::do_prefill(const std::vector<int32_t> & tokens,
         }
         last_logits_ = std::move(logits);
         pos += n_tok;
+        i += n_tok;
+        if (save_snapshot && !snapshot_saved && pos == snap_pos) {
+            snapshot_saved = snapshot_save(snap_slot);
+            if (!snapshot_saved) {
+                std::fprintf(stderr,
+                             "[deepseek4] failed to save snapshot slot=%d pos=%d\n",
+                             snap_slot, snap_pos);
+            } else if (spec_enabled_ && spec_drafter_) {
+                // Discard checkpoint-only rows once their snapshot is saved.
+                // Retain just the already-captured prefix of the final SWA
+                // window, so distant checkpoints do not bridge a huge gap in
+                // host feature memory.
+                const int processed = i;
+                const int final_new_rows =
+                    std::max(0, processed - spec_final_from);
+                keep_spec_feature_tail(
+                    spec_feat_window_,
+                    (size_t) spec_old_rows_for_final +
+                    (size_t) final_new_rows);
+            }
+        }
     }
+    keep_spec_feature_tail(spec_feat_window_,
+                           (size_t) std::max(0, w_.n_swa));
     if (timing) {
         log_step_tel("prefill", n_total, steps, elapsed_s(phase_t0), tel_acc);
     }
@@ -1522,6 +1601,11 @@ bool DeepSeek4Backend::do_decode(int committed, int n_gen,
 
 GenerateResult DeepSeek4Backend::generate_impl(const GenerateRequest & req,
                                                 const DaemonIO & io) {
+    return generate_from_state(req, io, 0);
+}
+
+GenerateResult DeepSeek4Backend::generate_from_state(
+        const GenerateRequest & req, const DaemonIO & io, int kv_offset) {
     GenerateResult result;
     DaemonIO out_io = io.with_token_callback(req.on_token);
     auto t0 = Clock::now();
@@ -1530,8 +1614,25 @@ GenerateResult DeepSeek4Backend::generate_impl(const GenerateRequest & req,
         sampler_rng_.seed(sampler_.seed);
     }
 
-    // Prefill
-    int committed = do_prefill(req.prompt, out_io);
+    if (kv_offset < 0 || kv_offset > (int) req.prompt.size()) {
+        result.fail(GenerateErrorCode::PrefillFailed,
+                    "restored prefix exceeds prompt length");
+        return result;
+    }
+
+    // Prefill only the suffix that is not already represented by a restored
+    // snapshot. An exact full-prompt hit can decode immediately from the
+    // logits and speculative feature window saved with the cache state.
+    int committed = kv_offset;
+    if (kv_offset == 0) {
+        committed = do_prefill(req.prompt, out_io, 0,
+                               req.snap_slot, req.snap_pos);
+    } else if (kv_offset < (int) req.prompt.size()) {
+        std::vector<int32_t> suffix(req.prompt.begin() + kv_offset,
+                                    req.prompt.end());
+        committed = do_prefill(suffix, out_io, kv_offset,
+                               req.snap_slot, req.snap_pos);
+    }
     if (committed < 0) {
         result.fail(GenerateErrorCode::PrefillFailed);
         return result;
@@ -1627,19 +1728,53 @@ GenerateResult DeepSeek4Backend::generate_impl(const GenerateRequest & req,
 // ── Snapshots ───────────────────────────────────────────────────────────
 
 bool DeepSeek4Backend::snapshot_save(int slot) {
-    if (slot < 0 || slot >= PREFIX_SLOTS) return false;
-    // TODO: Implement snapshot save (copy KV cache + HC state to CPU)
-    return false;
+    if (slot < 0 || slot >= PREFIX_SLOTS || !snap_backend_ ||
+        cache_.cur_pos <= 0 || last_logits_.empty()) {
+        return false;
+    }
+
+    snapshot_free(slot);
+    if (!deepseek4_snapshot_save(cache_, snap_backend_, snapshots_[slot])) {
+        return false;
+    }
+
+    try {
+        auto & aux = snapshot_aux_[slot];
+        aux.last_logits = last_logits_;
+        aux.spec_feat_window = spec_feat_window_;
+        keep_spec_feature_tail(aux.spec_feat_window,
+                               (size_t) std::max(0, w_.n_swa));
+        aux.used = true;
+    } catch (const std::bad_alloc &) {
+        snapshot_free(slot);
+        return false;
+    }
+
+    const size_t core_bytes = snapshots_[slot].buf
+        ? ggml_backend_buffer_get_size(snapshots_[slot].buf) : 0;
+    const size_t aux_bytes =
+        (snapshot_aux_[slot].last_logits.size() +
+         snapshot_aux_[slot].spec_feat_window.size()) * sizeof(float);
+    std::fprintf(stderr,
+                 "[deepseek4] snapshot saved slot=%d pos=%d size=%.1f MiB\n",
+                 slot, snapshots_[slot].cur_pos,
+                 (double) (core_bytes + aux_bytes) / (1024.0 * 1024.0));
+    return true;
 }
 
 void DeepSeek4Backend::snapshot_free(int slot) {
     if (slot < 0 || slot >= PREFIX_SLOTS) return;
     free_deepseek4_snapshot(snapshots_[slot]);
+    snapshot_aux_[slot] = SnapshotAux{};
 }
 
 bool DeepSeek4Backend::snapshot_used(int slot) const {
     if (slot < 0 || slot >= PREFIX_SLOTS) return false;
-    return snapshots_[slot].ctx != nullptr;
+    const auto & snap = snapshots_[slot];
+    const auto & aux = snapshot_aux_[slot];
+    return snap.ctx != nullptr && snap.buf != nullptr && snap.cur_pos > 0 &&
+           aux.used && w_.n_vocab > 0 &&
+           aux.last_logits.size() == (size_t) w_.n_vocab;
 }
 
 int DeepSeek4Backend::snapshot_cur_pos(int slot) const {
@@ -1647,11 +1782,47 @@ int DeepSeek4Backend::snapshot_cur_pos(int slot) const {
     return snapshots_[slot].cur_pos;
 }
 
+bool DeepSeek4Backend::snapshot_restore(int slot) {
+    if (!snapshot_used(slot)) return false;
+
+    std::vector<float> restored_logits;
+    std::vector<float> restored_features;
+    try {
+        restored_logits = snapshot_aux_[slot].last_logits;
+        restored_features = snapshot_aux_[slot].spec_feat_window;
+    } catch (const std::bad_alloc &) {
+        return false;
+    }
+
+    if (!deepseek4_snapshot_restore(snapshots_[slot], cache_)) {
+        return false;
+    }
+    last_logits_ = std::move(restored_logits);
+    spec_feat_window_ = std::move(restored_features);
+    return true;
+}
+
 GenerateResult DeepSeek4Backend::restore_and_generate_impl(
         int slot, const GenerateRequest & req, const DaemonIO & io) {
-    // TODO: Implement snapshot restore + generate
-    (void)slot;
-    return generate_impl(req, io);
+    GenerateResult result;
+    if (!snapshot_used(slot)) {
+        result.fail(GenerateErrorCode::InvalidSnapshotSlot);
+        return result;
+    }
+
+    const int snap_pos = snapshot_cur_pos(slot);
+    if (snap_pos > (int) req.prompt.size()) {
+        std::fprintf(stderr,
+                     "[pc] DeepSeek snapshot longer than prompt "
+                     "(snap=%d > prompt=%zu) -- fresh prefill fallback\n",
+                     snap_pos, req.prompt.size());
+        return generate_impl(req, io);
+    }
+    if (!snapshot_restore(slot)) {
+        result.fail(GenerateErrorCode::BackendSpecific, "snapshot restore");
+        return result;
+    }
+    return generate_from_state(req, io, snap_pos);
 }
 
 bool DeepSeek4Backend::handle_compress(const std::string & line,
@@ -1680,7 +1851,7 @@ void DeepSeek4Backend::shutdown() {
     maybe_save_routing_stats();
     free_drafter();
     for (int i = 0; i < PREFIX_SLOTS; i++) {
-        free_deepseek4_snapshot(snapshots_[i]);
+        snapshot_free(i);
     }
     free_deepseek4_cache(cache_);
     expert_runtime_.reset();

--- a/server/src/deepseek4/deepseek4_backend.cpp
+++ b/server/src/deepseek4/deepseek4_backend.cpp
@@ -1176,9 +1176,10 @@ bool DeepSeek4Backend::park(ParkTarget target) {
 
     maybe_save_routing_stats();
     for (int i = 0; i < PREFIX_SLOTS; ++i) {
-        free_deepseek4_snapshot(snapshots_[i]);
+        snapshot_free(i);
     }
     last_logits_.clear();
+    last_logits_pos_ = -1;
     free_deepseek4_cache(cache_);
     expert_runtime_.reset();
     stream_engine_.destroy();
@@ -1319,6 +1320,7 @@ int DeepSeek4Backend::do_prefill(const std::vector<int32_t> & tokens,
         reset_deepseek4_cache(cache_);
     }
     last_logits_.clear();
+    last_logits_pos_ = -1;
     int spec_final_from = n_total;
     int spec_snap_from = n_total;
     int spec_snap_to = 0;
@@ -1447,6 +1449,7 @@ int DeepSeek4Backend::do_prefill(const std::vector<int32_t> & tokens,
         }
         last_logits_ = std::move(logits);
         pos += n_tok;
+        last_logits_pos_ = cache_.cur_pos;
         i += n_tok;
         if (save_snapshot && !snapshot_saved && pos == snap_pos) {
             snapshot_saved = snapshot_save(snap_slot);
@@ -1584,6 +1587,13 @@ bool DeepSeek4Backend::do_decode(int committed, int n_gen,
         if (process_logits) {
             history.push_back(next_token);
         }
+        if (generated > 0) {
+            // The forward above advanced cache_ through the previously
+            // emitted token. Retain its logits so a later manual/continued
+            // snapshot can resume at exactly cache_.cur_pos.
+            last_logits_ = std::move(logits);
+            last_logits_pos_ = cache_.cur_pos;
+        }
         out_tokens.push_back(next_token);
         const auto emit_t0 = Clock::now();
         io.emit(next_token);
@@ -1676,6 +1686,10 @@ GenerateResult DeepSeek4Backend::generate_from_state(
             const int win_len = feat_row > 0 ? (int) (spec_feat_window_.size() / feat_row) : 0;
             std::vector<int32_t> spec_toks;
             spec_ran = true;
+            // The DSpark API does not return the final target logits. Once it
+            // advances the target cache, reject post-decode snapshots rather
+            // than pairing that state with stale prefill logits.
+            last_logits_pos_ = -1;
             if (!run_deepseek4_dspark_spec_decode(
                     backend_, cfg_.device.gpu, w_, cache_, *spec_drafter_, committed, seed,
                     req.n_gen - 1,
@@ -1729,7 +1743,9 @@ GenerateResult DeepSeek4Backend::generate_from_state(
 
 bool DeepSeek4Backend::snapshot_save(int slot) {
     if (slot < 0 || slot >= PREFIX_SLOTS || !snap_backend_ ||
-        cache_.cur_pos <= 0 || last_logits_.empty()) {
+        cache_.cur_pos <= 0 || last_logits_pos_ != cache_.cur_pos ||
+        w_.n_vocab <= 0 ||
+        last_logits_.size() != (size_t) w_.n_vocab) {
         return false;
     }
 
@@ -1799,6 +1815,7 @@ bool DeepSeek4Backend::snapshot_restore(int slot) {
     }
     last_logits_ = std::move(restored_logits);
     spec_feat_window_ = std::move(restored_features);
+    last_logits_pos_ = cache_.cur_pos;
     return true;
 }
 

--- a/server/src/deepseek4/deepseek4_backend.h
+++ b/server/src/deepseek4/deepseek4_backend.h
@@ -88,6 +88,9 @@ private:
     DeepSeek4Snapshot      snapshots_[PREFIX_SLOTS];
     SnapshotAux            snapshot_aux_[PREFIX_SLOTS];
     std::vector<float>     last_logits_;
+    // Absolute cache position represented by last_logits_. A snapshot is
+    // safe only when this matches cache_.cur_pos.
+    int                    last_logits_pos_ = -1;
 
     // DSpark speculative decode (opt-in: DFLASH_DS4_SPEC=1 + DFLASH_DS4_DRAFT=<gguf>).
     bool                           spec_enabled_ = false;

--- a/server/src/deepseek4/deepseek4_backend.h
+++ b/server/src/deepseek4/deepseek4_backend.h
@@ -80,7 +80,13 @@ private:
 
     // Snapshots
     static constexpr int PREFIX_SLOTS = 64;
+    struct SnapshotAux {
+        std::vector<float> last_logits;
+        std::vector<float> spec_feat_window;
+        bool used = false;
+    };
     DeepSeek4Snapshot      snapshots_[PREFIX_SLOTS];
+    SnapshotAux            snapshot_aux_[PREFIX_SLOTS];
     std::vector<float>     last_logits_;
 
     // DSpark speculative decode (opt-in: DFLASH_DS4_SPEC=1 + DFLASH_DS4_DRAFT=<gguf>).
@@ -93,10 +99,20 @@ private:
 
     bool load_spec_drafter();
     void release_spec_drafter(bool mark_parked);
+    void keep_spec_feature_tail(std::vector<float> & features,
+                                size_t max_rows) const;
 
     // Prefill prompt tokens in chunks, return absolute committed position.
     int do_prefill(const std::vector<int32_t> & tokens, const DaemonIO & io,
-                   int kv_offset = 0);
+                   int kv_offset = 0, int snap_slot = -1, int snap_pos = -1);
+
+    // Generate after either a fresh prefill or a restored prefix. kv_offset is
+    // the number of prompt tokens already represented by cache_ and the
+    // auxiliary logits/speculative state.
+    GenerateResult generate_from_state(const GenerateRequest & req,
+                                       const DaemonIO & io,
+                                       int kv_offset);
+    bool snapshot_restore(int slot);
 
     // Autoregressive decode loop.
     bool do_decode(int committed, int n_gen,

--- a/server/src/deepseek4/deepseek4_graph.cpp
+++ b/server/src/deepseek4/deepseek4_graph.cpp
@@ -7835,6 +7835,49 @@ ggml_tensor * clone_snapshot_tensor(ggml_context * ctx,
     return dst;
 }
 
+ggml_tensor * clone_snapshot_rows(ggml_context * ctx,
+                                  const ggml_tensor * src,
+                                  int live_rows,
+                                  const char * name) {
+    if (!ctx || !src || ggml_n_dims(src) != 2 || live_rows < 0 ||
+        live_rows > src->ne[1]) {
+        return nullptr;
+    }
+    // GGML tensors cannot have an empty physical dimension. Keep one
+    // allocated row for an empty logical prefix, but copy zero bytes below.
+    const int64_t allocated_rows = std::max(1, live_rows);
+    ggml_tensor * dst = ggml_new_tensor_2d(
+        ctx, src->type, src->ne[0], allocated_rows);
+    if (!dst) return nullptr;
+    if (name && *name) ggml_set_name(dst, name);
+    return dst;
+}
+
+size_t tensor_prefix_bytes(const ggml_tensor * tensor, int rows) {
+    if (!tensor || rows <= 0) return 0;
+    return ggml_row_size(tensor->type, tensor->ne[0]) * (size_t) rows;
+}
+
+bool copy_tensor_prefix_from_backend(const ggml_tensor * src,
+                                     ggml_tensor * dst,
+                                     int rows) {
+    if (!src || !dst || rows < 0) return false;
+    const size_t bytes = tensor_prefix_bytes(src, rows);
+    if (bytes > ggml_nbytes(src) || bytes > ggml_nbytes(dst)) return false;
+    if (bytes > 0) ggml_backend_tensor_get(src, dst->data, 0, bytes);
+    return true;
+}
+
+bool copy_tensor_prefix_to_backend(const ggml_tensor * src,
+                                   ggml_tensor * dst,
+                                   int rows) {
+    if (!src || !dst || rows < 0) return false;
+    const size_t bytes = tensor_prefix_bytes(src, rows);
+    if (bytes > ggml_nbytes(src) || bytes > ggml_nbytes(dst)) return false;
+    if (bytes > 0) ggml_backend_tensor_set(dst, src->data, 0, bytes);
+    return true;
+}
+
 bool copy_tensor_from_backend(const ggml_tensor * src, ggml_tensor * dst) {
     if (!src || !dst) return false;
     const size_t bytes = ggml_nbytes(src);
@@ -7861,14 +7904,44 @@ bool tensors_compatible(const ggml_tensor * a, const ggml_tensor * b) {
     return true;
 }
 
+bool prefix_tensors_compatible(const ggml_tensor * snap,
+                               const ggml_tensor * cache,
+                               int live_rows) {
+    if (!!snap != !!cache) return false;
+    if (!snap) return live_rows == 0;
+    // A right-sized zero/one-row tensor reports one logical GGML dimension,
+    // while its full-capacity cache tensor reports two. Compare the physical
+    // row layout instead of ggml_n_dims() so those valid snapshots restore.
+    if (live_rows < 0 || cache->ne[1] <= 0 ||
+        snap->type != cache->type ||
+        snap->ne[0] != cache->ne[0] || live_rows > cache->ne[1]) {
+        return false;
+    }
+    for (int i = 2; i < GGML_MAX_DIMS; ++i) {
+        if (snap->ne[i] != cache->ne[i]) return false;
+    }
+    return snap->ne[1] == std::max(1, live_rows);
+}
+
 }  // namespace
 
 bool deepseek4_snapshot_save(const DeepSeek4Cache & cache,
                              ggml_backend_t snapshot_backend,
                              DeepSeek4Snapshot & out) {
     if (!snapshot_backend || !cache.ctx || !cache.buf || !cache.hc_state ||
-        cache.layers.size() != (size_t)cache.n_layer) {
+        cache.layers.size() != (size_t)cache.n_layer || cache.cur_pos < 0 ||
+        cache.cur_pos > cache.max_ctx) {
         return false;
+    }
+    for (const auto & layer : cache.layers) {
+        if (layer.n_comp < 0 || layer.n_index_comp < 0 ||
+            (layer.comp_kv && layer.n_comp > layer.comp_kv->ne[1]) ||
+            (!layer.comp_kv && layer.n_comp != 0) ||
+            (layer.index_comp_kv &&
+             layer.n_index_comp > layer.index_comp_kv->ne[1]) ||
+            (!layer.index_comp_kv && layer.n_index_comp != 0)) {
+            return false;
+        }
     }
 
     free_deepseek4_snapshot(out);
@@ -7892,8 +7965,13 @@ bool deepseek4_snapshot_save(const DeepSeek4Cache & cache,
         const auto & src = cache.layers[(size_t)il];
         auto & dst = out.layers[(size_t)il];
         dst.raw_kv = clone_snapshot_tensor(out.ctx, src.raw_kv, nullptr);
-        dst.comp_kv = clone_snapshot_tensor(out.ctx, src.comp_kv, nullptr);
-        dst.index_comp_kv = clone_snapshot_tensor(out.ctx, src.index_comp_kv, nullptr);
+        dst.comp_kv = src.comp_kv
+            ? clone_snapshot_rows(out.ctx, src.comp_kv, src.n_comp, nullptr)
+            : nullptr;
+        dst.index_comp_kv = src.index_comp_kv
+            ? clone_snapshot_rows(out.ctx, src.index_comp_kv,
+                                  src.n_index_comp, nullptr)
+            : nullptr;
         dst.attn_compressor.state_kv =
             clone_snapshot_tensor(out.ctx, src.attn_compressor.state_kv, nullptr);
         dst.attn_compressor.state_score =
@@ -7930,9 +8008,13 @@ bool deepseek4_snapshot_save(const DeepSeek4Cache & cache,
         dst.n_comp = src.n_comp;
         dst.n_index_comp = src.n_index_comp;
         if (!copy_tensor_from_backend(src.raw_kv, dst.raw_kv) ||
-            (src.comp_kv && !copy_tensor_from_backend(src.comp_kv, dst.comp_kv)) ||
+            (src.comp_kv &&
+             !copy_tensor_prefix_from_backend(src.comp_kv, dst.comp_kv,
+                                              src.n_comp)) ||
             (src.index_comp_kv &&
-             !copy_tensor_from_backend(src.index_comp_kv, dst.index_comp_kv)) ||
+             !copy_tensor_prefix_from_backend(src.index_comp_kv,
+                                              dst.index_comp_kv,
+                                              src.n_index_comp)) ||
             (src.attn_compressor.state_kv &&
              !copy_tensor_from_backend(src.attn_compressor.state_kv,
                                        dst.attn_compressor.state_kv)) ||
@@ -7957,30 +8039,79 @@ bool deepseek4_snapshot_save(const DeepSeek4Cache & cache,
 bool deepseek4_snapshot_restore(const DeepSeek4Snapshot & snap,
                                 DeepSeek4Cache & cache) {
     if (!snap.ctx || !cache.ctx || !cache.buf || !snap.hc_state_snap ||
-        snap.layers.size() != cache.layers.size()) {
+        snap.layers.size() != cache.layers.size() || snap.cur_pos < 0 ||
+        snap.cur_pos > cache.max_ctx) {
+        std::fprintf(stderr,
+                     "[deepseek4] snapshot restore: invalid header "
+                     "(snap_ctx=%d cache_ctx=%d snap_layers=%zu "
+                     "cache_layers=%zu pos=%d max_ctx=%d)\n",
+                     snap.ctx != nullptr, cache.ctx != nullptr,
+                     snap.layers.size(), cache.layers.size(),
+                     snap.cur_pos, cache.max_ctx);
         return false;
     }
-    if (!tensors_compatible(snap.hc_state_snap, cache.hc_state) ||
-        !copy_tensor_to_backend(snap.hc_state_snap, cache.hc_state)) {
+    if (!tensors_compatible(snap.hc_state_snap, cache.hc_state)) {
+        std::fprintf(stderr,
+                     "[deepseek4] snapshot restore: incompatible HC state\n");
         return false;
     }
 
+    // Validate the complete layout before changing the live cache. Compressed
+    // tensors are deliberately right-sized to their logical row counts;
+    // inactive capacity rows are not part of the snapshot contract.
+    for (size_t il = 0; il < cache.layers.size(); ++il) {
+        const auto & src = snap.layers[il];
+        const auto & dst = cache.layers[il];
+        const bool raw_ok = tensors_compatible(src.raw_kv, dst.raw_kv);
+        const bool comp_ok = prefix_tensors_compatible(
+            src.comp_kv, dst.comp_kv, src.n_comp);
+        const bool index_ok = prefix_tensors_compatible(
+            src.index_comp_kv, dst.index_comp_kv, src.n_index_comp);
+        const bool attn_kv_ok = tensors_compatible(
+            src.attn_compressor.state_kv, dst.attn_compressor.state_kv);
+        const bool attn_score_ok = tensors_compatible(
+            src.attn_compressor.state_score, dst.attn_compressor.state_score);
+        const bool index_kv_ok = tensors_compatible(
+            src.indexer_compressor.state_kv, dst.indexer_compressor.state_kv);
+        const bool index_score_ok = tensors_compatible(
+            src.indexer_compressor.state_score,
+            dst.indexer_compressor.state_score);
+        if (!raw_ok || !comp_ok || !index_ok || !attn_kv_ok ||
+            !attn_score_ok || !index_kv_ok || !index_score_ok) {
+            std::fprintf(stderr,
+                         "[deepseek4] snapshot restore: incompatible layer %zu "
+                         "(raw=%d comp=%d[%d/%lld/%lld] "
+                         "index=%d[%d/%lld/%lld] states=%d/%d/%d/%d)\n",
+                         il, raw_ok, comp_ok, src.n_comp,
+                         (long long) (src.comp_kv ? src.comp_kv->ne[1] : 0),
+                         (long long) (dst.comp_kv ? dst.comp_kv->ne[1] : 0),
+                         index_ok, src.n_index_comp,
+                         (long long) (src.index_comp_kv
+                             ? src.index_comp_kv->ne[1] : 0),
+                         (long long) (dst.index_comp_kv
+                             ? dst.index_comp_kv->ne[1] : 0),
+                         attn_kv_ok, attn_score_ok,
+                         index_kv_ok, index_score_ok);
+            return false;
+        }
+    }
+
+    if (!copy_tensor_to_backend(snap.hc_state_snap, cache.hc_state)) {
+        std::fprintf(stderr,
+                     "[deepseek4] snapshot restore: HC copy failed\n");
+        return false;
+    }
     for (size_t il = 0; il < cache.layers.size(); ++il) {
         const auto & src = snap.layers[il];
         auto & dst = cache.layers[il];
-        if (!tensors_compatible(src.raw_kv, dst.raw_kv) ||
-            !tensors_compatible(src.comp_kv, dst.comp_kv) ||
-            !tensors_compatible(src.index_comp_kv, dst.index_comp_kv) ||
-            !tensors_compatible(src.attn_compressor.state_kv, dst.attn_compressor.state_kv) ||
-            !tensors_compatible(src.attn_compressor.state_score, dst.attn_compressor.state_score) ||
-            !tensors_compatible(src.indexer_compressor.state_kv, dst.indexer_compressor.state_kv) ||
-            !tensors_compatible(src.indexer_compressor.state_score, dst.indexer_compressor.state_score)) {
-            return false;
-        }
         if (!copy_tensor_to_backend(src.raw_kv, dst.raw_kv) ||
-            (src.comp_kv && !copy_tensor_to_backend(src.comp_kv, dst.comp_kv)) ||
+            (src.comp_kv &&
+             !copy_tensor_prefix_to_backend(src.comp_kv, dst.comp_kv,
+                                            src.n_comp)) ||
             (src.index_comp_kv &&
-             !copy_tensor_to_backend(src.index_comp_kv, dst.index_comp_kv)) ||
+             !copy_tensor_prefix_to_backend(src.index_comp_kv,
+                                            dst.index_comp_kv,
+                                            src.n_index_comp)) ||
             (src.attn_compressor.state_kv &&
              !copy_tensor_to_backend(src.attn_compressor.state_kv,
                                      dst.attn_compressor.state_kv)) ||
@@ -7992,7 +8123,10 @@ bool deepseek4_snapshot_restore(const DeepSeek4Snapshot & snap,
                                      dst.indexer_compressor.state_kv)) ||
             (src.indexer_compressor.state_score &&
              !copy_tensor_to_backend(src.indexer_compressor.state_score,
-                                     dst.indexer_compressor.state_score))) {
+                                       dst.indexer_compressor.state_score))) {
+            std::fprintf(stderr,
+                         "[deepseek4] snapshot restore: layer %zu copy failed\n",
+                         il);
             return false;
         }
         dst.n_comp = src.n_comp;

--- a/server/src/server/disk_prefix_cache.cpp
+++ b/server/src/server/disk_prefix_cache.cpp
@@ -252,7 +252,15 @@ void DiskPrefixCache::learn_layout(int slot) {
     if (layout_known_ && !layout_from_disk_) return;  // already verified from live model
 
     auto ref = backend_.snapshot_ref(slot);
-    if (!ref.ctx) return;
+    if (!ref.ctx) {
+        if (backend_.snapshot_used(slot)) {
+            backend_snapshot_unsupported_ = true;
+            std::fprintf(stderr,
+                         "[disk-cache] disabled: backend snapshots are "
+                         "memory-only\n");
+        }
+        return;
+    }
 
     std::array<uint8_t, 16> prev_id = layout_id_;
     bool had_disk_layout = layout_from_disk_;

--- a/server/src/server/disk_prefix_cache.h
+++ b/server/src/server/disk_prefix_cache.h
@@ -113,7 +113,9 @@ public:
     DiskPrefixCache(const DiskPrefixCache &) = delete;
     DiskPrefixCache & operator=(const DiskPrefixCache &) = delete;
 
-    bool disabled() const { return config_.cache_dir.empty(); }
+    bool disabled() const {
+        return config_.cache_dir.empty() || backend_snapshot_unsupported_;
+    }
 
     // Initialize: create directory, scan existing files, learn layout from
     // first available snapshot. Returns false on fatal error.
@@ -170,6 +172,10 @@ public:
 private:
     DiskCacheConfig config_;
     ModelBackend &  backend_;
+    // Some backends support in-memory snapshots but deliberately do not
+    // implement SnapshotRef/adoption. Detect that once from a live slot and
+    // stop scheduling disk work for the rest of the process.
+    bool backend_snapshot_unsupported_ = false;
 
     // Continued checkpoint tracking (per-session).
     int continued_last_store_pos_ = 0;

--- a/server/src/server/prefix_cache.cpp
+++ b/server/src/server/prefix_cache.cpp
@@ -13,6 +13,27 @@ namespace dflash::common {
 // ─── Chat marker resolution ────────────────────────────────────────────
 
 bool resolve_chat_markers(const Tokenizer & tok, ChatMarkers & out) {
+    // DeepSeek V4 uses full-width punctuation in its control tokens. Require
+    // each marker to encode as its exact vocabulary token so an unrelated BPE
+    // tokenizer cannot be misclassified merely because it can spell the text.
+    const auto exact_control_token = [&tok](const char * marker) -> int32_t {
+        const int32_t id = tok.token_to_id(marker);
+        if (id < 0) return -1;
+        const auto encoded = tok.encode(marker);
+        return encoded.size() == 1 && encoded[0] == id ? id : -1;
+    };
+    const int32_t ds_bos = exact_control_token("<｜begin▁of▁sentence｜>");
+    const int32_t ds_eos = exact_control_token("<｜end▁of▁sentence｜>");
+    const int32_t ds_user = exact_control_token("<｜User｜>");
+    const int32_t ds_assistant = exact_control_token("<｜Assistant｜>");
+    if (ds_bos >= 0 && ds_eos >= 0 && ds_user >= 0 && ds_assistant >= 0) {
+        out.family = "deepseek";
+        out.sys_role_prefix = {ds_bos};
+        out.end_msg_seqs = {{ds_eos}};
+        out.next_role_starts = {{ds_user}, {ds_assistant}};
+        return true;
+    }
+
     // Try Qwen family: <|im_end|> and <|im_start|> should be single tokens.
     auto im_end = tok.encode("<|im_end|>");
     auto im_start = tok.encode("<|im_start|>");

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -1713,6 +1713,57 @@ TEST_CASE(ServerUnitFixture, test_stop_sequence_holdback_extends) {
 // Prefix cache hash tests (model-free)
 // ═══════════════════════════════════════════════════════════════════════
 
+static std::string write_deepseek_marker_tokenizer_fixture() {
+    gguf_context * g = gguf_init_empty();
+    const char * tokens[] = {
+        "x",
+        "<｜begin▁of▁sentence｜>",
+        "<｜end▁of▁sentence｜>",
+        "<｜User｜>",
+        "<｜Assistant｜>",
+    };
+    const uint32_t token_types[] = {1, 3, 3, 3, 3};
+    gguf_set_arr_str(g, "tokenizer.ggml.tokens", tokens,
+                     sizeof(tokens) / sizeof(tokens[0]));
+    gguf_set_arr_data(g, "tokenizer.ggml.token_type", GGUF_TYPE_UINT32,
+                      token_types,
+                      sizeof(token_types) / sizeof(token_types[0]));
+    gguf_set_val_str(g, "tokenizer.ggml.model", "gpt2");
+    gguf_set_val_str(g, "tokenizer.ggml.pre", "qwen35");
+    gguf_set_val_u32(g, "tokenizer.ggml.bos_token_id", 1);
+    gguf_set_val_u32(g, "tokenizer.ggml.eos_token_id", 2);
+
+    const std::string path = "/tmp/dflash_test_deepseek_markers.gguf";
+    gguf_write_to_file(g, path.c_str(), /*only_meta=*/false);
+    gguf_free(g);
+    return path;
+}
+
+TEST_CASE(ServerUnitFixture, test_resolve_deepseek_chat_markers) {
+    const std::string path = write_deepseek_marker_tokenizer_fixture();
+    Tokenizer tokenizer;
+    TEST_ASSERT(tokenizer.load_from_gguf(path.c_str()));
+
+    ChatMarkers markers;
+    TEST_ASSERT(resolve_chat_markers(tokenizer, markers));
+    TEST_ASSERT(markers.family == "deepseek");
+    TEST_ASSERT(markers.sys_role_prefix == std::vector<int32_t>({1}));
+    TEST_ASSERT(markers.end_msg_seqs ==
+                std::vector<std::vector<int32_t>>({{2}}));
+    TEST_ASSERT(markers.next_role_starts ==
+                std::vector<std::vector<int32_t>>({{3}, {4}}));
+
+    // Completed assistant turn followed by the next user marker. The reusable
+    // boundary includes that role marker, matching the server's other chat
+    // families and leaving only the new user content for suffix prefill.
+    const std::vector<int32_t> prompt = {
+        1, 100, 3, 101, 4, 102, 2, 3, 103, 4,
+    };
+    TEST_ASSERT(find_all_boundaries(prompt, markers) ==
+                std::vector<int>({8}));
+    unlink(path.c_str());
+}
+
 TEST_CASE(ServerUnitFixture, test_hash_prefix_deterministic) {
     std::vector<int32_t> ids = {100, 200, 300, 400, 500};
     auto h1 = hash_prefix(ids.data(), (int)ids.size());

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -2913,6 +2913,10 @@ struct MockBackend : ModelBackend {
     void shutdown() override {}
 };
 
+struct MockMemoryOnlySnapshotBackend : MockBackend {
+    bool snapshot_used(int slot) const override { return slot == 0; }
+};
+
 // ─── MockBackendWithLayout ──────────────────────────────────────────────
 // Extends MockBackend with a real ggml_context so DiskPrefixCache can
 // iterate tensors in compute_layout_id and write a real .dkv file.
@@ -3118,6 +3122,19 @@ TEST_CASE(ServerUnitFixture, test_disk_cache_disabled_when_no_dir) {
     std::vector<int32_t> ids = {1, 2, 3, 4, 5};
     TEST_ASSERT(!cache.lookup(ids, 0));
     TEST_ASSERT(!cache.save(0, ids));
+}
+
+TEST_CASE(ServerUnitFixture, test_disk_cache_disables_memory_only_backend) {
+    MockMemoryOnlySnapshotBackend backend;
+    DiskCacheConfig cfg;
+    cfg.cache_dir = "/tmp/dflash_test_disk_cache_memory_only";
+    DiskPrefixCache cache(cfg, backend);
+    TEST_ASSERT(!cache.disabled());
+
+    // A live in-memory snapshot with no SnapshotRef means this backend cannot
+    // serialize or adopt disk entries. Detect it once and skip later disk work.
+    cache.learn_layout(0);
+    TEST_ASSERT(cache.disabled());
 }
 
 TEST_CASE(ServerUnitFixture, test_disk_cache_init_creates_directory) {

--- a/server/tests/test_deepseek4_unit.cpp
+++ b/server/tests/test_deepseek4_unit.cpp
@@ -1873,6 +1873,7 @@ static void test_monolithic_snapshot_preserves_decode_state() {
     layer.n_index_comp = 3;
     backend.cache_.cur_pos = 7;
     backend.last_logits_ = {1.0f, 4.0f, 2.0f};
+    backend.last_logits_pos_ = 7;
     backend.spec_feat_window_ = {9.0f, 8.0f, 7.0f, 6.0f};
 
     const auto raw_before = read_tensor_bytes(layer.raw_kv);
@@ -1892,6 +1893,7 @@ static void test_monolithic_snapshot_preserves_decode_state() {
     layer.n_comp = 0;
     layer.n_index_comp = 0;
     backend.last_logits_ = {-1.0f};
+    backend.last_logits_pos_ = -1;
     backend.spec_feat_window_.clear();
 
     TEST_ASSERT(backend.snapshot_restore(0));
@@ -1905,21 +1907,33 @@ static void test_monolithic_snapshot_preserves_decode_state() {
     TEST_ASSERT(backend.last_logits_ == std::vector<float>({1.0f, 4.0f, 2.0f}));
     TEST_ASSERT(backend.spec_feat_window_ ==
                 std::vector<float>({9.0f, 8.0f, 7.0f, 6.0f}));
+    TEST_ASSERT(backend.last_logits_pos_ == 7);
 
     GenerateRequest exact;
     exact.prompt.assign(7, 0);
-    exact.n_gen = 0;
-    TEST_ASSERT(backend.restore_and_generate_impl(0, exact, DaemonIO{}).ok());
+    exact.n_gen = 1;
+    const GenerateResult exact_result =
+        backend.restore_and_generate_impl(0, exact, DaemonIO{});
+    TEST_ASSERT(exact_result.ok());
+    TEST_ASSERT(exact_result.tokens == std::vector<int32_t>({1}));
     TEST_ASSERT(backend.cache_.cur_pos == 7);
     TEST_ASSERT(backend.last_logits_ == std::vector<float>({1.0f, 4.0f, 2.0f}));
 
-    backend.snapshot_free(0);
+    // A cache state that advanced without corresponding logits (for example,
+    // after DSpark) must not be persisted with stale decode state.
+    backend.cache_.cur_pos = 8;
+    TEST_ASSERT(!backend.snapshot_save(1));
+    backend.cache_.cur_pos = 7;
+    TEST_ASSERT(!backend.snapshot_save(-1));
+    TEST_ASSERT(!backend.snapshot_save(ModelBackend::kMaxSlots));
+
+    // Parking the target releases both the core tensors and the potentially
+    // large host-side logits/feature vectors for every populated slot.
+    TEST_ASSERT(backend.park(ParkTarget::TargetModel));
     TEST_ASSERT(!backend.snapshot_used(0));
     TEST_ASSERT(backend.snapshot_aux_[0].last_logits.empty());
     TEST_ASSERT(backend.snapshot_aux_[0].spec_feat_window.empty());
     TEST_ASSERT(!backend.snapshot_restore(0));
-    TEST_ASSERT(!backend.snapshot_save(-1));
-    TEST_ASSERT(!backend.snapshot_save(ModelBackend::kMaxSlots));
 
     std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
 }

--- a/server/tests/test_deepseek4_unit.cpp
+++ b/server/tests/test_deepseek4_unit.cpp
@@ -1172,6 +1172,15 @@ static std::vector<uint8_t> read_tensor_bytes(const ggml_tensor * tensor) {
     return data;
 }
 
+static std::vector<uint8_t> read_tensor_rows(const ggml_tensor * tensor,
+                                             int rows) {
+    const size_t bytes = rows > 0
+        ? ggml_row_size(tensor->type, tensor->ne[0]) * (size_t) rows : 0;
+    std::vector<uint8_t> data(bytes);
+    if (bytes > 0) ggml_backend_tensor_get(tensor, data.data(), 0, bytes);
+    return data;
+}
+
 static bool init_snapshot_test_shard(DeepSeek4LayerSplitAdapter & adapter) {
     adapter.shards_.resize(1);
     auto & shard = adapter.shards_[0];
@@ -1733,8 +1742,8 @@ static void test_snapshot_save_restore() {
     write_tensor_pattern(layer.indexer_compressor.state_score, 79);
 
     const std::vector<uint8_t> raw_before = read_tensor_bytes(layer.raw_kv);
-    const std::vector<uint8_t> comp_before = read_tensor_bytes(layer.comp_kv);
-    const std::vector<uint8_t> index_before = read_tensor_bytes(layer.index_comp_kv);
+    const std::vector<uint8_t> comp_before = read_tensor_rows(layer.comp_kv, 5);
+    const std::vector<uint8_t> index_before = read_tensor_rows(layer.index_comp_kv, 3);
     const std::vector<uint8_t> attn_kv_before =
         read_tensor_bytes(layer.attn_compressor.state_kv);
     const std::vector<uint8_t> attn_score_before =
@@ -1755,6 +1764,8 @@ static void test_snapshot_save_restore() {
     TEST_ASSERT(adapter.snapshot_save(0));
     TEST_ASSERT(adapter.snapshot_used(0));
     TEST_ASSERT(adapter.snapshot_cur_pos(0) == 7);
+    TEST_ASSERT(adapter.snapshots_[0].shards[0].layers[0].comp_kv->ne[1] == 5);
+    TEST_ASSERT(adapter.snapshots_[0].shards[0].layers[0].index_comp_kv->ne[1] == 3);
 
     adapter.cur_pos_ = 0;
     adapter.last_tok_ = -1;
@@ -1782,12 +1793,30 @@ static void test_snapshot_save_restore() {
     TEST_ASSERT(layer.n_comp == 5);
     TEST_ASSERT(layer.n_index_comp == 3);
     TEST_ASSERT(read_tensor_bytes(layer.raw_kv) == raw_before);
-    TEST_ASSERT(read_tensor_bytes(layer.comp_kv) == comp_before);
-    TEST_ASSERT(read_tensor_bytes(layer.index_comp_kv) == index_before);
+    TEST_ASSERT(read_tensor_rows(layer.comp_kv, 5) == comp_before);
+    TEST_ASSERT(read_tensor_rows(layer.index_comp_kv, 3) == index_before);
     TEST_ASSERT(read_tensor_bytes(layer.attn_compressor.state_kv) == attn_kv_before);
     TEST_ASSERT(read_tensor_bytes(layer.attn_compressor.state_score) == attn_score_before);
     TEST_ASSERT(read_tensor_bytes(layer.indexer_compressor.state_kv) == index_kv_before);
     TEST_ASSERT(read_tensor_bytes(layer.indexer_compressor.state_score) == index_score_before);
+
+    // A zero-row compressed prefix is represented by one physical GGML row.
+    // ggml_n_dims() reports that tensor as 1D, so restore must validate its
+    // row layout rather than reject it against the full 2D cache capacity.
+    adapter.snapshot_free(0);
+    layer.n_comp = 0;
+    layer.n_index_comp = 0;
+    cache.cur_pos = 1;
+    adapter.cur_pos_ = 1;
+    adapter.last_tok_ = 7;
+    TEST_ASSERT(adapter.snapshot_save(0));
+    TEST_ASSERT(adapter.snapshots_[0].shards[0].layers[0].comp_kv->ne[1] == 1);
+    TEST_ASSERT(adapter.snapshots_[0].shards[0].layers[0].index_comp_kv->ne[1] == 1);
+    cache.cur_pos = 0;
+    TEST_ASSERT(adapter.snapshot_restore(0));
+    TEST_ASSERT(cache.cur_pos == 1);
+    TEST_ASSERT(layer.n_comp == 0);
+    TEST_ASSERT(layer.n_index_comp == 0);
 
     adapter.snapshot_free(0);
     TEST_ASSERT(!adapter.snapshot_used(0));
@@ -1798,6 +1827,127 @@ static void test_snapshot_save_restore() {
     TEST_ASSERT(!adapter.snapshot_restore(0));
     TEST_ASSERT(!adapter.snapshot_save(-1));
     TEST_ASSERT(!adapter.snapshot_save(ModelBackend::kMaxSlots));
+
+    std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
+}
+
+static bool init_monolithic_snapshot_test_backend(DeepSeek4Backend & backend) {
+    backend.backend_ = ggml_backend_cpu_init();
+    backend.snap_backend_ = ggml_backend_cpu_init();
+    if (!backend.backend_ || !backend.snap_backend_) return false;
+    backend.w_.n_layer = 1;
+    backend.w_.n_embd = 4;
+    backend.w_.n_hc = 1;
+    backend.w_.n_vocab = 3;
+    backend.w_.head_dim = 4;
+    backend.w_.n_swa = 8;
+    backend.w_.n_indexer_head_dim = 2;
+    backend.w_.compress_ratios = {4};
+    return create_deepseek4_cache(backend.backend_, backend.w_, 16,
+                                  backend.cache_);
+}
+
+static void test_monolithic_snapshot_preserves_decode_state() {
+    std::fprintf(stderr,
+                 "  test_monolithic_snapshot_preserves_decode_state ...");
+
+    DeepSeek4BackendConfig cfg;
+    DeepSeek4Backend backend(cfg);
+    TEST_ASSERT(init_monolithic_snapshot_test_backend(backend));
+    if (!backend.cache_.buf || backend.cache_.layers.empty()) {
+        std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
+        return;
+    }
+
+    auto & layer = backend.cache_.layers[0];
+    write_tensor_pattern(layer.raw_kv, 13);
+    write_tensor_pattern(layer.comp_kv, 31);
+    write_tensor_pattern(layer.index_comp_kv, 47);
+    write_tensor_pattern(layer.attn_compressor.state_kv, 59);
+    write_tensor_pattern(layer.attn_compressor.state_score, 71);
+    write_tensor_pattern(layer.indexer_compressor.state_kv, 83);
+    write_tensor_pattern(layer.indexer_compressor.state_score, 97);
+    write_tensor_pattern(backend.cache_.hc_state, 109);
+
+    layer.n_comp = 5;
+    layer.n_index_comp = 3;
+    backend.cache_.cur_pos = 7;
+    backend.last_logits_ = {1.0f, 4.0f, 2.0f};
+    backend.spec_feat_window_ = {9.0f, 8.0f, 7.0f, 6.0f};
+
+    const auto raw_before = read_tensor_bytes(layer.raw_kv);
+    const auto comp_before = read_tensor_rows(layer.comp_kv, layer.n_comp);
+    const auto index_before =
+        read_tensor_rows(layer.index_comp_kv, layer.n_index_comp);
+    const auto hc_before = read_tensor_bytes(backend.cache_.hc_state);
+
+    TEST_ASSERT(backend.snapshot_save(0));
+    TEST_ASSERT(backend.snapshot_used(0));
+    TEST_ASSERT(backend.snapshot_cur_pos(0) == 7);
+    TEST_ASSERT(backend.snapshots_[0].layers[0].comp_kv->ne[1] == 5);
+    TEST_ASSERT(backend.snapshots_[0].layers[0].index_comp_kv->ne[1] == 3);
+
+    ggml_backend_buffer_clear(backend.cache_.buf, 0);
+    backend.cache_.cur_pos = 0;
+    layer.n_comp = 0;
+    layer.n_index_comp = 0;
+    backend.last_logits_ = {-1.0f};
+    backend.spec_feat_window_.clear();
+
+    TEST_ASSERT(backend.snapshot_restore(0));
+    TEST_ASSERT(backend.cache_.cur_pos == 7);
+    TEST_ASSERT(layer.n_comp == 5);
+    TEST_ASSERT(layer.n_index_comp == 3);
+    TEST_ASSERT(read_tensor_bytes(layer.raw_kv) == raw_before);
+    TEST_ASSERT(read_tensor_rows(layer.comp_kv, 5) == comp_before);
+    TEST_ASSERT(read_tensor_rows(layer.index_comp_kv, 3) == index_before);
+    TEST_ASSERT(read_tensor_bytes(backend.cache_.hc_state) == hc_before);
+    TEST_ASSERT(backend.last_logits_ == std::vector<float>({1.0f, 4.0f, 2.0f}));
+    TEST_ASSERT(backend.spec_feat_window_ ==
+                std::vector<float>({9.0f, 8.0f, 7.0f, 6.0f}));
+
+    GenerateRequest exact;
+    exact.prompt.assign(7, 0);
+    exact.n_gen = 0;
+    TEST_ASSERT(backend.restore_and_generate_impl(0, exact, DaemonIO{}).ok());
+    TEST_ASSERT(backend.cache_.cur_pos == 7);
+    TEST_ASSERT(backend.last_logits_ == std::vector<float>({1.0f, 4.0f, 2.0f}));
+
+    backend.snapshot_free(0);
+    TEST_ASSERT(!backend.snapshot_used(0));
+    TEST_ASSERT(backend.snapshot_aux_[0].last_logits.empty());
+    TEST_ASSERT(backend.snapshot_aux_[0].spec_feat_window.empty());
+    TEST_ASSERT(!backend.snapshot_restore(0));
+    TEST_ASSERT(!backend.snapshot_save(-1));
+    TEST_ASSERT(!backend.snapshot_save(ModelBackend::kMaxSlots));
+
+    std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
+}
+
+static void test_spec_feature_tail_is_bounded() {
+    std::fprintf(stderr, "  test_spec_feature_tail_is_bounded ...");
+
+    DeepSeek4BackendConfig cfg;
+    DeepSeek4Backend backend(cfg);
+    backend.w_.n_embd = 2;
+    backend.w_.n_swa = 3;
+    backend.spec_drafter_ = std::make_unique<DSparkDrafter>();
+    backend.spec_drafter_->n_target_layers = 1;
+
+    std::vector<float> features = {
+        0.0f, 1.0f,
+        2.0f, 3.0f,
+        4.0f, 5.0f,
+        6.0f, 7.0f,
+        8.0f, 9.0f,
+    };
+    backend.keep_spec_feature_tail(features, 3);
+    TEST_ASSERT(features ==
+                std::vector<float>({4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f}));
+
+    features.push_back(10.0f);  // malformed partial feature row
+    backend.keep_spec_feature_tail(features, 3);
+    TEST_ASSERT(features.empty());
 
     std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
 }
@@ -3252,6 +3402,8 @@ int main() {
     test_dspark_park_all_releases_drafter();
     test_dspark_raw_ring_rollback_after_wrap(backend);
     test_snapshot_save_restore();
+    test_monolithic_snapshot_preserves_decode_state();
+    test_spec_feature_tail_is_bounded();
     test_reset_request_state();
     test_reset_deepseek4_cache(backend);
     test_adapter_guard_paths();


### PR DESCRIPTION
## Summary

- recognize the exact DeepSeek V4 chat control tokens so reusable turn boundaries are found
- implement monolithic DeepSeek V4 snapshot save, restore, exact-hit decode, and suffix-only prefill
- preserve logits and the bounded DSpark feature window across cache hits
- right-size compressed KV snapshot rows so slot memory follows live state rather than maximum context
- track the cache position represented by decode logits and reject unsafe post-DSpark snapshots
- release all auxiliary snapshot RAM when the target is parked
- stop scheduling disk work after detecting a memory-only snapshot backend
- add marker, cache-state, zero-row, feature-window, lifecycle, disk-gating, and restore regression tests

This addresses prefix-cache defect 2 from #572. The separate all-logits safety fix described there is already present on main.

## Safety

DeepSeek detection requires all four strings to be exact special vocabulary tokens and leaves every other tokenizer family unchanged. Restore validates the complete snapshot layout before copying it into the live cache. Inactive compressed-cache capacity is intentionally omitted because its logical row counts hide it and future writes replace it.

A snapshot is now accepted only when its saved logits represent the same absolute position as the core cache. DSpark post-decode state is conservatively rejected because that API does not return final target logits.

## Validation

Validated on lucebox2 with ROCm gfx1151 and the 102 GB DeepSeek-V4-Flash ROCMFP2 Strix model:

- HIP build succeeded for the server and all test targets
- full CTest suite: 344/344 passed
- review-fix real-model smoke: cold and exact-hit responses were byte-identical; warm prefill was 0.0 ms
- memory-only disk capability was detected and disk work disabled after the first live inline snapshot
- AR exact hit: 2716.0 ms cold prefill to 0.0 ms warm; response content byte-identical
- AR suffix hit: 2986.9 ms cold to 576.7 ms warm; response content byte-identical
- DSpark exact hit: 2901.1 ms cold to 0.0 ms warm; response content byte-identical, acceptance 1.0
- DSpark suffix hit: 3050.7 ms cold to 554.2 ms warm; response content byte-identical, acceptance 1.0
- 968-token disjoint-window DSpark case: bounded 20.2 MiB snapshot, byte-identical response, acceptance 1.0

The exact and suffix probes exercised the real HTTP prefix-cache path, not only the snapshot helpers.