### PR TITLE
feat(ds4): prototype same-process attention output groups

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -389,6 +389,7 @@ add_library(dflash_common STATIC
     src/gemma4/gemma4_layer_split_adapter.cpp
     # DeepSeek V4 Flash target arch
     src/deepseek4/deepseek4_loader.cpp
+    src/deepseek4/deepseek4_attention_parallel.cpp
     src/deepseek4/deepseek4_graph.cpp
     src/deepseek4/deepseek4_backend.cpp
     src/deepseek4/deepseek4_daemon.cpp

--- a/server/docs/DS4.md
+++ b/server/docs/DS4.md
@@ -28,6 +28,7 @@ DeepSeek V4 Flash is a 43-layer MoE model with:
 |------|-------|
 | Backend selection / init | `src/common/backend_factory.cpp`, `src/deepseek4/deepseek4_backend.{h,cpp}`, `src/deepseek4/deepseek4_layer_split_adapter.{h,cpp}` |
 | Per-shard forward graph | `src/deepseek4/deepseek4_graph.cpp` |
+| Same-process grouped attention-output experiment | `src/deepseek4/deepseek4_attention_parallel.{h,cpp}` |
 | Model weights and metadata | `src/deepseek4/deepseek4_internal.h`, `src/deepseek4/deepseek4_loader.cpp` |
 | HC pre/post CUDA kernel | `src/deepseek4/deepseek4_hc_cuda.cu`, `.h` |
 | DSpark runtime | `src/deepseek4/deepseek4_dspark*.{h,cpp}` |

--- a/server/docs/ENVIRONMENT.md
+++ b/server/docs/ENVIRONMENT.md
@@ -36,6 +36,7 @@ consolidation of this list into CLI flags is tracked as follow-up work.
 | `DFLASH_DS4_TP_TARGETED_JOIN_SPLIT` / `DFLASH_MOE_TP_TARGETED_JOIN_SPLIT` | unset | BURN-IN: start a main-GPU split only at each peer-result join, avoiding an extra peer fence per MoE layer. |
 | `DFLASH_DS4_COMP_PAD_STRIDE` | 16 | BURN-IN: compressed-KV padding bucket (`16`, `32`, `64`, or `128`); wider exact-masked buckets reduce verifier graph recapture churn. |
 | `DFLASH_DS4_DISABLE_GROUPED_OUTPUT_PROJECTION` | unset | DEBUG: restore the materialized output projection when diagnosing grouped-view copies across unlike runtimes. |
+| `DFLASH_DS4_ATTN_TP_GROUPS` / `DFLASH_DS4_ATTN_TP_MIN_CONTEXT` | 0 / 0 | OPT-IN: split tail attention output-A groups onto the existing same-runtime, in-process peer GPU after the selected context. Correct but slower on the qualified R9700 + Strix profile; keep disabled. See `HETEROGENEOUS_STAGE_PLANNER.md`. |
 | `DFLASH_DS4_DRAFT_BACKEND` / `DFLASH_DS4_DRAFT_GPU` | compiled backend / target device | Select the in-process DSpark backend and device. |
 | `DFLASH_CUDA_BACKEND_PATH` / `DFLASH_HIP_BACKEND_PATH` | auto-discovered beside the executable | Explicit peer module file path for a mixed CUDA+HIP build. |
 | `GGML_BATCH_PEER_COPIES` | unset | BURN-IN: batch peer-runtime copies and unlike-runtime host staging with one source wait per split. `GGML_CUDA_BATCH_PEER_COPIES` remains a compatibility alias. |
@@ -92,6 +93,8 @@ consolidation of this list into CLI flags is tracked as follow-up work.
 - `DFLASH_DRAFT_PERSIST` - laguna_backend.cpp
 - `DFLASH_DROP_COLD` - qwen35moe_backend.cpp, qwen35moe_pipelined_decode.cpp
 - `DFLASH_DS4_ADAPTIVE_WIDTH` - deepseek4_dspark_spec.cpp
+- `DFLASH_DS4_ATTN_TP_GROUPS` - deepseek4_backend.cpp
+- `DFLASH_DS4_ATTN_TP_MIN_CONTEXT` - deepseek4_backend.cpp
 - `DFLASH_DS4_COMP_PAD_STRIDE` - deepseek4_graph.cpp
 - `DFLASH_DS4_CROSS_VENDOR_OWNER_SUMS` - deepseek4_fused_verify.inc
 - `DFLASH_DS4_CUDA_LAYERS` - deepseek4_layer_split_adapter.cpp

--- a/server/docs/HETEROGENEOUS_STAGE_PLANNER.md
+++ b/server/docs/HETEROGENEOUS_STAGE_PLANNER.md
@@ -104,6 +104,38 @@ enough to reach 100 tok/s; the next optimization must reduce full-width expert
 kernel time or overlap another independent stage, not add synchronization or
 small matrix shards.
 
+## Grouped attention-output experiment
+
+An opt-in DeepSeek4 experiment splits the eight grouped output-A projections
+after MLA attention: six groups remain on the R9700 and two run concurrently
+on Strix Halo. Shared attention, RoPE, compressors, the authoritative KV cache,
+and output-B remain unchanged on the R9700. The peer owns only its immutable
+weight slice; there is no mirrored cache or speculative rollback state.
+
+The path is intentionally restricted to the existing in-process, same-runtime
+two-GPU scheduler. It refuses IPC and mixed CUDA/HIP pairs. It also runs only
+inside stable explicit-attention verifier graphs with widths 2 through 6.
+`DFLASH_DS4_ATTN_TP_GROUPS` selects the number of tail groups assigned to the
+peer, while `DFLASH_DS4_ATTN_TP_MIN_CONTEXT` can delay activation. Both are
+burn-in controls and the split is disabled by default.
+
+The 2026-08-05 R9700 + Strix Halo q=5 qualification used one warmup and three
+measured 2K-context, 128-token requests. Every request produced the expected
+SHA-256
+`0f785a7ffa406498aafb14553966eaed0f52220fed0f7cc016b66921d104d194`
+with 0.96 DSpark acceptance.
+
+| Plan | Engine tok/s | Client median tok/s | Scheduler splits | Decision |
+|---|---:|---:|---:|---|
+| Established projection on R9700 | 68.3 | 83.162 | 130 | Keep |
+| Output-A groups 6 main / 2 peer | 54.0–54.1 | 65.271 | 259 | Reject as a speed optimization |
+
+The split is numerically correct but about 21% slower. Its small parallel
+projection cannot repay 129 additional scheduler boundaries per verify graph.
+Keep the implementation opt-in as a correctness-tested mechanism for future
+schedulers; do not enable it in the Lucebox performance profile unless the
+cross-device boundary count is reduced first.
+
 ## Reproduction
 
 Use `scripts/qualify_ds4_q5_amd.sh`. The runner records the source commit,
@@ -118,6 +150,9 @@ EXPERT_TOP_K=4
 DYNAMIC_ROUTE_BALANCE=1
 DYNAMIC_MAIN_SLOTS_X4=13
 ```
+
+For the rejected grouped attention-output A/B, add
+`ATTENTION_TP_GROUPS=2 ATTENTION_TP_MIN_CONTEXT=0`; use `0` for the control.
 
 Do not promote a candidate from a microbenchmark alone. It must pass unit/GPU
 oracles, the exact response hash, warmups, and at least three measured model

--- a/server/scripts/qualify_ds4_q5_amd.sh
+++ b/server/scripts/qualify_ds4_q5_amd.sh
@@ -48,9 +48,11 @@ DYNAMIC_MAIN_SLOTS_X4="${DYNAMIC_MAIN_SLOTS_X4:-}"
 SHARED_FFN_PEER_FRACTION="${SHARED_FFN_PEER_FRACTION:-0}"
 FUSED_OWNER_RESIDUAL="${FUSED_OWNER_RESIDUAL:-0}"
 ALIGN_SHARED_IDS="${ALIGN_SHARED_IDS:-0}"
+ATTENTION_TP_GROUPS="${ATTENTION_TP_GROUPS:-0}"
+ATTENTION_TP_MIN_CONTEXT="${ATTENTION_TP_MIN_CONTEXT:-0}"
 EXPERT_TOP_K="${EXPERT_TOP_K:-4}"
 VERIFY_WIDTH=$((4 + Q5_VERIFY + 2 * Q6_VERIFY))
-RUN_ID="${RUN_ID:-ds4-q${VERIFY_WIDTH}-fr${FORCE_GRAPH_REPLAY}-direct${DIRECT_INDEXER_TOPK}-radix${BLOCK_RADIX_TOPK}-x4p1${FP4_Q5_X4_PLUS1}-cp${CRITICAL_PATH_PLACEMENT}-r${MAIN_TO_PEER_RATE}-sf${SHARED_FFN_PEER_FRACTION}-or${FUSED_OWNER_RESIDUAL}-ai${ALIGN_SHARED_IDS}-$(date -u +%Y%m%dT%H%M%SZ)}"
+RUN_ID="${RUN_ID:-ds4-q${VERIFY_WIDTH}-fr${FORCE_GRAPH_REPLAY}-direct${DIRECT_INDEXER_TOPK}-radix${BLOCK_RADIX_TOPK}-x4p1${FP4_Q5_X4_PLUS1}-cp${CRITICAL_PATH_PLACEMENT}-r${MAIN_TO_PEER_RATE}-sf${SHARED_FFN_PEER_FRACTION}-or${FUSED_OWNER_RESIDUAL}-ai${ALIGN_SHARED_IDS}-at${ATTENTION_TP_GROUPS}-$(date -u +%Y%m%dT%H%M%SZ)}"
 OUT_ROOT="${OUT_ROOT:-$CHECKOUT/results/ds4_q5_context_qualification}"
 OUT_DIR="$OUT_ROOT/$RUN_ID"
 SERVER_LOG="$OUT_DIR/server.log"
@@ -107,6 +109,14 @@ case "$ALIGN_SHARED_IDS" in
     0|1) ;;
     *) echo "ALIGN_SHARED_IDS must be 0 or 1" >&2; exit 2 ;;
 esac
+if [[ ! "$ATTENTION_TP_GROUPS" =~ ^[0-7]$ ]]; then
+    echo "ATTENTION_TP_GROUPS must be an integer from 0 through 7" >&2
+    exit 2
+fi
+if [[ ! "$ATTENTION_TP_MIN_CONTEXT" =~ ^[0-9]+$ ]]; then
+    echo "ATTENTION_TP_MIN_CONTEXT must be a non-negative integer" >&2
+    exit 2
+fi
 if [[ ! "$EXPERT_TOP_K" =~ ^[1-9][0-9]*$ ]] || ((EXPERT_TOP_K > 16)); then
     echo "EXPERT_TOP_K must be an integer from 1 through 16" >&2
     exit 2
@@ -289,6 +299,12 @@ fi
 if [[ "$ALIGN_SHARED_IDS" == 1 ]]; then
     server_env+=("DFLASH_CUDA_MMVQ_MOE_ALIGN_SHARED_IDS=1")
 fi
+if ((ATTENTION_TP_GROUPS > 0)); then
+    server_env+=(
+        "DFLASH_DS4_ATTN_TP_GROUPS=$ATTENTION_TP_GROUPS"
+        "DFLASH_DS4_ATTN_TP_MIN_CONTEXT=$ATTENTION_TP_MIN_CONTEXT"
+    )
+fi
 if [[ -n "$CUDA_DISABLE_GRAPHS_DEVICES" ]]; then
     server_env+=(
         "GGML_CUDA_DISABLE_GRAPHS_DEVICES=$CUDA_DISABLE_GRAPHS_DEVICES"
@@ -381,6 +397,8 @@ server_args=(
     echo "shared_ffn_peer_fraction=$SHARED_FFN_PEER_FRACTION"
     echo "fused_owner_residual=$FUSED_OWNER_RESIDUAL"
     echo "align_shared_ids=$ALIGN_SHARED_IDS"
+    echo "attention_tp_groups=$ATTENTION_TP_GROUPS"
+    echo "attention_tp_min_context=$ATTENTION_TP_MIN_CONTEXT"
     echo "expert_top_k=$EXPERT_TOP_K"
     echo "cache_slots=$CACHE_SLOTS"
     echo "mmvq_max_ncols=$MMVQ_MAX_NCOLS"

--- a/server/src/deepseek4/deepseek4_attention_parallel.cpp
+++ b/server/src/deepseek4/deepseek4_attention_parallel.cpp
@@ -1,0 +1,178 @@
+#include "deepseek4_attention_parallel.h"
+
+#include "deepseek4_internal.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <vector>
+
+namespace dflash::common {
+
+namespace {
+
+void set_error(std::string * error, const std::string & message) {
+    if (error) *error = message;
+}
+
+bool tensor_rows_match(const ggml_tensor * source,
+                       const ggml_tensor * destination) {
+    return source && destination && source->type == destination->type &&
+           source->ne[0] == destination->ne[0] &&
+           source->nb[1] == destination->nb[1];
+}
+
+bool copy_tensor_rows(const ggml_tensor * source,
+                      ggml_tensor * destination,
+                      int source_row,
+                      int rows,
+                      std::vector<uint8_t> & staging,
+                      std::string * error) {
+    if (!tensor_rows_match(source, destination) || source_row < 0 || rows < 0 ||
+        source_row + rows > source->ne[1] || rows > destination->ne[1]) {
+        set_error(error, "attention peer tensor row layout mismatch");
+        return false;
+    }
+    if (rows == 0) return true;
+
+    const size_t row_bytes = source->nb[1];
+    const size_t bytes = row_bytes * (size_t) rows;
+    staging.resize(bytes);
+    ggml_backend_tensor_get(source, staging.data(),
+                            row_bytes * (size_t) source_row, bytes);
+    ggml_backend_tensor_set(destination, staging.data(), 0, bytes);
+    return true;
+}
+
+}  // namespace
+
+DeepSeek4AttentionParallelPlan plan_deepseek4_attention_groups(
+        int n_head,
+        int n_out_group,
+        int requested_peer_groups) {
+    DeepSeek4AttentionParallelPlan plan;
+    if (n_head <= 0 || n_out_group <= 1 || n_head % n_out_group != 0 ||
+        requested_peer_groups <= 0 || requested_peer_groups >= n_out_group) {
+        return plan;
+    }
+    plan.total_groups = n_out_group;
+    plan.peer_groups = requested_peer_groups;
+    plan.main_groups = n_out_group - requested_peer_groups;
+    plan.heads_per_group = n_head / n_out_group;
+    return plan;
+}
+
+DeepSeek4AttentionParallelState::~DeepSeek4AttentionParallelState() {
+    free_deepseek4_attention_parallel(*this);
+}
+
+void free_deepseek4_attention_parallel(DeepSeek4AttentionParallelState & state) {
+    state.layers.clear();
+    if (state.weights_buf) {
+        ggml_backend_buffer_free(state.weights_buf);
+        state.weights_buf = nullptr;
+    }
+    if (state.weights_ctx) {
+        ggml_free(state.weights_ctx);
+        state.weights_ctx = nullptr;
+    }
+    state.main_backend = nullptr;
+    state.peer_backend = nullptr;
+    state.plan = {};
+    state.min_context = 0;
+}
+
+bool init_deepseek4_attention_parallel(
+        ggml_backend_t main_backend,
+        ggml_backend_t peer_backend,
+        const DeepSeek4Weights & weights,
+        int peer_groups,
+        int min_context,
+        DeepSeek4AttentionParallelState & out,
+        std::string * error) {
+    free_deepseek4_attention_parallel(out);
+
+    const DeepSeek4AttentionParallelPlan plan =
+        plan_deepseek4_attention_groups(
+            weights.n_head, weights.n_out_group, peer_groups);
+    if (!main_backend || !peer_backend || main_backend == peer_backend ||
+        !plan.valid()) {
+        set_error(error, "attention group split requires two distinct backends and a legal group count");
+        return false;
+    }
+    out.main_backend = main_backend;
+    out.peer_backend = peer_backend;
+    out.plan = plan;
+    out.min_context = std::max(0, min_context);
+    out.layers.resize((size_t) weights.n_layer);
+
+    ggml_init_params weights_params{};
+    weights_params.mem_size =
+        ggml_tensor_overhead() * (size_t) (weights.n_layer + 8) + 4096;
+    weights_params.no_alloc = true;
+    out.weights_ctx = ggml_init(weights_params);
+    if (!out.weights_ctx) {
+        set_error(error, "failed to create attention peer weight context");
+        free_deepseek4_attention_parallel(out);
+        return false;
+    }
+
+    const int peer_output_rows = plan.peer_groups * weights.n_lora_o;
+    for (int il = 0; il < weights.n_layer; ++il) {
+        const DeepSeek4Layer & source_layer = weights.layers[(size_t) il];
+        DeepSeek4AttentionParallelLayer & destination =
+            out.layers[(size_t) il];
+        if (!source_layer.attn_output_a) {
+            set_error(error, "attention group split source weight is missing");
+            free_deepseek4_attention_parallel(out);
+            return false;
+        }
+
+        destination.output_a = ggml_new_tensor_2d(
+            out.weights_ctx,
+            source_layer.attn_output_a->type,
+            source_layer.attn_output_a->ne[0], peer_output_rows);
+
+        char name[96];
+        std::snprintf(name, sizeof(name), "blk.%d.attn_output_a.peer", il);
+        ggml_set_name(destination.output_a, name);
+    }
+
+    out.weights_buf =
+        ggml_backend_alloc_ctx_tensors(out.weights_ctx, peer_backend);
+    if (!out.weights_buf) {
+        set_error(error, "failed to allocate attention peer weights");
+        free_deepseek4_attention_parallel(out);
+        return false;
+    }
+    ggml_backend_buffer_set_usage(
+        out.weights_buf, GGML_BACKEND_BUFFER_USAGE_WEIGHTS);
+
+    ggml_backend_synchronize(main_backend);
+    std::vector<uint8_t> staging;
+    const int first_peer_row = plan.main_groups * weights.n_lora_o;
+    size_t copied_bytes = 0;
+    for (int il = 0; il < weights.n_layer; ++il) {
+        const ggml_tensor * source =
+            weights.layers[(size_t) il].attn_output_a;
+        ggml_tensor * destination = out.layers[(size_t) il].output_a;
+        if (!copy_tensor_rows(
+                source, destination, first_peer_row, peer_output_rows,
+                staging, error)) {
+            free_deepseek4_attention_parallel(out);
+            return false;
+        }
+        copied_bytes += ggml_nbytes(destination);
+    }
+    ggml_backend_synchronize(peer_backend);
+
+    std::fprintf(stderr,
+        "[deepseek4-attn-tp] initialized single-process split "
+        "main=%d groups peer=%d groups peer_weights=%.1f MiB "
+        "min_context=%d\n",
+        plan.main_groups, plan.peer_groups,
+        (double) copied_bytes / (1024.0 * 1024.0),
+        out.min_context);
+    return true;
+}
+
+}  // namespace dflash::common

--- a/server/src/deepseek4/deepseek4_attention_parallel.h
+++ b/server/src/deepseek4/deepseek4_attention_parallel.h
@@ -1,0 +1,91 @@
+// Single-process DeepSeek V4 attention-group parallelism.
+//
+// The primary GPU owns shared MLA attention and its authoritative cache state.
+// A second GPU owns a contiguous tail of the grouped output-A projection.
+// Both branches run in one ggml scheduler graph and meet at one deferred
+// device-side copy per layer.
+
+#pragma once
+
+#include "ggml.h"
+#include "ggml-backend.h"
+
+#include <string>
+#include <vector>
+
+namespace dflash::common {
+
+struct DeepSeek4Weights;
+
+struct DeepSeek4AttentionParallelPlan {
+    int total_groups = 0;
+    int main_groups = 0;
+    int peer_groups = 0;
+    int heads_per_group = 0;
+
+    bool valid() const {
+        return total_groups > 1 && main_groups > 0 && peer_groups > 0 &&
+               main_groups + peer_groups == total_groups &&
+               heads_per_group > 0;
+    }
+};
+
+// Returns an empty plan when the model dimensions or requested split are not
+// legal.  Groups are the indivisible unit: no attention head is split between
+// devices.
+DeepSeek4AttentionParallelPlan plan_deepseek4_attention_groups(
+    int n_head,
+    int n_out_group,
+    int requested_peer_groups);
+
+struct DeepSeek4AttentionParallelLayer {
+    // Peer-owned slice containing the final `peer_groups * n_lora_o` rows of
+    // the grouped output-A projection.
+    ggml_tensor * output_a = nullptr;
+};
+
+struct DeepSeek4AttentionParallelState {
+    DeepSeek4AttentionParallelState() = default;
+    ~DeepSeek4AttentionParallelState();
+    DeepSeek4AttentionParallelState(
+        const DeepSeek4AttentionParallelState &) = delete;
+    DeepSeek4AttentionParallelState & operator=(
+        const DeepSeek4AttentionParallelState &) = delete;
+
+    ggml_backend_t main_backend = nullptr;
+    ggml_backend_t peer_backend = nullptr;
+    DeepSeek4AttentionParallelPlan plan;
+    int min_context = 0;
+
+    ggml_context * weights_ctx = nullptr;
+    ggml_backend_buffer_t weights_buf = nullptr;
+    std::vector<DeepSeek4AttentionParallelLayer> layers;
+
+    bool enabled_for(int n_tokens, int kv_start, bool stable_cache_graph) const {
+        return plan.valid() && stable_cache_graph &&
+               n_tokens > 1 && n_tokens <= 6 && kv_start >= min_context;
+    }
+};
+
+// Per-layer graph metadata used when the fused verifier pins work to the two
+// local HIP backends and registers the single peer-to-main handoff.
+struct DeepSeek4AttentionParallelGraphInputs {
+    std::vector<ggml_tensor *> peer_nodes;
+    std::vector<ggml_tensor *> deferred_peer_copy_nodes;
+    ggml_tensor * main_output = nullptr;
+    ggml_tensor * peer_output = nullptr;
+    ggml_tensor * output = nullptr;
+};
+
+bool init_deepseek4_attention_parallel(
+    ggml_backend_t main_backend,
+    ggml_backend_t peer_backend,
+    const DeepSeek4Weights & weights,
+    int peer_groups,
+    int min_context,
+    DeepSeek4AttentionParallelState & out,
+    std::string * error = nullptr);
+
+void free_deepseek4_attention_parallel(DeepSeek4AttentionParallelState & state);
+
+}  // namespace dflash::common

--- a/server/src/deepseek4/deepseek4_backend.cpp
+++ b/server/src/deepseek4/deepseek4_backend.cpp
@@ -1,6 +1,7 @@
 // DeepSeek4Backend implementation — AR-only decode, chunked prefill.
 
 #include "deepseek4_backend.h"
+#include "deepseek4_attention_parallel.h"
 #include "deepseek4_internal.h"
 #include "common/dynamic_backend.h"
 #include "common/peer_access.h"
@@ -148,6 +149,43 @@ struct Ds4MoeTpConfig {
     bool concentrate_secondary = false;
     bool profile_hot_on_secondary = false;
 };
+
+struct Ds4AttentionTpConfig {
+    int peer_groups = 0;
+    int min_context = 0;
+    bool valid = true;
+
+    bool requested() const { return peer_groups > 0; }
+};
+
+static Ds4AttentionTpConfig ds4_attention_tp_config() {
+    Ds4AttentionTpConfig result;
+    const char * groups_raw = std::getenv("DFLASH_DS4_ATTN_TP_GROUPS");
+    if (!groups_raw || !*groups_raw || std::strcmp(groups_raw, "0") == 0) {
+        return result;
+    }
+    char * groups_end = nullptr;
+    const long groups = std::strtol(groups_raw, &groups_end, 10);
+    if (groups_end == groups_raw || *groups_end != '\0' || groups <= 0 ||
+        groups > std::numeric_limits<int>::max()) {
+        result.valid = false;
+        return result;
+    }
+    result.peer_groups = (int) groups;
+
+    const char * context_raw =
+        std::getenv("DFLASH_DS4_ATTN_TP_MIN_CONTEXT");
+    if (!context_raw || !*context_raw) return result;
+    char * context_end = nullptr;
+    const long context = std::strtol(context_raw, &context_end, 10);
+    if (context_end == context_raw || *context_end != '\0' || context < 0 ||
+        context > std::numeric_limits<int>::max()) {
+        result.valid = false;
+        return result;
+    }
+    result.min_context = (int) context;
+    return result;
+}
 
 static Ds4MoeTpConfig ds4_moe_tp_config(int local_gpu) {
     Ds4MoeTpConfig result;
@@ -917,6 +955,9 @@ bool DeepSeek4Backend::init() {
     if (env_flag_enabled("DFLASH_DS4_MOE_TP") && !init_moe_tensor_parallel()) {
         return false;
     }
+    if (!init_attention_parallel()) {
+        return false;
+    }
 
     if (const char * stats_path = std::getenv("DFLASH_DS4_ROUTING_STATS_OUT")) {
         if (*stats_path) {
@@ -1026,6 +1067,52 @@ bool DeepSeek4Backend::init_moe_tensor_parallel() {
                  "[deepseek4-moe-tp] enabled local_experts=%d remote_experts=%d\n",
                  moe_placement_.total_hot,
                  w_.n_layer * w_.n_expert - moe_placement_.total_hot);
+    return true;
+}
+
+bool DeepSeek4Backend::init_attention_parallel() {
+    cache_.attention_parallel = nullptr;
+    attention_parallel_.reset();
+
+    const Ds4AttentionTpConfig attention = ds4_attention_tp_config();
+    if (!attention.valid) {
+        std::fprintf(stderr,
+            "[deepseek4-attn-tp] invalid configuration; "
+            "DFLASH_DS4_ATTN_TP_GROUPS must be a positive integer and "
+            "DFLASH_DS4_ATTN_TP_MIN_CONTEXT must be non-negative\n");
+        return false;
+    }
+    if (!attention.requested()) return true;
+
+    const Ds4MoeTpConfig moe = ds4_moe_tp_config(cfg_.device.gpu);
+    if (!moe.in_process || !expert_backend_ || !moe_hybrid_ ||
+        moe_hybrid_->cold_backend != expert_backend_) {
+        std::fprintf(stderr,
+            "[deepseek4-attn-tp] requires DFLASH_DS4_MOE_TP_INPROC=1 "
+            "and the existing local secondary GPU backend\n");
+        return false;
+    }
+    const BackendPairCapabilities capabilities =
+        backend_pair_capabilities(backend_, expert_backend_);
+    if (!capabilities.same_runtime) {
+        std::fprintf(stderr,
+            "[deepseek4-attn-tp] requires two GPUs in the same runtime; "
+            "mixed CUDA/HIP pairs are not supported\n");
+        return false;
+    }
+
+    auto state = std::make_shared<DeepSeek4AttentionParallelState>();
+    std::string error;
+    if (!init_deepseek4_attention_parallel(
+            backend_, expert_backend_, w_, attention.peer_groups,
+            attention.min_context, *state, &error)) {
+        std::fprintf(stderr,
+            "[deepseek4-attn-tp] initialization failed: %s\n",
+            error.c_str());
+        return false;
+    }
+    attention_parallel_ = std::move(state);
+    cache_.attention_parallel = attention_parallel_.get();
     return true;
 }
 
@@ -1414,6 +1501,8 @@ bool DeepSeek4Backend::park(ParkTarget target) {
     }
     last_logits_.clear();
     last_logits_pos_ = -1;
+    cache_.attention_parallel = nullptr;
+    attention_parallel_.reset();
     free_deepseek4_cache(cache_);
     expert_runtime_.reset();
     stream_engine_.destroy();
@@ -1475,6 +1564,22 @@ bool DeepSeek4Backend::unpark(ParkTarget target) {
 
         if (env_flag_enabled("DFLASH_DS4_MOE_TP") &&
             !init_moe_tensor_parallel()) {
+            free_deepseek4_cache(cache_);
+            free_deepseek4_weights(w_);
+            expert_runtime_.reset();
+            stream_engine_.destroy();
+            moe_hybrid_.reset();
+            if (expert_backend_) {
+                ggml_backend_free(expert_backend_);
+                expert_backend_ = nullptr;
+            }
+            moe_placement_ = {};
+            moe_decode_placement_ = {};
+            return false;
+        }
+        if (!init_attention_parallel()) {
+            cache_.attention_parallel = nullptr;
+            attention_parallel_.reset();
             free_deepseek4_cache(cache_);
             free_deepseek4_weights(w_);
             expert_runtime_.reset();
@@ -2172,6 +2277,8 @@ void DeepSeek4Backend::shutdown() {
     for (int i = 0; i < PREFIX_SLOTS; i++) {
         snapshot_free(i);
     }
+    cache_.attention_parallel = nullptr;
+    attention_parallel_.reset();
     free_deepseek4_cache(cache_);
     expert_runtime_.reset();
     stream_engine_.destroy();

--- a/server/src/deepseek4/deepseek4_backend.h
+++ b/server/src/deepseek4/deepseek4_backend.h
@@ -150,6 +150,7 @@ private:
     bool requires_monolithic_model() const;
     bool validate_prefill_mode() const;
     bool init_moe_tensor_parallel();
+    bool init_attention_parallel();
     bool compute_uniform_hybrid_placement(const DeepSeek4Weights & w,
                                           int max_ctx,
                                           MoeHybridPlacement & out,
@@ -158,6 +159,7 @@ private:
     void maybe_save_routing_stats();
 
     std::shared_ptr<MoeHybridStorage> moe_hybrid_;
+    std::shared_ptr<DeepSeek4AttentionParallelState> attention_parallel_;
     MoeHybridPlacement                moe_placement_;
     MoeHybridPlacement                moe_decode_placement_;
     MoeHybridStreamEngine             stream_engine_;

--- a/server/src/deepseek4/deepseek4_fused_verify.inc
+++ b/server/src/deepseek4/deepseek4_fused_verify.inc
@@ -383,6 +383,9 @@ static bool ds4_build_fused_verify_graph(
     if (hybrid) {
         fg.hybrid_inputs.assign((size_t) w.n_layer, {});
     }
+    if (cache.attention_parallel) {
+        fg.attention_parallel_inputs.assign((size_t) w.n_layer, {});
+    }
     const int n_embd = w.n_embd;
     const int n_hc = w.n_hc;
     const BackendPairCapabilities pair_capabilities = hybrid
@@ -481,6 +484,10 @@ static bool ds4_build_fused_verify_graph(
 
         // ── Batched attention ──
         DeepSeek4AttentionGraphInputs ain{};
+        DeepSeek4AttentionParallelGraphInputs * attention_inputs =
+            cache.attention_parallel
+                ? &fg.attention_parallel_inputs[(size_t) il]
+                : nullptr;
         ain.rope_pos = ex.pos_q;
         ain.neg_pos = ex.neg_q;
         ain.raw_kv_rows = ex.rawrows;
@@ -535,7 +542,11 @@ static bool ds4_build_fused_verify_graph(
         ggml_tensor * normed = build_rms_norm(ctx, attn_in, L.attn_norm, w.rms_eps);
         ggml_tensor * attn_out = build_mla_attention(ctx, gf, normed, w, L, lc, il,
                                                      lane_kv_start, lane_q, &ain,
-                                                     i32b, i32ab, i64ab);
+                                                     i32b, i32ab, i64ab,
+                                                     nullptr,
+                                                     DeepSeek4AttentionImpl::Explicit,
+                                                     cache.attention_parallel,
+                                                     attention_inputs);
         if (!attn_out) return false;
         if (!i32b.empty() || !i32ab.empty() || !i64ab.empty()) {
             std::fprintf(stderr, "[ds4-fused-verify] layer %d dynamic bindings; cannot fuse\n", il);
@@ -911,6 +922,21 @@ static bool ds4_build_fused_verify_graph(
         pin_main(fg.i64_bundle);
         pin_main(fg.mask_bundle);
         for (ggml_tensor * hids : fg.hash_ids) pin_main(hids);
+        for (const DeepSeek4AttentionParallelGraphInputs & inputs :
+             fg.attention_parallel_inputs) {
+            for (ggml_tensor * node : inputs.peer_nodes) {
+                pin_peer(node);
+            }
+            for (ggml_tensor * node :
+                 inputs.deferred_peer_copy_nodes) {
+                pin_main(node);
+                ggml_backend_sched_add_deferred_peer_copy_node(
+                    fg.sched, node);
+            }
+            pin_main(inputs.main_output);
+            pin_main(inputs.peer_output);
+            pin_main(inputs.output);
+        }
         for (const MoeHybridGraphInputs & inputs : fg.hybrid_inputs) {
             if (mixed_policy.pin_route_weights) {
                 for (ggml_tensor * node : inputs.router_nodes) {

--- a/server/src/deepseek4/deepseek4_graph.cpp
+++ b/server/src/deepseek4/deepseek4_graph.cpp
@@ -9,6 +9,7 @@
 //   6. MoE FFN (hash routing + top-k + shared expert + clamped SwiGLU)
 
 #include "deepseek4_internal.h"
+#include "deepseek4_attention_parallel.h"
 #include "deepseek4_hc_cuda.h"
 #include "internal.h"
 #include "../common/step_graph.h"
@@ -1618,7 +1619,9 @@ static ggml_tensor * build_mla_attention(
         std::vector<DeepSeek4I32ArrayBinding> & i32_array_inputs,
         std::vector<DeepSeek4I64ArrayBinding> & i64_array_inputs,
         std::vector<DeepSeek4F32ArrayBinding> * f32_array_inputs = nullptr,
-        DeepSeek4AttentionImpl attention_impl = DeepSeek4AttentionImpl::Explicit) {
+        DeepSeek4AttentionImpl attention_impl = DeepSeek4AttentionImpl::Explicit,
+        DeepSeek4AttentionParallelState * attention_parallel = nullptr,
+        DeepSeek4AttentionParallelGraphInputs * attention_parallel_inputs = nullptr) {
 
     const int n_embd    = w.n_embd;
     const int head_dim  = w.head_dim;
@@ -1627,6 +1630,23 @@ static ggml_tensor * build_mla_attention(
     const int n_out_group = w.n_out_group;
     const int n_lora_o  = w.n_lora_o;
     const int ratio     = w.compress_ratios[layer_idx];
+    const bool stable_cache_graph = cached_inputs &&
+        cached_inputs->raw_kv_rows && cached_inputs->attn_row_mask;
+    bool use_attention_parallel = attention_parallel &&
+        attention_parallel_inputs && stable_cache_graph &&
+        attention_impl == DeepSeek4AttentionImpl::Explicit &&
+        layer_idx >= 0 &&
+        layer_idx < (int) attention_parallel->layers.size() &&
+        attention_parallel->enabled_for(
+            n_tokens, kv_start, stable_cache_graph);
+    DeepSeek4AttentionParallelLayer * attention_peer_layer =
+        use_attention_parallel
+            ? &attention_parallel->layers[(size_t) layer_idx]
+            : nullptr;
+    if (use_attention_parallel && !attention_peer_layer->output_a) {
+        use_attention_parallel = false;
+        attention_peer_layer = nullptr;
+    }
 
     // ── Q path: cur → q_a → norm → q_b → per-head norm ─────────────
     // q_a: [n_embd, n_tokens] → [n_lora_q, n_tokens]
@@ -2260,9 +2280,6 @@ static ggml_tensor * build_mla_attention(
             rope_n_ctx_orig);
     }
 
-    // Flatten to [head_dim*n_head, n_tokens] for output projection
-    ggml_tensor * attn_out = ggml_reshape_2d(ctx, context, head_dim * n_head, n_tokens);
-
     // ── Grouped output projection ──────────────────────────────────
     // DS4 output uses grouped low-rank projection:
     //   attn_out: [head_dim*n_head, n_tokens] → reshape [group_dim, n_tokens, n_groups]
@@ -2270,17 +2287,84 @@ static ggml_tensor * build_mla_attention(
     //   batched matmul over n_groups: → [n_lora_o, n_tokens, n_groups]
     //   → reshape [n_lora_o*n_groups, n_tokens]
     //   out_b: [n_lora_o*n_groups, n_embd] → final: [n_embd, n_tokens]
-    const int group_dim = head_dim * (n_head / n_out_group);  // 512 * 8 = 4096
-    // Reshape attn_out: [32768, n_tokens] → [4096, 8, n_tokens] → permute to [4096, n_tokens, 8]
-    attn_out = ggml_reshape_3d(ctx, attn_out, group_dim, n_out_group, n_tokens);
-    attn_out = ggml_permute(ctx, attn_out, 0, 2, 1, 3);
-    if (n_tokens == 1) {
-        attn_out = ggml_cont(ctx, attn_out);
+    const int group_dim =
+        head_dim * (n_head / n_out_group);  // 512 * 8 = 4096
+    auto build_group_low = [&](ggml_tensor * branch_context,
+                               ggml_tensor * output_a,
+                               int group_count) {
+        const int branch_heads = group_count * (n_head / n_out_group);
+        // A head slice is strided across tokens. Materialize it locally before
+        // reshaping so both devices consume the same canonical [D,H,T] order.
+        branch_context = ggml_is_contiguous(branch_context)
+            ? branch_context : ggml_cont(ctx, branch_context);
+        ggml_tensor * branch_out = ggml_reshape_2d(
+            ctx, branch_context, head_dim * branch_heads, n_tokens);
+        branch_out = ggml_reshape_3d(
+            ctx, branch_out, group_dim, group_count, n_tokens);
+        branch_out = ggml_permute(ctx, branch_out, 0, 2, 1, 3);
+        if (n_tokens == 1) {
+            branch_out = ggml_cont(ctx, branch_out);
+        }
+        ggml_tensor * out_a_3d = ggml_reshape_3d(
+            ctx, output_a, group_dim, n_lora_o, group_count);
+        return ggml_mul_mat(ctx, out_a_3d, branch_out);
+    };
+
+    ggml_tensor * attn_low = nullptr;
+    if (use_attention_parallel) {
+        const DeepSeek4AttentionParallelPlan & plan =
+            attention_parallel->plan;
+        ggml_tensor * main_output_a = ggml_view_2d(
+            ctx, L.attn_output_a, group_dim,
+            (int64_t) plan.main_groups * n_lora_o,
+            L.attn_output_a->nb[1], 0);
+        const int main_heads =
+            plan.main_groups * plan.heads_per_group;
+        const int peer_heads =
+            plan.peer_groups * plan.heads_per_group;
+        auto context_slice = [&](int first_head, int head_count) {
+            return ggml_view_3d(
+                ctx, context, head_dim, head_count, n_tokens,
+                context->nb[1], context->nb[2],
+                (size_t) first_head * context->nb[1]);
+        };
+        ggml_tensor * main_low = build_group_low(
+            context_slice(0, main_heads), main_output_a,
+            plan.main_groups);
+        ggml_tensor * peer_low = build_group_low(
+            context_slice(main_heads, peer_heads),
+            attention_peer_layer->output_a,
+            plan.peer_groups);
+
+        // Shared attention stays byte-for-byte on the primary GPU. The peer
+        // graph delta starts only after its result, so the scheduler transfers
+        // one compact context slice and executes one independent projection.
+        ggml_build_forward_expand(gf, context);
+        const int peer_node_begin = ggml_graph_n_nodes(gf);
+        ggml_set_output(peer_low);
+        ggml_build_forward_expand(gf, peer_low);
+        const int peer_node_end = ggml_graph_n_nodes(gf);
+        for (int ni = peer_node_begin; ni < peer_node_end; ++ni) {
+            attention_parallel_inputs->peer_nodes.push_back(
+                ggml_graph_node(gf, ni));
+        }
+
+        // Queue the independent primary branch before introducing the only
+        // peer-to-primary dependency for this layer.
+        ggml_build_forward_expand(gf, main_low);
+        ggml_tensor * peer_ready = ggml_ds4_deferred_peer_copy(
+            ctx, peer_low);
+        ggml_set_input(peer_ready);
+        ggml_set_output(peer_ready);
+        attention_parallel_inputs->deferred_peer_copy_nodes.push_back(
+            peer_ready);
+        attention_parallel_inputs->main_output = main_low;
+        attention_parallel_inputs->peer_output = peer_ready;
+        attn_low = ggml_concat(ctx, main_low, peer_ready, 2);
+    } else {
+        attn_low = build_group_low(
+            context, L.attn_output_a, n_out_group);
     }
-    // attn_out is now [group_dim, n_tokens, n_out_group]
-    ggml_tensor * out_a_3d = ggml_reshape_3d(ctx, L.attn_output_a, group_dim, n_lora_o, n_out_group);
-    // out_a_3d: [group_dim, n_lora_o, n_out_group] — ne[2] matches
-    ggml_tensor * attn_low = ggml_mul_mat(ctx, out_a_3d, attn_out);
     // attn_low: [n_lora_o, n_tokens, n_out_group]
     ggml_tensor * out = nullptr;
     const bool grouped_output_projection =
@@ -2300,6 +2384,10 @@ static ggml_tensor * build_mla_attention(
         attn_low = ggml_reshape_2d(
             ctx, attn_low, n_lora_o * n_out_group, n_tokens);
         out = ggml_mul_mat(ctx, L.attn_output_b, attn_low);
+    }
+
+    if (use_attention_parallel) {
+        attention_parallel_inputs->output = out;
     }
 
     return out;
@@ -4608,6 +4696,8 @@ struct DeepSeek4FusedDecodeGraph {
     ggml_tensor * mask_bundle = nullptr;   // additive score mask (0 / -1e30), may be null
     std::vector<ggml_tensor *> hash_ids;
     std::vector<MoeHybridGraphInputs> hybrid_inputs;
+    std::vector<DeepSeek4AttentionParallelGraphInputs>
+        attention_parallel_inputs;
     std::vector<AuthoritativeRouteOutput> authoritative_routes;
     ggml_tensor * logits = nullptr;
     ggml_backend_sched_t sched = nullptr;
@@ -4620,6 +4710,7 @@ struct DeepSeek4FusedDecodeGraph {
         logits = nullptr;
         hash_ids.clear();
         hybrid_inputs.clear();
+        attention_parallel_inputs.clear();
         authoritative_routes.clear();
         shape_key.clear();
         last_use = 0;
@@ -8134,6 +8225,7 @@ void free_deepseek4_cache(DeepSeek4Cache & c) {
     if (c.buf) { ggml_backend_buffer_free(c.buf); c.buf = nullptr; }
     c.layers.clear();
     c.hc_state = nullptr;
+    c.attention_parallel = nullptr;
 }
 
 void reset_deepseek4_cache(DeepSeek4Cache & c) {

--- a/server/src/deepseek4/deepseek4_internal.h
+++ b/server/src/deepseek4/deepseek4_internal.h
@@ -38,6 +38,7 @@ struct MoeHybridConfig;
 struct MoeHybridRoutingStats;
 struct MoeExpertComputeRuntime;
 class MoeHybridStreamEngine;
+struct DeepSeek4AttentionParallelState;
 
 struct DeepSeek4StepTelemetry {
     uint64_t total_us = 0;
@@ -286,6 +287,11 @@ struct DeepSeek4Cache {
 
     // Lazily created on the first deepseek4_step_layer_range call.
     DeepSeek4LayerRangeCache * layer_range_cache = nullptr;
+
+    // Non-owning link to the optional single-process attention-group runtime.
+    // DeepSeek4Backend owns it and releases cached graphs before this pointer or
+    // either GPU backend can disappear.
+    DeepSeek4AttentionParallelState * attention_parallel = nullptr;
 
     ggml_context *        ctx = nullptr;
     ggml_backend_buffer_t buf = nullptr;

--- a/server/tests/test_deepseek4_unit.cpp
+++ b/server/tests/test_deepseek4_unit.cpp
@@ -13,6 +13,7 @@
 #include "common/layer_split_backend.h"
 #include "common/layer_split_runtime.h"
 #include "common/layer_split_utils.h"
+#include "deepseek4/deepseek4_attention_parallel.h"
 #include "deepseek4/deepseek4_dspark.h"
 
 #include <memory>
@@ -61,6 +62,33 @@ static bool nearly_equal(float a, float b, float atol = 1.0e-5f, float rtol = 1.
     const float diff = std::fabs(a - b);
     const float scale = std::max(std::fabs(a), std::fabs(b));
     return diff <= atol + rtol * scale;
+}
+
+static void test_attention_group_parallel_plan() {
+    std::fprintf(stderr, "  test_attention_group_parallel_plan ...");
+    const DeepSeek4AttentionParallelPlan plan =
+        plan_deepseek4_attention_groups(64, 8, 2);
+    TEST_ASSERT(plan.valid());
+    TEST_ASSERT(plan.total_groups == 8);
+    TEST_ASSERT(plan.main_groups == 6);
+    TEST_ASSERT(plan.peer_groups == 2);
+    TEST_ASSERT(plan.heads_per_group == 8);
+
+    TEST_ASSERT(!plan_deepseek4_attention_groups(64, 8, 0).valid());
+    TEST_ASSERT(!plan_deepseek4_attention_groups(64, 8, 8).valid());
+    TEST_ASSERT(!plan_deepseek4_attention_groups(63, 8, 2).valid());
+    TEST_ASSERT(!plan_deepseek4_attention_groups(64, 1, 1).valid());
+
+    DeepSeek4AttentionParallelState state;
+    state.plan = plan;
+    state.min_context = 1024;
+    TEST_ASSERT(state.enabled_for(5, 1024, true));
+    TEST_ASSERT(state.enabled_for(6, 1024, true));
+    TEST_ASSERT(!state.enabled_for(1, 1024, true));
+    TEST_ASSERT(!state.enabled_for(7, 1024, true));
+    TEST_ASSERT(!state.enabled_for(5, 1023, true));
+    TEST_ASSERT(!state.enabled_for(5, 1024, false));
+    std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
 }
 
 static ggml_tensor * test_hc_row_normalize(ggml_context * ctx, ggml_tensor * x) {
@@ -4102,6 +4130,7 @@ int main() {
     }
 
     test_compressor_pooling_correctness(backend);
+    test_attention_group_parallel_plan();
     test_chunked_graph_allocator(backend);
     test_swiglu_ds4_cpu_correctness(backend);
     test_moe_routing_correctness(backend);


### PR DESCRIPTION
## Summary

- add an opt-in 6/2-style split of DeepSeek4 grouped output-A projections across the existing in-process GPU pair
- keep shared MLA attention, RoPE, compressors, authoritative KV state, and output-B unchanged on the main GPU
- copy only immutable peer-owned projection weights and use one deferred peer return per layer
- reject IPC and mixed-runtime pairs; keep the feature disabled by default
- record the exact correctness and performance qualification so the rejected profile is not rediscovered

## Qualification

R9700 + Strix Halo, q=5 DSpark, 2K context, 128 output tokens, one warmup plus three measured requests:

| Plan | Engine tok/s | Client median tok/s | Scheduler splits |
|---|---:|---:|---:|
| Control | 68.3 | 83.162 | 130 |
| 6 main / 2 peer output groups | 54.0-54.1 | 65.271 | 259 |

All requests matched SHA-256 0f785a7ffa406498aafb14553966eaed0f52220fed0f7cc016b66921d104d194 with 0.96 acceptance. The mechanism is correct, but this scheduler topology is about 21% slower, so it remains opt-in and is not proposed as a performance default.

## Tests

- dual-architecture HIP dflash_server build on lucebox5
- full test_deepseek4_unit suite on lucebox5, including ROCm GPU oracles
- final 2K/128-token model-backed exact-hash run with the opt-in enabled
- bash -n server/scripts/qualify_ds4_q5_amd.sh
- git diff --check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

