### PR TITLE
fix(ds4): preserve layer-major prefill across compressor boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release
           cmake --build build \
             --target test_flash_attn_sparse test_deepseek4_mmid_grouped_cuda \
+              test_deepseek4_unit \
             -j"$(nproc)"
 
       - name: Run flash-attn sparse kernel test on the 3090
@@ -183,6 +184,9 @@ jobs:
 
       - name: Run grouped MMID dispatch and parity test on the 3090
         run: ./server/build/test_deepseek4_mmid_grouped_cuda
+
+      - name: Run DeepSeek4 graph-generation regression on the 3090
+        run: ./server/build/test_deepseek4_unit
 
       # Optional model-backed end-to-end smoke (real spec-decode on the 3090),
       # disabled by default because it builds dflash_server and lazy-loads the
@@ -286,15 +290,17 @@ jobs:
             -DDFLASH27B_HIP_ARCHITECTURES=gfx1151 \
             -DDFLASH27B_SERVER=OFF \
             -DDFLASH27B_TESTS=ON \
+            -DGGML_HIP_GRAPHS=ON \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_HIP_FLAGS=-DDFLASH_WAVE_SIZE=32
           cmake --build "$RUNNER_TEMP/rocmfp-build" \
             --target test_rocmfp4 test_rocmfpx test_rocmfp4_hip_tail test_rocmfpx_mmq \
-              test_deepseek4_mmid_grouped_cuda test_recurrent_snapshot test_server_unit \
+              test_deepseek4_mmid_grouped_cuda test_deepseek4_unit \
+              test_recurrent_snapshot test_server_unit \
             --parallel 8
           ctest --test-dir "$RUNNER_TEMP/rocmfp-build" \
             --output-on-failure \
-            -R 'rocmfp4_reference|rocmfpx_reference|rocmfp4_hip_tail|rocmfpx_mmq|deepseek4_mmid_grouped_cuda|recurrent_snapshot|ChainRollbackPolicy'
+            -R 'rocmfp4_reference|rocmfpx_reference|rocmfp4_hip_tail|rocmfpx_mmq|deepseek4_mmid_grouped_cuda|deepseek4_unit|recurrent_snapshot|ChainRollbackPolicy'
 
   build-windows:
     name: Build Windows (MSVC + CUDA, library + server targets)

--- a/server/src/deepseek4/deepseek4_backend.cpp
+++ b/server/src/deepseek4/deepseek4_backend.cpp
@@ -799,6 +799,7 @@ int DeepSeek4Backend::capture_safe_prefill_tokens(
         int token_offset,
         int requested_tokens,
         int final_capture_from,
+        bool batch_final_capture,
         bool snapshot_pending,
         int snapshot_capture_from,
         int snapshot_capture_to) {
@@ -812,7 +813,9 @@ int DeepSeek4Backend::capture_safe_prefill_tokens(
         }
     };
 
-    split_at(final_capture_from);
+    if (!batch_final_capture) {
+        split_at(final_capture_from);
+    }
     if (snapshot_pending) {
         split_at(snapshot_capture_from);
         split_at(snapshot_capture_to);
@@ -1400,8 +1403,13 @@ int DeepSeek4Backend::do_prefill(const std::vector<int32_t> & tokens,
             n_tok = snap_pos - pos;
         }
         if (spec_enabled_ && spec_drafter_) {
+            const bool batch_final_capture =
+                !w_.moe_hybrid &&
+                cache_.prefill_mode != PrefillAttentionMode::Exact &&
+                n_tok > 4 &&
+                n_tok <= DS4_MAX_LAYER_MAJOR_PREFILL_TOKENS;
             n_tok = capture_safe_prefill_tokens(
-                i, n_tok, spec_final_from,
+                i, n_tok, spec_final_from, batch_final_capture,
                 save_snapshot && !snapshot_saved,
                 spec_snap_from, spec_snap_to);
         }
@@ -1427,6 +1435,21 @@ int DeepSeek4Backend::do_prefill(const std::vector<int32_t> & tokens,
             (capture_final || capture_snapshot)) {
             spec_hooks.capture_layer_ids = &spec_drafter_->capture_layer_ids;
             spec_hooks.capture_out = &spec_cap;
+            int capture_begin = n_tok;
+            int capture_end = 0;
+            if (capture_final) {
+                capture_begin = std::min(
+                    capture_begin, std::max(0, spec_final_from - i));
+                capture_end = n_tok;
+            }
+            if (capture_snapshot) {
+                capture_begin = std::min(
+                    capture_begin, std::max(0, spec_snap_from - i));
+                capture_end = std::max(
+                    capture_end, std::min(n_tok, spec_snap_to - i));
+            }
+            spec_hooks.capture_token_begin = capture_begin;
+            spec_hooks.capture_token_end = capture_end;
             hp = &spec_hooks;
         }
         if (moe_hybrid_ && (expert_runtime_.compute || expert_backend_)) {

--- a/server/src/deepseek4/deepseek4_backend.cpp
+++ b/server/src/deepseek4/deepseek4_backend.cpp
@@ -795,6 +795,31 @@ void DeepSeek4Backend::keep_spec_feature_tail(
     features.resize(keep_floats);
 }
 
+int DeepSeek4Backend::capture_safe_prefill_tokens(
+        int token_offset,
+        int requested_tokens,
+        int final_capture_from,
+        bool snapshot_pending,
+        int snapshot_capture_from,
+        int snapshot_capture_to) {
+    if (requested_tokens <= 0) return 0;
+
+    int safe_tokens = requested_tokens;
+    const auto split_at = [&](int boundary) {
+        const int distance = boundary - token_offset;
+        if (distance > 0 && distance < safe_tokens) {
+            safe_tokens = distance;
+        }
+    };
+
+    split_at(final_capture_from);
+    if (snapshot_pending) {
+        split_at(snapshot_capture_from);
+        split_at(snapshot_capture_to);
+    }
+    return safe_tokens;
+}
+
 bool DeepSeek4Backend::init() {
     // The shared MMVQ/MMQ crossover defaults to q=3 for NVIDIA. On gfx1151,
     // DSpark q=4 is faster through MMVQ. Keep AR and other devices unchanged,
@@ -1373,6 +1398,12 @@ int DeepSeek4Backend::do_prefill(const std::vector<int32_t> & tokens,
         if (save_snapshot && !snapshot_saved &&
             snap_pos > pos && snap_pos < pos + n_tok) {
             n_tok = snap_pos - pos;
+        }
+        if (spec_enabled_ && spec_drafter_) {
+            n_tok = capture_safe_prefill_tokens(
+                i, n_tok, spec_final_from,
+                save_snapshot && !snapshot_saved,
+                spec_snap_from, spec_snap_to);
         }
 
         // Embed tokens

--- a/server/src/deepseek4/deepseek4_backend.h
+++ b/server/src/deepseek4/deepseek4_backend.h
@@ -105,11 +105,12 @@ private:
     void keep_spec_feature_tail(std::vector<float> & features,
                                 size_t max_rows) const;
     // Limit a prefill batch to a region with a uniform DSpark capture policy.
-    // This keeps the fast unhooked path for the prompt bulk while ensuring
-    // every token in the final/checkpoint feature windows is actually hooked.
+    // Layer-major prefill can capture a subrange without splitting the final
+    // feature window; other paths still stop exactly at capture boundaries.
     static int capture_safe_prefill_tokens(int token_offset,
                                            int requested_tokens,
                                            int final_capture_from,
+                                           bool batch_final_capture,
                                            bool snapshot_pending,
                                            int snapshot_capture_from,
                                            int snapshot_capture_to);

--- a/server/src/deepseek4/deepseek4_backend.h
+++ b/server/src/deepseek4/deepseek4_backend.h
@@ -104,6 +104,15 @@ private:
     void release_spec_drafter(bool mark_parked);
     void keep_spec_feature_tail(std::vector<float> & features,
                                 size_t max_rows) const;
+    // Limit a prefill batch to a region with a uniform DSpark capture policy.
+    // This keeps the fast unhooked path for the prompt bulk while ensuring
+    // every token in the final/checkpoint feature windows is actually hooked.
+    static int capture_safe_prefill_tokens(int token_offset,
+                                           int requested_tokens,
+                                           int final_capture_from,
+                                           bool snapshot_pending,
+                                           int snapshot_capture_from,
+                                           int snapshot_capture_to);
 
     // Prefill prompt tokens in chunks, return absolute committed position.
     int do_prefill(const std::vector<int32_t> & tokens, const DaemonIO & io,

--- a/server/src/deepseek4/deepseek4_graph.cpp
+++ b/server/src/deepseek4/deepseek4_graph.cpp
@@ -5922,6 +5922,7 @@ static int ds4_try_layer_major_prefill(
         int kv_start,
         std::vector<float> & out_logits,
         const int32_t * token_ids,
+        Ds4VerifyHooks * verify_hooks,
         DeepSeek4StepTelemetry * telemetry) {
     if (!backend || !embed || n_tokens <= 4 ||
         n_tokens > DS4_MAX_LAYER_MAJOR_PREFILL_TOKENS ||
@@ -5929,6 +5930,14 @@ static int ds4_try_layer_major_prefill(
         return 0;
     }
     if (cache.prefill_mode == PrefillAttentionMode::Exact) return 0;
+    // Layer-major prefill returns only the final-position logits. DSpark's
+    // per-layer feature capture is supported below, but verifier requests for
+    // every position's logits/argmax must retain the generic path.
+    if (verify_hooks &&
+        (verify_hooks->all_logits_out || verify_hooks->argmax_out ||
+         verify_hooks->prefer_argmax_only)) {
+        return 0;
+    }
     if (!ds4_backend_is_gpu(backend) || !hc_out_weights.loaded ||
         hc_out_weights.scale_data.empty() || !w.output_hc_fn ||
         !w.output_hc_base) {
@@ -5961,6 +5970,54 @@ static int ds4_try_layer_major_prefill(
     const int64_t hc_dim = (int64_t) n_embd * n_hc;
     const int64_t mix_dim = 2 * (int64_t) n_hc + (int64_t) n_hc * n_hc;
     const int next_pos = kv_start + n_tokens;
+
+    const std::vector<int> * capture_layer_ids =
+        verify_hooks ? verify_hooks->capture_layer_ids : nullptr;
+    std::vector<float> * capture_out =
+        verify_hooks ? verify_hooks->capture_out : nullptr;
+    const bool capture_enabled = capture_layer_ids && capture_out &&
+                                 !capture_layer_ids->empty();
+    std::vector<float> capture_hc_state;
+    if (capture_out) {
+        capture_out->clear();
+    }
+    if (capture_enabled) {
+        capture_out->assign(
+            (size_t) n_tokens * capture_layer_ids->size() * n_embd, 0.0f);
+        capture_hc_state.resize((size_t) hc_dim * n_tokens);
+    }
+    const auto capture_layer = [&](int layer, ggml_tensor * state) {
+        if (!capture_enabled || !state) return;
+        const auto first = std::find(capture_layer_ids->begin(),
+                                     capture_layer_ids->end(), layer);
+        if (first == capture_layer_ids->end()) return;
+
+        const auto read_t0 = Ds4TimingClock::now();
+        ggml_backend_tensor_get(state, capture_hc_state.data(), 0,
+                                sizeof(float) * capture_hc_state.size());
+        if (telemetry) {
+            telemetry->full_graph_read_us += ds4_elapsed_us(
+                read_t0, Ds4TimingClock::now());
+        }
+
+        const size_t n_capture = capture_layer_ids->size();
+        for (size_t ci = 0; ci < n_capture; ++ci) {
+            if ((*capture_layer_ids)[ci] != layer) continue;
+            for (int t = 0; t < n_tokens; ++t) {
+                float * dst = capture_out->data() +
+                    ((size_t) t * n_capture + ci) * n_embd;
+                const float * src = capture_hc_state.data() +
+                    (size_t) t * hc_dim;
+                for (int d = 0; d < n_embd; ++d) {
+                    float sum = 0.0f;
+                    for (int h = 0; h < n_hc; ++h) {
+                        sum += src[(size_t) h * n_embd + d];
+                    }
+                    dst[d] = sum / (float) n_hc;
+                }
+            }
+        }
+    };
 
     Ds4LayerMajorGraphCache * graph_cache = nullptr;
     bool cache_hit = false;
@@ -6131,6 +6188,7 @@ static int ds4_try_layer_major_prefill(
                 telemetry->full_graph_compute_us += ds4_elapsed_us(
                     compute_t0, Ds4TimingClock::now());
             }
+            capture_layer(il, (il & 1) == 0 ? state_b : state_a);
             if (layer.logits) {
                 out_logits.resize((size_t) w.n_vocab);
                 ggml_backend_tensor_get(
@@ -6357,6 +6415,8 @@ static int ds4_try_layer_major_prefill(
                 compute_t0, Ds4TimingClock::now());
         }
 
+        capture_layer(il, state_out);
+
         if (logits) {
             out_logits.resize((size_t) w.n_vocab);
             ggml_backend_tensor_get(logits, out_logits.data(), 0,
@@ -6534,14 +6594,19 @@ bool deepseek4_step_layer_range(
         n_tokens > 4 && n_tokens <= DS4_MAX_LAYER_MAJOR_PREFILL_TOKENS &&
         layer_begin == 0 && is_last_shard && out_logits &&
         ds4_backend_is_gpu(backend);
+    const bool layer_major_hooks_supported =
+        !verify_hooks ||
+        (!verify_hooks->all_logits_out && !verify_hooks->argmax_out &&
+         !verify_hooks->prefer_argmax_only);
     // The standard layer-major pipeline owns an exact batched compressor.
     // Let it see the wide prompt before the generic boundary splitter turns
-    // the request into ratio-sized (typically four-token) forwards.
+    // the request into ratio-sized (typically four-token) forwards. It also
+    // owns DSpark feature capture, so the final capture window stays batched.
     const bool standard_layer_major_prefill =
         !w.moe_hybrid && cache.prefill_mode != PrefillAttentionMode::Exact &&
         n_tokens > 4 && n_tokens <= DS4_MAX_LAYER_MAJOR_PREFILL_TOKENS &&
         layer_begin == 0 && is_last_shard && out_logits &&
-        ds4_backend_is_gpu(backend) && !verify_hooks;
+        ds4_backend_is_gpu(backend) && layer_major_hooks_supported;
     // These graphs are rebuilt around an owner join on every layer, so tensor
     // metadata addresses can be recycled for different topologies.  Until
     // the full heterogeneous layer is captured as one stable scheduler graph,
@@ -6723,7 +6788,8 @@ bool deepseek4_step_layer_range(
             fused_decode_graph_cache, backend, w, cache,
             hc_layer_weights_range, hc_output_weights_range,
             hash_routing_tables_range, scratch.hash_expert_ids, embed,
-            n_tokens, kv_start, *out_logits, token_ids, telemetry);
+            n_tokens, kv_start, *out_logits, token_ids, verify_hooks,
+            telemetry);
         if (prc < 0) return false;
         if (prc > 0) {
             if (telemetry) {

--- a/server/src/deepseek4/deepseek4_graph.cpp
+++ b/server/src/deepseek4/deepseek4_graph.cpp
@@ -6534,6 +6534,14 @@ bool deepseek4_step_layer_range(
         n_tokens > 4 && n_tokens <= DS4_MAX_LAYER_MAJOR_PREFILL_TOKENS &&
         layer_begin == 0 && is_last_shard && out_logits &&
         ds4_backend_is_gpu(backend);
+    // The standard layer-major pipeline owns an exact batched compressor.
+    // Let it see the wide prompt before the generic boundary splitter turns
+    // the request into ratio-sized (typically four-token) forwards.
+    const bool standard_layer_major_prefill =
+        !w.moe_hybrid && cache.prefill_mode != PrefillAttentionMode::Exact &&
+        n_tokens > 4 && n_tokens <= DS4_MAX_LAYER_MAJOR_PREFILL_TOKENS &&
+        layer_begin == 0 && is_last_shard && out_logits &&
+        ds4_backend_is_gpu(backend);
     // These graphs are rebuilt around an owner join on every layer, so tensor
     // metadata addresses can be recycled for different topologies.  Until
     // the full heterogeneous layer is captured as one stable scheduler graph,
@@ -6551,7 +6559,8 @@ bool deepseek4_step_layer_range(
     // as sequential execution while retaining safe batched prefixes.
     const int first_chunk = deepseek4_safe_compressor_batch_tokens(w, kv_start, n_tokens);
     if (first_chunk > 0 && first_chunk < n_tokens &&
-        !fused_verify_candidate && !heterogeneous_sparse_prefill) {
+        !fused_verify_candidate && !heterogeneous_sparse_prefill &&
+        !standard_layer_major_prefill) {
         const int input_width = layer_begin == 0 ? n_embd : hc_dim;
         std::vector<float> hc_all;
         std::vector<float> shard_out_all;
@@ -6709,9 +6718,7 @@ bool deepseek4_step_layer_range(
 
     // Large full-model prefill batches use the device-resident layer-major
     // pipeline. DSpark verification remains on its exact q=2..4 path below.
-    if (n_tokens > 4 &&
-        n_tokens <= DS4_MAX_LAYER_MAJOR_PREFILL_TOKENS && layer_begin == 0 &&
-        is_last_shard && out_logits && ds4_backend_is_gpu(backend)) {
+    if (standard_layer_major_prefill) {
         const int prc = ds4_try_layer_major_prefill(
             fused_decode_graph_cache, backend, w, cache,
             hc_layer_weights_range, hc_output_weights_range,

--- a/server/src/deepseek4/deepseek4_graph.cpp
+++ b/server/src/deepseek4/deepseek4_graph.cpp
@@ -5977,6 +5977,14 @@ static int ds4_try_layer_major_prefill(
         verify_hooks ? verify_hooks->capture_out : nullptr;
     const bool capture_enabled = capture_layer_ids && capture_out &&
                                  !capture_layer_ids->empty();
+    const int capture_begin = verify_hooks
+        ? std::clamp(verify_hooks->capture_token_begin, 0, n_tokens) : 0;
+    const int requested_capture_end =
+        verify_hooks && verify_hooks->capture_token_end >= 0
+            ? verify_hooks->capture_token_end : n_tokens;
+    const int capture_end = std::clamp(
+        requested_capture_end, capture_begin, n_tokens);
+    const int capture_tokens = capture_end - capture_begin;
     std::vector<float> capture_hc_state;
     if (capture_out) {
         capture_out->clear();
@@ -5984,16 +5992,18 @@ static int ds4_try_layer_major_prefill(
     if (capture_enabled) {
         capture_out->assign(
             (size_t) n_tokens * capture_layer_ids->size() * n_embd, 0.0f);
-        capture_hc_state.resize((size_t) hc_dim * n_tokens);
+        capture_hc_state.resize((size_t) hc_dim * capture_tokens);
     }
     const auto capture_layer = [&](int layer, ggml_tensor * state) {
-        if (!capture_enabled || !state) return;
+        if (!capture_enabled || capture_tokens <= 0 || !state) return;
         const auto first = std::find(capture_layer_ids->begin(),
                                      capture_layer_ids->end(), layer);
         if (first == capture_layer_ids->end()) return;
 
         const auto read_t0 = Ds4TimingClock::now();
-        ggml_backend_tensor_get(state, capture_hc_state.data(), 0,
+        const size_t capture_offset =
+            (size_t) capture_begin * hc_dim * sizeof(float);
+        ggml_backend_tensor_get(state, capture_hc_state.data(), capture_offset,
                                 sizeof(float) * capture_hc_state.size());
         if (telemetry) {
             telemetry->full_graph_read_us += ds4_elapsed_us(
@@ -6003,11 +6013,11 @@ static int ds4_try_layer_major_prefill(
         const size_t n_capture = capture_layer_ids->size();
         for (size_t ci = 0; ci < n_capture; ++ci) {
             if ((*capture_layer_ids)[ci] != layer) continue;
-            for (int t = 0; t < n_tokens; ++t) {
+            for (int t = capture_begin; t < capture_end; ++t) {
                 float * dst = capture_out->data() +
                     ((size_t) t * n_capture + ci) * n_embd;
                 const float * src = capture_hc_state.data() +
-                    (size_t) t * hc_dim;
+                    (size_t) (t - capture_begin) * hc_dim;
                 for (int d = 0; d < n_embd; ++d) {
                     float sum = 0.0f;
                     for (int h = 0; h < n_hc; ++h) {

--- a/server/src/deepseek4/deepseek4_graph.cpp
+++ b/server/src/deepseek4/deepseek4_graph.cpp
@@ -6541,7 +6541,7 @@ bool deepseek4_step_layer_range(
         !w.moe_hybrid && cache.prefill_mode != PrefillAttentionMode::Exact &&
         n_tokens > 4 && n_tokens <= DS4_MAX_LAYER_MAJOR_PREFILL_TOKENS &&
         layer_begin == 0 && is_last_shard && out_logits &&
-        ds4_backend_is_gpu(backend);
+        ds4_backend_is_gpu(backend) && !verify_hooks;
     // These graphs are rebuilt around an owner join on every layer, so tensor
     // metadata addresses can be recycled for different topologies.  Until
     // the full heterogeneous layer is captured as one stable scheduler graph,

--- a/server/src/deepseek4/deepseek4_internal.h
+++ b/server/src/deepseek4/deepseek4_internal.h
@@ -382,6 +382,10 @@ bool deepseek4_step(
 struct Ds4VerifyHooks {
     const std::vector<int> * capture_layer_ids = nullptr;  // e.g. {40,41,42}
     std::vector<float> *     capture_out = nullptr;         // [n_cap*n_embd * n_tokens]
+    // Optional relative token range for layer-major feature readback. Generic
+    // verifier paths may ignore this and return the complete batch.
+    int                      capture_token_begin = 0;
+    int                      capture_token_end = -1;        // exclusive; -1 = n_tokens
     std::vector<float> *     all_logits_out = nullptr;      // [n_vocab * n_tokens]
     std::vector<int32_t> *   argmax_out = nullptr;          // [n_tokens], optional GPU result
     bool                     prefer_argmax_only = false;     // skip logits D2H when available

--- a/server/tests/test_deepseek4_unit.cpp
+++ b/server/tests/test_deepseek4_unit.cpp
@@ -1970,27 +1970,29 @@ static void test_dspark_prefill_capture_boundaries() {
     std::fprintf(stderr, "  test_dspark_prefill_capture_boundaries ...");
 
     using Backend = DeepSeek4Backend;
-    // A wide prompt keeps its fast, unhooked bulk batch and stops exactly at
-    // the final SWA feature window.
+    // Layer-major prefill captures only the requested tail from a wide graph,
+    // while generic paths still stop exactly at the final feature window.
     TEST_ASSERT(Backend::capture_safe_prefill_tokens(
-                    0, 2048, 1920, false, 0, 0) == 1920);
+                    0, 2048, 1920, true, false, 0, 0) == 2048);
     TEST_ASSERT(Backend::capture_safe_prefill_tokens(
-                    1920, 128, 1920, false, 0, 0) == 128);
+                    0, 2048, 1920, false, false, 0, 0) == 1920);
+    TEST_ASSERT(Backend::capture_safe_prefill_tokens(
+                    1920, 128, 1920, false, false, 0, 0) == 128);
 
     // A pending checkpoint contributes both edges of its capture window. The
     // resulting batches are either wholly hooked or wholly unhooked.
     TEST_ASSERT(Backend::capture_safe_prefill_tokens(
-                    0, 2048, 1920, true, 384, 512) == 384);
+                    0, 2048, 1920, true, true, 384, 512) == 384);
     TEST_ASSERT(Backend::capture_safe_prefill_tokens(
-                    384, 1664, 1920, true, 384, 512) == 128);
+                    384, 1664, 1920, true, true, 384, 512) == 128);
     TEST_ASSERT(Backend::capture_safe_prefill_tokens(
-                    512, 1536, 1920, false, 384, 512) == 1408);
+                    512, 1536, 1920, false, false, 384, 512) == 1408);
 
     // Boundaries at a batch edge and empty requests need no extra split.
     TEST_ASSERT(Backend::capture_safe_prefill_tokens(
-                    0, 128, 128, true, 128, 256) == 128);
+                    0, 128, 128, false, true, 128, 256) == 128);
     TEST_ASSERT(Backend::capture_safe_prefill_tokens(
-                    10, 0, 20, true, 12, 18) == 0);
+                    10, 0, 20, false, true, 12, 18) == 0);
 
     std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
 }

--- a/server/tests/test_deepseek4_unit.cpp
+++ b/server/tests/test_deepseek4_unit.cpp
@@ -1966,6 +1966,35 @@ static void test_spec_feature_tail_is_bounded() {
     std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
 }
 
+static void test_dspark_prefill_capture_boundaries() {
+    std::fprintf(stderr, "  test_dspark_prefill_capture_boundaries ...");
+
+    using Backend = DeepSeek4Backend;
+    // A wide prompt keeps its fast, unhooked bulk batch and stops exactly at
+    // the final SWA feature window.
+    TEST_ASSERT(Backend::capture_safe_prefill_tokens(
+                    0, 2048, 1920, false, 0, 0) == 1920);
+    TEST_ASSERT(Backend::capture_safe_prefill_tokens(
+                    1920, 128, 1920, false, 0, 0) == 128);
+
+    // A pending checkpoint contributes both edges of its capture window. The
+    // resulting batches are either wholly hooked or wholly unhooked.
+    TEST_ASSERT(Backend::capture_safe_prefill_tokens(
+                    0, 2048, 1920, true, 384, 512) == 384);
+    TEST_ASSERT(Backend::capture_safe_prefill_tokens(
+                    384, 1664, 1920, true, 384, 512) == 128);
+    TEST_ASSERT(Backend::capture_safe_prefill_tokens(
+                    512, 1536, 1920, false, 384, 512) == 1408);
+
+    // Boundaries at a batch edge and empty requests need no extra split.
+    TEST_ASSERT(Backend::capture_safe_prefill_tokens(
+                    0, 128, 128, true, 128, 256) == 128);
+    TEST_ASSERT(Backend::capture_safe_prefill_tokens(
+                    10, 0, 20, true, 12, 18) == 0);
+
+    std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
+}
+
 static void test_reset_request_state() {
     std::fprintf(stderr, "  test_reset_request_state ...");
 
@@ -3418,6 +3447,7 @@ int main() {
     test_snapshot_save_restore();
     test_monolithic_snapshot_preserves_decode_state();
     test_spec_feature_tail_is_bounded();
+    test_dspark_prefill_capture_boundaries();
     test_reset_request_state();
     test_reset_deepseek4_cache(backend);
     test_adapter_guard_paths();


### PR DESCRIPTION
## Summary

- allow eligible full-model GPU prefill to reach the layer-major pipeline before generic compressor-boundary splitting
- preserve DSpark feature capture natively in layer-major prefill
- read back only the requested final capture window while keeping the wide prefill graph intact
- retain boundary splitting for exact mode, hybrid/dynamic execution, verifier logits, and snapshot boundaries

## Root cause

The generic compressor safety split predates layer-major prefill. It divided a 2K prompt into mostly four-token forwards before the optimized ROCmFPX path could run.

Final review also found that the first DSpark capture-safety follow-up fixed feature correctness by splitting off the final 128-token capture window, but that tail then fell back to the generic path. This reduced warmed Strix prefill from the qualified ~331-335 tok/s range to ~248 tok/s. Layer-major prefill now captures the requested HC feature subrange directly, preserving both correctness and the wide graph.

## Validation

- head: `30d0ebd3662199dfc8fa41b26068b19fef2afa59`
- combined with PR #565 on current `main` for the intended merge-order qualification
- Radeon 8060S / Strix Halo, ROCm 7.2.4, performance profile, 2.9 GHz GPU
- target: `DeepSeek-V4-Flash-ROCMFP2-STRIX.gguf`
- drafter: `DeepSeek-V4-Flash-DSpark-draft-Q4RMFP4-denseF16.gguf`
- 2,049-token prompt + 510-token DSpark decode, one warmup + two measured runs
- sparse prefill: **353.21, 355.08 tok/s** (**354.15 median**)
- server decode: **36.7, 36.8 tok/s** (**36.75 median**)
- acceptance: **1.00** on both measured runs
- response SHA-256: `7f49c316495203809bebaf6d97206336a052634194ee768675868de141f6dd51` on every run
- full `test_deepseek4_unit`: passed
- grouped MMID GPU parity: passed, 50 cases / 1,597,440 compared bytes

The model artifact, GTT configuration, and ROCmFPX kernels were unchanged.
