### PR TITLE
feat(deepseek4): add experimental PFlash prefill compression

### DIFF
--- a/optimizations/pflash/README.md
+++ b/optimizations/pflash/README.md
@@ -213,6 +213,7 @@ What we built:
 
 - **Single 24 GB GPU** target (RTX 3090 reference). On 32+ GB cards, drafter + target can coexist and the park/unpark dance disappears.
 - **Qwen3.6-27B Q4_K_M target + Qwen3-0.6B drafter** is the validated pair. Other targets/drafters need keep_ratio + alpha re-calibration.
+- **DeepSeek V4 Flash is supported experimentally on the monolithic backend.** The HTTP server bridges the DeepSeek and Qwen drafter tokenizers, keeps the large target resident when memory permits, and temporarily releases/restores the DSpark decode drafter. Local layer-split DeepSeek PFlash is not implemented; a remote PFlash drafter remains available for that placement.
 - **NIAH single-needle** is the only retrieval task validated end-to-end. Multi-doc QA, long-form code retrieval, etc. still TBD.
 - **sm_80+** required for BSA (RTX 3090 sm_86 is the reference). On sm_75 (Turing) the build auto-disables BSA and falls back to the WMMA path; expect a slower drafter forward at long ctx.
 

--- a/server/src/common/feature_gate.cpp
+++ b/server/src/common/feature_gate.cpp
@@ -32,6 +32,8 @@ std::string check_feature_compatibility(
         features.pflash_enabled || args.draft_path != nullptr;
     const bool mixed_draft_placement =
         draft_placement_used && target_backend != draft_backend;
+    const bool split_target =
+        args.device.is_layer_split() || args.remote_target_shard.enabled();
 
     // ── IPC auxiliary options × IPC enablement
     if (!args.remote_draft.enabled() &&
@@ -158,6 +160,12 @@ std::string check_feature_compatibility(
         !arch_supports_pflash_compression(arch)) {
         return "model architecture '" + arch +
                "' does not support PFlash compression";
+    }
+    if (features.pflash_enabled && arch == "deepseek4" && split_target &&
+        !mixed_draft_placement) {
+        return "local PFlash compression for deepseek4 requires a "
+               "single-device target; use a monolithic target or place the "
+               "PFlash drafter on a remote backend";
     }
 
     // ── --ds4-prefill × architecture

--- a/server/src/common/model_capabilities.h
+++ b/server/src/common/model_capabilities.h
@@ -68,7 +68,7 @@ inline constexpr ArchCapabilities kArchCapabilities[] = {
     {"laguna",     true,  false, false, true,    kMono, kMono, kMono,  kNever, kNever},
     {"qwen3",      false, false, true,  false,   kNever, kNever, kNever, kNever, kNever},
     {"gemma4",     true,  false, false, false,   kMono, kNever, kNever, kBoth, kNever},
-    {"deepseek4",  true,  false, false, false,   kNever, kNever, kNever, kNever, kNever},
+    {"deepseek4",  true,  false, true,  false,   kNever, kNever, kNever, kNever, kNever},
 };
 
 inline constexpr std::size_t kArchCount =

--- a/server/src/deepseek4/deepseek4_backend.cpp
+++ b/server/src/deepseek4/deepseek4_backend.cpp
@@ -3,6 +3,7 @@
 #include "deepseek4_backend.h"
 #include "deepseek4_internal.h"
 #include "common/dynamic_backend.h"
+#include "common/io_utils.h"
 #include "common/peer_access.h"
 #include "common/sampler.h"
 
@@ -1896,14 +1897,123 @@ GenerateResult DeepSeek4Backend::restore_and_generate_impl(
     return generate_from_state(req, io, snap_pos);
 }
 
+ModelBackend::CompressResult DeepSeek4Backend::compress(
+        const CompressRequest & req) {
+    CompressResult result;
+    if (req.input_ids.empty() || req.drafter_path.empty() || parked_) {
+        return result;
+    }
+
+    // DSpark often occupies the secondary GPU on mixed DeepSeek systems.
+    // Release it while PFlash scores the prompt, then restore it before target
+    // generation. Keep the 100 GB DeepSeek target resident: reloading it would
+    // erase PFlash's TTFT gain and parking clears target prefix snapshots. If
+    // the PFlash drafter cannot coexist, the caller can place it remotely.
+    const bool restore_spec = spec_drafter_ != nullptr;
+    bool restore_ok = true;
+
+    if (restore_spec && !park(ParkTarget::DraftModel)) {
+        return result;
+    }
+    if (backend_) ggml_backend_synchronize(backend_);
+    if (expert_backend_) ggml_backend_synchronize(expert_backend_);
+
+    auto load_pflash = [&]() {
+        std::fprintf(stderr,
+                     "[pflash][deepseek4] loading drafter from %s on gpu=%d ...\n",
+                     req.drafter_path.c_str(), req.drafter_gpu);
+        if (!load_drafter(req.drafter_path, /*gpu_layers=*/999,
+                          req.drafter_gpu, pflash_drafter_)) {
+            std::fprintf(stderr,
+                         "[pflash][deepseek4] drafter init failed: %s\n",
+                         dflash27b_last_error());
+            return false;
+        }
+        pflash_drafter_loaded_ = true;
+        std::fprintf(stderr, "[pflash][deepseek4] drafter ready\n");
+        return true;
+    };
+
+    if (!pflash_drafter_loaded_ && !load_pflash()) {
+        // A failed load may leave an owned backend or partial allocations.
+        release_pflash_drafter();
+    }
+
+    if (pflash_drafter_loaded_) {
+        result.compressed_ids = drafter_score_and_compress(
+            pflash_drafter_, req.input_ids, req.keep_ratio);
+        result.ok = !result.compressed_ids.empty();
+        if (result.ok) {
+            std::fprintf(stderr,
+                         "[pflash][deepseek4] %zu -> %zu tokens\n",
+                         req.input_ids.size(), result.compressed_ids.size());
+        } else {
+            std::fprintf(stderr,
+                         "[pflash][deepseek4] compression failed: %s\n",
+                         dflash27b_last_error());
+        }
+    }
+
+    // DSpark restore needs its memory back. Without DSpark, honor persistent
+    // residency so repeated PFlash requests can reuse the PFlash weights.
+    const bool release_after =
+        req.residency_action == DraftResidencyAction::ReleaseAfterUse ||
+        restore_spec;
+    if (release_after) release_pflash_drafter();
+
+    if (restore_spec && !unpark(ParkTarget::DraftModel)) {
+        std::fprintf(stderr,
+                     "[pflash][deepseek4] failed to restore DSpark after compression\n");
+        restore_ok = false;
+    }
+    if (!restore_ok) {
+        result = {};
+    }
+    return result;
+}
+
 bool DeepSeek4Backend::handle_compress(const std::string & line,
                                         const DaemonIO & io) {
-    (void)line; (void)io;
-    std::fprintf(stderr, "[deepseek4] compress not yet supported\n");
-    return false;
+    const bool skip_park = line.size() >= 16 &&
+        line.compare(line.size() - 7, 7, " nopark") == 0;
+
+    char prompt_path[1024];
+    int keep_x1000 = 0;
+    char drafter_path[1024] = {0};
+    const int parsed = std::sscanf(
+        line.c_str() + 9, "%1023s %d %1023s",
+        prompt_path, &keep_x1000, drafter_path);
+    if (parsed < 2) {
+        std::fprintf(stderr,
+                     "[pflash][deepseek4] bad args, need: "
+                     "<bin> <keep_x1000> [drafter.gguf]\n");
+        io.emit(-1);
+        return false;
+    }
+
+    CompressRequest req;
+    req.input_ids = read_int32_file(prompt_path);
+    req.keep_ratio = (float) keep_x1000 / 1000.0f;
+    req.drafter_path = parsed >= 3 && drafter_path[0]
+        ? drafter_path
+        : "/opt/lucebox/models/drafter/Qwen3-0.6B-BF16.gguf";
+    req.skip_park = skip_park;
+
+    CompressResult result = compress(req);
+    for (int32_t token : result.compressed_ids) io.emit(token);
+    io.emit(-1);
+    return result.ok;
+}
+
+void DeepSeek4Backend::release_pflash_drafter() {
+    if (!pflash_drafter_loaded_ && !pflash_drafter_.backend) return;
+    dflash::common::free_drafter(pflash_drafter_);
+    pflash_drafter_loaded_ = false;
+    std::fprintf(stderr, "[pflash][deepseek4] drafter freed\n");
 }
 
 void DeepSeek4Backend::free_drafter() {
+    release_pflash_drafter();
     // Keep the configured path so request-scoped residency and an explicit
     // later `unpark draft` can restore the DSpark model.
     release_spec_drafter(/*mark_parked=*/true);

--- a/server/src/deepseek4/deepseek4_backend.h
+++ b/server/src/deepseek4/deepseek4_backend.h
@@ -15,6 +15,7 @@
 #include "../common/moe_hybrid_stream.h"
 #include "deepseek4_internal.h"
 #include "deepseek4_dspark.h"
+#include "qwen3/qwen3_drafter.h"
 
 #include "ggml.h"
 #include "ggml-backend.h"
@@ -55,6 +56,7 @@ public:
                                              const GenerateRequest & req,
                                              const DaemonIO & io) override;
 
+    CompressResult compress(const CompressRequest & req) override;
     bool handle_compress(const std::string & line,
                          const DaemonIO & io) override;
     void free_drafter() override;
@@ -91,6 +93,14 @@ private:
     // Absolute cache position represented by last_logits_. A snapshot is
     // safe only when this matches cache_.cur_pos.
     int                    last_logits_pos_ = -1;
+
+    // PFlash speculative-prefill drafter. This is separate from the DSpark
+    // decode drafter below: it uses a small Qwen model to select prompt spans,
+    // then releases its request scratch before DeepSeek prefill starts.
+    DrafterContext                 pflash_drafter_;
+    bool                           pflash_drafter_loaded_ = false;
+
+    void release_pflash_drafter();
 
     // DSpark speculative decode (opt-in: DFLASH_DS4_SPEC=1 + DFLASH_DS4_DRAFT=<gguf>).
     bool                           spec_enabled_ = false;

--- a/server/test/test_feature_gate.cpp
+++ b/server/test/test_feature_gate.cpp
@@ -146,6 +146,26 @@ static void test_feature_gate_pflash_requires_drafter_and_supported_arch() {
         args, "gemma4", PlacementBackend::Cuda, features).empty());
     TEST_ASSERT(gate_result(
         args, "qwen35", PlacementBackend::Cuda, features).empty());
+
+    // DeepSeek supports local PFlash through its monolithic backend and
+    // remote PFlash regardless of the target's tokenizer. Its layer-split
+    // adapter does not own a local PFlash drafter yet.
+    BackendArgs deepseek_local;
+    deepseek_local.model_path = "/nonexistent/model.gguf";
+    TEST_ASSERT(gate_result(
+        deepseek_local, "deepseek4", PlacementBackend::Cuda, features).empty());
+
+    BackendArgs deepseek_split;
+    deepseek_split.model_path = "/nonexistent/model.gguf";
+    TEST_ASSERT(parse_placement_device_list(
+        "cuda:0,cuda:1", deepseek_split.device));
+    TEST_ASSERT(!gate_result(
+        deepseek_split, "deepseek4", PlacementBackend::Cuda, features).empty());
+
+    deepseek_split.draft_device.backend = PlacementBackend::Hip;
+    deepseek_split.remote_draft.ipc_bin = "/usr/bin/draft-ipc";
+    TEST_ASSERT(gate_result(
+        deepseek_split, "deepseek4", PlacementBackend::Cuda, features).empty());
 }
 
 static void test_feature_gate_validates_target_split_topology() {


### PR DESCRIPTION
## Summary

- add typed PFlash compression to the monolithic DeepSeek V4 backend using the existing Qwen3 drafter
- keep the large DeepSeek target resident while PFlash scores the prompt
- temporarily release and restore the DSpark decode drafter when both features share GPU memory
- allow local monolithic and remote-drafter PFlash while rejecting unsupported local layer-split placement clearly
- document the support boundary and retain the legacy daemon compress command

## Why this is a draft

The integration is functional and live-tested, but prompt compression is lossy and the DeepSeek keep ratio is not qualified broadly enough to enable by default. The local HIP Qwen scoring pass also dominates the current latency, so remote or secondary-GPU scoring is the main follow-up.

## Validation

- final mixed HIP-primary and CUDA dflash_server build passed on lucebox2
- feature-gate test passed locally and on lucebox2: 130 assertions, 0 failures
- mixed target plus DSpark lifecycle smoke passed: DSpark parked, PFlash loaded and freed, DSpark restored, generation returned READY with 0.6667 speculative acceptance

### Long-prompt measurement

DeepSeek V4 Flash, 22.8K-token retrieval prompt on lucebox2:

| Mode | PFlash scoring | Target prefill | End to end | Retrieval output |
|---|---:|---:|---:|---|
| Uncompressed | - | 97.2 s | 123.7 s | LUCENT-4-8-2-7 |
| PFlash, keep 20% | 43.3 s | 17.0 s | 61.3 s | LUCENT-4B27 |

This is about 2x faster end to end in that run, but the changed transcription shows why the feature remains experimental. A 30% keep run took 72.5 s and did not improve that answer. An aggressive 20% keep run at only 4.6K tokens lost the needle entirely; normal automatic mode remains gated to long prompts.

## Limitations

- experimental and opt-in; retrieval and generation quality need a broader qualification matrix
- local layer-split DeepSeek PFlash is not implemented; use a monolithic target or remote PFlash drafter
- the local HIP scorer took 37-43 seconds in the measured long-prompt runs
- this PR implements PFlash only; it does not change KVFlash or DeepSeek KV-cache offloading


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

