### PR TITLE
feat(concurrency): concurrent paged serving

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,12 +82,16 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release
           cmake --build build --target \
             test_dflash test_generate test_flash_attn_sparse test_server_unit \
-            test_deepseek4_unit -j$(nproc)
+            test_deepseek4_unit test_feature_gate test_seq_slot_manager \
+            test_seq_engine_contract test_seq_batch_plan test_client_send_buffer \
+            test_model_smoke test_batched_gdn -j$(nproc)
 
       - name: Run C++ server unit tests
         run: |
           cd server/build
-          ctest --output-on-failure -R "server_unit|deepseek4_unit" --no-tests=error
+          ctest --output-on-failure \
+            -R "server_unit|deepseek4_unit|feature_gate|seq_slot_manager|seq_engine_contract|seq_batch_plan|client_send_buffer|batched_gdn_cpu" \
+            --no-tests=error
 
       - name: Populate venv with cu128 torch + setuptools
         # First pass: install the workspace's default deps. dflash declares
@@ -207,6 +211,8 @@ jobs:
             test_rocmfp_mix_slice_matvec
             test_rocmfp_mix_gateup_glu
             test_ds4_mix_registry_teardown
+            test_model_smoke
+            test_batched_gdn
           )
           if [[ "$RUN_SPARSE_ATTENTION_TEST" == "true" ]]; then
             targets+=(test_flash_attn_sparse)
@@ -222,6 +228,11 @@ jobs:
           ./server/build/test_deepseek4_unit
           ctest --test-dir server/build --output-on-failure \
             -R 'rocmfp3_mix_registry|rocmfp_mix_slice_matvec|rocmfp_mix_gateup_glu|ds4_mix_registry_teardown'
+
+      - name: Run concurrent-serving kernel tests
+        run: |
+          ctest --test-dir server/build --output-on-failure \
+            -R '^(test_model_smoke\.PagedAttention\.|batched_gdn$)' --no-tests=error
 
       # Optional model-backed end-to-end smoke (real spec-decode on the 3090),
       # disabled by default because it builds dflash_server and lazy-loads the
@@ -338,11 +349,11 @@ jobs:
               test_deepseek4_mmid_grouped_cuda test_deepseek4_unit \
               test_recurrent_snapshot test_server_unit test_rocmfp3_mix_registry \
               test_rocmfp_mix_slice_matvec test_rocmfp_mix_gateup_glu \
-              test_ds4_mix_registry_teardown \
+              test_ds4_mix_registry_teardown test_model_smoke test_batched_gdn \
             --parallel 8
           ctest --test-dir "$RUNNER_TEMP/rocmfp-build" \
             --output-on-failure \
-            -R 'rocmfp4_reference|rocmfpx_reference|rocmfp4_hip_tail|rocmfpx_mmq|deepseek4_mmid_grouped_cuda|deepseek4_unit|recurrent_snapshot|ChainRollbackPolicy|rocmfp3_mix_registry|rocmfp_mix_slice_matvec|rocmfp_mix_gateup_glu|ds4_mix_registry_teardown'
+            -R 'rocmfp4_reference|rocmfpx_reference|rocmfp4_hip_tail|rocmfpx_mmq|deepseek4_mmid_grouped_cuda|deepseek4_unit|recurrent_snapshot|ChainRollbackPolicy|rocmfp3_mix_registry|rocmfp_mix_slice_matvec|rocmfp_mix_gateup_glu|ds4_mix_registry_teardown|test_model_smoke\.PagedAttention\.|batched_gdn$'
 
   build-windows:
     name: Build Windows (MSVC + CUDA, library + server targets)

--- a/README.md
+++ b/README.md
@@ -367,7 +367,10 @@ When compression is on, multi-turn continuations automatically use **FlowKV**: a
 | `DFLASH_PREFILL_CACHE_SLOTS=N` | `0` | Container-entrypoint equivalent of `--prefill-cache-slots`; the native binary itself uses the CLI flag. |
 | `--kv-cache-dir <path>` | — | Persist prefix cache to disk |
 | `--kv-cache-budget N` | — | On-disk cache size cap |
-| `--paged-attention` | off | Exact 16-token block-table decode for single-device Qwen3.6-27B AR; see [paged attention](optimizations/paged_attention/README.md) |
+| `--paged-attention` | off | Exact 16-token block-table attention for Qwen3.6-27B; see [paged attention](optimizations/paged_attention/README.md) |
+| `--max-concurrency N` | `1` | Maximum concurrent sequence slots. Values 2–64 enable paged attention automatically. |
+| `--kv-pool-tokens N` | `0` (auto) | Shared physical K/V capacity for concurrent paged serving. Requires `--max-concurrency` greater than 1. Zero derives capacity from available device memory; explicit values are rounded to whole 16-token blocks. |
+| `--admission-coalesce-ms N` | `20` | Idle-to-busy batching window for concurrent serving, from 0 to 1000 ms; `0` disables it. |
 
 **Bounded KV residency (KVFlash)**
 

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -147,6 +147,7 @@ elseif(DFLASH27B_GPU_BACKEND STREQUAL "hip")
     endif()
     set(GGML_HIP  ON  CACHE BOOL "" FORCE)
     set(GGML_HIP_RCCL OFF CACHE BOOL "" FORCE)
+    set(GGML_HIP_GRAPHS OFF CACHE BOOL "Enable experimental HIP graph replay")
     set(DFLASH27B_GGML_BACKEND_TARGET ggml-hip)
     set(DFLASH27B_HIP_ARCHITECTURES "" CACHE STRING "HIP GPU targets, e.g. gfx906;gfx1100")
     set(GGML_BACKEND_DL OFF CACHE BOOL "" FORCE)
@@ -447,7 +448,8 @@ add_library(dflash_common STATIC
     src/common/dflash_draft_graph.cpp
     src/common/dflash_draft_kv.cpp
     src/common/dflash_spec_decode.cpp
-    src/common/paged_kv_pool.cpp
+    src/common/concurrency/paged_kv_pool.cpp
+    src/qwen35/concurrency/qwen35_slot_manager.cpp
     src/common/layer_split_backend.cpp
     src/common/layer_split_runtime.cpp
     src/qwen35/graph_builders.cpp
@@ -473,6 +475,7 @@ add_library(dflash_common STATIC
     src/qwen35/layer_split_daemon.cpp
     src/qwen35/qwen35_backend.cpp
     src/qwen35/qwen35_tensor_parallel.cpp
+    src/qwen35/concurrency/qwen35_seq_engine.cpp
     src/qwen35/qwen35_layer_split_adapter.cpp
     src/qwen35/qwen35_dflash_target.cpp
     src/qwen35/qwen35_layer_split_dflash_target.cpp
@@ -1347,7 +1350,9 @@ if(DFLASH27B_TESTS)
     endif()
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_generate.cpp")
         add_executable(test_generate test/test_generate.cpp)
-        target_include_directories(test_generate PRIVATE ${DFLASH27B_SRC_INCLUDE_DIRS})
+        target_include_directories(test_generate PRIVATE
+            ${DFLASH27B_SRC_INCLUDE_DIRS}
+            ${CMAKE_CURRENT_SOURCE_DIR}/test)
         target_link_libraries(test_generate PRIVATE dflash_common ggml ${DFLASH27B_GGML_BACKEND_TARGET})
     endif()
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_kvflash.cpp")
@@ -1367,10 +1372,43 @@ if(DFLASH27B_TESTS)
         # Pure host-side allocator test: no model, ggml, or GPU is required.
         add_executable(test_paged_kv_pool
             test/test_paged_kv_pool.cpp
-            src/common/paged_kv_pool.cpp)
+            src/common/concurrency/paged_kv_pool.cpp)
         target_include_directories(test_paged_kv_pool PRIVATE
             ${CMAKE_CURRENT_SOURCE_DIR}/src)
         list(APPEND _raw_unit_test_targets test_paged_kv_pool)
+    endif()
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_seq_slot_manager.cpp")
+        # Host-side slot bookkeeping test (concurrent serving): no GPU.
+        add_executable(test_seq_slot_manager
+            test/test_seq_slot_manager.cpp
+            src/qwen35/concurrency/qwen35_slot_manager.cpp
+            src/common/concurrency/paged_kv_pool.cpp)
+        target_include_directories(test_seq_slot_manager PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src)
+        list(APPEND _raw_unit_test_targets test_seq_slot_manager)
+    endif()
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_seq_engine_contract.cpp")
+        # SeqEngine conformance checker + the fakes that prove it bites: no GPU.
+        add_executable(test_seq_engine_contract test/test_seq_engine_contract.cpp)
+        target_include_directories(test_seq_engine_contract PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src
+            ${CMAKE_CURRENT_SOURCE_DIR}/test)
+        list(APPEND _raw_unit_test_targets test_seq_engine_contract)
+    endif()
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_seq_batch_plan.cpp")
+        # Pure-host tests for model-neutral token-budget/FIFO planning.
+        add_executable(test_seq_batch_plan test/test_seq_batch_plan.cpp)
+        target_include_directories(test_seq_batch_plan PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src
+            ${CMAKE_CURRENT_SOURCE_DIR}/test)
+        list(APPEND _raw_unit_test_targets test_seq_batch_plan)
+    endif()
+    if(UNIX AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_client_send_buffer.cpp")
+        # Buffered non-blocking client writer test (socketpair): no GPU.
+        add_executable(test_client_send_buffer test/test_client_send_buffer.cpp)
+        target_include_directories(test_client_send_buffer PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src)
+        list(APPEND _raw_unit_test_targets test_client_send_buffer)
     endif()
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_dflash.cpp")
         add_executable(test_dflash test/test_dflash.cpp)
@@ -1502,6 +1540,7 @@ if(DFLASH27B_TESTS)
         add_executable(test_server_unit ${_server_unit_sources})
         target_sources(test_server_unit PRIVATE
             src/server/http_server.cpp
+            src/server/scheduler.cpp
             src/server/model_card.cpp
             src/server/prompt_normalize.cpp
             src/qwen3/anchor_scan.cpp)
@@ -1818,20 +1857,36 @@ if(DFLASH27B_TESTS)
     endif()
     endif()
 
+    function(dflash_add_ggml_gpu_executable target source)
+        add_executable(${target} ${source})
+        target_link_libraries(${target} PRIVATE
+            ggml ${DFLASH27B_GGML_BACKEND_TARGET} ggml-base)
+        if(DFLASH27B_GPU_BACKEND STREQUAL "cuda")
+            target_link_libraries(${target} PRIVATE CUDA::cudart)
+        else()
+            target_link_libraries(${target} PRIVATE hip::host)
+        endif()
+        target_include_directories(${target} PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/deps/llama.cpp/ggml/include
+            ${CMAKE_CURRENT_SOURCE_DIR}/deps/llama.cpp/ggml/src)
+    endfunction()
+
+    if((DFLASH27B_GPU_BACKEND STREQUAL "cuda" OR
+        DFLASH27B_GPU_BACKEND STREQUAL "hip")
+       AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_batched_gdn.cpp")
+        dflash_add_ggml_gpu_executable(
+            test_batched_gdn test/test_batched_gdn.cpp)
+        add_test(NAME batched_gdn COMMAND test_batched_gdn)
+        add_test(NAME batched_gdn_cpu COMMAND test_batched_gdn --cpu)
+        if(TARGET check)
+            add_dependencies(check test_batched_gdn)
+        endif()
+    endif()
     if((DFLASH27B_GPU_BACKEND STREQUAL "cuda" OR
         DFLASH27B_GPU_BACKEND STREQUAL "hip")
        AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/bench_paged_attention.cpp")
-        add_executable(bench_paged_attention test/bench_paged_attention.cpp)
-        target_link_libraries(bench_paged_attention PRIVATE
-            ggml ${DFLASH27B_GGML_BACKEND_TARGET} ggml-base)
-        if(DFLASH27B_GPU_BACKEND STREQUAL "cuda")
-            target_link_libraries(bench_paged_attention PRIVATE CUDA::cudart)
-        else()
-            target_link_libraries(bench_paged_attention PRIVATE hip::host)
-        endif()
-        target_include_directories(bench_paged_attention PRIVATE
-            ${CMAKE_CURRENT_SOURCE_DIR}/deps/llama.cpp/ggml/include
-            ${CMAKE_CURRENT_SOURCE_DIR}/deps/llama.cpp/ggml/src)
+        dflash_add_ggml_gpu_executable(
+            bench_paged_attention test/bench_paged_attention.cpp)
     endif()
 endif()
 
@@ -1846,6 +1901,7 @@ if(DFLASH27B_SERVER)
         add_executable(dflash_server
             src/server/server_main.cpp
             src/server/http_server.cpp
+            src/server/scheduler.cpp
             src/server/model_card.cpp
             src/server/prompt_normalize.cpp
         )

--- a/server/deps/llama.cpp/ggml/include/ggml.h
+++ b/server/deps/llama.cpp/ggml/include/ggml.h
@@ -1738,6 +1738,15 @@ extern "C" {
             struct ggml_tensor  * b,  // source
             struct ggml_tensor  * c); // row indices
 
+    // As ggml_set_rows, but negative row ids are ignored. Intended for
+    // fixed-shape graph buckets whose padding rows must not update state.
+    // Backends that do not implement masking must report this op unsupported.
+    GGML_API struct ggml_tensor * ggml_set_rows_masked(
+            struct ggml_context * ctx,
+            struct ggml_tensor  * a,
+            struct ggml_tensor  * b,
+            struct ggml_tensor  * c);
+
     GGML_API struct ggml_tensor * ggml_diag(
         struct ggml_context     * ctx,
         struct ggml_tensor      * a);
@@ -2484,13 +2493,17 @@ extern "C" {
     // block_table[t/block_size, seq]*block_size + t%block_size.
     // The initial CUDA/HIP implementation supports D=256 and independently
     // typed F16, Q4_0, or Q8_0 K/V pools.
-    GGML_API struct ggml_tensor * ggml_paged_attn(
+    // active_slot_ids optionally maps compact query rows to physical block-
+    // table columns / length entries. A negative id is a padding row and
+    // produces a zero attention output. NULL selects row identity.
+    GGML_API struct ggml_tensor * ggml_paged_attn_ext(
             struct ggml_context * ctx,
             struct ggml_tensor  * q,
             struct ggml_tensor  * k,
             struct ggml_tensor  * v,
             struct ggml_tensor  * block_table,
             struct ggml_tensor  * kv_seq_lens,
+            struct ggml_tensor  * active_slot_ids,
             float                 scale,
             int                   block_size,
             int                   max_kv_seq_len);
@@ -2849,6 +2862,19 @@ extern "C" {
             struct ggml_tensor  * g,
             struct ggml_tensor  * beta,
             struct ggml_tensor  * state);
+
+    // Compact-batch in-place recurrence. active_slot_ids maps the compact
+    // sequence axis to physical state slabs; negative or out-of-range ids
+    // use zero state and do not write back.
+    GGML_API struct ggml_tensor * ggml_gated_delta_net_active_inplace(
+            struct ggml_context * ctx,
+            struct ggml_tensor  * q,
+            struct ggml_tensor  * k,
+            struct ggml_tensor  * v,
+            struct ggml_tensor  * g,
+            struct ggml_tensor  * beta,
+            struct ggml_tensor  * state,
+            struct ggml_tensor  * active_slot_ids);
 
     GGML_API void ggml_gated_delta_net_set_skip_intermediate(
             struct ggml_tensor * tensor,

--- a/server/deps/llama.cpp/ggml/src/ggml-backend-meta.cpp
+++ b/server/deps/llama.cpp/ggml/src/ggml-backend-meta.cpp
@@ -817,6 +817,8 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
         for (int i = 0; i < 5; i++) {
             GGML_ASSERT(src_ss[i].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED);
         }
+        GGML_ASSERT(tensor->src[5] == nullptr ||
+                    src_ss[5].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED);
         return src_ss[0];
     };
 
@@ -835,7 +837,8 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
     auto handle_gated_delta_net = [&](const std::vector<ggml_backend_meta_split_state> & src_ss) -> ggml_backend_meta_split_state {
         if (src_ss[0].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED && src_ss[1].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED &&
                 src_ss[2].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED && src_ss[3].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED &&
-                src_ss[4].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED && src_ss[5].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED) {
+                src_ss[4].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED && src_ss[5].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED &&
+                (tensor->src[8] == nullptr || src_ss[8].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED)) {
             return src_ss[0];
         }
         GGML_ASSERT(src_ss[0].axis == GGML_BACKEND_SPLIT_AXIS_1);
@@ -846,6 +849,8 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
         // state shape is (S_v*S_v*H, K, n_seqs); the heads dim is nested inside axis 0,
         // so a head-aligned split on the input cache reshapes to axis 0 here (not axis 2).
         GGML_ASSERT(src_ss[5].axis == GGML_BACKEND_SPLIT_AXIS_2 || src_ss[5].axis == GGML_BACKEND_SPLIT_AXIS_1 || src_ss[5].axis == GGML_BACKEND_SPLIT_AXIS_0);
+        GGML_ASSERT(tensor->src[8] == nullptr ||
+                    src_ss[8].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED);
         return {GGML_BACKEND_SPLIT_AXIS_0, {0}, 1, {1}};
     };
 

--- a/server/deps/llama.cpp/ggml/src/ggml-cpu/ops.cpp
+++ b/server/deps/llama.cpp/ggml/src/ggml-cpu/ops.cpp
@@ -5005,6 +5005,7 @@ static void ggml_compute_forward_set_rows_f32(
     const int64_t ir1 = std::min(ir0 + dr, nr);
 
     ggml_from_float_t const from_float = ggml_get_type_traits_cpu(dst->type)->from_float;
+    const bool masked = ggml_get_op_params_i32(dst, 0) != 0;
 
     for (int64_t i03 = 0; i03 < ne03; ++i03) {
         for (int64_t i02 = 0; i02 < ne02; ++i02) {
@@ -5014,6 +5015,10 @@ static void ggml_compute_forward_set_rows_f32(
                 const int64_t i10 = i;
 
                 const int64_t i1 = *(idx_t *) ((char *) src1->data + i10*nb10 + i11*nb11 + i12*nb12);
+
+                if (i1 < 0 && masked) {
+                    continue;
+                }
 
                 GGML_ASSERT(i1 >= 0 && i1 < ne1);
 
@@ -10518,11 +10523,13 @@ static void ggml_compute_forward_gated_delta_net_one_chunk(
     ggml_tensor * src_g     = dst->src[3];
     ggml_tensor * src_beta  = dst->src[4];
     ggml_tensor * src_state = dst->src[5];
+    ggml_tensor * src_active_slots = dst->src[8];
 
     const int64_t S_v      = src_v->ne[0];
     const int64_t H        = src_v->ne[1];
     const int64_t n_tokens = src_v->ne[2];
     const int64_t n_seqs   = src_v->ne[3];
+    const int64_t n_state_slots = src_state->ne[3];
 
     GGML_ASSERT(ggml_is_contiguous_rows(src_q));
     GGML_ASSERT(ggml_is_contiguous_rows(src_k));
@@ -10556,10 +10563,24 @@ static void ggml_compute_forward_gated_delta_net_one_chunk(
     // attn_scores: S_v * H * n_tokens * n_seqs floats
     // new_states:  S_v * S_v * H * n_seqs floats
     const int64_t attn_score_elems = S_v * H * n_tokens * n_seqs;
-    float * attn_out_base  = (float *)dst->data;
-    float * state_out_base = (float *)dst->data + attn_score_elems;
+    float * attn_out_base = (float *)dst->data;
+    float * compact_state_out_base =
+        (float *)dst->data + attn_score_elems;
+    const bool inplace_state = ggml_get_op_params_i32(dst, 1) != 0;
+    float * state_out_base = inplace_state
+        ? (float *)src_state->data
+        : compact_state_out_base;
 
     const float * state_in_base = (const float *)src_state->data;
+    const int32_t * active_slot_ids = src_active_slots
+        ? (const int32_t *)src_active_slots->data
+        : nullptr;
+    if (src_active_slots) {
+        GGML_ASSERT(inplace_state);
+        GGML_ASSERT(src_active_slots->type == GGML_TYPE_I32);
+        GGML_ASSERT(ggml_is_contiguous(src_active_slots));
+        GGML_ASSERT(ggml_nelements(src_active_slots) == n_seqs);
+    }
 
   //const int64_t rq1 = nev1 / neq1;
   //const int64_t rk1 = nev1 / nek1;
@@ -10571,6 +10592,13 @@ static void ggml_compute_forward_gated_delta_net_one_chunk(
     for (int64_t ir = ir0; ir < ir1; ++ir) {
         const int64_t iv1 = ir % H; // head_index
         const int64_t iv3 = ir / H; // sequence
+        const int32_t mapped_seq = active_slot_ids
+            ? active_slot_ids[iv3]
+            : (int32_t)iv3;
+        const int32_t physical_seq =
+            mapped_seq >= 0 && mapped_seq < n_state_slots
+                ? mapped_seq
+                : -1;
 
         const int64_t iq1 = iv1 % neq1;
         const int64_t ik1 = iv1 % nek1;
@@ -10578,11 +10606,19 @@ static void ggml_compute_forward_gated_delta_net_one_chunk(
         const int64_t iq3 = iv3 / rq3;
         const int64_t ik3 = iv3 / rk3;
 
-        float * s_out = state_out_base + (iv3 * H + iv1) * S_v * S_v;
+        float * s_out = physical_seq >= 0
+            ? state_out_base + ((int64_t)physical_seq * H + iv1) * S_v * S_v
+            : compact_state_out_base + (iv3 * H + iv1) * S_v * S_v;
 
         // copy input state into output buffer and operate in-place
-        const float * s_in = state_in_base + (iv3 * H + iv1) * S_v * S_v;
-        memcpy(s_out, s_in, S_v * S_v * sizeof(float));
+        const float * s_in = physical_seq >= 0
+            ? state_in_base + ((int64_t)physical_seq * H + iv1) * S_v * S_v
+            : nullptr;
+        if (!s_in) {
+            memset(s_out, 0, S_v * S_v * sizeof(float));
+        } else if (s_out != s_in) {
+            memcpy(s_out, s_in, S_v * S_v * sizeof(float));
+        }
 
         // attn output pointer for first token of this (head, seq)
         float * attn_data = attn_out_base + (iv3 * n_tokens * H + iv1) * S_v;

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/gated_delta_net.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/gated_delta_net.cu
@@ -43,6 +43,32 @@ __device__ __forceinline__ float gdn_subgroup_broadcast_lane0(float value, int w
     return __shfl_sync(0xffffffffU, value, 0, width);
 }
 
+template <int S_v>
+static __device__ __forceinline__ float * gdn_select_state(
+        const int * active_slot_ids, float * dst, float * state_out,
+        int sequence, int h_idx, int64_t H, int64_t n_tokens,
+        int64_t n_seqs, int64_t n_state_slots, int & physical_sequence,
+        int64_t & physical_state_offset) {
+    const int mapped_sequence = active_slot_ids
+        ? active_slot_ids[sequence]
+        : sequence;
+    physical_sequence = mapped_sequence >= 0 &&
+            mapped_sequence < n_state_slots
+        ? mapped_sequence
+        : -1;
+    const int64_t compact_state_offset =
+        ((int64_t)sequence * H + h_idx) * S_v * S_v;
+    physical_state_offset = physical_sequence >= 0
+        ? ((int64_t)physical_sequence * H + h_idx) * S_v * S_v
+        : 0;
+    if (!active_slot_ids) return state_out + compact_state_offset;
+    if (physical_sequence >= 0) {
+        return state_out + physical_state_offset;
+    }
+    const int64_t attn_score_elems = S_v * H * n_tokens * n_seqs;
+    return dst + attn_score_elems + compact_state_offset;
+}
+
 template <int S_v, bool KDA, bool TREE_MODE, bool WRITE_INTER, typename InterT = float>
 __global__ void __launch_bounds__((ggml_cuda_get_physical_warp_size() < S_v ? ggml_cuda_get_physical_warp_size() : S_v) * 4, 2)
 gated_delta_net_cuda(const float * q,
@@ -51,6 +77,7 @@ gated_delta_net_cuda(const float * q,
                                      const float * g,
                                      const float * beta,
                                      const float * curr_state,
+                                     const int *   active_slot_ids,
                                      float *       dst,
                                      float *       state_out,
                                      const int *   parent_ids,    // TREE_MODE only; else ignored
@@ -58,6 +85,7 @@ gated_delta_net_cuda(const float * q,
                                      int64_t       H,
                                      int64_t       n_tokens,
                                      int64_t       n_seqs,
+                                  int64_t       n_state_slots,
                                      int64_t       sq1,
                                      int64_t       sq2,
                                      int64_t       sq3,
@@ -82,7 +110,11 @@ gated_delta_net_cuda(const float * q,
     const int64_t attn_score_elems = S_v * H * n_tokens * n_seqs;
     const int64_t final_state_elems = S_v * S_v * H * n_seqs;
     float *       attn_data        = dst;
-    float *       state            = state_out;
+    int physical_sequence = 0;
+    int64_t physical_state_offset = 0;
+    float * state = gdn_select_state<S_v>(
+        active_slot_ids, dst, state_out, sequence, h_idx, H, n_tokens,
+        n_seqs, n_state_slots, physical_sequence, physical_state_offset);
     InterT * inter_states = nullptr;
     InterT * inter_base   = nullptr;
     if constexpr (WRITE_INTER || TREE_MODE) {
@@ -95,9 +127,9 @@ gated_delta_net_cuda(const float * q,
         inter_base = inter_states + (sequence * n_tokens * H + h_idx) * S_v * S_v;
     }
 
-    const int64_t state_offset = (sequence * H + h_idx) * S_v * S_v;
-    state += state_offset;
-    curr_state += state_offset + col * S_v;
+    const float * curr_state_seq = physical_sequence >= 0
+        ? curr_state + physical_state_offset + col * S_v
+        : nullptr;
     attn_data += (sequence * n_tokens * H + h_idx) * S_v;
     constexpr int warp_size = ggml_cuda_get_physical_warp_size() < S_v ? ggml_cuda_get_physical_warp_size() : S_v;
     static_assert(S_v % warp_size == 0, "S_v must be a multiple of warp_size");
@@ -108,7 +140,7 @@ gated_delta_net_cuda(const float * q,
 #pragma unroll
     for (int r = 0; r < rows_per_lane; r++) {
         const int i = r * warp_size + lane;
-        s_shard[r]  = curr_state[i];
+        s_shard[r]  = curr_state_seq ? curr_state_seq[i] : 0.0f;
     }
 
     // TREE_MODE: pointer base for parent lookups. Each sequence has its own
@@ -136,7 +168,7 @@ gated_delta_net_cuda(const float * q,
 #pragma unroll
                     for (int r = 0; r < rows_per_lane; r++) {
                         const int i = r * warp_size + lane;
-                        s_shard[r] = curr_state[i];
+                        s_shard[r] = curr_state_seq ? curr_state_seq[i] : 0.0f;
                     }
                 } else if (parent_t != t - 1) {
                     // Branch: this token's parent is somewhere earlier in the
@@ -267,12 +299,14 @@ gated_delta_net_cuda_grouped_cols(const float * q,
                                   const float * g,
                                   const float * beta,
                                   const float * curr_state,
+                                  const int *   active_slot_ids,
                                   float *       dst,
                                   float *       state_out,
                                   InterT *      persist_inter,
                                   int64_t       H,
                                   int64_t       n_tokens,
                                   int64_t       n_seqs,
+                                  int64_t       n_state_slots,
                                   int64_t       sq1,
                                   int64_t       sq2,
                                   int64_t       sq3,
@@ -311,7 +345,11 @@ gated_delta_net_cuda_grouped_cols(const float * q,
     const int64_t attn_score_elems = S_v * H * n_tokens * n_seqs;
     const int64_t final_state_elems = S_v * S_v * H * n_seqs;
     float *       attn_data        = dst;
-    float *       state            = state_out;
+    int physical_sequence = 0;
+    int64_t physical_state_offset = 0;
+    float * state = gdn_select_state<S_v>(
+        active_slot_ids, dst, state_out, sequence, h_idx, H, n_tokens,
+        n_seqs, n_state_slots, physical_sequence, physical_state_offset);
     InterT * inter_states = nullptr;
     InterT * inter_base   = nullptr;
     if constexpr (WRITE_INTER) {
@@ -321,9 +359,9 @@ gated_delta_net_cuda_grouped_cols(const float * q,
         inter_base = inter_states + (sequence * n_tokens * H + h_idx) * S_v * S_v;
     }
 
-    const int64_t state_offset = (sequence * H + h_idx) * S_v * S_v;
-    state += state_offset;
-    curr_state += state_offset;
+    const float * curr_state_seq = physical_sequence >= 0
+        ? curr_state + physical_state_offset
+        : nullptr;
     attn_data += (sequence * n_tokens * H + h_idx) * S_v;
     float state_shard[COLS][rows_per_lane];
 
@@ -333,7 +371,9 @@ gated_delta_net_cuda_grouped_cols(const float * q,
 #pragma unroll
         for (int r = 0; r < rows_per_lane; ++r) {
             const int row = r * WIDTH + lane;
-            state_shard[c][r] = curr_state[col * S_v + row];
+            state_shard[c][r] = curr_state_seq
+                ? curr_state_seq[col * S_v + row]
+                : 0.0f;
         }
     }
 
@@ -446,11 +486,13 @@ template <bool KDA, bool TREE_MODE, bool WRITE_INTER, typename InterT = float>
 static void launch_gated_delta_net(
         const float * q_d, const float * k_d, const float * v_d,
         const float * g_d, const float * b_d, const float * s_d,
+        const int * active_slot_ids_d,
         float * dst_d,
         float * state_out_d,
         const int * parent_ids_d,
         InterT * persist_inter_d,
         int64_t S_v,   int64_t H, int64_t n_tokens, int64_t n_seqs,
+        int64_t n_state_slots,
         int64_t sq1,   int64_t sq2, int64_t sq3,
         int64_t sv1,   int64_t sv2, int64_t sv3,
         int64_t sb1,   int64_t sb2, int64_t sb3,
@@ -477,20 +519,20 @@ static void launch_gated_delta_net(
     switch (S_v) {
         case 16:
             gated_delta_net_cuda<16, KDA, TREE_MODE, WRITE_INTER, InterT><<<grid_dims, block_dims, 0, stream>>>(
-                q_d, k_d, v_d, g_d, b_d, s_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, H,
-                n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,
+                q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, H,
+                n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,
                 sb1, sb2, sb3, neqk1_magic, rq3_magic, scale);
             break;
         case 32:
             gated_delta_net_cuda<32, KDA, TREE_MODE, WRITE_INTER, InterT><<<grid_dims, block_dims, 0, stream>>>(
-                q_d, k_d, v_d, g_d, b_d, s_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, H,
-                n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,
+                q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, H,
+                n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,
                 sb1, sb2, sb3, neqk1_magic, rq3_magic, scale);
             break;
         case 64: {
             gated_delta_net_cuda<64, KDA, TREE_MODE, WRITE_INTER, InterT><<<grid_dims, block_dims, 0, stream>>>(
-                q_d, k_d, v_d, g_d, b_d, s_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, H,
-                n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,
+                q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, H,
+                n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,
                 sb1, sb2, sb3, neqk1_magic, rq3_magic, scale);
             break;
         }
@@ -508,33 +550,33 @@ static void launch_gated_delta_net(
                         dim3 grouped_grid_dims(H, n_seqs, (groups + column_groups_per_block * groups_per_warp - 1) / (column_groups_per_block * groups_per_warp));
                         dim3 grouped_block_dims(32, column_groups_per_block, 1);
                         gated_delta_net_cuda_grouped_cols<128, cols, width, 32, WRITE_INTER, InterT><<<grouped_grid_dims, grouped_block_dims, 0, stream>>>(
-                            q_d, k_d, v_d, g_d, b_d, s_d, dst_d, state_out_d, persist_inter_d, H,
-                            n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,
+                            q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, persist_inter_d, H,
+                            n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,
                             sb1, sb2, sb3, neqk1_magic, rq3_magic, scale);
                     } else if (warp_size == 64) {
                         constexpr int groups_per_warp = 64 / width;
                         dim3 grouped_grid_dims(H, n_seqs, (groups + column_groups_per_block * groups_per_warp - 1) / (column_groups_per_block * groups_per_warp));
                         dim3 grouped_block_dims(64, column_groups_per_block, 1);
                         gated_delta_net_cuda_grouped_cols<128, cols, width, 64, WRITE_INTER, InterT><<<grouped_grid_dims, grouped_block_dims, 0, stream>>>(
-                            q_d, k_d, v_d, g_d, b_d, s_d, dst_d, state_out_d, persist_inter_d, H,
-                            n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,
+                            q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, persist_inter_d, H,
+                            n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,
                             sb1, sb2, sb3, neqk1_magic, rq3_magic, scale);
                     } else {
                         gated_delta_net_cuda<128, KDA, TREE_MODE, WRITE_INTER, InterT><<<grid_dims, block_dims, 0, stream>>>(
-                            q_d, k_d, v_d, g_d, b_d, s_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, H,
-                            n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,
+                            q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, H,
+                            n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,
                             sb1, sb2, sb3, neqk1_magic, rq3_magic, scale);
                     }
                 } else {
                     gated_delta_net_cuda<128, KDA, TREE_MODE, WRITE_INTER, InterT><<<grid_dims, block_dims, 0, stream>>>(
-                        q_d, k_d, v_d, g_d, b_d, s_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, H,
-                        n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,
+                        q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, H,
+                        n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,
                         sb1, sb2, sb3, neqk1_magic, rq3_magic, scale);
                 }
             } else {
                 gated_delta_net_cuda<128, KDA, TREE_MODE, WRITE_INTER, InterT><<<grid_dims, block_dims, 0, stream>>>(
-                    q_d, k_d, v_d, g_d, b_d, s_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, H,
-                    n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,
+                    q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, H,
+                    n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,
                     sb1, sb2, sb3, neqk1_magic, rq3_magic, scale);
             }
             break;
@@ -560,6 +602,9 @@ void ggml_cuda_op_gated_delta_net(ggml_backend_cuda_context & ctx, ggml_tensor *
     // intermediate states directly to persist_inter->data instead of the
     // embedded region inside dst, saving a downstream ggml_cpy.
     ggml_tensor * src_persist_inter = dst->src[7];
+    // Optional 9th source maps compact sequence rows to physical recurrent
+    // state slabs. Negative ids are graph-bucket padding rows.
+    ggml_tensor * src_active_slots = dst->src[8];
 
     GGML_TENSOR_LOCALS(int64_t, neq, src_q, ne);
     GGML_TENSOR_LOCALS(size_t , nbq, src_q, nb);
@@ -573,6 +618,7 @@ void ggml_cuda_op_gated_delta_net(ggml_backend_cuda_context & ctx, ggml_tensor *
     const int64_t H        = nev1;
     const int64_t n_tokens = nev2;
     const int64_t n_seqs   = nev3;
+    const int64_t n_state_slots = src_state->ne[3];
 
     const bool kda = (src_g->ne[0] == S_v);
 
@@ -594,6 +640,9 @@ void ggml_cuda_op_gated_delta_net(ggml_backend_cuda_context & ctx, ggml_tensor *
     float *       state_out_d = inplace_state ? (float *) src_state->data : dst_d + attn_score_elems;
     const int *   parent_ids_d = src_parent
         ? (const int *) src_parent->data
+        : nullptr;
+    const int *   active_slot_ids_d = src_active_slots
+        ? (const int *) src_active_slots->data
         : nullptr;
     void *        persist_inter_d = src_persist_inter
         ? src_persist_inter->data
@@ -618,6 +667,13 @@ void ggml_cuda_op_gated_delta_net(ggml_backend_cuda_context & ctx, ggml_tensor *
         GGML_ASSERT(src_parent->type == GGML_TYPE_I32);
         GGML_ASSERT(ggml_is_contiguous(src_parent));
         GGML_ASSERT(ggml_nelements(src_parent) == n_tokens * n_seqs);
+    }
+    if (src_active_slots) {
+        GGML_ASSERT(inplace_state);
+        GGML_ASSERT(!src_parent);
+        GGML_ASSERT(src_active_slots->type == GGML_TYPE_I32);
+        GGML_ASSERT(ggml_is_contiguous(src_active_slots));
+        GGML_ASSERT(ggml_nelements(src_active_slots) == n_seqs);
     }
 
     // strides in floats (beta strides used for both g and beta offset computation)
@@ -647,35 +703,35 @@ void ggml_cuda_op_gated_delta_net(ggml_backend_cuda_context & ctx, ggml_tensor *
             if (kda) {                                                                          \
                 if (tree_mode) {                                                                \
                     launch_gated_delta_net<true, true, true, INTER_T>(                          \
-                        q_d, k_d, v_d, g_d, b_d, s_d, dst_d, state_out_d, parent_ids_d, persist_typed, \
-                        S_v, H, n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,                 \
+                        q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_typed, \
+                        S_v, H, n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,                 \
                         sb1, sb2, sb3, neqk1, rq3, scale, stream);                              \
                 } else if (write_intermediate) {                                                \
                     launch_gated_delta_net<true, false, true, INTER_T>(                         \
-                        q_d, k_d, v_d, g_d, b_d, s_d, dst_d, state_out_d, nullptr, persist_typed, \
-                        S_v, H, n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,                 \
+                        q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, nullptr, persist_typed, \
+                        S_v, H, n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,                 \
                         sb1, sb2, sb3, neqk1, rq3, scale, stream);                              \
                 } else {                                                                        \
                     launch_gated_delta_net<true, false, false, INTER_T>(                        \
-                        q_d, k_d, v_d, g_d, b_d, s_d, dst_d, state_out_d, nullptr, persist_typed, \
-                        S_v, H, n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,                 \
+                        q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, nullptr, persist_typed, \
+                        S_v, H, n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,                 \
                         sb1, sb2, sb3, neqk1, rq3, scale, stream);                              \
                 }                                                                               \
             } else {                                                                            \
                 if (tree_mode) {                                                                \
                     launch_gated_delta_net<false, true, true, INTER_T>(                         \
-                        q_d, k_d, v_d, g_d, b_d, s_d, dst_d, state_out_d, parent_ids_d, persist_typed, \
-                        S_v, H, n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,                 \
+                        q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_typed, \
+                        S_v, H, n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,                 \
                         sb1, sb2, sb3, neqk1, rq3, scale, stream);                              \
                 } else if (write_intermediate) {                                                \
                     launch_gated_delta_net<false, false, true, INTER_T>(                        \
-                        q_d, k_d, v_d, g_d, b_d, s_d, dst_d, state_out_d, nullptr, persist_typed, \
-                        S_v, H, n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,                 \
+                        q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, nullptr, persist_typed, \
+                        S_v, H, n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,                 \
                         sb1, sb2, sb3, neqk1, rq3, scale, stream);                              \
                 } else {                                                                        \
                     launch_gated_delta_net<false, false, false, INTER_T>(                       \
-                        q_d, k_d, v_d, g_d, b_d, s_d, dst_d, state_out_d, nullptr, persist_typed, \
-                        S_v, H, n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,                 \
+                        q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, nullptr, persist_typed, \
+                        S_v, H, n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,                 \
                         sb1, sb2, sb3, neqk1, rq3, scale, stream);                              \
                 }                                                                               \
             }                                                                                   \

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -3987,6 +3987,9 @@ static bool ggml_cuda_should_fuse_rope_set_rows(const ggml_tensor * rope,
     if (rope->op != GGML_OP_ROPE || view->op != GGML_OP_VIEW || set_rows->op != GGML_OP_SET_ROWS) {
         return false;
     }
+    if (ggml_get_op_params_i32(set_rows, 0) != 0) {
+        return false;
+    }
     // ne3 not tested
     if (rope->src[0]->ne[3] != 1) {
         return false;
@@ -5986,6 +5989,12 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
             } break;
         case GGML_OP_SET_ROWS:
             {
+                if (ggml_get_op_params_i32(op, 0) != 0 &&
+                    op->type != GGML_TYPE_F32 &&
+                    op->type != GGML_TYPE_F16 &&
+                    op->type != GGML_TYPE_BF16) {
+                    return false;
+                }
                 return (op->type == GGML_TYPE_F32 || op->type == GGML_TYPE_F16 || op->type == GGML_TYPE_BF16 ||
                        op->type == GGML_TYPE_Q4_0 || op->type == GGML_TYPE_Q4_1 || op->type == GGML_TYPE_Q5_0 ||
                        op->type == GGML_TYPE_Q5_1 || op->type == GGML_TYPE_Q8_0 || op->type == GGML_TYPE_IQ4_NL ||

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/paged-attn.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/paged-attn.cu
@@ -178,6 +178,7 @@ static __global__ void paged_attn_decode(
         const float2  * __restrict__ q_ds_glob,
         const char    * __restrict__ block_table,
         const char    * __restrict__ kv_seq_lens,
+        const char    * __restrict__ active_slot_ids,
         char          * __restrict__ dst,
         half          * __restrict__ partial_acc,
         float2        * __restrict__ partial_meta,
@@ -186,6 +187,7 @@ static __global__ void paged_attn_decode(
         int64_t v_nb1,   int64_t v_nb2,
         int64_t bt_nb0,  int64_t bt_nb1,
         int64_t ksl_nb0,
+        int64_t asi_nb0,
         int64_t dst_nb1, int64_t dst_nb2,
         int32_t n_head,
         int32_t n_head_kv,
@@ -218,8 +220,13 @@ static __global__ void paged_attn_decode(
     const int n_seq        = gridDim.y;
     const int n_partitions = gridDim.z;
 
-    const int32_t kv_seq_len_raw =
-        *(const int32_t *) (kv_seq_lens + (int64_t) seq * ksl_nb0);
+    const int32_t physical_seq = active_slot_ids
+        ? *(const int32_t *) (active_slot_ids + (int64_t) seq * asi_nb0)
+        : seq;
+    const int32_t kv_seq_len_raw = physical_seq < 0
+        ? 0
+        : *(const int32_t *) (kv_seq_lens +
+                              (int64_t) physical_seq * ksl_nb0);
     const int64_t table_capacity =
         (int64_t) max_blocks * block_size;
     const int32_t kv_seq_len = kv_seq_len_raw <= 0
@@ -358,7 +365,7 @@ static __global__ void paged_attn_decode(
             const int32_t physical_block =
                 *(const int32_t *) (block_table +
                     (int64_t) logical_block * bt_nb0 +
-                    (int64_t) seq * bt_nb1);
+                    (int64_t) physical_seq * bt_nb1);
             if (physical_block >= 0 && physical_block < n_physical_blocks) {
                 phys_mine =
                     physical_block * block_size + my_token % block_size;
@@ -590,6 +597,7 @@ bool ggml_cuda_paged_attn_supported(const ggml_tensor * dst) {
     const ggml_tensor * v             = dst->src[2];
     const ggml_tensor * block_table   = dst->src[3];
     const ggml_tensor * kv_seq_lens   = dst->src[4];
+    const ggml_tensor * active_slot_ids = dst->src[5];
 
     if (!q || !k || !v || !block_table || !kv_seq_lens) {
         return false;
@@ -600,7 +608,8 @@ bool ggml_cuda_paged_attn_supported(const ggml_tensor * dst) {
         !paged_attn_type_supported(k->type) ||
         !paged_attn_type_supported(v->type) ||
         block_table->type != GGML_TYPE_I32 ||
-        kv_seq_lens->type != GGML_TYPE_I32) {
+        kv_seq_lens->type != GGML_TYPE_I32 ||
+        (active_slot_ids && active_slot_ids->type != GGML_TYPE_I32)) {
         return false;
     }
 
@@ -609,6 +618,7 @@ bool ggml_cuda_paged_attn_supported(const ggml_tensor * dst) {
         v->nb[0] != ggml_type_size(v->type) ||
         block_table->nb[0] != sizeof(int32_t) ||
         kv_seq_lens->nb[0] != sizeof(int32_t) ||
+        (active_slot_ids && active_slot_ids->nb[0] != sizeof(int32_t)) ||
         dst->nb[0] != sizeof(float)) {
         return false;
     }
@@ -634,13 +644,23 @@ bool ggml_cuda_paged_attn_supported(const ggml_tensor * dst) {
     }
 
     if (block_table->ne[0] <= 0 ||
-        block_table->ne[1] != q->ne[1] ||
+        block_table->ne[1] != kv_seq_lens->ne[0] ||
         block_table->ne[2] != 1 ||
         block_table->ne[3] != 1 ||
-        kv_seq_lens->ne[0] != q->ne[1] ||
         kv_seq_lens->ne[1] != 1 ||
         kv_seq_lens->ne[2] != 1 ||
         kv_seq_lens->ne[3] != 1) {
+        return false;
+    }
+
+    // Compacted batches address slots through active_slot_ids (one entry per
+    // query token); dense batches require one table column per query token.
+    if (active_slot_ids
+            ? (active_slot_ids->ne[0] != q->ne[1] ||
+               active_slot_ids->ne[1] != 1 ||
+               active_slot_ids->ne[2] != 1 ||
+               active_slot_ids->ne[3] != 1)
+            : block_table->ne[1] != q->ne[1]) {
         return false;
     }
 
@@ -707,6 +727,7 @@ static bool try_launch_paged_attn(
     const ggml_tensor * v            = dst->src[2];
     const ggml_tensor * block_table  = dst->src[3];
     const ggml_tensor * kv_seq_lens = dst->src[4];
+    const ggml_tensor * active_slot_ids = dst->src[5];
 
     const int32_t n_head    = (int32_t) q->ne[2];
     const int32_t n_head_kv = (int32_t) k->ne[2];
@@ -855,6 +876,7 @@ static bool try_launch_paged_attn(
         q_ds_glob,
         (const char *) block_table->data,
         (const char *) kv_seq_lens->data,
+        active_slot_ids ? (const char *) active_slot_ids->data : nullptr,
         (char *) dst->data,
         partial_acc,
         partial_meta,
@@ -863,6 +885,7 @@ static bool try_launch_paged_attn(
         v->nb[1], v->nb[2],
         block_table->nb[0], block_table->nb[1],
         kv_seq_lens->nb[0],
+        active_slot_ids ? active_slot_ids->nb[0] : 0,
         dst->nb[1], dst->nb[2],
         n_head,
         n_head_kv,

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/set-rows.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/set-rows.cu
@@ -191,7 +191,8 @@ static __global__ void k_set_rows(const src_t * __restrict__ src0,
                                   const uint3   ne01,
                                   const uint3   ne02,
                                   const uint3   ne11_fd,
-                                  const uint3   ne12_fd) {
+                                  const uint3   ne12_fd,
+                                  const bool    skip_negative) {
     const int64_t i = int64_t(blockDim.x) * blockIdx.x + threadIdx.x;
 
     if (i >= ne_total) {
@@ -218,6 +219,9 @@ static __global__ void k_set_rows(const src_t * __restrict__ src0,
     const int64_t i10 = i01;
 
     const int64_t dst_row = *(src1 + i10*s10 + i11*s11 + i12*s12);
+    if (skip_negative && dst_row < 0) {
+        return;
+    }
 
     const src_t * src0_row = src0 + i01*s01 + i02*s02 + i03*s03;
     dst_t * dst_row_ptr    = dst + dst_row*s1 + i02*s2 + i03*s3;
@@ -238,7 +242,8 @@ static void set_rows_cuda(
         const size_t nb01, const size_t nb02, const size_t nb03,
         const size_t nb10, const size_t nb11, const size_t nb12,
         const size_t nb1, const size_t nb2, const size_t nb3,
-        cudaStream_t stream) {
+        cudaStream_t stream,
+        bool skip_negative) {
 
     const int64_t ne_total = ne00 * ne01 * ne02 * ne03;
     const int num_blocks = (ne_total + CUDA_SET_ROWS_BLOCK_SIZE - 1) / CUDA_SET_ROWS_BLOCK_SIZE;
@@ -265,7 +270,7 @@ static void set_rows_cuda(
 
         k_set_rows<<<grid_size, block_size, 0, stream>>>(src0_d, src1_d, dst_d, ne_total, ne10, ne11, ne12, ne13, s01,
                                                          s02, s03, s10, s11, s12, s1, s2, s3, ne00_fd, ne01_fd, ne02_fd,
-                                                         ne11_fd, ne12_fd);
+                                                         ne11_fd, ne12_fd, skip_negative);
     }
 }
 
@@ -277,6 +282,9 @@ static void set_rows_cuda(ggml_backend_cuda_context & ctx, const ggml_tensor * s
     GGML_TENSOR_BINARY_OP_LOCALS
 
     cudaStream_t stream = ctx.stream();
+    const bool skip_negative = ggml_get_op_params_i32(dst, 0) != 0;
+    GGML_ASSERT(!skip_negative || dst->type == GGML_TYPE_F32 ||
+                dst->type == GGML_TYPE_F16 || dst->type == GGML_TYPE_BF16);
 
 
     if (dst->type == GGML_TYPE_F32) {
@@ -287,7 +295,7 @@ static void set_rows_cuda(ggml_backend_cuda_context & ctx, const ggml_tensor * s
             nb01, nb02, nb03,
             nb10, nb11, nb12,
             nb1, nb2, nb3,
-            stream
+            stream, skip_negative
         );
     } else if (dst->type == GGML_TYPE_F16) {
         set_rows_cuda(
@@ -297,7 +305,7 @@ static void set_rows_cuda(ggml_backend_cuda_context & ctx, const ggml_tensor * s
             nb01, nb02, nb03,
             nb10, nb11, nb12,
             nb1, nb2, nb3,
-            stream
+            stream, skip_negative
         );
     } else if (dst->type == GGML_TYPE_BF16) {
         set_rows_cuda(
@@ -307,7 +315,7 @@ static void set_rows_cuda(ggml_backend_cuda_context & ctx, const ggml_tensor * s
             nb01, nb02, nb03,
             nb10, nb11, nb12,
             nb1, nb2, nb3,
-            stream
+            stream, skip_negative
         );
     } else if (dst->type == GGML_TYPE_Q4_0) {
         set_rows_cuda_quant<idx_t, block_q4_0, QK4_0, quantize_f32_q4_0_block>(
@@ -533,6 +541,10 @@ static void set_rows_dual_dispatch(ggml_backend_cuda_context & ctx, ggml_tensor 
 
 bool ggml_cuda_set_rows_dual_supported(const ggml_tensor * a, const ggml_tensor * b) {
     if (a->op != GGML_OP_SET_ROWS || b->op != GGML_OP_SET_ROWS) {
+        return false;
+    }
+    if (ggml_get_op_params_i32(a, 0) != 0 ||
+        ggml_get_op_params_i32(b, 0) != 0) {
         return false;
     }
     if (a->type != b->type || a->data == b->data) {

--- a/server/deps/llama.cpp/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/server/deps/llama.cpp/ggml/src/ggml-metal/ggml-metal-device.m
@@ -1185,7 +1185,8 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
         case GGML_OP_RWKV_WKV7:
             return true;
         case GGML_OP_GATED_DELTA_NET:
-            return has_simdgroup_reduction && op->src[2]->ne[0] % 32 == 0;
+            return has_simdgroup_reduction && op->src[2]->ne[0] % 32 == 0 &&
+                   op->src[8] == NULL;
         case GGML_OP_SOLVE_TRI:
         case GGML_OP_MUL_MAT:
         case GGML_OP_MUL_MAT_ID:
@@ -1252,6 +1253,10 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
             return op->src[0]->type != GGML_TYPE_NVFP4;
         case GGML_OP_SET_ROWS:
             {
+                if (ggml_get_op_params_i32(op, 0) != 0) {
+                    return false;
+                }
+
                 if (op->src[0]->type != GGML_TYPE_F32) {
                     return false;
                 }

--- a/server/deps/llama.cpp/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/server/deps/llama.cpp/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -355,6 +355,7 @@ static int ggml_metal_op_encode_impl(ggml_metal_op_t ctx, int idx) {
             } break;
         case GGML_OP_SET_ROWS:
             {
+                GGML_ASSERT(ggml_get_op_params_i32(node, 0) == 0);
                 n_fuse = ggml_metal_op_set_rows(ctx, idx);
             } break;
         case GGML_OP_DIAG:

--- a/server/deps/llama.cpp/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/server/deps/llama.cpp/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -3997,6 +3997,7 @@ static bool ggml_sycl_compute_forward(ggml_backend_sycl_context & ctx, struct gg
             ggml_sycl_op_set(ctx, dst);
             break;
         case GGML_OP_SET_ROWS:
+            GGML_ASSERT(ggml_get_op_params_i32(dst, 0) == 0);
             ggml_sycl_op_set_rows(ctx, dst);
             break;
         case GGML_OP_DUP:
@@ -4778,6 +4779,9 @@ static bool ggml_backend_sycl_device_supports_op(ggml_backend_dev_t dev, const g
 
         case GGML_OP_SET_ROWS:
             {
+                if (ggml_get_op_params_i32(op, 0) != 0) {
+                    return false;
+                }
                 return ((op->type == GGML_TYPE_F32 || op->type == GGML_TYPE_F16 || op->type == GGML_TYPE_BF16 ||
                          op->type == GGML_TYPE_Q8_0 || op->type == GGML_TYPE_Q5_1 || op->type == GGML_TYPE_Q5_0 ||
                          op->type == GGML_TYPE_Q4_1 || op->type == GGML_TYPE_Q4_0 || op->type == GGML_TYPE_IQ4_NL) &&
@@ -4951,8 +4955,9 @@ static bool ggml_backend_sycl_device_supports_op(ggml_backend_dev_t dev, const g
         case GGML_OP_RWKV_WKV6:
         case GGML_OP_RWKV_WKV7:
         case GGML_OP_GATED_LINEAR_ATTN:
-        case GGML_OP_GATED_DELTA_NET:
             return true;
+        case GGML_OP_GATED_DELTA_NET:
+            return op->src[8] == nullptr;
         case GGML_OP_SSM_CONV:
             return op->type == GGML_TYPE_F32 &&
                    op->src[0]->type == GGML_TYPE_F32 &&

--- a/server/deps/llama.cpp/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/server/deps/llama.cpp/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -13141,6 +13141,7 @@ static bool ggml_vk_build_graph(ggml_backend_vk_context * ctx, ggml_cgraph * cgr
 
         break;
     case GGML_OP_SET_ROWS:
+        GGML_ASSERT(ggml_get_op_params_i32(node, 0) == 0);
         ggml_vk_set_rows(ctx, compute_ctx, src0, src1, node);
 
         break;
@@ -15537,6 +15538,9 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
             }
         case GGML_OP_SET_ROWS:
             {
+                if (ggml_get_op_params_i32(op, 0) != 0) {
+                    return false;
+                }
                 switch (op->type) {
                     case GGML_TYPE_F32:
                     case GGML_TYPE_F16:
@@ -15776,6 +15780,11 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
             return true; // all inputs are contiguous, see ggml.c
         case GGML_OP_GATED_DELTA_NET:
             {
+                // The Vulkan kernel addresses state by compact sequence row
+                // and does not consume the physical-slot mapping in src[8].
+                if (op->src[8] != nullptr) {
+                    return false;
+                }
                 const uint32_t S_v = op->src[2]->ne[0];
                 if (S_v != 32 && S_v != 64 && S_v != 128) {
                     return false;

--- a/server/deps/llama.cpp/ggml/src/ggml.c
+++ b/server/deps/llama.cpp/ggml/src/ggml.c
@@ -4110,6 +4110,16 @@ struct ggml_tensor * ggml_set_rows(
     return result;
 }
 
+struct ggml_tensor * ggml_set_rows_masked(
+        struct ggml_context * ctx,
+        struct ggml_tensor  * a,
+        struct ggml_tensor  * b,
+        struct ggml_tensor  * c) {
+    struct ggml_tensor * result = ggml_set_rows(ctx, a, b, c);
+    ggml_set_op_params_i32(result, 0, 1);
+    return result;
+}
+
 // ggml_diag
 
 struct ggml_tensor * ggml_diag(
@@ -5687,13 +5697,14 @@ struct ggml_tensor * ggml_flash_attn_sparse(
 
 // ggml_paged_attn
 
-struct ggml_tensor * ggml_paged_attn(
+struct ggml_tensor * ggml_paged_attn_ext(
         struct ggml_context * ctx,
         struct ggml_tensor  * q,
         struct ggml_tensor  * k,
         struct ggml_tensor  * v,
         struct ggml_tensor  * block_table,
         struct ggml_tensor  * kv_seq_lens,
+        struct ggml_tensor  * active_slot_ids,
         float                 scale,
         int                   block_size,
         int                   max_kv_seq_len) {
@@ -5702,6 +5713,7 @@ struct ggml_tensor * ggml_paged_attn(
     GGML_ASSERT(v->type == GGML_TYPE_F16 || v->type == GGML_TYPE_Q4_0 || v->type == GGML_TYPE_Q8_0);
     GGML_ASSERT(block_table->type == GGML_TYPE_I32);
     GGML_ASSERT(kv_seq_lens->type == GGML_TYPE_I32);
+    GGML_ASSERT(active_slot_ids == NULL || active_slot_ids->type == GGML_TYPE_I32);
 
     GGML_ASSERT(q->ne[0] == k->ne[0] && q->ne[0] == v->ne[0]);
     GGML_ASSERT(k->ne[1] == v->ne[1]);
@@ -5711,10 +5723,16 @@ struct ggml_tensor * ggml_paged_attn(
     GGML_ASSERT(q->ne[3] == 1 && k->ne[3] == 1 && v->ne[3] == 1);
 
     GGML_ASSERT(block_table->ne[0] > 0);
-    GGML_ASSERT(block_table->ne[1] == q->ne[1]);
     GGML_ASSERT(block_table->ne[2] == 1 && block_table->ne[3] == 1);
-    GGML_ASSERT(kv_seq_lens->ne[0] == q->ne[1]);
+    GGML_ASSERT(block_table->ne[1] == kv_seq_lens->ne[0]);
     GGML_ASSERT(kv_seq_lens->ne[1] == 1 && kv_seq_lens->ne[2] == 1 && kv_seq_lens->ne[3] == 1);
+    if (active_slot_ids) {
+        GGML_ASSERT(ggml_is_contiguous(active_slot_ids));
+        GGML_ASSERT(active_slot_ids->ne[0] == q->ne[1]);
+        GGML_ASSERT(active_slot_ids->ne[1] == 1 && active_slot_ids->ne[2] == 1 && active_slot_ids->ne[3] == 1);
+    } else {
+        GGML_ASSERT(block_table->ne[1] == q->ne[1]);
+    }
 
     GGML_ASSERT(block_size > 0);
     GGML_ASSERT(k->ne[1] % block_size == 0);
@@ -5733,6 +5751,7 @@ struct ggml_tensor * ggml_paged_attn(
     result->src[2] = v;
     result->src[3] = block_table;
     result->src[4] = kv_seq_lens;
+    result->src[5] = active_slot_ids;
 
     return result;
 }
@@ -6534,14 +6553,15 @@ struct ggml_tensor * ggml_solve_tri(
 
 // ggml_gated_delta_net
 
-struct ggml_tensor * ggml_gated_delta_net(
+static struct ggml_tensor * ggml_gated_delta_net_impl(
         struct ggml_context * ctx,
         struct ggml_tensor  * q,
         struct ggml_tensor  * k,
         struct ggml_tensor  * v,
         struct ggml_tensor  * g,
         struct ggml_tensor  * beta,
-        struct ggml_tensor  * state) {
+        struct ggml_tensor  * state,
+        struct ggml_tensor  * active_slot_ids) {
     GGML_ASSERT(ggml_is_contiguous_rows(q));
     GGML_ASSERT(ggml_is_contiguous_rows(k));
     GGML_ASSERT(ggml_is_contiguous_rows(v));
@@ -6555,6 +6575,7 @@ struct ggml_tensor * ggml_gated_delta_net(
     GGML_ASSERT(g->type == GGML_TYPE_F32);
     GGML_ASSERT(beta->type == GGML_TYPE_F32);
     GGML_ASSERT(state->type == GGML_TYPE_F32);
+    GGML_ASSERT(active_slot_ids == NULL || active_slot_ids->type == GGML_TYPE_I32);
 
     const int64_t S_v      = v->ne[0];
     const int64_t H        = v->ne[1];
@@ -6565,7 +6586,14 @@ struct ggml_tensor * ggml_gated_delta_net(
     GGML_ASSERT(g->ne[0] == 1 || g->ne[0] == S_v);
     GGML_ASSERT(beta->ne[0] == 1);
 
-    GGML_ASSERT(ggml_nelements(state) == S_v * S_v * H * n_seqs);
+    GGML_ASSERT(state->ne[0] == S_v && state->ne[1] == S_v && state->ne[2] == H);
+    if (active_slot_ids) {
+        GGML_ASSERT(ggml_is_contiguous(active_slot_ids));
+        GGML_ASSERT(active_slot_ids->ne[0] == n_seqs);
+        GGML_ASSERT(active_slot_ids->ne[1] == 1 && active_slot_ids->ne[2] == 1 && active_slot_ids->ne[3] == 1);
+    } else {
+        GGML_ASSERT(ggml_nelements(state) == S_v * S_v * H * n_seqs);
+    }
 
     // Pack output, final new_state, and per-step intermediate states into one tensor.
     // Layout (in units of `S_v * H`-wide rows):
@@ -6587,8 +6615,20 @@ struct ggml_tensor * ggml_gated_delta_net(
     result->src[3] = g;
     result->src[4] = beta;
     result->src[5] = state;
+    result->src[8] = active_slot_ids;
 
     return result;
+}
+
+struct ggml_tensor * ggml_gated_delta_net(
+        struct ggml_context * ctx,
+        struct ggml_tensor  * q,
+        struct ggml_tensor  * k,
+        struct ggml_tensor  * v,
+        struct ggml_tensor  * g,
+        struct ggml_tensor  * beta,
+        struct ggml_tensor  * state) {
+    return ggml_gated_delta_net_impl(ctx, q, k, v, g, beta, state, NULL);
 }
 
 struct ggml_tensor * ggml_gated_delta_net_inplace(
@@ -6600,6 +6640,22 @@ struct ggml_tensor * ggml_gated_delta_net_inplace(
         struct ggml_tensor  * beta,
         struct ggml_tensor  * state) {
     struct ggml_tensor * result = ggml_gated_delta_net(ctx, q, k, v, g, beta, state);
+    ggml_set_op_params_i32(result, 1, 1);
+    return result;
+}
+
+struct ggml_tensor * ggml_gated_delta_net_active_inplace(
+        struct ggml_context * ctx,
+        struct ggml_tensor  * q,
+        struct ggml_tensor  * k,
+        struct ggml_tensor  * v,
+        struct ggml_tensor  * g,
+        struct ggml_tensor  * beta,
+        struct ggml_tensor  * state,
+        struct ggml_tensor  * active_slot_ids) {
+    GGML_ASSERT(active_slot_ids != NULL);
+    struct ggml_tensor * result = ggml_gated_delta_net_impl(
+        ctx, q, k, v, g, beta, state, active_slot_ids);
     ggml_set_op_params_i32(result, 1, 1);
     return result;
 }
@@ -6621,7 +6677,14 @@ void ggml_gated_delta_net_set_skip_intermediate(
     // Compact only the plain chain path. Tree/persistent variants need
     // intermediate states for branch reloads or explicit capture storage.
     const bool can_compact = tensor->src[6] == NULL && tensor->src[7] == NULL;
-    tensor->ne[1] = n_tokens*n_seqs + S_v*n_seqs;
+    // A plain in-place GDN writes final state directly into src[5], so its
+    // packed result does not need the otherwise mandatory final-state region.
+    // Active-slot buckets retain that region as scratch for negative padding
+    // rows, which deliberately have no physical recurrent-state slab.
+    const bool inplace_state = ggml_get_op_params_i32(tensor, 1) != 0;
+    const bool active_slots = tensor->src[8] != NULL;
+    tensor->ne[1] = n_tokens*n_seqs +
+                    (inplace_state && !active_slots ? 0 : S_v*n_seqs);
     if (!skip_intermediate || !can_compact) {
         tensor->ne[1] += S_v*n_tokens*n_seqs;
     }

--- a/server/share/status.html
+++ b/server/share/status.html
@@ -197,7 +197,9 @@ function formatMessages(messagesStr) {
 
 function update(data) {
   const badge = document.getElementById('phase-badge');
-  badge.textContent = data.phase;
+  badge.textContent = data.active_requests
+    ? data.phase + ' (' + data.active_requests + ' active)'
+    : data.phase;
   badge.className = 'badge badge-' + data.phase;
   document.getElementById('total-req').textContent = data.total_requests;
 

--- a/server/src/common/backend_args.h
+++ b/server/src/common/backend_args.h
@@ -25,6 +25,11 @@ struct BackendFeatureConfig {
     // time rather than through BackendArgs.
     bool routing_stats_requested = false;    // --freq / --collect-routing
     bool adaptive_experts_requested = false; // --adaptive-experts
+
+    // A fixed KVFlash pool requested through DFLASH_KVFLASH. "auto" is
+    // resolved later by the backend because only it has the VRAM budget needed
+    // to know whether a pool will actually be active.
+    bool kvflash_enabled = false;
 };
 
 // A superset of all per-architecture config fields. The factory reads only
@@ -59,6 +64,12 @@ struct BackendArgs {
     // only the fields they support.
     int             fa_window        = 0;  // 0 = full attention. qwen3.6 full-attn layers must see the whole context; a finite window drops the system prompt/tools -> breaks tool calls.
     bool            paged_attention  = false;  // 16-token paged K/V blocks for AR decode
+    // Concurrent decode slots (--max-concurrency). > 1 requires paged_attention;
+    // the backend serves that many sequences through the seq_* slot API.
+    int             max_concurrency  = 1;
+    // Total paged K/V pool in tokens shared by all slots (--kv-pool-tokens;
+    // block-rounded). 0 = derive capacity from available device memory.
+    long long       kv_pool_tokens   = 0;
     int             kq_stride_pad    = 32;
     int             draft_swa_window = 0;
     int             draft_ctx_max    = 4096;

--- a/server/src/common/backend_factory.cpp
+++ b/server/src/common/backend_factory.cpp
@@ -271,6 +271,8 @@ std::unique_ptr<ModelBackend> create_backend(
         cfg.stream_fd          = args.stream_fd;
         cfg.fa_window          = args.fa_window;
         cfg.paged_attention    = args.paged_attention;
+        cfg.max_concurrency    = args.max_concurrency;
+        cfg.kv_pool_tokens     = args.kv_pool_tokens;
         cfg.kq_stride_pad      = args.kq_stride_pad;
         cfg.draft_swa_window   = args.draft_swa_window;
         cfg.draft_ctx_max      = args.draft_ctx_max;

--- a/server/src/common/concurrency/paged_kv_pool.cpp
+++ b/server/src/common/concurrency/paged_kv_pool.cpp
@@ -65,11 +65,22 @@ PagedKvPool::PagedKvPool(uint32_t physical_block_count,
 
 PagedKvStatus PagedKvPool::acquire(PagedKvRequestId request_id,
                                    PagedKvSequenceHandle & out_handle) {
+    return acquire_reserved(request_id, 0, out_handle);
+}
+
+PagedKvStatus PagedKvPool::acquire_reserved(
+        PagedKvRequestId request_id, uint32_t token_capacity,
+        PagedKvSequenceHandle & out_handle) {
     if (request_to_slot_.find(request_id) != request_to_slot_.end()) {
         return PagedKvStatus::DuplicateRequest;
     }
     if (free_sequence_slots_.empty()) {
         return PagedKvStatus::SequenceSlotsExhausted;
+    }
+
+    const uint32_t reserve_blocks = blocks_for_tokens(token_capacity);
+    if (reserve_blocks > free_blocks_.size()) {
+        return PagedKvStatus::BlocksExhausted;
     }
 
     const uint32_t slot = take_lowest(free_sequence_slots_);
@@ -82,9 +93,31 @@ PagedKvStatus PagedKvPool::acquire(PagedKvRequestId request_id,
     sequence.request_id = request_id;
     sequence.generation = generation;
     sequence.active = true;
+    take_reserved_blocks(sequence, reserve_blocks);
     request_to_slot_.emplace(request_id, slot);
 
     out_handle = {slot, generation};
+    return PagedKvStatus::Ok;
+}
+
+PagedKvStatus PagedKvPool::reserve_capacity(
+        PagedKvSequenceHandle handle, uint32_t token_capacity) {
+    const PagedKvStatus status = validate(handle);
+    if (status != PagedKvStatus::Ok) return status;
+
+    SequenceState & sequence = sequences_[handle.slot];
+    const uint32_t target_blocks = blocks_for_tokens(token_capacity);
+    const uint64_t owned_blocks =
+        (uint64_t)sequence.block_table.size() +
+        sequence.reserved_blocks.size();
+    if (target_blocks <= owned_blocks) return PagedKvStatus::Ok;
+
+    const uint32_t additional_blocks =
+        target_blocks - static_cast<uint32_t>(owned_blocks);
+    if (additional_blocks > free_blocks_.size()) {
+        return PagedKvStatus::BlocksExhausted;
+    }
+    take_reserved_blocks(sequence, additional_blocks);
     return PagedKvStatus::Ok;
 }
 
@@ -145,10 +178,14 @@ PagedKvStatus PagedKvPool::release(PagedKvSequenceHandle handle) {
     for (uint32_t block : sequence.block_table) {
         give_back(free_blocks_, block);
     }
+    for (uint32_t block : sequence.reserved_blocks) {
+        give_back(free_blocks_, block);
+    }
     sequence.request_id = 0;
     sequence.kv_seq_len = 0;
     sequence.active = false;
     sequence.block_table.clear();
+    sequence.reserved_blocks.clear();
     give_back(free_sequence_slots_, handle.slot);
     return PagedKvStatus::Ok;
 }
@@ -161,6 +198,7 @@ void PagedKvPool::reset() {
         sequence.kv_seq_len = 0;
         sequence.active = false;
         sequence.block_table.clear();
+        sequence.reserved_blocks.clear();
     }
     refill(free_sequence_slots_, static_cast<uint32_t>(sequences_.size()));
     refill(free_blocks_, physical_block_count_);
@@ -176,7 +214,20 @@ PagedKvStatus PagedKvPool::sequence(
     PagedKvSequenceSnapshot snapshot;
     snapshot.kv_seq_len = sequence.kv_seq_len;
     snapshot.block_table = sequence.block_table;
+    snapshot.reserved_block_count =
+        static_cast<uint32_t>(sequence.reserved_blocks.size());
     out_sequence = std::move(snapshot);
+    return PagedKvStatus::Ok;
+}
+
+PagedKvStatus PagedKvPool::owned_block_count(
+        PagedKvSequenceHandle handle, uint32_t & out_count) const {
+    const PagedKvStatus status = validate(handle);
+    if (status != PagedKvStatus::Ok) return status;
+
+    const SequenceState & sequence = sequences_[handle.slot];
+    out_count = static_cast<uint32_t>(
+        sequence.block_table.size() + sequence.reserved_blocks.size());
     return PagedKvStatus::Ok;
 }
 
@@ -203,15 +254,28 @@ PagedKvStatus PagedKvPool::extend_block_table(SequenceState & sequence,
     if (required_blocks <= current_blocks) return PagedKvStatus::Ok;
 
     const uint32_t additional_blocks = required_blocks - current_blocks;
-    if (additional_blocks > free_blocks_.size()) {
+    const uint64_t available_blocks =
+        (uint64_t)sequence.reserved_blocks.size() + free_blocks_.size();
+    if (additional_blocks > available_blocks) {
         return PagedKvStatus::BlocksExhausted;
     }
 
     sequence.block_table.reserve(required_blocks);
     for (uint32_t i = 0; i < additional_blocks; ++i) {
-        sequence.block_table.push_back(take_lowest(free_blocks_));
+        std::vector<uint32_t> & source = sequence.reserved_blocks.empty()
+            ? free_blocks_ : sequence.reserved_blocks;
+        sequence.block_table.push_back(take_lowest(source));
     }
     return PagedKvStatus::Ok;
+}
+
+void PagedKvPool::take_reserved_blocks(SequenceState & sequence,
+                                       uint32_t additional_blocks) {
+    sequence.reserved_blocks.reserve(
+        sequence.reserved_blocks.size() + additional_blocks);
+    for (uint32_t i = 0; i < additional_blocks; ++i) {
+        give_back(sequence.reserved_blocks, take_lowest(free_blocks_));
+    }
 }
 
 }  // namespace dflash::common

--- a/server/src/common/concurrency/paged_kv_pool.h
+++ b/server/src/common/concurrency/paged_kv_pool.h
@@ -7,8 +7,7 @@
 // block/slot indices into offsets within their own pooled K/V tensors.
 //
 // The single-request backend consumes sequence() directly; the concurrent
-// scheduler drives the multi-sequence slot, capacity, and handle-generation
-// machinery through SeqSlotManager.
+// engines compose this allocator with their own per-slot lifecycle records.
 //
 // Not thread-safe; callers must serialize access. Pool state is unspecified
 // if a std::bad_alloc escapes any call.
@@ -77,6 +76,9 @@ struct PagedKvAppendResult {
 struct PagedKvSequenceSnapshot {
     uint32_t kv_seq_len = 0;
     std::vector<uint32_t> block_table;
+    // Physical blocks held for future append() calls by this sequence. They
+    // are not visible in block_table until append consumes them.
+    uint32_t reserved_block_count = 0;
 };
 
 // Allocator front-end: hands out sequence slots and physical block indices.
@@ -91,13 +93,14 @@ public:
 
     uint32_t block_size() const { return block_size_; }
     uint32_t physical_block_count() const { return physical_block_count_; }
-    // Admission capacity: SeqSlotManager sizes its slot table from this.
+    // Admission capacity: a concurrent engine sizes its slot table from this.
     uint32_t max_sequences() const {
         return static_cast<uint32_t>(sequences_.size());
     }
     uint32_t active_sequence_count() const {
         return static_cast<uint32_t>(request_to_slot_.size());
     }
+    // Blocks that are neither appended nor reserved by an active sequence.
     uint32_t free_block_count() const {
         return static_cast<uint32_t>(free_blocks_.size());
     }
@@ -106,6 +109,25 @@ public:
     // empty; no blocks are allocated until append().
     PagedKvStatus acquire(PagedKvRequestId request_id,
                           PagedKvSequenceHandle & out_handle);
+
+    // Claim a sequence slot and atomically reserve enough physical blocks for
+    // `token_capacity` future tokens. The logical sequence still starts empty;
+    // append() moves reserved blocks into its visible block table as needed.
+    // On any status failure, no slot or block is consumed and `out_handle` is
+    // unchanged. This is the admission primitive for chunked prompt prefill:
+    // once it succeeds, another sequence cannot strand this prompt halfway
+    // through by consuming the remainder of its capacity.
+    PagedKvStatus acquire_reserved(PagedKvRequestId request_id,
+                                   uint32_t token_capacity,
+                                   PagedKvSequenceHandle & out_handle);
+
+    // Atomically ensure an active sequence owns enough appended plus reserved
+    // blocks to cover `token_capacity` logical tokens. This does not advance
+    // kv_seq_len or expose new block-table entries; append() consumes the
+    // private reservation later. Existing excess capacity is retained. On a
+    // status failure no block moves and the sequence is unchanged.
+    PagedKvStatus reserve_capacity(PagedKvSequenceHandle handle,
+                                   uint32_t token_capacity);
 
     // Advance kv_seq_len by `token_count`, allocating new blocks as needed.
     // By default return every appended token's cache destination; when
@@ -129,6 +151,10 @@ public:
     PagedKvStatus sequence(PagedKvSequenceHandle handle,
                            PagedKvSequenceSnapshot & out_sequence) const;
 
+    // Return appended plus reserved blocks without copying the block table.
+    PagedKvStatus owned_block_count(PagedKvSequenceHandle handle,
+                                    uint32_t & out_count) const;
+
 private:
     // Bookkeeping for one sequence slot. `generation` survives release so
     // the next acquire on this slot invalidates old handles.
@@ -138,6 +164,10 @@ private:
         uint32_t kv_seq_len = 0;
         bool active = false;
         std::vector<uint32_t> block_table;
+        // Min-heap of blocks promised to this sequence but not yet made
+        // visible by append(). Reserved blocks are excluded from the global
+        // free list and returned by release()/reset().
+        std::vector<uint32_t> reserved_blocks;
     };
 
     // Blocks needed to hold `token_count` tokens (ceiling division).
@@ -151,6 +181,11 @@ private:
     // does). All-or-nothing on BlocksExhausted.
     PagedKvStatus extend_block_table(SequenceState & sequence,
                                      uint32_t required_blocks);
+
+    // Move exactly `additional_blocks` globally free blocks into a sequence's
+    // private reservation. Caller must preflight availability.
+    void take_reserved_blocks(SequenceState & sequence,
+                              uint32_t additional_blocks);
 
     // Take the lowest free index off `free_list`, which must be non-empty.
     static uint32_t take_lowest(std::vector<uint32_t> & free_list);

--- a/server/src/common/concurrency/seq_engine.h
+++ b/server/src/common/concurrency/seq_engine.h
@@ -1,0 +1,335 @@
+// SeqEngine — concurrent serving over decode slots (iteration-level
+// scheduling), the boundary between the HTTP scheduler and a backend that can
+// hold several live sequences at once.
+//
+// A backend qualifies when it can keep several independent sequences in a
+// paged KV cache and execute a batched decode step. Any additional
+// per-sequence model state is owned by the concrete engine, not by this
+// interface. admit() claims a slot and queues its prompt without compute.
+// Each step() then advances a scheduler-selected cohort of prompt slices
+// alongside the complete live decode batch. Once a prefill completes, the
+// scheduler advances that slot one token per step(), feeding each sampled
+// token back as the next step's input — which is what lets it override a token
+// (thinking-budget force-close) before it is committed to the cache.
+//
+// The split of duties is deliberate and is the reason this interface exists
+// apart from ModelBackend:
+//   scheduler   policy — who gets admitted, when a slot stops, what reaches
+//               the client, how a slow reader is handled
+//   engine      mechanism — KV blocks, backend-owned per-sequence state, the
+//               batched forward, sampling
+// Nothing above this interface knows about block tables, and nothing below it
+// knows about sockets.
+//
+// Threading contract: every call comes from ONE thread — the same one that
+// calls ModelBackend::generate() — so implementations need no locking.
+//
+// ── Adding a backend ────────────────────────────────────────────────────
+// Implement this interface next to the model;
+// qwen35/concurrency/qwen35_seq_engine.* is the worked example. Return it
+// from ModelBackend::seq_engine(). Nothing else in the server changes:
+// scheduler_loop() takes over the worker thread
+// as soon as seq_engine() returns non-null.
+//
+// Reuse only genuinely model-neutral pieces such as PagedKvPool. Prompt and
+// slot lifecycle state belongs beside the backend that interprets it; a new
+// engine supplies that host record together with its device-side prefill,
+// batched forward, and metadata uploads.
+//
+// What must never reach this interface, or anything above it: block tables,
+// graph shapes, and per-sequence model state (recurrent/SSM/conv tensors,
+// cache layout). A model that seems to need SeqEngine widened to serve
+// concurrently is the signal that the split has slipped — the model-specific
+// part belongs inside the engine, not in the contract.
+//
+// test/seq_engine_contract.h drives an engine through exactly the call
+// sequence the scheduler makes and returns the violations it finds; run a new
+// engine through it before wiring it up.
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "common/sampler.h"
+
+namespace dflash::common {
+
+// Model-neutral prefill planning for continuous batching. The scheduler owns
+// arrival order and fairness; the engine advertises the useful work envelope
+// and lowers the selected slices into its model-specific graph.
+struct PrefillCandidate {
+    int slot = -1;
+    uint64_t order = 0;
+};
+
+struct PrefillSlice {
+    int slot = -1;
+    int max_tokens = 0;
+};
+
+struct StepPlanLimits {
+    int max_prefill_sequences = 1;
+    int max_prefill_tokens_per_sequence = 512;
+    int max_prefill_tokens_total = 512;
+    int prefill_allocation_quantum = 512;
+};
+
+// Select the oldest eligible sequences, then distribute the step's token
+// capacity in engine-owned quanta. Strict FIFO determines cohort membership;
+// a rotating cursor prevents the oldest member from always winning a partial
+// final round.
+inline std::vector<PrefillSlice> plan_prefill_slices(
+        const std::vector<PrefillCandidate> & candidates,
+        const StepPlanLimits & limits,
+        size_t round_robin_start = 0) {
+    std::vector<PrefillSlice> slices;
+    if (candidates.empty() || limits.max_prefill_sequences <= 0 ||
+        limits.max_prefill_tokens_per_sequence <= 0 ||
+        limits.max_prefill_tokens_total <= 0 ||
+        limits.prefill_allocation_quantum <= 0) {
+        return slices;
+    }
+
+    std::vector<PrefillCandidate> ordered = candidates;
+    std::stable_sort(ordered.begin(), ordered.end(),
+        [](const PrefillCandidate & a, const PrefillCandidate & b) {
+            if (a.order != b.order) return a.order < b.order;
+            return a.slot < b.slot;
+        });
+
+    const int selected = std::min(
+        (int)ordered.size(), limits.max_prefill_sequences);
+    const int64_t selected_capacity =
+        (int64_t)selected * limits.max_prefill_tokens_per_sequence;
+    int budget = (int)std::min<int64_t>(
+        limits.max_prefill_tokens_total, selected_capacity);
+    slices.reserve((size_t)selected);
+    for (int i = 0; i < selected; ++i) {
+        slices.push_back({ordered[(size_t)i].slot, 0});
+    }
+
+    while (budget > 0) {
+        bool granted = false;
+        for (size_t offset = 0; offset < slices.size(); ++offset) {
+            const size_t idx =
+                (round_robin_start + offset) % slices.size();
+            PrefillSlice & slice = slices[idx];
+            const int room =
+                limits.max_prefill_tokens_per_sequence - slice.max_tokens;
+            if (room <= 0) continue;
+            const int grant = std::min({
+                limits.prefill_allocation_quantum, room, budget});
+            if (grant <= 0) continue;
+            slice.max_tokens += grant;
+            budget -= grant;
+            granted = true;
+            if (budget == 0) break;
+        }
+        if (!granted) break;
+    }
+
+    slices.erase(
+        std::remove_if(slices.begin(), slices.end(),
+            [](const PrefillSlice & slice) { return slice.max_tokens <= 0; }),
+        slices.end());
+    return slices;
+}
+
+class SeqEngine {
+public:
+    virtual ~SeqEngine() = default;
+
+    // Number of decode slots served concurrently. Fixed for the engine's
+    // lifetime: the scheduler sizes its own per-slot array from this once and
+    // then indexes it by the slot id admit() returns.
+    virtual int slot_count() const = 0;
+    // Per-sequence logical context bound. The scheduler owns generation
+    // policy and clamps its output cap against this value after admission.
+    virtual int max_context() const = 0;
+
+    struct AdmitResult {
+        enum class Status {
+            admitted,
+            busy,
+            failed,
+        };
+
+        Status status = Status::failed;
+        int slot = -1;
+        std::string error;
+    };
+
+    // Admit one request into a free slot and queue its prompt for chunked
+    // prefill. No model compute is performed here. Implementations may reserve
+    // persistent capacity atomically so that every admitted prompt can finish;
+    // subsequent step() calls advance scheduler-selected prompt slices.
+    //
+    // `sampler` is the only source of truth for how the slot samples:
+    // sampler.needs_logit_processing() selects CPU sampling over GPU argmax
+    // AND decides whether sampler.seed is honoured. There is deliberately no
+    // separate do_sample flag — a second copy of that one fact is something
+    // an engine can disagree with, and the failure mode is silent (a seeded
+    // request sampling nondeterministically, with no error anywhere).
+    virtual AdmitResult admit(uint64_t request_id,
+                              const std::vector<int32_t> & prompt,
+                              const SamplerCfg & sampler) = 0;
+
+    struct StepInput {
+        int     slot  = -1;
+        int32_t token = -1;   // token to commit at this slot's next position
+    };
+    struct DecodeOutput {
+        int     slot   = -1;
+        int32_t token  = -1;  // newly sampled token (pending until next step)
+        bool    failed = false;
+        // Present when failed=true so the scheduler can report an honest
+        // per-request error instead of silently truncating generation.
+        std::string error;
+    };
+
+    struct PrefillOutput {
+        enum class Status {
+            advanced,
+            completed,
+            failed,
+        };
+
+        int slot = -1;
+        Status status = Status::advanced;
+        // Present only for completed: the request's first sampled token,
+        // pending until the scheduler feeds it into the next decode step.
+        int32_t token = -1;
+        // Present only for failed.
+        std::string error;
+    };
+
+    // One scheduler iteration owns both kinds of logical work. `decode` must
+    // contain every currently decoding slot exactly once; `prefills` is the
+    // bounded subset of pending prompt work selected by scheduler policy.
+    // Device graph shapes, staging indices, cache blocks, and model state stay
+    // behind the engine boundary.
+    struct StepPlan {
+        std::vector<StepInput>    decode;
+        std::vector<PrefillSlice> prefills;
+    };
+
+    struct StepResult {
+        std::vector<DecodeOutput>  decode;
+        std::vector<PrefillOutput> prefills;
+        // A non-empty error is fatal for the whole live cohort and carries
+        // no usable row output. Validation
+        // failures occur before mutation; a device/build/compute failure may
+        // leave backend state partially advanced, so the caller must retire
+        // every live sequence before invoking step() again.
+        std::string error;
+
+        bool ok() const { return error.empty(); }
+    };
+
+    // Useful per-step work envelope at the requested live decode width. The
+    // scheduler fills this capacity and distributes it fairly; an engine may
+    // advertise different sequence, per-sequence, and total-token limits for
+    // idle, mixed, or larger decode buckets.
+    virtual StepPlanLimits step_plan_limits(int decode_rows) const = 0;
+
+    // A successful result returns one decode output for every decode input and
+    // one explicit advanced/completed/failed result for every selected
+    // prefill. Invalid plans return a fatal error without advancing state.
+    // Runtime failures are terminal for the live cohort and may follow partial
+    // backend mutation, but expose no consumable payload.
+    virtual StepResult step(const StepPlan & plan) = 0;
+
+    // Release a slot's KV blocks and mark it free. Safe on failed slots.
+    virtual void retire(int slot) = 0;
+
+    // EOS check for scheduler-side stop decisions.
+    virtual bool token_is_eos(int32_t token) const = 0;
+};
+
+// Validate the model-neutral step protocol before the scheduler consumes any
+// output. Malformed row ownership is fatal because re-feeding a token after an
+// omitted output would silently corrupt that sequence.
+inline std::string validate_step_result(
+        const SeqEngine::StepPlan & plan,
+        const SeqEngine::StepResult & result,
+        int slot_count) {
+    if (slot_count < 1) return "slot count must be positive";
+    const bool payload_empty = result.decode.empty() && result.prefills.empty();
+    if (!result.error.empty()) {
+        return payload_empty ? std::string{}
+                             : "fatal result exposes partial payload";
+    }
+
+    std::vector<uint8_t> decode_planned((size_t)slot_count, 0);
+    std::vector<uint8_t> prefill_planned((size_t)slot_count, 0);
+    for (const SeqEngine::StepInput & input : plan.decode) {
+        if (input.slot < 0 || input.slot >= slot_count || input.token < 0)
+            return "decode plan contains an invalid row";
+        if (decode_planned[(size_t)input.slot])
+            return "decode plan contains a duplicate slot";
+        decode_planned[(size_t)input.slot] = 1;
+    }
+    for (const PrefillSlice & slice : plan.prefills) {
+        if (slice.slot < 0 || slice.slot >= slot_count ||
+            slice.max_tokens <= 0)
+            return "prefill plan contains an invalid slice";
+        if (decode_planned[(size_t)slice.slot] ||
+            prefill_planned[(size_t)slice.slot])
+            return "step plan assigns a slot more than once";
+        prefill_planned[(size_t)slice.slot] = 1;
+    }
+
+    std::vector<uint8_t> decode_seen((size_t)slot_count, 0);
+    for (const SeqEngine::DecodeOutput & output : result.decode) {
+        if (output.slot < 0 || output.slot >= slot_count ||
+            !decode_planned[(size_t)output.slot])
+            return "decode output names an unplanned slot";
+        if (decode_seen[(size_t)output.slot])
+            return "step returned duplicate decode outputs";
+        if (output.failed && (output.token >= 0 || output.error.empty()))
+            return "failed decode has invalid payload";
+        if (!output.failed && (output.token < 0 || !output.error.empty()))
+            return "successful decode has invalid payload";
+        decode_seen[(size_t)output.slot] = 1;
+    }
+
+    using PrefillStatus = SeqEngine::PrefillOutput::Status;
+    std::vector<uint8_t> prefill_seen((size_t)slot_count, 0);
+    for (const SeqEngine::PrefillOutput & output : result.prefills) {
+        if (output.slot < 0 || output.slot >= slot_count ||
+            !prefill_planned[(size_t)output.slot])
+            return "prefill output names an unselected slot";
+        if (prefill_seen[(size_t)output.slot])
+            return "step returned duplicate prefill outputs";
+        if (output.status != PrefillStatus::advanced &&
+            output.status != PrefillStatus::completed &&
+            output.status != PrefillStatus::failed)
+            return "prefill output has an unknown status";
+        if (output.status == PrefillStatus::advanced &&
+            (output.token >= 0 || !output.error.empty()))
+            return "advanced prefill carries completion payload";
+        if (output.status == PrefillStatus::completed &&
+            (output.token < 0 || !output.error.empty()))
+            return "completed prefill has invalid payload";
+        if (output.status == PrefillStatus::failed &&
+            (output.token >= 0 || output.error.empty()))
+            return "failed prefill has invalid payload";
+        prefill_seen[(size_t)output.slot] = 1;
+    }
+
+    for (const SeqEngine::StepInput & input : plan.decode)
+        if (!decode_seen[(size_t)input.slot])
+            return "step omitted an output for a decode slot";
+    for (const PrefillSlice & slice : plan.prefills)
+        if (!prefill_seen[(size_t)slice.slot])
+            return "step omitted an output for a selected prefill";
+    if (payload_empty && (!plan.decode.empty() || !plan.prefills.empty()))
+        return "valid planned work returned no output";
+    return {};
+}
+
+}  // namespace dflash::common

--- a/server/src/common/feature_gate.cpp
+++ b/server/src/common/feature_gate.cpp
@@ -192,12 +192,55 @@ std::string check_feature_compatibility(
             return "--paged-attention cannot be combined with PFlash prefill "
                    "compression";
         }
+        if (features.kvflash_enabled) {
+            return "--paged-attention cannot be combined with KVFlash";
+        }
         // The pool rounds max_ctx up to a whole number of blocks, so the top
         // of the range is what can be rounded without overflowing int.
         if (args.device.max_ctx <= 0 ||
             args.device.max_ctx > INT_MAX - PAGED_BLOCK_SIZE + 1) {
             return "--paged-attention requires a positive --max-ctx small "
                    "enough to round up to whole blocks";
+        }
+    }
+
+    // ── --max-concurrency × paged attention
+    // Concurrent decode slots are currently implemented only by the paged
+    // qwen35 backend. The common scheduler does not require a particular
+    // model-state representation; each backend owns whatever per-slot state
+    // its graph needs alongside one block-table column per sequence.
+    // Everything the paged cluster above rejects is transitively rejected,
+    // so the rules here are only about the flag pair itself.
+    if (args.max_concurrency < 1) {
+        return "--max-concurrency must be at least 1";
+    }
+    if (args.max_concurrency > 1) {
+        if (!args.paged_attention) {
+            return "--max-concurrency requires --paged-attention";
+        }
+        // The paged pool addresses tokens with uint32; 64 slots is far above
+        // any batch the decode kernel has been sized for and keeps the
+        // fixed-width decode batch bounded.
+        if (args.max_concurrency > 64) {
+            return "--max-concurrency must be at most 64";
+        }
+        // Physical capacity is memory-derived and capped independently of the
+        // logical slot count, so max-concurrency no longer multiplies max_ctx
+        // in the pool's tensor address space.
+    }
+    if (args.kv_pool_tokens != 0) {
+        if (args.max_concurrency <= 1) {
+            return "--kv-pool-tokens requires --max-concurrency greater than 1";
+        }
+        // The cache appends one scratch block after the physical pool, and
+        // the requested pool itself is rounded up to a whole block. Cap the
+        // request at the largest aligned pool that leaves room for scratch.
+        const int64_t max_pool_tokens = paged_kv_address_cap();
+        if (args.kv_pool_tokens < PAGED_BLOCK_SIZE ||
+            args.kv_pool_tokens > max_pool_tokens) {
+            return "--kv-pool-tokens must be in [" +
+                   std::to_string(PAGED_BLOCK_SIZE) + ", " +
+                   std::to_string(max_pool_tokens) + "]";
         }
     }
 

--- a/server/src/common/kvflash_pager.h
+++ b/server/src/common/kvflash_pager.h
@@ -599,6 +599,15 @@ struct KvFlashAutoBudget {
     int     speed_cap_tokens = 16384;
 };
 
+// The compatibility gate can reject a fixed KVFlash pool before model setup.
+// "auto" is deliberately excluded: only the backend's VRAM-aware sizing can
+// determine whether an automatic pool will actually be active.
+inline bool kvflash_fixed_pool_requested(const char * value) {
+    return value != nullptr &&
+           std::strcmp(value, "auto") != 0 &&
+           std::atoi(value) > 0;
+}
+
 // Pool size from DFLASH_KVFLASH for a backend with `cfg` protections:
 // 0 = off; otherwise rounded to a 256 multiple, floored at
 // min_pool_tokens(cfg) (eviction must keep a victim) and clamped to

--- a/server/src/common/model_backend.h
+++ b/server/src/common/model_backend.h
@@ -22,6 +22,7 @@
 #include "ggml.h"
 #include "ggml-backend.h"
 #include "sampler.h"
+#include "concurrency/seq_engine.h"
 #include "placement/draft_residency.h"
 
 namespace dflash::common {
@@ -320,6 +321,19 @@ struct ModelBackend {
 
     virtual GenerateResult generate_impl(const GenerateRequest & req,
                                          const DaemonIO & io) = 0;
+
+    // ── Concurrent serving ───────────────────────────────────────────
+    // Backends that can hold several live sequences at once and execute a
+    // batched decode over paged KV expose them as decode slots through a
+    // SeqEngine (common/concurrency/seq_engine.h). Any additional
+    // per-sequence model state is an implementation detail of that engine.
+    // nullptr — the
+    // default — means this backend serves one request at a time and the
+    // server drives it through generate().
+    //
+    // The engine is owned by the backend; the returned pointer is borrowed
+    // and stays valid until shutdown().
+    virtual SeqEngine * seq_engine() { return nullptr; }
 
     // ── Snapshots ────────────────────────────────────────────────────
     // With right-sized CPU-resident snapshots, each slot costs only

--- a/server/src/common/paged_attention_config.h
+++ b/server/src/common/paged_attention_config.h
@@ -8,6 +8,9 @@
 
 #pragma once
 
+#include <algorithm>
+#include <cstdint>
+
 namespace dflash::common {
 
 constexpr int PAGED_BLOCK_SIZE = 16;
@@ -18,6 +21,43 @@ constexpr int paged_block_count(int max_ctx) {
 
 constexpr int paged_token_capacity(int max_ctx) {
     return paged_block_count(max_ctx) * PAGED_BLOCK_SIZE;
+}
+
+constexpr int64_t paged_kv_address_cap() {
+    return ((int64_t)INT32_MAX - PAGED_BLOCK_SIZE) / PAGED_BLOCK_SIZE *
+        PAGED_BLOCK_SIZE;
+}
+
+// Inputs for sizing a concurrent paged pool from memory that remains after
+// model weights have loaded. `fixed_cache_bytes` covers cache allocations that
+// do not shrink with the pool (one prefill staging K/V, per-slot recurrent
+// state, and metadata); `reserve_bytes` leaves room for runtime graph buffers.
+struct PagedKvAutoBudget {
+    int64_t free_bytes        = 0;
+    int64_t fixed_cache_bytes = 0;
+    int64_t reserve_bytes     = 0;
+    int64_t bytes_per_token   = 0;
+};
+
+// Return a whole-block physical capacity, capped by the old
+// n_slots * max_ctx policy and by the pool's signed-int tensor address space.
+// Zero means the supplied memory budget cannot hold even one block.
+inline int64_t paged_kv_auto_pool_tokens(int max_ctx, int n_slots,
+                                         const PagedKvAutoBudget & budget) {
+    if (max_ctx < 1 || n_slots < 1 || budget.free_bytes <= 0 ||
+        budget.bytes_per_token <= 0) {
+        return 0;
+    }
+    const int64_t usable = std::max<int64_t>(
+        0, budget.free_bytes - budget.fixed_cache_bytes -
+               budget.reserve_bytes);
+    int64_t tokens = usable / budget.bytes_per_token;
+    tokens = (tokens / PAGED_BLOCK_SIZE) * PAGED_BLOCK_SIZE;
+    const int64_t logical_cap =
+        (int64_t)n_slots * (int64_t)paged_token_capacity(max_ctx);
+    const int64_t address_cap = paged_kv_address_cap();
+    return std::max<int64_t>(
+        0, std::min(tokens, std::min(logical_cap, address_cap)));
 }
 
 }  // namespace dflash::common

--- a/server/src/common/step_graph.h
+++ b/server/src/common/step_graph.h
@@ -51,6 +51,11 @@ struct StepGraph {
     // Used by contiguous replay, KVFlash, and paged attention; null when the
     // graph uses the legacy contiguous ggml_cpy write.
     ggml_tensor *   kv_write_rows = nullptr;
+    // Compact decode row -> physical sequence slot. Padding rows carry -1.
+    // state_slot_ids has the same shape but maps padding to a safe readable
+    // slot for graph-level conv-state gathers.
+    ggml_tensor *   active_slot_ids = nullptr;
+    ggml_tensor *   state_slot_ids = nullptr;
 
     // Output
     ggml_tensor *   logits = nullptr;
@@ -81,6 +86,8 @@ inline void step_graph_free(StepGraph & sg) {
     sg.hidden_input = nullptr;
     sg.parent_ids = nullptr;
     sg.kv_write_rows = nullptr;
+    sg.active_slot_ids = nullptr;
+    sg.state_slot_ids = nullptr;
     sg.logits = nullptr;
     sg.hidden_states = nullptr;
     sg.argmax_tokens = nullptr;

--- a/server/src/internal.h
+++ b/server/src/internal.h
@@ -342,6 +342,13 @@ bool load_draft_gguf(const std::string & path,
 
 void free_draft_weights(DraftWeights & w);
 
+struct PrefillStagingSet {
+    std::vector<ggml_tensor *> k;
+    std::vector<ggml_tensor *> v;
+    std::vector<ggml_tensor *> ssm_state;
+    std::vector<ggml_tensor *> conv_state;
+};
+
 // ─── Target cache (persistent state between forward calls) ────────
 
 // Pre-allocated, backend-resident state that persists across decode steps.
@@ -363,6 +370,12 @@ struct TargetCache {
     ggml_type kv_k_type = GGML_TYPE_Q8_0;
     ggml_type kv_v_type = GGML_TYPE_Q8_0;
 
+    // Concurrent-serving slot count (--max-concurrency). 1 = classic single-sequence
+    // cache. When > 1, ssm_state/conv_state carry a trailing slot axis, the
+    // paged metadata tensors widen to n_seq_slots columns, and each prefill
+    // staging lane holds one sequence's contiguous K/V (see below).
+    int n_seq_slots = 1;
+
     // When true, K is FWHT-rotated in the graph before writing to the
     // standard-type cache (Q4_0/Q8_0/etc), and Q is rotated at attention
     // time. This gives TurboQuant-style outlier spreading with fast FA
@@ -375,11 +388,19 @@ struct TargetCache {
     std::vector<ggml_tensor *> attn_v;
 
     // Gated DeltaNet recurrent state: one per delta-net layer.
-    // ssm_state: [S_v, S_v, H_v] f32    (head_v_dim^2 × num_v_heads)
-    // conv_state: [(kernel-1), conv_channels] f32
-    // where conv_channels = d_inner + 2 * n_group * d_state
+    // ssm_state: [S_v, S_v, H_v, n_seq_slots] f32  (head_v_dim^2 × num_v_heads)
+    // conv_state: [(kernel-1), conv_channels, n_seq_slots] f32
+    // where conv_channels = d_inner + 2 * n_group * d_state.
+    // n_seq_slots is 1 for the classic single-sequence cache (identical
+    // layout to the historical 3D/2D tensors); slot s of a multi-slot cache
+    // is the contiguous slab at index s of the trailing axis.
     std::vector<ggml_tensor *> ssm_state;    // size = n_delta_layers (48)
     std::vector<ggml_tensor *> conv_state;
+
+    // Concurrent prefill staging (only when n_seq_slots > 1). Each lane owns
+    // one complete K/V + recurrent-state set, so lane capacity and validity
+    // have one source of truth.
+    std::vector<PrefillStagingSet> prefill_staging;
 
     // Snapshot buffers for speculative decoding rollback. Sized identically
     // to ssm_state/conv_state above. Populated by snapshot_ssm_state() and
@@ -426,8 +447,10 @@ struct TargetCache {
     // gallocr-managed graph inputs lets decode steps update them append-only
     // — one table entry per new 16-token block plus a 4-byte length per step
     // — instead of re-uploading the whole live table before every compute.
-    ggml_tensor * paged_block_table = nullptr;   // I32 [max_blocks, 1]
-    ggml_tensor * paged_kv_seq_lens = nullptr;   // I32 [1]
+    // Column s of the block table (and entry s of the lens) belongs to
+    // sequence slot s; single-sequence caches have exactly one column.
+    ggml_tensor * paged_block_table = nullptr;   // I32 [max_blocks_per_seq, n_seq_slots]
+    ggml_tensor * paged_kv_seq_lens = nullptr;   // I32 [n_seq_slots]
 };
 
 // Snapshot the current SSM+conv state into TargetCache::*_snap tensors.
@@ -542,6 +565,13 @@ bool restore_target_cache_chain(const PrefixSnapshot * thick,
 // max_ctx rounded up to PAGED_BLOCK_SIZE so the last partial page has physical
 // rows. Non-paged callers retain the legacy rule that ctx_alloc cannot grow
 // the allocation beyond max_ctx.
+// `n_seq_slots` (concurrent serving): number of sequence slots the cache
+// serves at once. > 1 requires paged_attention; it adds a trailing slot axis
+// to the recurrent state, widens the paged metadata to one block-table column
+// per slot, allocates the contiguous prefill staging K/V, and skips the
+// spec-decode rollback tensors entirely (concurrent decode is AR-only). With
+// n_seq_slots > 1 the attention K/V tensors are sized by ctx_alloc (the shared
+// pool capacity plus one scratch block) rather than one sequence's max_ctx.
 bool create_target_cache(const TargetWeights & w,
                          int max_ctx,
                          int max_verify_tokens,
@@ -549,7 +579,9 @@ bool create_target_cache(const TargetWeights & w,
                          TargetCache & out,
                          bool prefill_only = false,
                          int ctx_alloc = 0,
-                         bool paged_attention = false);
+                         bool paged_attention = false,
+                         int n_seq_slots = 1,
+                         int max_concurrent_prefills = 1);
 
 // `f32_ssm_intermediates` enables exact per-token checkpoints for the opt-in
 // layer-split fast rollback path. The default preserves the established Q8_0
@@ -565,7 +597,9 @@ bool create_target_cache_partial(const TargetWeights & w,
                                  bool allocate_target_feat,
                                  int ctx_alloc = 0,
                                  bool f32_ssm_intermediates = false,
-                                 bool paged_attention = false);
+                                 bool paged_attention = false,
+                                 int n_seq_slots = 1,
+                                 int max_concurrent_prefills = 1);
 
 void free_target_cache(TargetCache & c);
 
@@ -579,6 +613,19 @@ void reset_target_cache(TargetCache & c);
 // overwritten during prefill anyway. Essential between HTTP requests to avoid
 // stale delta-net state corrupting subsequent prefills.
 void reset_recurrent_state(TargetCache & c);
+
+// Zero the prefill staging tensors — K/V and the staging conv/ssm state
+// slabs (multi-slot caches only; no-op otherwise). Called at each admission
+// so the staging region behaves exactly like the freshly reset cache the
+// dense prefill path expects. When staging_idx > 0, zeroes the extra set.
+void reset_prefill_staging(TargetCache & c, int staging_idx = 0);
+
+// Access one component of a staging lane. Invalid indices return an empty
+// vector so callers can fail graph construction without dereferencing state.
+const std::vector<ggml_tensor *> & staging_k_for(const TargetCache & c, int idx);
+const std::vector<ggml_tensor *> & staging_v_for(const TargetCache & c, int idx);
+const std::vector<ggml_tensor *> & staging_ssm_for(const TargetCache & c, int idx);
+const std::vector<ggml_tensor *> & staging_conv_for(const TargetCache & c, int idx);
 
 // Reallocate a prefill-only cache with full rollback tensors, copying all live
 // state (KV, SSM, conv, target_feat) device-to-device. Frees the old cache.
@@ -620,14 +667,59 @@ struct QwenGraphInputs {
     bool          capture_delta_intermediate = false; // if true, populate out_delta_captures
     bool          capture_moe_router = false; // if true, expose selected expert ids for MoE layers
     int           fa_window = 0;  // sliding window for FA layers: 0 = full attention
-    bool          last_token_logits_only = false; // if true, only compute logits for last token (prefill optimization)
+    int           logits_tail_rows = 0; // compute logits only for last n rows; 0 = all
     ggml_tensor * parent_ids = nullptr; // [n_tokens] i32; tree mode when non-null
-    // [n_tokens,n_head_kv] i64 physical destination rows; non-null selects the
-    // step-invariant ggml_set_rows KV write.
+    // [n_tokens,n_head_kv] i64 physical destination rows for the
+    // ggml_set_rows KV write; step-invariant except under paged prefill,
+    // which pairs it with a legacy cpy into the staging tensors.
     ggml_tensor * kv_write_rows = nullptr;
-    // Paged decode: attention reads cache.paged_block_table /
-    // cache.paged_kv_seq_lens instead of a dense KV view.
-    bool paged_attention = false;
+    ggml_tensor * paged_block_table = nullptr; // [max_blocks,n_seqs] i32
+    // [n_seqs] i32; valid cached K/V tokens per sequence.
+    ggml_tensor * paged_kv_seq_lens = nullptr;
+    // [n_seqs] i32 mapping compact decode rows to physical cache/state slots.
+    // A value of -1 denotes a graph-bucket padding row.
+    ggml_tensor * active_slot_ids = nullptr;
+    // [n_seqs] i32 gather-safe variant: padding maps to slot zero. Used only
+    // for reading the much smaller conv-state slabs; writes use active ids.
+    ggml_tensor * state_slot_ids = nullptr;
+    // Concurrent-slot serving (paged only):
+    //   n_seqs > 1  — batched decode: the token axis is the SEQUENCE axis
+    //     (n_tokens == n_seqs, one token per slot). DeltaNet runs with
+    //     n_seq_tokens=1 over the full state slabs, and the paged attention
+    //     output is permuted from [D,n_seq,Hq] to the dense [D,Hq,n_tokens]
+    //     layout before the reshape.
+    //   seq_slot — the slot whose conv/ssm slabs the prefill_commit copy
+    //     targets (and the slab a plain single-sequence forward against a
+    //     multi-slot cache would select).
+    //   paged_prefill — chunked prefill of one slot: K/V reads and the legacy
+    //     cpy writes go to the selected staging lane (contiguous, masked, stride-1 —
+    //     numerically identical to the dense path), while kv_write_rows
+    //     dual-writes the same rows into the scattered pool blocks.
+    //   paged_max_kv_len — batched decode: max kv_seq_len over live slots,
+    //     used (256-padded) as the kernel launch bound instead of
+    //     kv_start + n_tokens, which is meaningless across slots.
+    //   n_prefill_tokens — fused prefill+decode: the first n_prefill_tokens
+    //     rows of the token axis are one sequence's prefill chunk (staging
+    //     reads, masked, kv_start offset) and the remaining n_seqs rows are
+    //     the compact batched decode (one token per live row, paged reads).
+    //     Projections, FFN, norms, and the LM head run once over the whole
+    //     batch; only the attention and DeltaNet cores split. Requires
+    //     paged_prefill && compact_slots && n_tokens ==
+    //     n_prefill_tokens + n_seqs. 0 = not fused.
+    //   prefill_commit — final prefill chunk: append per-delta-layer copies
+    //     of the staging conv/ssm state into slot seq_slot's slabs at the
+    //     END of the graph (after the batched decode state write-back).
+    // Fused steps set logits_tail_rows to n_seqs (+1 on the committing
+    // chunk, whose extra leading row is the prompt's last token).
+    int  n_seqs = 1;
+    int  seq_slot = 0;
+    bool paged_prefill = false;
+    int  paged_max_kv_len = 0;
+    int  n_prefill_tokens = 0;
+    bool prefill_commit = false;
+    // Which prefill staging lane the graph uses. 0 by default for all
+    // existing callers.
+    int  staging_idx = 0;
     // Capture the LAST token's post-RoPE/post-rotation Q per full-attention
     // layer into cache.q_cap (KVFlash target-QK scorer). Step-invariant:
     // node properties depend only on n_tokens and the layer index.

--- a/server/src/qwen35/concurrency/qwen35_seq_engine.cpp
+++ b/server/src/qwen35/concurrency/qwen35_seq_engine.cpp
@@ -1,0 +1,640 @@
+// Concurrent slot engine for the paged Qwen3.5/3.6 backend
+// (--max-concurrency N).
+//
+// All calls come from the HTTP scheduler thread, which is also the only
+// caller of the pool, step graph, and device metadata uploads.
+
+#include "qwen35_seq_engine.h"
+
+#include "qwen35_backend.h"
+#include "graph_builders.h"
+#include "attn_masks.h"
+#include "prefill_helpers.h"
+#include "common/sampler.h"
+#include "internal.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <utility>
+#include <vector>
+
+namespace dflash::common {
+
+namespace {
+
+// Denser than pure power-of-2: reduces padding waste at non-power-of-2
+// live counts (e.g. C=5 uses bucket=6 at 17% waste vs bucket=8 at 37.5%).
+int decode_bucket_width(int live_count) {
+    static constexpr int buckets[] = {1, 2, 3, 4, 6, 8, 12, 16, 24, 32, 48, 64};
+    for (int b : buckets)
+        if (b >= live_count) return b;
+    return 64;
+}
+
+// A multi-slot cache owns one cohesive object per prefill staging lane.
+int staging_set_capacity(const TargetCache & cache) {
+    return cache.n_seq_slots <= 1 ? 1 : (int)cache.prefill_staging.size();
+}
+
+
+} // namespace
+
+bool Qwen35SeqEngine::token_is_eos(int32_t token) const {
+    return b_.token_is_eos(token);
+}
+
+SeqEngine::AdmitResult Qwen35SeqEngine::admit(
+        uint64_t request_id,
+        const std::vector<int32_t> & prompt,
+        const SamplerCfg & sampler) {
+    const int lease_capacity =
+        std::min(max_prefills_, staging_set_capacity(b_.cache_));
+    std::vector<uint8_t> staging_in_use((size_t)lease_capacity, 0);
+    for (int i = 0; i < slots_.slot_count(); ++i) {
+        if (!slots_.is_prefilling(i)) continue;
+        const int idx = slots_.slot(i).staging_idx;
+        if (idx >= 0 && idx < lease_capacity) {
+            staging_in_use[(size_t)idx] = 1;
+        }
+    }
+    const auto free_lease = std::find(
+        staging_in_use.begin(), staging_in_use.end(), (uint8_t)0);
+    if (free_lease == staging_in_use.end()) {
+        return {AdmitResult::Status::busy, -1,
+                "all prefill staging lanes are busy"};
+    }
+    const int staging_idx = (int)(free_lease - staging_in_use.begin());
+    return slots_.admit(request_id, prompt, sampler, staging_idx);
+}
+
+int32_t Qwen35SeqEngine::sample_graph_row(
+        int slot, int logits_row, const int32_t * cached_argmax,
+        std::vector<float> * logits_scratch) {
+    const TargetWeights & w = b_.w_;
+    const int vocab = w.n_vocab;
+    Qwen35Slot & seq = slots_.slot(slot);
+    int32_t token = -1;
+    if (seq.sampler.needs_logit_processing()) {
+        std::vector<float> local_logits;
+        std::vector<float> & logits = logits_scratch
+            ? *logits_scratch
+            : local_logits;
+        if (logits.empty()) logits.resize((size_t)vocab);
+        ggml_backend_tensor_get_async(
+            b_.target_backend_, b_.sg_.logits, logits.data(),
+            (size_t)logits_row * (size_t)vocab * sizeof(float),
+            sizeof(float) * (size_t)vocab);
+        ggml_backend_synchronize(b_.target_backend_);
+        token = sample_logits(logits.data(), vocab, seq.sampler,
+                              seq.sample_history, seq.rng);
+    } else if (cached_argmax) {
+        token = *cached_argmax;
+    } else {
+        ggml_backend_tensor_get_async(
+            b_.target_backend_, b_.sg_.argmax_tokens, &token,
+            (size_t)logits_row * sizeof(int32_t), sizeof(int32_t));
+        ggml_backend_synchronize(b_.target_backend_);
+    }
+    return b_.apply_min_tokens_floor(
+        token, seq.generated_tokens(),
+        (size_t)logits_row * (size_t)vocab * sizeof(float));
+}
+
+bool Qwen35SeqEngine::upload_block_table_delta(
+        int slot, int first_block, const int32_t * blocks, size_t count) {
+    if (count == 0) return true;
+    ggml_tensor * table = b_.cache_.paged_block_table;
+    if (!table || slot < 0 || slot >= table->ne[1] || first_block < 0 ||
+        (uint64_t)first_block + count > (uint64_t)table->ne[0]) {
+        return false;
+    }
+    // `blocks` commonly points into a temporary PrefillChunk vector or a
+    // stack-local StepAppend. Keep this tiny metadata write synchronous so
+    // the backend never observes a source whose lifetime has ended.
+    ggml_backend_tensor_set(
+        table, blocks,
+        (size_t)slot * table->nb[1] +
+            (size_t)first_block * sizeof(int32_t),
+        count * sizeof(int32_t));
+    return true;
+}
+
+void Qwen35SeqEngine::fail_prefill(
+        int slot, std::vector<PrefillOutput> & outputs,
+        const char * log_message, const char * client_message) {
+    if (!slots_.is_prefilling(slot)) return;
+    std::fprintf(stderr, "[parallel] %s — failing slot %d\n",
+                 log_message, slot);
+    PrefillOutput out;
+    out.slot = slot;
+    out.status = PrefillOutput::Status::failed;
+    out.error = client_message;
+    outputs.push_back(std::move(out));
+}
+
+Qwen35SeqEngine::PrefillStage Qwen35SeqEngine::stage_prefill_chunk(
+        int slot, int max_tokens, int staging_idx,
+        std::vector<PrefillOutput> & outputs) {
+    PrefillStage stage;
+    if (!slots_.is_prefilling(slot)) return stage;
+
+    Qwen35Slot & pending = slots_.slot(slot);
+    stage.kv_pos = pending.cur_pos;
+    stage.staging_idx = staging_idx;
+    if (stage.kv_pos == 0) {
+        reset_prefill_staging(b_.cache_, staging_idx);
+    }
+    stage.chunk = std::min(
+        max_tokens, pending.prompt_len - stage.kv_pos);
+    if (stage.chunk <= 0) return PrefillStage{};
+    stage.commit = stage.kv_pos + stage.chunk >= pending.prompt_len;
+
+    Qwen35SlotManager::PrefillChunk chunk =
+        slots_.append_prefill(slot, stage.chunk);
+    if (!chunk.ok || chunk.rows.size() != (size_t)stage.chunk) {
+        fail_prefill(slot, outputs, "prefill K/V allocation failed",
+                             "prefill K/V allocation failed");
+        return PrefillStage{};
+    }
+    if (!upload_block_table_delta(
+            slot, chunk.first_new_block, chunk.new_blocks.data(),
+            chunk.new_blocks.size())) {
+        fail_prefill(
+            slot, outputs, "prefill block-table delta exceeds device capacity",
+            "prefill block-table update failed");
+        return PrefillStage{};
+    }
+
+    stage.rows = std::move(chunk.rows);
+    stage.embeddings.resize((size_t)b_.w_.n_embd * stage.chunk);
+    if (!b_.w_.embedder.embed(
+            pending.sample_history.data() + stage.kv_pos, stage.chunk,
+            stage.embeddings.data())) {
+        fail_prefill(slot, outputs, "prefill embed failed",
+                             "prefill embedding failed");
+        return PrefillStage{};
+    }
+    stage.ready = true;
+    return stage;
+}
+
+bool Qwen35SeqEngine::run_prefill_graph(
+        const PrefillStage & prefill, int prefill_slot,
+        std::vector<PrefillOutput> & outputs) {
+    const TargetWeights & w = b_.w_;
+    StepGraph & sg = b_.sg_;
+    const int hidden = w.n_embd;
+    const int chunk = prefill.chunk;
+    const bool commit = prefill.commit;
+    const int kv_pos = prefill.kv_pos;
+    const int staging_idx = prefill.staging_idx;
+
+    const bool with_mask =
+        (b_.cfg_.kq_stride_pad > KQ_MASK_PAD) || (chunk > 1);
+    bool built = build_target_step(
+        sg, w, b_.cache_, b_.target_backend_,
+        /*kv_start=*/kv_pos, /*n_tokens=*/chunk,
+        with_mask, /*capture=*/false,
+        /*capture_delta_intermediate=*/false,
+        /*fa_window=*/0,
+        /*logits_tail_rows=*/1,
+        b_.cfg_.kq_stride_pad,
+        /*capture_moe_router=*/false,
+        /*kvflash_mask=*/false,
+        /*capture_qk=*/false,
+        /*paged_attention=*/false,
+        /*n_seqs=*/1,
+        /*seq_slot=*/prefill_slot,
+        /*paged_prefill=*/true,
+        /*paged_max_kv_len=*/0,
+        /*n_prefill_tokens=*/0,
+        /*prefill_commit=*/commit,
+        /*compact_slots=*/false,
+        /*staging_idx=*/staging_idx);
+    if (!built || !sg.kv_write_rows) {
+        fail_prefill(prefill_slot, outputs,
+                             "prefill graph build failed",
+                             "prefill graph build failed");
+        return false;
+    }
+
+    const int n_total = chunk;
+    embed_buf_.resize((size_t)hidden * n_total);
+    std::copy(prefill.embeddings.begin(), prefill.embeddings.end(),
+              embed_buf_.begin());
+    ggml_backend_tensor_set_async(
+        b_.target_backend_, sg.inp_embed, embed_buf_.data(), 0,
+        sizeof(float) * (size_t)hidden * n_total);
+
+    pos_buf_.resize((size_t)4 * n_total);
+    fill_qwen35_mrope_positions(pos_buf_.data(), kv_pos, n_total);
+    ggml_backend_tensor_set_async(
+        b_.target_backend_, sg.positions, pos_buf_.data(), 0,
+        sizeof(int32_t) * pos_buf_.size());
+
+    rows_buf_.resize((size_t)n_total * w.n_head_kv);
+    for (int h = 0; h < w.n_head_kv; h++)
+        for (int i = 0; i < chunk; i++)
+            rows_buf_[(size_t)h * n_total + i] = prefill.rows[(size_t)i];
+    ggml_backend_tensor_set_async(
+        b_.target_backend_, sg.kv_write_rows, rows_buf_.data(), 0,
+        sizeof(int64_t) * rows_buf_.size());
+
+    upload_qwen35_causal_mask(
+        sg.attn_mask, kv_pos, chunk, b_.cfg_.kq_stride_pad);
+
+    const auto st = ggml_backend_graph_compute(b_.target_backend_, sg.gf);
+    if (st != GGML_STATUS_SUCCESS) {
+        fail_prefill(prefill_slot, outputs,
+                             "prefill compute failed",
+                             "prefill compute failed");
+        return false;
+    }
+    return true;
+}
+
+SeqEngine::StepResult Qwen35SeqEngine::step(const StepPlan & plan) {
+    StepResult result;
+    std::vector<DecodeOutput> & decode_outputs = result.decode;
+    std::vector<PrefillOutput> & prefill_outputs = result.prefills;
+    const std::vector<StepInput> & inputs = plan.decode;
+    const int n_slots = slots_.slot_count();
+
+    auto fail_step = [&](const std::string & error) {
+        result.decode.clear();
+        result.prefills.clear();
+        result.error = error;
+        return std::move(result);
+    };
+
+    if ((int)inputs.size() != slots_.decoding_count()) {
+        return fail_step("decode plan does not cover every live slot");
+    }
+    std::vector<uint8_t> decode_seen((size_t)n_slots, 0);
+    for (const StepInput & in : inputs) {
+        if (in.slot < 0 || in.slot >= n_slots || in.token < 0 ||
+            decode_seen[(size_t)in.slot] ||
+            !slots_.is_active(in.slot) || slots_.is_prefilling(in.slot)) {
+            return fail_step("invalid or duplicate decode row in step plan");
+        }
+        decode_seen[(size_t)in.slot] = 1;
+    }
+
+    const StepPlanLimits limits =
+        step_plan_limits((int)inputs.size());
+    const int slice_limit = limits.max_prefill_tokens_per_sequence;
+    if ((int)plan.prefills.size() > limits.max_prefill_sequences) {
+        return fail_step("prefill plan exceeds engine sequence capacity");
+    }
+    int prefill_tokens_total = 0;
+    std::vector<uint8_t> prefill_seen((size_t)n_slots, 0);
+    for (const PrefillSlice & slice : plan.prefills) {
+        if (slice.slot < 0 || slice.slot >= n_slots ||
+            slice.max_tokens <= 0 || slice.max_tokens > slice_limit ||
+            prefill_seen[(size_t)slice.slot] ||
+            decode_seen[(size_t)slice.slot] ||
+            !slots_.is_prefilling(slice.slot)) {
+            return fail_step("invalid or duplicate prefill slice in step plan");
+        }
+        prefill_seen[(size_t)slice.slot] = 1;
+        prefill_tokens_total += slice.max_tokens;
+        if (prefill_tokens_total > limits.max_prefill_tokens_total) {
+            return fail_step(
+                "prefill plan exceeds engine total-token capacity");
+        }
+    }
+    if (inputs.empty() && plan.prefills.empty()) return result;
+
+    const TargetWeights & w = b_.w_;
+    StepGraph & sg = b_.sg_;
+    const int hidden    = w.n_embd;
+    const int n_head_kv = w.n_head_kv;
+
+    decode_outputs.reserve(inputs.size());
+    prefill_outputs.reserve(plan.prefills.size());
+    output_rows_.clear();        output_rows_.reserve(inputs.size());
+    live_tokens_.clear();        live_tokens_.reserve(inputs.size());
+    live_positions_.clear();     live_positions_.reserve(inputs.size());
+    live_physical_rows_.clear(); live_physical_rows_.reserve(inputs.size());
+    live_slot_ids_.clear();      live_slot_ids_.reserve(inputs.size());
+
+    int max_kv_len = 1;
+    for (const StepInput & in : inputs) {
+        DecodeOutput out;
+        out.slot = in.slot;
+        out.failed = true;
+        int compact_row = -1;
+        if (in.slot < 0 || in.slot >= n_slots) {
+            out.error = "invalid decode slot";
+            decode_outputs.push_back(out);
+            output_rows_.push_back(compact_row);
+            continue;
+        }
+        const Qwen35SlotManager::StepAppend app =
+            slots_.append_token(in.slot, in.token);
+        if (!app.ok) {
+            out.error = app.busy
+                ? "paged KV pool exhausted during decode; raise "
+                  "--kv-pool-tokens or lower --max-ctx/--max-concurrency"
+                : "decode K/V append failed";
+            decode_outputs.push_back(out);
+            output_rows_.push_back(compact_row);
+            continue;
+        }
+        if (app.new_block >= 0) {
+            if (!upload_block_table_delta(
+                    in.slot, app.new_block_index, &app.new_block, 1)) {
+                out.error = "decode block-table entry exceeds device capacity";
+                decode_outputs.push_back(out);
+                output_rows_.push_back(compact_row);
+                continue;
+            }
+        }
+        compact_row = (int)live_tokens_.size();
+        live_tokens_.push_back(in.token);
+        live_positions_.push_back(app.position);
+        live_physical_rows_.push_back(app.physical_row);
+        live_slot_ids_.push_back(in.slot);
+        max_kv_len = std::max(max_kv_len, app.position + 1);
+        out.failed = false;
+        decode_outputs.push_back(out);
+        output_rows_.push_back(compact_row);
+    }
+    const int live_count = (int)live_tokens_.size();
+    const bool with_decode = live_count > 0;
+    // Prefill membership, ordering, and token limits come from the common
+    // scheduler. Staging identity remains request-owned below this boundary.
+    prefill_slots_.clear();
+    prefill_token_limits_.clear();
+    for (const PrefillSlice & slice : plan.prefills) {
+        prefill_slots_.push_back(slice.slot);
+        prefill_token_limits_.push_back(slice.max_tokens);
+    }
+
+    auto advance_prefill_only = [&](int pslot, int max_tokens) {
+        const int staging_idx = slots_.slot(pslot).staging_idx;
+        const size_t results_before = prefill_outputs.size();
+        PrefillStage prefill = stage_prefill_chunk(
+            pslot, max_tokens, staging_idx, prefill_outputs);
+        if (!prefill.ready) {
+            if (prefill_outputs.size() == results_before) {
+                fail_prefill(
+                    pslot, prefill_outputs,
+                    "prefill made no progress despite reserved capacity",
+                    "prefill scheduler made no progress");
+            }
+            return false;
+        }
+        if (!run_prefill_graph(prefill, pslot, prefill_outputs)) return false;
+
+        int32_t argmax = -1;
+        if (prefill.commit) {
+            ggml_backend_tensor_get_async(
+                b_.target_backend_, b_.sg_.argmax_tokens, &argmax, 0,
+                sizeof(argmax));
+        }
+        ggml_backend_synchronize(b_.target_backend_);
+
+        PrefillOutput out;
+        out.slot = pslot;
+        if (prefill.commit) {
+            out.status = PrefillOutput::Status::completed;
+            out.token = sample_graph_row(
+                pslot, 0, &argmax, &logits_buf_);
+            slots_.commit_prefill(pslot);
+        }
+        prefill_outputs.push_back(std::move(out));
+        return true;
+    };
+
+    // With no live decode rows, advance up to K independent prefills.
+    if (!with_decode) {
+        const int n_prefills_this_step =
+            std::min((int)prefill_slots_.size(), max_prefills_);
+        for (int pi = 0; pi < n_prefills_this_step; ++pi) {
+            advance_prefill_only(
+                prefill_slots_[(size_t)pi],
+                prefill_token_limits_[(size_t)pi]);
+        }
+        if (prefill_outputs.size() != plan.prefills.size()) {
+            return fail_step("selected prefill work made no progress");
+        }
+        return result;
+    }
+
+    // Keep K prefills moving while decode is active: one gets a standalone
+    // staging set, and the FIFO head is fused into the decode graph below.
+    if (max_prefills_ > 1 && prefill_slots_.size() > 1) {
+        advance_prefill_only(prefill_slots_[1], prefill_token_limits_[1]);
+    }
+
+    // ── Build and compute the fused/decode graph ───────────────────────
+    const int decode_bucket = decode_bucket_width(live_count);
+
+    dec_tokens_.assign((size_t)decode_bucket, 0);
+    dec_pos_.assign((size_t)4 * decode_bucket, 0);
+    dec_rows_.assign((size_t)decode_bucket * n_head_kv, scratch_row_);
+    active_slot_ids_.assign((size_t)decode_bucket, -1);
+    state_slot_ids_.assign((size_t)decode_bucket, 0);
+    seq_lens_.assign((size_t)n_slots, 0);
+    for (int row = 0; row < live_count; ++row) {
+        dec_tokens_[(size_t)row] = live_tokens_[(size_t)row];
+        const int pos = live_positions_[(size_t)row];
+        dec_pos_[(size_t)4 * row + 0] = pos;
+        dec_pos_[(size_t)4 * row + 1] = pos;
+        dec_pos_[(size_t)4 * row + 2] = pos;
+        active_slot_ids_[(size_t)row] = live_slot_ids_[(size_t)row];
+        state_slot_ids_[(size_t)row] = live_slot_ids_[(size_t)row];
+        seq_lens_[(size_t)live_slot_ids_[(size_t)row]] = pos + 1;
+        for (int h = 0; h < n_head_kv; ++h) {
+            dec_rows_[(size_t)h * decode_bucket + row] =
+                live_physical_rows_[(size_t)row];
+        }
+    }
+    PrefillStage prefill;
+    int prefill_slot = -1;
+    if (!prefill_slots_.empty()) {
+        prefill_slot = prefill_slots_.front();
+        const size_t results_before = prefill_outputs.size();
+        prefill = stage_prefill_chunk(
+            prefill_slot, prefill_token_limits_.front(),
+            slots_.slot(prefill_slot).staging_idx, prefill_outputs);
+        if (!prefill.ready && prefill_outputs.size() == results_before) {
+            fail_prefill(
+                prefill_slot, prefill_outputs,
+                "prefill made no progress despite reserved capacity",
+                "prefill scheduler made no progress");
+        }
+    }
+    bool with_prefill = prefill.ready;
+    const int chunk = prefill.chunk;
+    const bool commit = prefill.commit;
+    const int kv_pos = prefill.kv_pos;
+
+    auto fail_fused_prefill = [&]() {
+        fail_prefill(prefill_slot, prefill_outputs,
+                             "fused prefill graph build failed",
+                             "prefill graph build failed");
+        with_prefill = false;
+    };
+
+    bool built = false;
+    if (with_prefill) {
+        const bool with_mask =
+            (b_.cfg_.kq_stride_pad > KQ_MASK_PAD) || (chunk > 1);
+        built = build_target_step(
+            sg, w, b_.cache_, b_.target_backend_,
+            /*kv_start=*/kv_pos,
+            /*n_tokens=*/chunk + decode_bucket,
+            with_mask, /*capture=*/false,
+            /*capture_delta_intermediate=*/false,
+            /*fa_window=*/0,
+            /*logits_tail_rows=*/decode_bucket + (commit ? 1 : 0),
+            b_.cfg_.kq_stride_pad,
+            /*capture_moe_router=*/false,
+            /*kvflash_mask=*/false,
+            /*capture_qk=*/false,
+            /*paged_attention=*/true,
+            /*n_seqs=*/decode_bucket,
+            /*seq_slot=*/prefill_slot,
+            /*paged_prefill=*/true,
+            /*paged_max_kv_len=*/max_kv_len,
+            /*n_prefill_tokens=*/chunk,
+            /*prefill_commit=*/commit,
+            /*compact_slots=*/true,
+            /*staging_idx=*/prefill.staging_idx);
+        if (!built || !sg.kv_write_rows) fail_fused_prefill();
+    }
+    if (!with_prefill) {
+        built = build_target_step(
+            sg, w, b_.cache_, b_.target_backend_,
+            /*kv_start=*/0, /*n_tokens=*/decode_bucket,
+            /*with_mask=*/false, /*capture=*/false,
+            /*capture_delta_intermediate=*/false,
+            /*fa_window=*/0,
+            /*logits_tail_rows=*/0,
+            b_.cfg_.kq_stride_pad,
+            /*capture_moe_router=*/false,
+            /*kvflash_mask=*/false,
+            /*capture_qk=*/false,
+            /*paged_attention=*/true,
+            /*n_seqs=*/decode_bucket,
+            /*seq_slot=*/0,
+            /*paged_prefill=*/false,
+            /*paged_max_kv_len=*/max_kv_len,
+            /*n_prefill_tokens=*/0,
+            /*prefill_commit=*/false,
+            /*compact_slots=*/true);
+    }
+    if (!built || !sg.kv_write_rows) {
+        std::fprintf(stderr, "[parallel] fused/decode build failed\n");
+        for (DecodeOutput & out : decode_outputs) out.failed = true;
+        return fail_step("fused/decode graph build failed");
+    }
+
+    const int n_prefill = with_prefill ? chunk : 0;
+    const int n_decode = decode_bucket;
+    const int n_total = n_prefill + n_decode;
+    embed_buf_.resize((size_t)hidden * n_total);
+    if (n_prefill > 0) {
+        std::copy(prefill.embeddings.begin(), prefill.embeddings.end(),
+                  embed_buf_.begin());
+    }
+    if (!w.embedder.embed(dec_tokens_.data(), n_decode,
+                          embed_buf_.data() + (size_t)hidden * n_prefill)) {
+        for (DecodeOutput & out : decode_outputs) out.failed = true;
+        return fail_step("decode embedding failed");
+    }
+    ggml_backend_tensor_set_async(
+        b_.target_backend_, sg.inp_embed, embed_buf_.data(), 0,
+        sizeof(float) * (size_t)hidden * n_total);
+
+    pos_buf_.resize((size_t)4 * n_total);
+    if (n_prefill > 0) {
+        fill_qwen35_mrope_positions(pos_buf_.data(), kv_pos, n_prefill);
+    }
+    std::copy(dec_pos_.begin(), dec_pos_.begin() + (size_t)4 * n_decode,
+              pos_buf_.begin() + (size_t)4 * n_prefill);
+    ggml_backend_tensor_set_async(
+        b_.target_backend_, sg.positions, pos_buf_.data(), 0,
+        sizeof(int32_t) * pos_buf_.size());
+
+    rows_buf_.assign((size_t)n_total * n_head_kv, scratch_row_);
+    for (int h = 0; h < n_head_kv; h++) {
+        for (int i = 0; i < n_prefill; i++) {
+            rows_buf_[(size_t)h * n_total + i] =
+                prefill.rows[(size_t)i];
+        }
+        for (int s = 0; s < n_decode; s++) {
+            rows_buf_[(size_t)h * n_total + n_prefill + s] =
+                dec_rows_[(size_t)h * decode_bucket + s];
+        }
+    }
+    ggml_backend_tensor_set_async(
+        b_.target_backend_, sg.kv_write_rows, rows_buf_.data(), 0,
+        sizeof(int64_t) * rows_buf_.size());
+
+    ggml_backend_tensor_set_async(
+        b_.target_backend_, sg.active_slot_ids,
+        active_slot_ids_.data(), 0,
+        sizeof(int32_t) * active_slot_ids_.size());
+
+    if (n_prefill > 0) {
+        upload_qwen35_causal_mask(
+            sg.attn_mask, kv_pos, n_prefill, b_.cfg_.kq_stride_pad);
+    }
+    ggml_backend_tensor_set_async(
+        b_.target_backend_, sg.state_slot_ids,
+        state_slot_ids_.data(), 0,
+        sizeof(int32_t) * state_slot_ids_.size());
+    ggml_backend_tensor_set_async(
+        b_.target_backend_, b_.cache_.paged_kv_seq_lens,
+        seq_lens_.data(), 0,
+        sizeof(int32_t) * seq_lens_.size());
+
+    const auto st =
+        ggml_backend_graph_compute(b_.target_backend_, sg.gf);
+    if (st != GGML_STATUS_SUCCESS) {
+        std::fprintf(stderr, "[parallel] fused/decode compute failed\n");
+        for (DecodeOutput & out : decode_outputs) out.failed = true;
+        return fail_step("fused/decode compute failed");
+    }
+
+    // A committing fused graph exposes [prefill tail | decode rows].
+    // Non-committing prefill chunks expose only the decode rows.
+    const int dec_row0 = (n_prefill > 0 && commit) ? 1 : 0;
+    argmax_buf_.assign((size_t)(dec_row0 + n_decode), -1);
+    ggml_backend_tensor_get_async(
+        b_.target_backend_, sg.argmax_tokens, argmax_buf_.data(), 0,
+        sizeof(int32_t) * argmax_buf_.size());
+    ggml_backend_synchronize(b_.target_backend_);
+    for (size_t oi = 0; oi < decode_outputs.size(); ++oi) {
+        DecodeOutput & out = decode_outputs[oi];
+        if (out.failed) continue;
+        slots_.commit_step(out.slot);
+        const int row = dec_row0 + output_rows_[oi];
+        out.token = sample_graph_row(
+            out.slot, row, &argmax_buf_[(size_t)row], &logits_buf_);
+    }
+
+    if (with_prefill) {
+        PrefillOutput out;
+        out.slot = prefill_slot;
+        if (commit) {
+            out.status = PrefillOutput::Status::completed;
+            out.token = sample_graph_row(
+                prefill_slot, 0, &argmax_buf_[0], &logits_buf_);
+            slots_.commit_prefill(prefill_slot);
+        }
+        prefill_outputs.push_back(std::move(out));
+    }
+    return result;
+}
+
+void Qwen35SeqEngine::retire(int slot) {
+    if (!slots_.is_active(slot)) return;
+    slots_.retire(slot);
+}
+
+}  // namespace dflash::common

--- a/server/src/qwen35/concurrency/qwen35_seq_engine.h
+++ b/server/src/qwen35/concurrency/qwen35_seq_engine.h
@@ -1,0 +1,128 @@
+// Qwen35SeqEngine — SeqEngine implementation for the paged Qwen3.5/3.6
+// backend (--max-concurrency N).
+//
+// Three layers, each with one job:
+//   Qwen35SlotManager          host bookkeeping — pool-handle lifecycle,
+//                           admission arithmetic, per-slot sampler/RNG/
+//                           penalty history, the position counters
+//   Qwen35SeqEngine         the device half — chunked slot prefill, the
+//                           batched decode forward, sampling, and the
+//                           block-table / kv-length uploads
+//   Qwen35Backend           the model — weights, cache, step graph, the
+//                           paged pool, park/unpark, generate()
+//
+// The engine borrows the backend's GPU state rather than copying accessors
+// for it: it is a friend of Qwen35Backend so that concurrent serving can be
+// its own subsystem without widening the backend's public surface.
+//
+// Single-threaded by the SeqEngine contract — the HTTP scheduler thread is
+// the only caller of the engine, the pool, and the device uploads, so there
+// is no locking anywhere below here.
+
+#pragma once
+
+#include "common/concurrency/seq_engine.h"
+#include "qwen35_slot_manager.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+namespace dflash::common {
+
+class Qwen35Backend;
+
+class Qwen35SeqEngine final : public SeqEngine {
+public:
+    // `pool` and `backend` must outlive the engine. `scratch_row` is the
+    // first row of the block appended past the pool's index space, used as
+    // the K/V write destination of graph-bucket padding rows.
+    // `max_prefills` controls how many prefills can advance per step()
+    // (each uses its own staging set; must match the count allocated in
+    // TargetCache).
+    Qwen35SeqEngine(Qwen35Backend & backend, PagedKvPool & pool,
+                    int max_ctx, int64_t scratch_row,
+                    int max_prefills = 2)
+        : max_prefills_(std::max(1, max_prefills)), b_(backend),
+          slots_(pool, max_ctx), scratch_row_(scratch_row) {
+        prefill_slots_.reserve((size_t)slots_.slot_count());
+    }
+
+    int slot_count() const override { return slots_.slot_count(); }
+    int max_context() const override { return slots_.max_context(); }
+
+    AdmitResult admit(uint64_t request_id,
+                      const std::vector<int32_t> & prompt,
+                      const SamplerCfg & sampler) override;
+
+    StepResult step(const StepPlan & plan) override;
+    StepPlanLimits step_plan_limits(int decode_rows) const override {
+        const bool mixed = decode_rows > 0;
+        const int per_sequence = mixed ? 512 : 2048;
+        const int total_cap = mixed ? 2048 : 4096;
+        return {
+            max_prefills_,
+            per_sequence,
+            std::min(max_prefills_ * per_sequence, total_cap),
+            512,
+        };
+    }
+
+    void retire(int slot) override;
+
+    bool token_is_eos(int32_t token) const override;
+
+
+private:
+    struct PrefillStage {
+        bool ready = false;
+        int kv_pos = 0;
+        int chunk = 0;
+        bool commit = false;
+        int staging_idx = 0;
+        std::vector<int64_t> rows;
+        std::vector<float> embeddings;
+    };
+
+    int max_prefills_;
+
+    bool upload_block_table_delta(int slot, int first_block,
+                                  const int32_t * blocks, size_t count);
+    void fail_prefill(int slot, std::vector<PrefillOutput> & outputs,
+                              const char * log_message,
+                              const char * client_message);
+    PrefillStage stage_prefill_chunk(int slot, int max_tokens,
+                                     int staging_idx,
+                                     std::vector<PrefillOutput> & outputs);
+    bool run_prefill_graph(const PrefillStage & prefill, int prefill_slot,
+                          std::vector<PrefillOutput> & outputs);
+    int32_t sample_graph_row(int slot, int logits_row,
+                             const int32_t * cached_argmax = nullptr,
+                             std::vector<float> * logits_scratch = nullptr);
+
+    Qwen35Backend & b_;
+    Qwen35SlotManager slots_;
+    int64_t         scratch_row_ = 0;
+
+    // Hoisted per-step buffers (reused across step() calls).
+    std::vector<int>         prefill_slots_;
+    std::vector<int>         prefill_token_limits_;
+    std::vector<int>         output_rows_;
+    std::vector<int32_t>     live_tokens_;
+    std::vector<int32_t>     live_positions_;
+    std::vector<int64_t>     live_physical_rows_;
+    std::vector<int32_t>     live_slot_ids_;
+    std::vector<int32_t>     dec_tokens_;
+    std::vector<int32_t>     dec_pos_;
+    std::vector<int64_t>     dec_rows_;
+    std::vector<int32_t>     active_slot_ids_;
+    std::vector<int32_t>     state_slot_ids_;
+    std::vector<int32_t>     seq_lens_;
+    std::vector<float>       embed_buf_;
+    std::vector<int32_t>     pos_buf_;
+    std::vector<int64_t>     rows_buf_;
+    std::vector<int32_t>     argmax_buf_;
+    std::vector<float>       logits_buf_;
+};
+
+}  // namespace dflash::common

--- a/server/src/qwen35/concurrency/qwen35_slot_manager.cpp
+++ b/server/src/qwen35/concurrency/qwen35_slot_manager.cpp
@@ -1,0 +1,271 @@
+#include "qwen35_slot_manager.h"
+
+#include <algorithm>
+#include <cstdio>
+
+namespace dflash::common {
+
+Qwen35SlotManager::Qwen35SlotManager(PagedKvPool & pool, int max_ctx)
+    : pool_(pool), max_ctx_(max_ctx) {
+    slots_.assign(pool.max_sequences(), Qwen35Slot{});
+}
+
+int Qwen35SlotManager::decoding_count() const {
+    int n = 0;
+    for (const Qwen35Slot & s : slots_) {
+        n += s.decoding() ? 1 : 0;
+    }
+    return n;
+}
+
+uint32_t Qwen35SlotManager::decode_headroom_capacity(int logical_tokens) const {
+    const uint64_t extended =
+        static_cast<uint64_t>(std::max(0, logical_tokens)) +
+        pool_.block_size();
+    return static_cast<uint32_t>(std::min<uint64_t>(
+        static_cast<uint64_t>(max_ctx_), extended));
+}
+
+bool Qwen35SlotManager::capacity_fits_pool(uint32_t token_capacity) const {
+    const uint64_t blocks = token_capacity == 0 ? 0 :
+        1 + (static_cast<uint64_t>(token_capacity) - 1) /
+                pool_.block_size();
+    return blocks <= pool_.physical_block_count();
+}
+
+PagedKvStatus Qwen35SlotManager::protect_decode_headroom() {
+    struct TopUp {
+        PagedKvSequenceHandle handle;
+        uint32_t token_capacity = 0;
+    };
+
+    std::vector<TopUp> topups;
+    topups.reserve(slots_.size());
+    uint64_t total_additional = 0;
+    const uint64_t block_size = pool_.block_size();
+    for (const Qwen35Slot & slot : slots_) {
+        if (!slot.decoding()) continue;
+        const uint32_t capacity = decode_headroom_capacity(slot.cur_pos);
+        if (!capacity_fits_pool(capacity)) continue;
+
+        uint32_t owned_blocks = 0;
+        const PagedKvStatus status =
+            pool_.owned_block_count(slot.handle, owned_blocks);
+        if (status != PagedKvStatus::Ok) return status;
+        const uint64_t target_blocks = capacity == 0 ? 0 :
+            1 + (static_cast<uint64_t>(capacity) - 1) / block_size;
+        if (target_blocks <= owned_blocks) continue;
+        const uint32_t additional =
+            static_cast<uint32_t>(target_blocks - owned_blocks);
+        total_additional += additional;
+        topups.push_back({slot.handle, capacity});
+    }
+
+    // Preflight the whole cohort before moving a block, so a failed admission
+    // attempt cannot protect only whichever decoder happened to be visited
+    // first.
+    if (total_additional > pool_.free_block_count()) {
+        return PagedKvStatus::BlocksExhausted;
+    }
+    for (const TopUp & topup : topups) {
+        const PagedKvStatus status =
+            pool_.reserve_capacity(topup.handle, topup.token_capacity);
+        if (status != PagedKvStatus::Ok) return status;
+    }
+    return PagedKvStatus::Ok;
+}
+
+bool Qwen35SlotManager::is_active(int slot) const {
+    return slot >= 0 && slot < (int)slots_.size() &&
+           slots_[(size_t)slot].active();
+}
+
+bool Qwen35SlotManager::is_prefilling(int slot) const {
+    return is_active(slot) && slots_[(size_t)slot].prefilling();
+}
+
+SeqEngine::AdmitResult Qwen35SlotManager::admit(
+        uint64_t request_id, const std::vector<int32_t> & prompt,
+        const SamplerCfg & sampler, int staging_idx) {
+    using AdmitStatus = SeqEngine::AdmitResult::Status;
+    SeqEngine::AdmitResult r;
+    if (prompt.empty() || staging_idx < 0) {
+        r.error = prompt.empty() ? "empty prompt" : "invalid staging lease";
+        return r;
+    }
+    if (prompt.size() > static_cast<size_t>(max_ctx_)) {
+        r.error = "prompt exceeds max_ctx";
+        return r;
+    }
+    const int prompt_len = static_cast<int>(prompt.size());
+
+    // A prompt larger than the whole pool can NEVER be admitted; waiting
+    // for other sequences to drain would stall the queue forever and then
+    // fail anyway. Hard-fail it up front instead of reporting busy.
+    const uint64_t pool_capacity =
+        (uint64_t)pool_.physical_block_count() * pool_.block_size();
+    if ((uint64_t)prompt_len > pool_capacity) {
+        r.error = "prompt needs " + std::to_string(prompt_len) +
+                  " KV tokens but the pool holds " +
+                  std::to_string(pool_capacity) +
+                  "; raise --kv-pool-tokens or shorten the prompt";
+        return r;
+    }
+
+    int slot = -1;
+    for (int i = 0; i < (int)slots_.size(); i++) {
+        if (!slots_[(size_t)i].active()) { slot = i; break; }
+    }
+    if (slot < 0) {
+        r.status = AdmitStatus::busy;
+        r.error = "all decode slots are busy";
+        return r;
+    }
+
+    // A newly freed block belongs to any older decoder missing its rolling
+    // next-page reserve before it can belong to this admission.
+    const PagedKvStatus headroom_status = protect_decode_headroom();
+    if (headroom_status != PagedKvStatus::Ok) {
+        r.status = headroom_status == PagedKvStatus::BlocksExhausted
+            ? AdmitStatus::busy : AdmitStatus::failed;
+        r.error = r.status == AdmitStatus::busy
+            ? "existing decoders need the available KV headroom"
+            : paged_kv_status_string(headroom_status);
+        return r;
+    }
+
+    PagedKvSequenceHandle handle;
+    uint32_t reservation_capacity =
+        decode_headroom_capacity(prompt_len);
+    if (!capacity_fits_pool(reservation_capacity)) {
+        // The prompt itself fits, but this physical pool can never hold its
+        // following page. Preserve useful prompt-only behavior and report
+        // decode exhaustion later if the sequence reaches that boundary.
+        reservation_capacity = static_cast<uint32_t>(prompt_len);
+    }
+    const PagedKvStatus status = pool_.acquire_reserved(
+        request_id, reservation_capacity, handle);
+    if (status != PagedKvStatus::Ok) {
+        r.status = status == PagedKvStatus::SequenceSlotsExhausted ||
+                           status == PagedKvStatus::BlocksExhausted
+            ? AdmitStatus::busy : AdmitStatus::failed;
+        r.error = status == PagedKvStatus::BlocksExhausted
+            ? "not enough unreserved KV blocks for the prompt and decode headroom"
+            : paged_kv_status_string(status);
+        return r;
+    }
+
+    Qwen35Slot & s = slots_[(size_t)slot];
+    s.phase = Qwen35SlotPhase::prefill;
+    s.handle = handle;
+    s.cur_pos = 0;
+    s.prompt_len = prompt_len;
+    s.staging_idx = staging_idx;
+    s.sampler = sampler;
+    s.sample_history = prompt;
+    // Same predicate the engine uses to pick CPU sampling over GPU argmax:
+    // a seed only means anything when the sampler actually draws.
+    if (sampler.needs_logit_processing() && sampler.seed != 0) {
+        s.rng.seed(sampler.seed);
+    } else {
+        s.rng.seed(std::random_device{}());
+    }
+
+    r.status = AdmitStatus::admitted;
+    r.slot = slot;
+    return r;
+}
+
+Qwen35SlotManager::PrefillChunk Qwen35SlotManager::append_prefill(
+        int slot, int n_tokens) {
+    PrefillChunk out;
+    if (!is_prefilling(slot) || n_tokens < 1) return out;
+
+    Qwen35Slot & s = slots_[(size_t)slot];
+    if (s.cur_pos > s.prompt_len ||
+        n_tokens > s.prompt_len - s.cur_pos) {
+        return out;
+    }
+
+    PagedKvAppendResult app = pool_.append(s.handle, (uint32_t)n_tokens);
+    if (!app) {
+        // Admission reserved the whole prompt. Treat exhaustion here as a
+        // broken invariant, not a retryable condition: retrying a batch of
+        // all-prefill slots without any decoder able to retire would livelock.
+        if (app.status == PagedKvStatus::BlocksExhausted) {
+            std::fprintf(stderr,
+                "[parallel] reserved prefill capacity missing for slot %d\n",
+                slot);
+        }
+        return out;
+    }
+
+    out.rows.reserve(app.write_slots.size());
+    for (const PagedKvWriteSlot & write : app.write_slots) {
+        out.rows.push_back((int64_t)write.physical_token_index);
+        if (write.block_offset == 0) {
+            if (out.first_new_block < 0) {
+                out.first_new_block =
+                    (int)(write.logical_position / pool_.block_size());
+            }
+            out.new_blocks.push_back((int32_t)write.physical_block);
+        }
+    }
+    s.cur_pos += n_tokens;
+    out.ok = true;
+    return out;
+}
+
+void Qwen35SlotManager::commit_prefill(int slot) {
+    if (!is_prefilling(slot)) return;
+    Qwen35Slot & s = slots_[(size_t)slot];
+    if (s.cur_pos != s.prompt_len) return;
+    s.phase = Qwen35SlotPhase::decode;
+}
+
+Qwen35SlotManager::StepAppend Qwen35SlotManager::append_token(int slot,
+                                                        int32_t fed_token) {
+    StepAppend out;
+    if (!is_active(slot) || !slots_[(size_t)slot].decoding()) return out;
+    Qwen35Slot & s = slots_[(size_t)slot];
+    if (s.cur_pos >= max_ctx_) {
+        // No context left; the scheduler should have stopped this slot.
+        return out;
+    }
+    PagedKvAppendResult app = pool_.append(
+        s.handle, 1, /*only_first_last_slots=*/true);
+    if (!app || app.token_count != 1 ||
+        app.last.logical_position != (uint32_t)s.cur_pos) {
+        out.busy = app.status == PagedKvStatus::BlocksExhausted;
+        return out;
+    }
+    s.sample_history.push_back(fed_token);
+
+    out.ok = true;
+    out.physical_row = (int64_t)app.last.physical_token_index;
+    out.position = s.cur_pos;
+    if ((uint32_t)s.cur_pos % pool_.block_size() == 0) {
+        out.new_block = (int32_t)app.last.physical_block;
+        out.new_block_index = s.cur_pos / (int)pool_.block_size();
+    }
+    return out;
+}
+
+void Qwen35SlotManager::commit_step(int slot) {
+    if (!is_active(slot)) return;
+    slots_[(size_t)slot].cur_pos += 1;
+}
+
+void Qwen35SlotManager::retire(int slot) {
+    if (slot < 0 || slot >= (int)slots_.size()) return;
+    Qwen35Slot & s = slots_[(size_t)slot];
+    if (!s.active()) return;
+    const PagedKvStatus status = pool_.release(s.handle);
+    if (status != PagedKvStatus::Ok && status != PagedKvStatus::StaleHandle) {
+        std::fprintf(stderr, "[parallel] slot %d release failed: %s\n",
+                     slot, paged_kv_status_string(status));
+    }
+    s = Qwen35Slot{};
+}
+
+}  // namespace dflash::common

--- a/server/src/qwen35/concurrency/qwen35_slot_manager.h
+++ b/server/src/qwen35/concurrency/qwen35_slot_manager.h
@@ -1,0 +1,138 @@
+// Qwen35SlotManager — complete host-side state for each Qwen serving slot.
+//
+// Companion of PagedKvPool: the pool hands out sequence handles and physical
+// blocks; this class owns everything else a slot needs between admission and
+// retirement — the pool-handle lifecycle (including every error path), the
+// admission arithmetic (context clamp, prompt reservation, and rolling decode
+// headroom), on-demand block allocation, per-slot sampler/RNG/penalty-history
+// state, and the position counters.
+//
+// It deliberately owns NO device state. Prefill/decode allocation returns
+// physical rows and block-table deltas as plain vectors. Prompt, staging lease,
+// KV ownership, sampler, and progress live together here; the scheduler keeps
+// only its coarse request phase.
+//
+// Not thread-safe; the single scheduler thread is the only caller.
+
+#pragma once
+
+#include "common/concurrency/paged_kv_pool.h"
+#include "common/sampler.h"
+#include "common/concurrency/seq_engine.h"
+
+#include <cstdint>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace dflash::common {
+
+enum class Qwen35SlotPhase {
+    free,
+    prefill,
+    decode,
+};
+
+struct Qwen35Slot {
+    Qwen35SlotPhase phase = Qwen35SlotPhase::free;
+    PagedKvSequenceHandle handle;
+    // Prompt tokens are the immutable prefix of sample_history. Decode tokens
+    // append to the same allocation, avoiding a second full prompt copy.
+    int prompt_len = 0;
+    int cur_pos = 0;
+    int staging_idx = -1;
+    SamplerCfg sampler;
+    std::mt19937_64 rng{0x9E3779B97F4A7C15ull};
+    // Penalty history is recorded as fed rather than sampled: the scheduler
+    // may override a sample before the model consumes it.
+    std::vector<int32_t> sample_history;
+
+    int generated_tokens() const {
+        return sample_history.size() > (size_t)prompt_len
+            ? (int)(sample_history.size() - (size_t)prompt_len)
+            : 0;
+    }
+
+    bool active() const { return phase != Qwen35SlotPhase::free; }
+    bool prefilling() const { return phase == Qwen35SlotPhase::prefill; }
+    bool decoding() const { return phase == Qwen35SlotPhase::decode; }
+};
+
+class Qwen35SlotManager {
+public:
+    // `max_ctx` is the per-sequence logical bound; slot count comes from the
+    // pool's max_sequences. The pool must outlive the manager.
+    Qwen35SlotManager(PagedKvPool & pool, int max_ctx);
+
+    // Claim a free slot and atomically reserve all K/V blocks needed by the
+    // known prompt plus its next logical decode page when that page can exist
+    // in both max_ctx and the physical pool. Existing decoders are topped up
+    // first, so a younger admission cannot steal their next-page headroom.
+    // Prompts larger than the whole pool hard-fail; temporary capacity pressure
+    // reports busy. Seeds the slot RNG from sampler.seed only when the sampler
+    // actually draws, else nondeterministically.
+    SeqEngine::AdmitResult admit(uint64_t request_id,
+                                 const std::vector<int32_t> & prompt,
+                                 const SamplerCfg & sampler,
+                                 int staging_idx);
+
+    struct PrefillChunk {
+        bool ok = false;
+        std::vector<int64_t> rows;
+        // Delta to patch into the slot's device block-table column.
+        std::vector<int32_t> new_blocks;
+        int first_new_block = -1;
+    };
+
+    // Append `n_tokens` more prompt rows for a prefilling slot. Physical block
+    // ids come from the slot's admission reservation, so any append within the
+    // admitted prompt is guaranteed not to wait on another sequence.
+    PrefillChunk append_prefill(int slot, int n_tokens);
+
+    // Record a finished prefill and expose the slot to decode.
+    void commit_prefill(int slot);
+
+    struct StepAppend {
+        bool ok = false;
+        bool busy = false;    // no physical block available right now
+        int64_t physical_row = -1;
+        int position = -1;   // logical position the fed token is written at
+        int32_t new_block = -1;
+        int new_block_index = -1;
+    };
+
+    // Allocate the next decode token's cache row, report any new block-table
+    // entry, and log it to sample_history. cur_pos waits for commit_step().
+    StepAppend append_token(int slot, int32_t fed_token);
+
+    // The batched step's compute succeeded: cur_pos++.
+    void commit_step(int slot);
+
+    // Release the slot's blocks and clear its state. Safe on inactive slots
+    // and after a failed admission/prefill.
+    void retire(int slot);
+
+    int slot_count() const { return (int)slots_.size(); }
+    int max_context() const { return max_ctx_; }
+    int decoding_count() const;
+    bool is_active(int slot) const;
+    bool is_prefilling(int slot) const;
+    Qwen35Slot & slot(int i) { return slots_[(size_t)i]; }
+    const Qwen35Slot & slot(int i) const { return slots_[(size_t)i]; }
+
+private:
+    // Logical extent whose block count includes the sequence's current pages
+    // plus one future page, capped at max_ctx.
+    uint32_t decode_headroom_capacity(int logical_tokens) const;
+    bool capacity_fits_pool(uint32_t token_capacity) const;
+
+    // Atomically preflight and top up every decoding slot as one cohort before
+    // a younger sequence may reserve capacity.
+    PagedKvStatus protect_decode_headroom();
+
+    PagedKvPool & pool_;
+    int max_ctx_ = 0;
+    std::vector<Qwen35Slot> slots_;
+};
+
+}  // namespace dflash::common

--- a/server/src/qwen35/graph_builders.cpp
+++ b/server/src/qwen35/graph_builders.cpp
@@ -275,13 +275,34 @@ bool build_target_step(
     bool capture,
     bool capture_delta_intermediate,
     int fa_window,
-    bool last_token_logits_only,
+    int logits_tail_rows,
     int kq_stride_pad,
     bool capture_moe_router,
     bool kvflash_mask,
     bool capture_qk,
-    bool paged_attention) {
+    bool paged_attention,
+    int n_seqs,
+    int seq_slot,
+    bool paged_prefill,
+    int paged_max_kv_len,
+    int n_prefill_tokens,
+    bool prefill_commit,
+    bool compact_slots,
+    int staging_idx) {
     step_graph_free(sg);
+
+    // Compact n_seqs is a decode graph bucket width, not the physical
+    // slot count. active_slot_ids maps live rows to cache columns and uses -1
+    // for padding, so a valid bucket may be wider than cache.n_seq_slots.
+    const bool invalid_compact_width = n_seqs < 1 || n_seqs > 64;
+
+    // Fused prefill+decode: prefill rows lead, decode rows trail.
+    const bool fused = n_prefill_tokens > 0;
+    if (fused && (!paged_attention || !paged_prefill ||
+                  n_tokens != n_prefill_tokens + n_seqs ||
+                  !compact_slots || invalid_compact_width)) {
+        return false;
+    }
 
     // Persistent thread_local arena: rebuilt step graphs land at identical
     // addresses, keeping the ggml-cuda CUDA-graph cache key (nodes[0]) and
@@ -296,6 +317,34 @@ bool build_target_step(
     ip.no_alloc   = true;
     sg.ctx = ggml_init(ip);
     if (!sg.ctx) return false;
+
+    // ggml-cuda keys its graph cache by nodes[0]. Salting the metadata
+    // allocation shifts node addresses deterministically so each decode
+    // width bucket keeps an independent captured graph while sharing this
+    // single 512 MiB metadata arena.
+    int graph_key_slot = 0;
+    if (compact_slots) {
+        static constexpr int decode_buckets[] = {
+            1, 2, 3, 4, 6, 8, 12, 16, 24, 32, 48, 64,
+        };
+        bool found = false;
+        for (int i = 0; i < (int)(sizeof(decode_buckets) /
+                                  sizeof(decode_buckets[0])); ++i) {
+            if (decode_buckets[i] == n_seqs) {
+                graph_key_slot = i + 1;
+                found = true;
+                break;
+            }
+        }
+        if (!found) return false;
+    }
+    // Keep prefill and committing-prefill graphs away from stable decode
+    // captures, even when they use the same compact decode width.
+    if (paged_prefill)  graph_key_slot += 16;
+    if (prefill_commit) graph_key_slot += 32;
+    for (int i = 0; i < graph_key_slot; ++i) {
+        (void)ggml_new_tensor_1d(sg.ctx, GGML_TYPE_I32, 1);
+    }
 
     const int hidden = w.n_embd;
     sg.inp_embed = ggml_new_tensor_3d(sg.ctx, GGML_TYPE_F32, hidden, n_tokens, 1);
@@ -313,20 +362,68 @@ bool build_target_step(
         // kvflash mode: the physical span is the (smaller) pool capacity of
         // the attention tensors, so size the mask from those instead.
         int phys_ctx = cache.max_ctx;
-        for (auto * t : cache.attn_k) {
-            if (t) { phys_ctx = std::min(phys_ctx, (int)t->ne[1]); break; }
+        const auto & staging_k = staging_k_for(cache, 0);
+        if (paged_prefill && !staging_k.empty() && staging_k[0]) {
+            // Paged prefill reads the staging tensors, not the (larger,
+            // pool-sized) cache K/V — size the mask from those.
+            phys_ctx = std::min(phys_ctx, (int)staging_k[0]->ne[1]);
+        } else {
+            for (auto * t : cache.attn_k) {
+                if (t) { phys_ctx = std::min(phys_ctx, (int)t->ne[1]); break; }
+            }
         }
-        const int max_win_len = phys_ctx + n_tokens;
+        // Fused steps: the mask feeds only the prefill segment's flash
+        // attention, so its query axis is the chunk, not the whole batch.
+        const int q_rows = fused ? n_prefill_tokens : n_tokens;
+        const int max_win_len = phys_ctx + q_rows;
         const int kv_pad = align_up(max_win_len, kq_stride_pad);
-        const int q_pad  = align_up(n_tokens, KQ_MASK_PAD);
+        const int q_pad  = align_up(q_rows, KQ_MASK_PAD);
         sg.attn_mask = ggml_new_tensor_2d(sg.ctx, GGML_TYPE_F16, kv_pad, q_pad);
         ggml_set_name(sg.attn_mask, "attn_mask");
         ggml_set_input(sg.attn_mask);
     }
 
+    ggml_tensor * paged_block_table = nullptr;
+    ggml_tensor * paged_kv_seq_lens = nullptr;
     if (paged_attention) {
-        if (n_tokens != 1 || with_mask || fa_window != 0) return false;
+        if (fused) {
+            // Fused shape was validated above; it additionally needs the
+            // staging slabs read by its leading prefill segment.
+            if (cache.prefill_staging.empty()) {
+                return false;
+            }
+        } else {
+            // Classic paged decode is one physical sequence and one token.
+            // Concurrent decode always carries an explicit row-to-slot map.
+            if (compact_slots) {
+                if (n_tokens != n_seqs || invalid_compact_width) return false;
+            } else if (n_tokens != 1 || n_seqs != 1) {
+                return false;
+            }
+            if (paged_prefill || with_mask) return false;
+        }
+        if (fa_window != 0) return false;
+        // The paging metadata lives in the persistent target cache (next to
+        // the K/V pool), not as gallocr graph inputs: contents survive graph
+        // execution and rebuilds, so the backend uploads only what changed
+        // between decode steps.
         if (!cache.paged_block_table || !cache.paged_kv_seq_lens) return false;
+        if ((int)cache.paged_block_table->ne[1] != cache.n_seq_slots ||
+            (int)cache.paged_kv_seq_lens->ne[0] != cache.n_seq_slots) {
+            return false;
+        }
+        paged_block_table = cache.paged_block_table;
+        paged_kv_seq_lens = cache.paged_kv_seq_lens;
+    }
+    if (paged_attention && compact_slots) {
+        sg.active_slot_ids =
+            ggml_new_tensor_1d(sg.ctx, GGML_TYPE_I32, n_seqs);
+        sg.state_slot_ids =
+            ggml_new_tensor_1d(sg.ctx, GGML_TYPE_I32, n_seqs);
+        ggml_set_name(sg.active_slot_ids, "active_slot_ids");
+        ggml_set_name(sg.state_slot_ids, "state_slot_ids");
+        ggml_set_input(sg.active_slot_ids);
+        ggml_set_input(sg.state_slot_ids);
     }
 
     sg.gf = ggml_new_graph_custom(sg.ctx, 16384, false);
@@ -341,7 +438,7 @@ bool build_target_step(
     // physical slots, so the slot-mapped write stays active for masked,
     // multi-token, and feature-capturing forwards (decode AND spec verify).
     const bool use_kv_write_rows =
-        paged_attention ||
+        paged_attention || paged_prefill ||
         (!g_no_kvpad && !capture_delta_intermediate &&
          (kvflash_mask
               ? (fa_window == 0)
@@ -363,10 +460,20 @@ bool build_target_step(
     gi.capture_delta_intermediate = capture_delta_intermediate;
     gi.capture_moe_router         = capture_moe_router;
     gi.fa_window                  = fa_window;
-    gi.last_token_logits_only     = last_token_logits_only;
+    gi.logits_tail_rows           = logits_tail_rows;
     gi.kv_write_rows              = sg.kv_write_rows;
-    gi.paged_attention            = paged_attention;
+    gi.paged_block_table          = paged_block_table;
+    gi.paged_kv_seq_lens          = paged_kv_seq_lens;
+    gi.active_slot_ids            = sg.active_slot_ids;
+    gi.state_slot_ids             = sg.state_slot_ids;
     gi.q_capture                  = capture_qk;
+    gi.n_seqs                     = n_seqs;
+    gi.seq_slot                   = seq_slot;
+    gi.paged_prefill              = paged_prefill;
+    gi.paged_max_kv_len           = paged_max_kv_len;
+    gi.n_prefill_tokens           = n_prefill_tokens;
+    gi.prefill_commit             = prefill_commit;
+    gi.staging_idx                = staging_idx;
 
     QwenGraphOutputs go = build_qwen35_graph(sg.ctx, sg.gf, w, cache, gi);
     if (!go.logits) return false;

--- a/server/src/qwen35/graph_builders.h
+++ b/server/src/qwen35/graph_builders.h
@@ -79,6 +79,33 @@ bool build_hybrid_full_layer_step(
 // even though a mask is requested (the mask carries pool-slot validity and
 // must be re-uploaded by the caller before every compute). Used by both
 // single-token decode and multi-token spec verify; requires fa_window == 0.
+//
+// Concurrent-slot serving (multi-slot paged caches):
+//   `n_seqs` — compact decode graph-bucket width; the token axis is the
+//     sequence axis and n_tokens must equal n_seqs.
+//   `compact_slots` — explicit compact-row to physical-slot mapping. Required
+//     for concurrent and fused decode, including width-one buckets. n_seqs is
+//     in [1, 64] and may be wider than cache.n_seq_slots; active_slot_ids uses
+//     -1 for padding rows. Without it, paged attention is classic one-token,
+//     one-sequence decode only.
+//   `seq_slot` — the slot whose recurrent-state slabs the end-of-prefill
+//     commit copy (prefill_commit) targets; prefill chunks themselves run
+//     on the staging slabs.
+//   `paged_prefill` — chunk prefill of one slot: masked stride-1 reads and
+//     legacy writes go to the selected staging lane while kv_write_rows dual-writes
+//     the pool blocks. Pass paged_attention=false with it (prefill reads
+//     never touch the block table) — unless fusing, see n_prefill_tokens.
+//   `paged_max_kv_len` — batched decode: max kv_seq_len over live slots
+//     (kernel launch bound).
+//   `n_prefill_tokens` — fused prefill+decode step: the leading
+//     n_prefill_tokens rows are one slot's prefill chunk (staging reads at
+//     kv_start, masked; kv_write_rows covers the WHOLE batch) and the
+//     remaining n_seqs rows are the batched decode. Requires
+//     paged_attention && paged_prefill and
+//     n_tokens == n_prefill_tokens + n_seqs and compact_slots=true.
+//   `prefill_commit` — final prefill chunk: append staging→slot recurrent
+//     state copies at the end of the graph (see QwenGraphInputs).
+//   `logits_tail_rows` — logits/argmax only for the last n rows (0 = all).
 bool build_target_step(
     StepGraph & sg,
     const TargetWeights & w,
@@ -90,12 +117,20 @@ bool build_target_step(
     bool capture,
     bool capture_delta_intermediate = false,
     int fa_window = 0,
-    bool last_token_logits_only = false,
+    int logits_tail_rows = 0,
     int kq_stride_pad = KQ_MASK_PAD,
     bool capture_moe_router = false,
     bool kvflash_mask = false,
     bool capture_qk = false,
-    bool paged_attention = false);
+    bool paged_attention = false,
+    int n_seqs = 1,
+    int seq_slot = 0,
+    bool paged_prefill = false,
+    int paged_max_kv_len = 0,
+    int n_prefill_tokens = 0,
+    bool prefill_commit = false,
+    bool compact_slots = false,
+    int staging_idx = 0);
 
 // Full target forward: DDTree tree-verify mode.
 bool build_target_step_tree(

--- a/server/src/qwen35/layer_split_daemon.cpp
+++ b/server/src/qwen35/layer_split_daemon.cpp
@@ -5,6 +5,7 @@
 #include "internal.h"
 #include "io_utils.h"
 #include "qwen35_layer_split_dflash_target.h"
+#include "prefill_helpers.h"
 #include "common/dflash_spec_decode.h"
 
 #include <algorithm>
@@ -36,10 +37,8 @@ bool run_qwen35_layer_split_request(
         return false;
     }
 
-    int ubatch = (prompt.size() > 2048) ? 384 : 16;
-    if (const char * s = std::getenv("DFLASH27B_PREFILL_UBATCH")) {
-        ubatch = std::max(1, std::atoi(s));
-    }
+    const int ubatch = qwen35_prefill_ubatch(
+        (prompt.size() > 2048) ? 384 : 16);
     int last_tok = -1;
     if (!run_qwen35_layer_split_forward(shards, shards.front().weights,
                                         prompt, 0, ubatch, last_tok,

--- a/server/src/qwen35/prefill_helpers.h
+++ b/server/src/qwen35/prefill_helpers.h
@@ -1,0 +1,41 @@
+// Shared prefill helpers for Qwen3.5/3.6.
+
+#pragma once
+
+#include "attn_masks.h"
+#include "ggml-backend.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <vector>
+
+namespace dflash::common {
+
+inline int qwen35_prefill_ubatch(int fallback) {
+    const char * value = std::getenv("DFLASH27B_PREFILL_UBATCH");
+    return value ? std::max(1, std::atoi(value)) : fallback;
+}
+
+inline void fill_qwen35_mrope_positions(int32_t * positions,
+                                        int base_pos, int n_tokens) {
+    for (int i = 0; i < n_tokens; ++i) {
+        const int p = base_pos + i;
+        positions[4 * i + 0] = p;
+        positions[4 * i + 1] = p;
+        positions[4 * i + 2] = p;
+        positions[4 * i + 3] = 0;
+    }
+}
+
+inline void upload_qwen35_causal_mask(ggml_tensor * mask, int kv_start,
+                                       int n_tokens, int kq_stride_pad) {
+    if (!mask) return;
+    std::vector<uint16_t> data;
+    build_causal_mask(data, kv_start + n_tokens, n_tokens, kv_start,
+                      kq_stride_pad, /*win_start=*/0, (int)mask->ne[0]);
+    ggml_backend_tensor_set(mask, data.data(), 0,
+                            sizeof(uint16_t) * data.size());
+}
+
+}  // namespace dflash::common

--- a/server/src/qwen35/qwen35_backend.cpp
+++ b/server/src/qwen35/qwen35_backend.cpp
@@ -1,4 +1,5 @@
 #include "qwen35_backend.h"
+#include "concurrency/qwen35_seq_engine.h"
 #include "common/chain_rollback_policy.h"
 #include "placement/skip_park_guard.h"
 #include "qwen35_dflash_target.h"
@@ -8,6 +9,7 @@
 #include "common/dflash_draft_graph.h"
 #include "peer_access.h"
 #include "attn_masks.h"
+#include "prefill_helpers.h"
 #include "common/sampler.h"
 #ifdef DFLASH27B_HAVE_GPU_SAMPLER
 #include "common/geometric_sampler_cuda.h"
@@ -133,6 +135,45 @@ static FILE * open_dflash_floor_log() {
     if (!out) ::close(fd);
     return out;
 #endif
+}
+
+// Persistent concurrent-cache bytes that do not scale with the physical
+// paged pool. The estimate mirrors create_target_cache_partial(): one
+// max-context staging K/V, recurrent state for N slots plus one staging slot,
+// target features, paged metadata, Q capture, and the dead-row scratch block.
+static int64_t concurrent_fixed_cache_bytes(
+        const TargetWeights & w, int max_ctx, int n_slots,
+        int64_t kv_bytes_per_token, int max_concurrent_prefills = 1) {
+    const int64_t n_full_attn =
+        w.n_layer / w.full_attention_interval;
+    const int64_t n_delta = w.n_layer - n_full_attn;
+    const int64_t head_v_dim = w.ssm_d_inner / w.ssm_dt_rank;
+    const int64_t conv_ch =
+        w.ssm_d_inner + 2LL * w.ssm_n_group * w.ssm_d_state;
+    const int64_t state_per_layer =
+        (head_v_dim * head_v_dim * w.ssm_dt_rank +
+         (int64_t)(w.ssm_d_conv - 1) * conv_ch) *
+        (int64_t)sizeof(float);
+    const int64_t staging_state =
+        state_per_layer * n_delta * (int64_t)(max_concurrent_prefills - 1);
+    const int64_t recurrent =
+        state_per_layer * n_delta * (n_slots + 1LL);
+    const int64_t staging_kv =
+        kv_bytes_per_token * paged_token_capacity(max_ctx) *
+        (int64_t)max_concurrent_prefills;
+    const int64_t target_feat =
+        (int64_t)w.n_capture_layers * w.n_embd *
+        std::min(max_ctx, 4096) * (int64_t)sizeof(uint16_t);
+    const int64_t q_capture =
+        (int64_t)w.n_embd_head_k * w.n_head * n_full_attn *
+        (int64_t)sizeof(float);
+    const int64_t paged_metadata =
+        ((int64_t)paged_block_count(max_ctx) * n_slots + n_slots) *
+        (int64_t)sizeof(int32_t);
+    const int64_t scratch =
+        kv_bytes_per_token * PAGED_BLOCK_SIZE;
+    return recurrent + staging_state + staging_kv + target_feat +
+           q_capture + paged_metadata + scratch;
 }
 }  // namespace
 
@@ -307,12 +348,74 @@ bool Qwen35Backend::init() {
     }
     // Paged mode sizes the KV cache to whole blocks; otherwise KVFlash
     // decides the allocation (0 = full max_ctx).
-    const int ctx_alloc = cfg_.paged_attention
-        ? paged_token_capacity(cfg_.device.max_ctx)
-        : kvflash_tokens_;
+    const int n_slots = concurrent_slots();
+    const int max_concurrent_prefills = n_slots > 1
+        ? std::clamp(
+              env_int_or_default("DFLASH_MAX_CONCURRENT_PREFILLS", 2),
+              1, 2)
+        : 1;
+    if (n_slots > 1 && !cfg_.paged_attention) {
+        set_last_error("--max-concurrency requires --paged-attention");
+        return false;
+    }
+    // Concurrent slots share one physical pool. An explicit
+    // --kv-pool-tokens is rounded up to a whole block; otherwise capacity is
+    // derived from device-free memory after subtracting fixed concurrent cache
+    // state and a runtime graph reserve. This decouples max-concurrency from
+    // startup K/V allocation while retaining at least one full logical context.
+    // One extra scratch block is appended to the K/V tensors (outside the
+    // pool's index space) as the write target of dead decode-batch rows.
+    int64_t pool_tokens = 0;
+    if (n_slots > 1) {
+        if (cfg_.kv_pool_tokens > 0) {
+            pool_tokens = (int64_t)paged_token_capacity(
+                (int)std::min<int64_t>(
+                    cfg_.kv_pool_tokens, INT32_MAX - PAGED_BLOCK_SIZE));
+        } else {
+            PagedKvAutoBudget budget;
+            // TODO: Size tensor-parallel pools from each device's free memory
+            // and account for fixed cache tensors mirrored by the meta backend.
+            budget.free_bytes = (int64_t)gpu_free;
+            budget.bytes_per_token = kvf_budget.bytes_per_token;
+            budget.reserve_bytes = kvf_budget.reserve_bytes;
+            budget.fixed_cache_bytes = concurrent_fixed_cache_bytes(
+                w_, cfg_.device.max_ctx, n_slots, budget.bytes_per_token,
+                max_concurrent_prefills);
+            pool_tokens = paged_kv_auto_pool_tokens(
+                cfg_.device.max_ctx, n_slots, budget);
+            const int64_t one_context =
+                paged_token_capacity(cfg_.device.max_ctx);
+            std::fprintf(stderr,
+                "[parallel] auto KV pool: %lld tokens "
+                "(free %.2f GiB - fixed %.2f GiB - reserve %.2f GiB, "
+                "%.2f KiB/token; logical cap %lld)\n",
+                (long long)pool_tokens,
+                budget.free_bytes / 1073741824.0,
+                budget.fixed_cache_bytes / 1073741824.0,
+                budget.reserve_bytes / 1073741824.0,
+                budget.bytes_per_token / 1024.0,
+                (long long)n_slots * one_context);
+            if (pool_tokens < one_context) {
+                set_last_error(
+                    "not enough device memory for one max_ctx paged sequence; "
+                    "lower --max-ctx or set --kv-pool-tokens explicitly");
+                return false;
+            }
+        }
+        if (pool_tokens + PAGED_BLOCK_SIZE > INT32_MAX) {
+            set_last_error("paged KV pool exceeds INT32_MAX tokens");
+            return false;
+        }
+    }
+    const int ctx_alloc = n_slots > 1
+        ? (int)(pool_tokens + PAGED_BLOCK_SIZE)
+        : (cfg_.paged_attention
+               ? paged_token_capacity(cfg_.device.max_ctx)
+               : kvflash_tokens_);
     if (!create_target_cache(w_, cfg_.device.max_ctx, max_verify_tokens, target_backend_, cache_,
                              /*prefill_only=*/true, ctx_alloc,
-                             cfg_.paged_attention)) {
+                             cfg_.paged_attention, n_slots,
+                             max_concurrent_prefills)) {
         std::fprintf(stderr, "cache: %s\n", dflash27b_last_error());
         return false;
     }
@@ -332,18 +435,38 @@ bool Qwen35Backend::init() {
             return false;
         }
         try {
+            const uint32_t pool_blocks = n_slots > 1
+                ? (uint32_t)(pool_tokens / PAGED_BLOCK_SIZE)
+                : (uint32_t)paged_block_count(cfg_.device.max_ctx);
             paged_kv_pool_ = std::make_unique<PagedKvPool>(
-                (uint32_t)paged_block_count(cfg_.device.max_ctx),
-                /*max_sequences=*/1, PAGED_BLOCK_SIZE);
+                pool_blocks, /*max_sequences=*/(uint32_t)n_slots,
+                PAGED_BLOCK_SIZE);
         } catch (const std::exception & e) {
             std::fprintf(stderr, "[paged-attention] pool init failed: %s\n",
                          e.what());
             return false;
         }
+        if (n_slots > 1) {
+            seq_engine_ = std::make_unique<Qwen35SeqEngine>(
+                *this, *paged_kv_pool_, cfg_.device.max_ctx,
+                /*scratch_row=*/pool_tokens,
+                max_concurrent_prefills);  // first row of the scratch block
+            std::printf("[parallel] %d decode slots, %d prefill staging set%s, "
+                        "pool %u blocks x %u tokens"
+                        " (%lld shared tokens, per-seq max_ctx %d)\n",
+                        n_slots, max_concurrent_prefills,
+                        max_concurrent_prefills == 1 ? "" : "s",
+                        paged_kv_pool_->physical_block_count(),
+                        paged_kv_pool_->block_size(),
+                        (long long)pool_tokens, cfg_.device.max_ctx);
+        }
         std::printf("[paged-attention] %u physical blocks x %u tokens "
-                    "(%d logical tokens)\n",
+                    "(%llu pool tokens, per-sequence max_ctx %d)\n",
                     paged_kv_pool_->physical_block_count(),
-                    paged_kv_pool_->block_size(), cfg_.device.max_ctx);
+                    paged_kv_pool_->block_size(),
+                    (unsigned long long)paged_kv_pool_->physical_block_count() *
+                        paged_kv_pool_->block_size(),
+                    cfg_.device.max_ctx);
         std::fflush(stdout);
     }
     if (kvflash_active()) {
@@ -539,6 +662,43 @@ void Qwen35Backend::end_paged_sequence() {
     }
     paged_sequence_.reset();
 }
+
+// ── Concurrent slot serving (--max-concurrency N) ──────────────────────
+//
+// The engine lives in concurrency/qwen35_seq_engine.cpp; what stays here is the
+// model-level policy it borrows — EOS identity and the min-tokens floor,
+// both shared with the AR decode path.
+
+bool Qwen35Backend::token_is_eos(int32_t token) const {
+    return IS_EOS_TOK(token, w_);
+}
+
+int32_t Qwen35Backend::apply_min_tokens_floor(int32_t tok, int generated,
+                                              size_t logits_row_offset) {
+    // MIN_TOKENS_BEFORE_EOS (env DFLASH_MIN_TOKENS, default off): same
+    // policy as do_ar_decode — if the slot would stop before emitting the
+    // floor, substitute the best non-EOS token. The logits row is fetched
+    // on demand so the (common) GPU-argmax path pays nothing when the
+    // floor is off or not triggered.
+    const int floor = dflash_min_tokens_floor();
+    if (floor <= 0 || generated >= floor || !IS_EOS_TOK(tok, w_)) return tok;
+    const int vocab = w_.n_vocab;
+    std::vector<float> buf((size_t)vocab);
+    ggml_backend_tensor_get(sg_.logits, buf.data(), logits_row_offset,
+                            sizeof(float) * (size_t)vocab);
+    int alt = -1;
+    float best = -1e30f;
+    for (int v = 0; v < vocab; v++) {
+        if (IS_EOS_TOK(v, w_)) continue;
+        if (buf[(size_t)v] > best) { best = buf[(size_t)v]; alt = v; }
+    }
+    return alt >= 0 ? alt : tok;
+}
+
+SeqEngine * Qwen35Backend::seq_engine() {
+    return seq_engine_.get();
+}
+
 
 // ── print_ready_banner ──────────────────────────────────────────────────
 
@@ -1039,6 +1199,14 @@ GenerateResult Qwen35Backend::generate_impl(const GenerateRequest & req,
                                             const DaemonIO & io) {
     GenerateResult result;
     DaemonIO out_io = io.with_token_callback(req.on_token);
+    if (concurrent_slots() > 1) {
+        // begin_paged_sequence would reset the shared pool under every live
+        // slot; the scheduler must use the seq_* API instead.
+        result.fail(GenerateErrorCode::BackendSpecific,
+                    "generate() is unavailable with --max-concurrency; "
+                    "use the concurrent slot API");
+        return result;
+    }
     sampler_ = req.sampler;
     if (req.do_sample && sampler_.seed != 0) {
         sampler_rng_.seed(sampler_.seed);
@@ -1262,7 +1430,7 @@ GenerateResult Qwen35Backend::restore_and_generate_impl(int slot,
                                /*with_mask=*/pool, /*capture=*/false,
                                /*capture_delta_intermediate=*/false,
                                /*fa_window=*/0,
-                               /*last_token_logits_only=*/false,
+                               /*logits_tail_rows=*/0,
                                cfg_.kq_stride_pad,
                                should_capture_moe_router(),
                                /*kvflash_mask=*/pool,
@@ -1332,10 +1500,7 @@ int Qwen35Backend::do_prefill(const std::vector<int32_t> & tokens,
                                int kv_offset) {
     const int hidden = w_.n_embd;
     const int vocab  = w_.n_vocab;
-    int prefill_ubatch = 512;
-    if (const char * s = std::getenv("DFLASH27B_PREFILL_UBATCH")) {
-        prefill_ubatch = std::max(1, std::atoi(s));
-    }
+    int prefill_ubatch = qwen35_prefill_ubatch(512);
     const int prompt_len = (int)tokens.size();
     prefill_last_logits_valid_ = false;
 
@@ -1449,7 +1614,8 @@ int Qwen35Backend::do_prefill(const std::vector<int32_t> & tokens,
                                with_mask, /*capture=*/true,
                                /*capture_delta_intermediate=*/false,
                                /*fa_window=*/0,
-                               /*last_token_logits_only=*/(start + n_tokens < prompt_len),
+                               /*logits_tail_rows=*/
+                                   (start + n_tokens < prompt_len ? 1 : 0),
                                cfg_.kq_stride_pad,
                                should_capture_moe_router(),
                                /*kvflash_mask=*/kvf_paged)) {
@@ -1481,13 +1647,7 @@ int Qwen35Backend::do_prefill(const std::vector<int32_t> & tokens,
 
         // Positions (M-RoPE)
         std::vector<int32_t> pos_buf((size_t)4 * n_tokens, 0);
-        for (int i = 0; i < n_tokens; i++) {
-            const int p = kv_pos + i;
-            pos_buf[4 * i + 0] = p;
-            pos_buf[4 * i + 1] = p;
-            pos_buf[4 * i + 2] = p;
-            pos_buf[4 * i + 3] = 0;
-        }
+        fill_qwen35_mrope_positions(pos_buf.data(), kv_pos, n_tokens);
         ggml_backend_tensor_set(sg_.positions, pos_buf.data(), 0,
                                 sizeof(int32_t) * pos_buf.size());
 
@@ -1520,13 +1680,8 @@ int Qwen35Backend::do_prefill(const std::vector<int32_t> & tokens,
             ggml_backend_tensor_set(sg_.attn_mask, mask_buf.data(), 0,
                                     sizeof(uint16_t) * mask_buf.size());
         } else if (sg_.attn_mask) {
-            const int win_start = 0;
-            const int kv_len = kv_pos + n_tokens - win_start;
-            std::vector<uint16_t> mask_buf;
-            const int kv_pad_override = (int)sg_.attn_mask->ne[0];
-            build_causal_mask(mask_buf, kv_len, n_tokens, kv_pos, cfg_.kq_stride_pad, win_start, kv_pad_override);
-            ggml_backend_tensor_set(sg_.attn_mask, mask_buf.data(), 0,
-                                    sizeof(uint16_t) * mask_buf.size());
+            upload_qwen35_causal_mask(
+                sg_.attn_mask, kv_pos, n_tokens, cfg_.kq_stride_pad);
         }
 
         // Compute
@@ -1817,7 +1972,6 @@ bool Qwen35Backend::do_ar_decode(int committed, int n_gen,
     if (n_gen <= 0) return true;
 
     auto t_dec0_ar = std::chrono::steady_clock::now();
-    const int _min_floor = dflash_min_tokens_floor();
     static const int _repeat_guard = []{
         const int explicit_guard =
             env_int_or_default("DFLASH_DEGENERATE_RUN_TOKENS", -1);
@@ -1883,7 +2037,7 @@ bool Qwen35Backend::do_ar_decode(int committed, int n_gen,
                                /*with_mask=*/pool, /*capture=*/false,
                                /*capture_delta_intermediate=*/false,
                                /*fa_window=*/0,
-                               /*last_token_logits_only=*/false,
+                               /*logits_tail_rows=*/0,
                                cfg_.kq_stride_pad,
                                should_capture_moe_router(),
                                /*kvflash_mask=*/pool,
@@ -1984,29 +2138,8 @@ bool Qwen35Backend::do_ar_decode(int committed, int n_gen,
             }
         }
 
-        // MIN_TOKENS_BEFORE_EOS (env DFLASH_MIN_TOKENS, default 0=off): if the
-        // model tries to stop before producing N tokens in this decode call,
-        // suppress EOS and take the best NON-eos token instead. Targets the Q4
-        // 'preamble then stop, no tool_call' agentic stall. Env-gated so the
-        // default production lane is byte-for-byte unchanged.
-        {
-            if (_min_floor > 0 && (int)out_tokens.size() < _min_floor && IS_EOS_TOK(next_tok, w_)) {
-                int alt = -1; float altbest = -1e30f;
-                for (int v = 0; v < vocab; v++) {
-                    if (IS_EOS_TOK(v, w_)) continue;
-                    if (logits_buf[v] > altbest) { altbest = logits_buf[v]; alt = v; }
-                }
-                if (alt >= 0) {
-                    // Debug-only diagnostic: writes happen exclusively when the
-                    // operator opts into DFLASH_MIN_TOKENS, so the default
-                    // production lane never touches /tmp/dflash_floor.log.
-                    // Bound the local evidence file before appending.
-                    FILE* _d = open_dflash_floor_log();
-                    if (_d) { std::fprintf(_d, "[floor] eos@%d -> alt=%d\n", (int)out_tokens.size(), alt); std::fclose(_d); }
-                    next_tok = alt;
-                }
-            }
-        }
+        next_tok = apply_min_tokens_floor(
+            next_tok, (int)out_tokens.size(), /*logits_row_offset=*/0);
 
         maybe_force_close(next_tok);
 

--- a/server/src/qwen35/qwen35_backend.h
+++ b/server/src/qwen35/qwen35_backend.h
@@ -20,7 +20,8 @@
 #include "ddtree.h"
 #include "dflash_feature_ring.h"
 #include "common/dflash_draft_kv.h"
-#include "common/paged_kv_pool.h"
+#include "common/concurrency/paged_kv_pool.h"
+#include "concurrency/qwen35_seq_engine.h"
 #include "internal.h"         // TargetWeights, TargetCache, DraftWeights, PrefixSnapshot
 #include "qwen3/qwen3_drafter.h"  // DrafterContext, load_drafter, free_drafter, drafter_score_and_compress
 #include "kvflash_pager.h"         // bounded KV residency pool
@@ -54,6 +55,16 @@ struct Qwen35Config {
     int          fa_window       = 0;  // 0 = full attention. qwen3.6 full-attn layers must see the whole context; a finite window drops the system prompt/tools -> breaks tool calls.
     bool         paged_attention = false;
     int          kq_stride_pad   = 32;   // KQ_MASK_PAD or 256 for TBQ
+
+    // Concurrent slot serving (--max-concurrency). > 1 requires paged_attention:
+    // the backend allocates this many sequence slots (sequence-indexed
+    // recurrent state + one block-table column each) and serves them through
+    // a Qwen35SeqEngine instead of generate().
+    int          max_concurrency = 1;
+    // Total paged K/V pool size in tokens shared by all slots
+    // (--kv-pool-tokens; rounded up to whole 16-token blocks).
+    // 0 derives the shared physical capacity from available device memory.
+    int64_t      kv_pool_tokens  = 0;
 
     // Draft
     int          draft_swa_window = 0;
@@ -128,6 +139,16 @@ public:
     bool supports_dflash_spec_decode() const override { return !cfg_.paged_attention; }
     DFlashTarget * dflash_target() override;
     bool supports_remote_draft() const override { return true; }
+
+    // ── Concurrent slot serving (paged AR decode over N sequences) ────
+    // Non-null once init() has built the engine (--max-concurrency N with paged
+    // attention); null otherwise, which is what tells the server to serve
+    // one request at a time through generate().
+    SeqEngine * seq_engine() override;
+
+    // EOS identity of the loaded weights. Model-level, so it stays on the
+    // backend and is shared by the AR decode path and the engine.
+    bool token_is_eos(int32_t token) const;
 
     void shutdown() override;
 
@@ -268,14 +289,35 @@ private:
     std::size_t     prefill_last_logits_offset_ = 0;
     bool            prefill_last_logits_valid_  = false;
 
-    // The HTTP worker still runs one request at a time. The allocator and
-    // attention op are sequence-aware; this first integration owns one live
-    // sequence until recurrent DeltaNet state is also sequence-indexed.
-    // Page size comes from PAGED_BLOCK_SIZE (internal.h), shared with the
-    // graph builder and the cache's block-aligned physical sizing.
+    // The single-request path owns one live sequence. The allocator and
+    // attention op are sequence-aware; concurrent serving uses the engine
+    // below and adds the Qwen-specific sequence-indexed DeltaNet state.
+    // Page size comes from PAGED_BLOCK_SIZE (paged_attention_config.h),
+    // shared with the graph builder and the cache's block-aligned sizing.
     std::unique_ptr<PagedKvPool> paged_kv_pool_;
     std::optional<PagedKvSequenceHandle> paged_sequence_;
     PagedKvRequestId paged_request_id_ = 0;
+
+    // ── Concurrent slot engine (--max-concurrency N; only when concurrent_slots()>1)
+    // Slot count from configuration alone: init() needs it to size the pool
+    // before the engine exists, and generate_impl() needs it to refuse the
+    // single-sequence path. Afterwards the engine is the authority
+    // (SeqEngine::slot_count()).
+    int concurrent_slots() const {
+        return cfg_.max_concurrency > 1 ? cfg_.max_concurrency : 1;
+    }
+
+    // Built by init() when the backend has more than one decode slot. It
+    // borrows this backend's weights, cache, step graph and paged pool —
+    // hence the friendship — and owns everything else concurrent serving
+    // needs (Qwen35SlotManager, slot prefill, the batched decode step).
+    std::unique_ptr<Qwen35SeqEngine> seq_engine_;
+    friend class Qwen35SeqEngine;
+
+    // DFLASH_MIN_TOKENS floor for the slot paths (mirrors do_ar_decode's
+    // EOS suppression); fetches the slot's logits row on demand.
+    int32_t apply_min_tokens_floor(int32_t tok, int generated,
+                                   size_t logits_row_offset);
 
     // ── DFlashTarget adapter (lazy-built) ────────────────────────────
     std::unique_ptr<DFlashTarget> dflash_target_;

--- a/server/src/qwen35/qwen35_dflash_target.cpp
+++ b/server/src/qwen35/qwen35_dflash_target.cpp
@@ -267,7 +267,7 @@ bool Qwen35DFlashTarget::verify_batch(
                            need_mask, /*capture=*/true,
                            /*capture_delta_intermediate=*/do_capture,
                            pool ? 0 : fa_window_,
-                           /*last_token_logits_only=*/false,
+                           /*logits_tail_rows=*/0,
                            kq_stride_pad_,
                            /*capture_moe_router=*/false,
                            /*kvflash_mask=*/pool)) {

--- a/server/src/qwen35/qwen35_layer_split_adapter.cpp
+++ b/server/src/qwen35/qwen35_layer_split_adapter.cpp
@@ -12,6 +12,7 @@
 #include "common/snapshot_backend.h"
 #include "qwen35/layer_split_forward.h"
 #include "qwen35/qwen35_layer_split_dflash_target.h"
+#include "qwen35/prefill_helpers.h"
 #include "qwen3/qwen3_drafter.h"
 #include "qwen3/qwen3_kvflash_scorer.h"
 #include "kv_quant.h"
@@ -534,10 +535,8 @@ bool Qwen35LayerSplitAdapter::prefill(const std::vector<int32_t> & prompt,
             base_pos, (size_t)base_pos + prompt.size(), cfg_.device.max_ctx);
         return false;
     }
-    int ubatch = cfg_.chunk > 0 ? cfg_.chunk : 512;
-    if (const char * s = std::getenv("DFLASH27B_PREFILL_UBATCH")) {
-        ubatch = std::max(1, std::atoi(s));
-    }
+    const int ubatch = qwen35_prefill_ubatch(
+        cfg_.chunk > 0 ? cfg_.chunk : 512);
     if (use_mixed_target_split()) {
         const bool ok = run_qwen35_mixed_layer_split_forward(
             shards_, remote_target_shard_, shards_.front().weights,

--- a/server/src/qwen35/qwen35_target_graph.cpp
+++ b/server/src/qwen35/qwen35_target_graph.cpp
@@ -79,14 +79,20 @@ bool create_target_cache(const TargetWeights & w,
                          TargetCache & out,
                          bool prefill_only,
                          int ctx_alloc,
-                         bool paged_attention) {
+                         bool paged_attention,
+                         int n_seq_slots,
+                         int max_concurrent_prefills) {
     return create_target_cache_partial(w, max_ctx, max_verify_tokens, backend,
                                        out, prefill_only,
                                        0, w.n_layer, true, ctx_alloc,
                                        /*f32_ssm_intermediates=*/false,
-                                       paged_attention);
+                                       paged_attention, n_seq_slots,
+                                       max_concurrent_prefills);
 }
 
+// concurrent_fixed_cache_bytes() in qwen35_backend.cpp mirrors this
+// function's non-pool allocations to size the auto KV pool — keep the two
+// in sync when adding or resizing cache tensors here.
 bool create_target_cache_partial(const TargetWeights & w,
                                  int max_ctx,
                                  int max_verify_tokens,
@@ -98,16 +104,25 @@ bool create_target_cache_partial(const TargetWeights & w,
                                  bool allocate_target_feat,
                                  int ctx_alloc,
                                  bool f32_ssm_intermediates,
-                                 bool paged_attention) {
+                                 bool paged_attention,
+                                 int n_seq_slots,
+                                 int max_concurrent_prefills) {
     if (layer_begin < 0) layer_begin = 0;
     if (layer_end < 0 || layer_end > w.n_layer) layer_end = w.n_layer;
     if (layer_begin > layer_end) {
         set_last_error("invalid target cache layer range");
         return false;
     }
+    if (n_seq_slots < 1) n_seq_slots = 1;
+    if (max_concurrent_prefills < 1) max_concurrent_prefills = 1;
+    if (n_seq_slots > 1 && !paged_attention) {
+        set_last_error("multi-slot target cache requires paged attention");
+        return false;
+    }
     out.backend = backend;
     out.max_ctx = max_ctx;
     out.cur_pos = 0;
+    out.n_seq_slots = n_seq_slots;
     if (max_verify_tokens <= 0) {
         max_verify_tokens = DFLASH27B_DRAFT_BLOCK_SIZE;
     }
@@ -120,6 +135,16 @@ bool create_target_cache_partial(const TargetWeights & w,
 
     out.attn_k.assign(n_full_attn, nullptr);
     out.attn_v.assign(n_full_attn, nullptr);
+    out.prefill_staging.clear();
+    if (n_seq_slots > 1) {
+        out.prefill_staging.resize((size_t)max_concurrent_prefills);
+        for (PrefillStagingSet & staging : out.prefill_staging) {
+            staging.k.assign(n_full_attn, nullptr);
+            staging.v.assign(n_full_attn, nullptr);
+            staging.ssm_state.assign(n_delta, nullptr);
+            staging.conv_state.assign(n_delta, nullptr);
+        }
+    }
     out.ssm_state.assign(n_delta, nullptr);
     out.conv_state.assign(n_delta, nullptr);
     out.ssm_state_snap.assign(n_delta, nullptr);
@@ -149,8 +174,12 @@ bool create_target_cache_partial(const TargetWeights & w,
     // may grow it to the next whole block, and it must size the pool to
     // exactly that: silent drift here would break block alignment.
     const bool bounded_pool = ctx_alloc > 0 && ctx_alloc < max_ctx;
+    // Multi-slot caches share one physical pool across sequences: ctx_alloc
+    // is the caller-computed pool capacity (plus the dead-slot scratch block)
+    // and may exceed one sequence's max_ctx.
+    const bool multi_slot = n_seq_slots > 1;
     const bool paged_padding = paged_attention && ctx_alloc > 0;
-    if (paged_attention) {
+    if (paged_attention && !multi_slot) {
         GGML_ASSERT(ctx_alloc == paged_token_capacity(max_ctx));
     }
     const int ctx_phys =
@@ -161,7 +190,11 @@ bool create_target_cache_partial(const TargetWeights & w,
 
     // ── Base context: KV cache + SSM/conv state + target_feat ────────
     {
-        const int base_tensors = 2 * n_full_attn + 2 * n_delta + 2;
+        const int extra_staging = multi_slot && max_concurrent_prefills > 1
+            ? (max_concurrent_prefills - 1) * (2 * n_full_attn + 2 * n_delta) : 0;
+        const int base_tensors = 2 * n_full_attn + 2 * n_delta + 2
+                               + (multi_slot ? 2 * n_full_attn + 2 * n_delta : 0)
+                               + extra_staging;
         ggml_init_params ip{};
         ip.mem_size   = (size_t)(base_tensors + 16) * ggml_tensor_overhead();
         ip.mem_buffer = nullptr;
@@ -187,20 +220,80 @@ bool create_target_cache_partial(const TargetWeights & w,
                 ggml_set_name(V, name);
                 out.attn_k[fa_idx] = K;
                 out.attn_v[fa_idx] = V;
+                if (multi_slot) {
+                    // Prefill staging: one sequence's contiguous K/V, sized to
+                    // the per-sequence logical bound (block-rounded like the
+                    // paged pool so prefill chunks never outgrow it).
+                    const int staging_rows = paged_token_capacity(max_ctx);
+                    ggml_tensor * SK = ggml_new_tensor_3d(out.base_ctx, kv_k_type,
+                                                          head_dim, staging_rows, w.n_head_kv);
+                    ggml_tensor * SV = ggml_new_tensor_3d(out.base_ctx, kv_v_type,
+                                                          head_dim, staging_rows, w.n_head_kv);
+                    std::snprintf(name, sizeof(name), "staging_k_%d", il);
+                    ggml_set_name(SK, name);
+                    std::snprintf(name, sizeof(name), "staging_v_%d", il);
+                    ggml_set_name(SV, name);
+                    out.prefill_staging[0].k[fa_idx] = SK;
+                    out.prefill_staging[0].v[fa_idx] = SV;
+                    for (size_t si = 1; si < out.prefill_staging.size(); ++si) {
+                        ggml_tensor * EK = ggml_new_tensor_3d(out.base_ctx, kv_k_type,
+                                                              head_dim, staging_rows, w.n_head_kv);
+                        ggml_tensor * EV = ggml_new_tensor_3d(out.base_ctx, kv_v_type,
+                                                              head_dim, staging_rows, w.n_head_kv);
+                        std::snprintf(name, sizeof(name), "staging_k_%d_s%zu", il, si);
+                        ggml_set_name(EK, name);
+                        std::snprintf(name, sizeof(name), "staging_v_%d_s%zu", il, si);
+                        ggml_set_name(EV, name);
+                        out.prefill_staging[si].k[fa_idx] = EK;
+                        out.prefill_staging[si].v[fa_idx] = EV;
+                    }
+                }
                 fa_idx++;
             } else {
                 if (!owns_layer) { dn_idx++; continue; }
-                // ssm_state: [head_v_dim, head_v_dim, num_v_heads]
-                ggml_tensor * S = ggml_new_tensor_3d(out.base_ctx, GGML_TYPE_F32,
-                                                     head_v_dim, head_v_dim, w.ssm_dt_rank);
-                // conv_state: [kernel-1, conv_channels]
-                ggml_tensor * C = ggml_new_tensor_2d(out.base_ctx, GGML_TYPE_F32,
-                                                     w.ssm_d_conv - 1, conv_ch);
+                // ssm_state: [head_v_dim, head_v_dim, num_v_heads, n_seq_slots]
+                // (identical layout to the historical 3D tensor when slots=1)
+                ggml_tensor * S = ggml_new_tensor_4d(out.base_ctx, GGML_TYPE_F32,
+                                                     head_v_dim, head_v_dim, w.ssm_dt_rank,
+                                                     n_seq_slots);
+                // conv_state: [kernel-1, conv_channels, n_seq_slots]
+                ggml_tensor * C = ggml_new_tensor_3d(out.base_ctx, GGML_TYPE_F32,
+                                                     w.ssm_d_conv - 1, conv_ch,
+                                                     n_seq_slots);
                 char name[64];
                 std::snprintf(name, sizeof(name), "ssm_state_%d", il);  ggml_set_name(S, name);
                 std::snprintf(name, sizeof(name), "conv_state_%d", il); ggml_set_name(C, name);
                 out.ssm_state[dn_idx]  = S;
                 out.conv_state[dn_idx] = C;
+                if (multi_slot) {
+                    // Prefill staging state: the in-flight sequence's conv/ssm
+                    // slab, isolated from the batched decode write-back that
+                    // touches every slot slab each step (see internal.h).
+                    ggml_tensor * SS = ggml_new_tensor_4d(out.base_ctx, GGML_TYPE_F32,
+                                                          head_v_dim, head_v_dim,
+                                                          w.ssm_dt_rank, 1);
+                    ggml_tensor * SC = ggml_new_tensor_3d(out.base_ctx, GGML_TYPE_F32,
+                                                          w.ssm_d_conv - 1, conv_ch, 1);
+                    std::snprintf(name, sizeof(name), "staging_ssm_state_%d", il);
+                    ggml_set_name(SS, name);
+                    std::snprintf(name, sizeof(name), "staging_conv_state_%d", il);
+                    ggml_set_name(SC, name);
+                    out.prefill_staging[0].ssm_state[dn_idx]  = SS;
+                    out.prefill_staging[0].conv_state[dn_idx] = SC;
+                    for (size_t si = 1; si < out.prefill_staging.size(); ++si) {
+                        ggml_tensor * ESS = ggml_new_tensor_4d(out.base_ctx, GGML_TYPE_F32,
+                                                               head_v_dim, head_v_dim,
+                                                               w.ssm_dt_rank, 1);
+                        ggml_tensor * ESC = ggml_new_tensor_3d(out.base_ctx, GGML_TYPE_F32,
+                                                               w.ssm_d_conv - 1, conv_ch, 1);
+                        std::snprintf(name, sizeof(name), "staging_ssm_%d_s%zu", il, si);
+                        ggml_set_name(ESS, name);
+                        std::snprintf(name, sizeof(name), "staging_conv_%d_s%zu", il, si);
+                        ggml_set_name(ESC, name);
+                        out.prefill_staging[si].ssm_state[dn_idx]  = ESS;
+                        out.prefill_staging[si].conv_state[dn_idx] = ESC;
+                    }
+                }
                 dn_idx++;
             }
         }
@@ -227,10 +320,11 @@ bool create_target_cache_partial(const TargetWeights & w,
         // buffer region may be recycled between attention consumers.
         if (paged_attention) {
             out.paged_block_table = ggml_new_tensor_2d(
-                out.base_ctx, GGML_TYPE_I32, paged_block_count(max_ctx), 1);
+                out.base_ctx, GGML_TYPE_I32, paged_block_count(max_ctx),
+                n_seq_slots);
             ggml_set_name(out.paged_block_table, "paged_block_table");
             out.paged_kv_seq_lens =
-                ggml_new_tensor_1d(out.base_ctx, GGML_TYPE_I32, 1);
+                ggml_new_tensor_1d(out.base_ctx, GGML_TYPE_I32, n_seq_slots);
             ggml_set_name(out.paged_kv_seq_lens, "paged_kv_seq_lens");
         } else {
             out.paged_block_table = nullptr;
@@ -247,7 +341,10 @@ bool create_target_cache_partial(const TargetWeights & w,
     }
 
     // ── Rollback context: snapshots + intermediates ───────────────────
-    if (!prefill_only) {
+    // Multi-slot caches skip these entirely: concurrent serving is paged and
+    // therefore AR-only (no spec-decode rollback), and the tensors are the
+    // single largest optional allocation (~0.8 GB at 48 delta layers).
+    if (!prefill_only && !multi_slot) {
         const int rb_tensors = 4 * n_delta;
         ggml_init_params ip{};
         ip.mem_size   = (size_t)(rb_tensors + 16) * ggml_tensor_overhead();
@@ -356,6 +453,7 @@ void free_target_cache(TargetCache & c) {
     if (c.rollback_ctx) { ggml_free(c.rollback_ctx);               c.rollback_ctx = nullptr; }
     c.attn_k.clear();
     c.attn_v.clear();
+    c.prefill_staging.clear();
     c.ssm_state.clear();
     c.conv_state.clear();
     c.ssm_state_snap.clear();
@@ -414,6 +512,71 @@ void reset_recurrent_state(TargetCache & c) {
     };
     zero_tensors(c.ssm_state);
     zero_tensors(c.conv_state);
+}
+
+namespace {
+
+const std::vector<ggml_tensor *> & empty_staging_set() {
+    static const std::vector<ggml_tensor *> empty;
+    return empty;
+}
+
+bool staging_index_in_bounds(const TargetCache & c, int idx) {
+    return idx >= 0 && (size_t)idx < c.prefill_staging.size();
+}
+
+bool staging_set_complete(const TargetCache & c, int idx,
+                          size_t n_full_attn, size_t n_delta) {
+    if (!staging_index_in_bounds(c, idx)) return false;
+    const PrefillStagingSet & staging = c.prefill_staging[(size_t)idx];
+    return staging.k.size() == n_full_attn &&
+           staging.v.size() == n_full_attn &&
+           staging.ssm_state.size() == n_delta &&
+           staging.conv_state.size() == n_delta;
+}
+
+} // namespace
+
+const std::vector<ggml_tensor *> & staging_k_for(const TargetCache & c, int idx) {
+    return staging_index_in_bounds(c, idx)
+        ? c.prefill_staging[(size_t)idx].k : empty_staging_set();
+}
+const std::vector<ggml_tensor *> & staging_v_for(const TargetCache & c, int idx) {
+    return staging_index_in_bounds(c, idx)
+        ? c.prefill_staging[(size_t)idx].v : empty_staging_set();
+}
+const std::vector<ggml_tensor *> & staging_ssm_for(const TargetCache & c, int idx) {
+    return staging_index_in_bounds(c, idx)
+        ? c.prefill_staging[(size_t)idx].ssm_state
+        : empty_staging_set();
+}
+const std::vector<ggml_tensor *> & staging_conv_for(const TargetCache & c, int idx) {
+    return staging_index_in_bounds(c, idx)
+        ? c.prefill_staging[(size_t)idx].conv_state
+        : empty_staging_set();
+}
+
+void reset_prefill_staging(TargetCache & c, int staging_idx) {
+    if (!staging_index_in_bounds(c, staging_idx)) {
+        set_last_error("invalid prefill staging index");
+        return;
+    }
+    const auto & sk = staging_k_for(c, staging_idx);
+    const auto & sv = staging_v_for(c, staging_idx);
+    const auto & ss = staging_ssm_for(c, staging_idx);
+    const auto & sc = staging_conv_for(c, staging_idx);
+    for (ggml_tensor * t : sk) {
+        if (t) ggml_backend_tensor_memset(t, 0, 0, ggml_nbytes(t));
+    }
+    for (ggml_tensor * t : sv) {
+        if (t) ggml_backend_tensor_memset(t, 0, 0, ggml_nbytes(t));
+    }
+    for (ggml_tensor * t : ss) {
+        if (t) ggml_backend_tensor_memset(t, 0, 0, ggml_nbytes(t));
+    }
+    for (ggml_tensor * t : sc) {
+        if (t) ggml_backend_tensor_memset(t, 0, 0, ggml_nbytes(t));
+    }
 }
 
 // Attach rollback tensors to an existing prefill cache without touching the
@@ -676,7 +839,23 @@ static ggml_tensor * build_full_attn_block(
     ggml_tensor * kv_write_rows = nullptr,
     ggml_tensor ** q_fa_out = nullptr,  // post-RoPE/post-rotation Q [head_dim, n_tokens, n_head]
     ggml_tensor * paged_block_table = nullptr,
-    ggml_tensor * paged_kv_seq_lens = nullptr
+    ggml_tensor * paged_kv_seq_lens = nullptr,
+    // Concurrent-slot paged prefill: reads and the legacy cpy writes target
+    // these contiguous staging tensors (dense-path numerics), while
+    // kv_write_rows dual-writes the same rows into the scattered pool blocks.
+    ggml_tensor * staging_k = nullptr,
+    ggml_tensor * staging_v = nullptr,
+    // Batched paged decode: max kv_seq_len across live slots. Overrides the
+    // kv_start + n_tokens launch bound, which spans one sequence only.
+    int paged_max_kv_len = 0,
+    // Compact decode row -> physical block-table column. Negative ids are
+    // graph-bucket padding rows.
+    ggml_tensor * active_slot_ids = nullptr,
+    // Fused prefill+decode: the first n_fused_prefill tokens are one slot's
+    // prefill chunk (staging reads at kv_start, masked) and the remaining
+    // n_tokens - n_fused_prefill are the batched paged decode. Projections
+    // and the output path stay whole-batch; only the attention core splits.
+    int n_fused_prefill = 0
 ) {
     const int head_dim = w.n_embd_head_k;
     const int n_head = w.n_head;
@@ -764,6 +943,10 @@ static ggml_tensor * build_full_attn_block(
         Kcur_T = ggml_turbo_wht(ctx, Kcur_T, 0);
     }
 
+    const bool paged_prefill = staging_k != nullptr && staging_v != nullptr;
+    const bool fused = n_fused_prefill > 0;
+    GGML_ASSERT(!fused || (paged_prefill && paged_block_table &&
+                           n_fused_prefill < n_tokens));
     if (kv_write_rows) {
         // Step-invariant: the destination tensor stays fixed while the input
         // indices carry contiguous, KVFlash, or paged physical rows.
@@ -772,18 +955,37 @@ static ggml_tensor * build_full_attn_block(
         ggml_tensor * Vcur_cont = ggml_is_contiguous(Vcur_T) ? Vcur_T : ggml_cont(ctx, Vcur_T);
         ggml_build_forward_expand(gf, ggml_set_rows(ctx, cache_k, Kcur_cont, kv_write_rows));
         ggml_build_forward_expand(gf, ggml_set_rows(ctx, cache_v, Vcur_cont, kv_write_rows));
-    } else {
-        // Legacy: kv_start as literal view offset (not step-invariant; prefill/verify/non-graph).
-        ggml_tensor * k_slot = ggml_view_3d(ctx, cache_k,
-            head_dim, n_tokens, n_head_kv,
-            cache_k->nb[1], cache_k->nb[2],
-            /*offset*/ cache_k->nb[1] * kv_start);
-        ggml_tensor * v_slot = ggml_view_3d(ctx, cache_v,
-            head_dim, n_tokens, n_head_kv,
-            cache_v->nb[1], cache_v->nb[2],
-            cache_v->nb[1] * kv_start);
-        ggml_build_forward_expand(gf, ggml_cpy(ctx, Kcur_T, k_slot));
-        ggml_build_forward_expand(gf, ggml_cpy(ctx, Vcur_T, v_slot));
+    }
+    if (!kv_write_rows || paged_prefill) {
+        // Legacy: kv_start as literal view offset (not step-invariant;
+        // prefill/verify/non-graph). Paged prefill points this at the
+        // contiguous staging tensors — the pool rows went through set_rows
+        // above — so chunk reads below see the dense layout. Fused mode
+        // stages only the prefill segment (the leading n_fused_prefill
+        // tokens); the decode rows live in the pool alone.
+        const int n_staged = fused ? n_fused_prefill : n_tokens;
+        ggml_tensor * stage_k_src = Kcur_T;
+        ggml_tensor * stage_v_src = Vcur_T;
+        if (fused) {
+            stage_k_src = ggml_view_3d(ctx, Kcur_T,
+                head_dim, n_staged, n_head_kv,
+                Kcur_T->nb[1], Kcur_T->nb[2], 0);
+            stage_v_src = ggml_view_3d(ctx, Vcur_T,
+                head_dim, n_staged, n_head_kv,
+                Vcur_T->nb[1], Vcur_T->nb[2], 0);
+        }
+        ggml_tensor * legacy_k = paged_prefill ? staging_k : cache_k;
+        ggml_tensor * legacy_v = paged_prefill ? staging_v : cache_v;
+        ggml_tensor * k_slot = ggml_view_3d(ctx, legacy_k,
+            head_dim, n_staged, n_head_kv,
+            legacy_k->nb[1], legacy_k->nb[2],
+            /*offset*/ legacy_k->nb[1] * kv_start);
+        ggml_tensor * v_slot = ggml_view_3d(ctx, legacy_v,
+            head_dim, n_staged, n_head_kv,
+            legacy_v->nb[1], legacy_v->nb[2],
+            legacy_v->nb[1] * kv_start);
+        ggml_build_forward_expand(gf, ggml_cpy(ctx, stage_k_src, k_slot));
+        ggml_build_forward_expand(gf, ggml_cpy(ctx, stage_v_src, v_slot));
     }
 
     // ── Flash attention over the valid slice
@@ -795,35 +997,86 @@ static ggml_tensor * build_full_attn_block(
     // the ggml-cuda CUDA-graph cache can replay. Same numerics as the existing
     // TQ3_0 path: the cache is zero-initialised, so padded rows contribute
     // exp(-row_max) ~ 0 to the (mask-less) softmax denominator.
-    const bool  step_invariant = (kv_write_rows != nullptr);
+    // Paged prefill is NOT step-invariant despite kv_write_rows being active:
+    // its reads are masked stride-1 staging views, exactly like the dense
+    // prefill path, so the 256-span zero-row trick must not kick in.
+    const bool  step_invariant = (kv_write_rows != nullptr) && !paged_prefill;
     const int fattn_stride  = (kv_k_type == GGML_TYPE_TQ3_0 || kv_v_type == GGML_TYPE_TQ3_0 ||
                                step_invariant) ? 256 : 1;
-    // Round a KV span up to the FA stride; `clamp` bounds it to the physical
-    // cache rows (max_ctx may not be 256-aligned).
-    const auto padded_kv_len = [&](int len, bool clamp) {
-        const int padded = ((len + fattn_stride - 1) / fattn_stride) * fattn_stride;
-        return clamp ? std::min(padded, (int)cache_k->ne[1]) : padded;
+    // Round a KV span up to the FA stride.
+    const auto padded_kv_len = [&](int len) {
+        return ((len + fattn_stride - 1) / fattn_stride) * fattn_stride;
     };
 
-    ggml_tensor * Qfa = ggml_permute(ctx, Q, 0, 2, 1, 3);
+    ggml_tensor * Qperm = ggml_permute(ctx, Q, 0, 2, 1, 3);
     // When K is rotated (TQ3_0 or explicit FWHT), Q needs forward rotation too.
     const bool q_rotate   = (kv_k_type == GGML_TYPE_TQ3_0) || kv_k_rotated;
     const bool out_rotate = (kv_v_type == GGML_TYPE_TQ3_0);
+    // A token-axis slice of Qperm, rotated/cont'd for the attention ops.
     // turbo_wht handles strided input, so when rotating we skip the separate
-    // ggml_cont — the rotation kernel makes the output contiguous.
-    if (q_rotate) {
-        Qfa = ggml_turbo_wht(ctx, Qfa, 0);
-    } else {
-        Qfa = ggml_cont(ctx, Qfa);
-    }
-    // Post-rotation Q matches the basis of the K rows in the cache, so a
-    // cosine between this Q and pooled cache keys equals the unrotated
-    // cosine (orthogonal transform).
-    if (q_fa_out) *q_fa_out = Qfa;
+    // ggml_cont — the rotation kernel makes the output contiguous. Fused mode
+    // conts each segment on its own: a slice of one whole-batch cont would
+    // stay strided on the token axis.
+    auto q_segment = [&](int off, int len) {
+        ggml_tensor * q = (off == 0 && len == n_tokens)
+            ? Qperm
+            : ggml_view_3d(ctx, Qperm, head_dim, len, n_head,
+                           Qperm->nb[1], Qperm->nb[2],
+                           (size_t)off * Qperm->nb[1]);
+        return q_rotate ? ggml_turbo_wht(ctx, q, 0) : ggml_cont(ctx, q);
+    };
 
     const float kq_scale = 1.0f / std::sqrt((float)head_dim);
+    auto paged_decode = [&](ggml_tensor * q, int launch_kv_len,
+                            bool dense_token_layout) {
+        const int padded = ((std::max(1, launch_kv_len) + 255) / 256) * 256;
+        const int launch_len = std::min(padded, (int)cache_k->ne[1]);
+        ggml_tensor * out = ggml_paged_attn_ext(
+            ctx, q, cache_k, cache_v, paged_block_table,
+            paged_kv_seq_lens, active_slot_ids, kq_scale,
+            PAGED_BLOCK_SIZE, launch_len);
+        if (dense_token_layout) {
+            out = ggml_cont(ctx, ggml_permute(ctx, out, 0, 2, 1, 3));
+        }
+        return out;
+    };
+
     ggml_tensor * attn = nullptr;
-    if (paged_block_table) {
+    if (fused) {
+        // ── Fused prefill+decode: two attention cores over disjoint token
+        // segments, each in its already-proven configuration. The prefill
+        // rows read this sequence's contiguous staging copy (masked,
+        // stride-1 — identical numerics to the pure prefill chunk); the
+        // decode rows read the pool through the block table (mask-less,
+        // per-slot lens). The prefilling slot's lens entry is 0 until
+        // commit, so the decode side never sees the partial sequence.
+        const int n_decode = n_tokens - n_fused_prefill;
+        ggml_tensor * Qfa_p = q_segment(0, n_fused_prefill);
+        const int p_win = std::min(kv_start + n_fused_prefill,
+                                   (int)staging_k->ne[1]);
+        ggml_tensor * Kfa = ggml_view_3d(ctx, staging_k,
+            head_dim, p_win, n_head_kv,
+            staging_k->nb[1], staging_k->nb[2], 0);
+        ggml_tensor * Vfa = ggml_view_3d(ctx, staging_v,
+            head_dim, p_win, n_head_kv,
+            staging_v->nb[1], staging_v->nb[2], 0);
+        ggml_tensor * attn_p = ggml_flash_attn_ext(ctx, Qfa_p, Kfa, Vfa,
+                                                   attn_mask, kq_scale,
+                                                   0.0f, 0.0f);
+
+        ggml_tensor * Qfa_d = q_segment(n_fused_prefill, n_decode);
+        const int launch_kv_len = paged_max_kv_len > 0 ? paged_max_kv_len : 1;
+        GGML_ASSERT(active_slot_ids);
+        // Join paged [D,n_seq,Hq] to dense [D,Hq,tokens].
+        ggml_tensor * attn_d = paged_decode(
+            Qfa_d, launch_kv_len, /*dense_token_layout=*/true);
+        attn = ggml_concat(ctx, attn_p, attn_d, 2);
+    } else if (paged_block_table) {
+        ggml_tensor * Qfa = q_segment(0, n_tokens);
+        // Post-rotation Q matches the basis of the K rows in the cache, so a
+        // cosine between this Q and pooled cache keys equals the unrotated
+        // cosine (orthogonal transform).
+        if (q_fa_out) *q_fa_out = Qfa;
         GGML_ASSERT(paged_kv_seq_lens);
         // The launch bound lands in op_params, and the ggml-cuda graph cache
         // memcmps the whole ggml_tensor: a live kv_len here would differ on
@@ -832,13 +1085,18 @@ static ggml_tensor * build_full_attn_block(
         // paged node's properties are stable within each window. Exact
         // per-sequence extents still come from kv_seq_lens on device; a larger
         // bound only over-sizes the partition grid, and partitions past the
-        // real length exit with a zero-weight sentinel. Clamped because
-        // ggml_paged_attn asserts max_kv_seq_len <= k->ne[1].
-        const int paged_launch_len = padded_kv_len(kv_len, /*clamp=*/true);
-        attn = ggml_paged_attn(ctx, Qfa, cache_k, cache_v,
-                               paged_block_table, paged_kv_seq_lens,
-                               kq_scale, PAGED_BLOCK_SIZE,
-                               paged_launch_len);
+        // real length exit with a zero-weight sentinel.
+        // Batched decode: kv_len (kv_start + n_tokens) describes one sequence;
+        // the launch bound must cover the longest live slot instead. Clamped
+        // because ggml_paged_attn asserts max_kv_seq_len <= k->ne[1].
+        const int launch_kv_len = paged_max_kv_len > 0 ? paged_max_kv_len : kv_len;
+        attn = paged_decode(
+            Qfa, launch_kv_len,
+            /*dense_token_layout=*/active_slot_ids && n_tokens > 1);
+        if (!active_slot_ids) {
+            // The only non-mapped paged caller is classic single-token AR.
+            GGML_ASSERT(n_tokens == 1);
+        }
     } else {
         // fa_window > 0: attend only to the last fa_window positions (cuts FA
         // cost during spec-decode verify at long contexts). Paged attention
@@ -847,25 +1105,35 @@ static ggml_tensor * build_full_attn_block(
         const int win_start = (fa_window > 0 && kv_start > fa_window)
                                   ? (kv_start - fa_window) : 0;
         const int win_len = kv_len - win_start;
-        // Never view past the cache tensor when step-invariant.
-        const int win_len_padded = padded_kv_len(win_len, /*clamp=*/step_invariant);
+        // Paged prefill reads the sequence's contiguous staging copy — the
+        // pool rows written by set_rows above belong to scattered blocks
+        // interleaved with OTHER sequences, so a [0, kv_len) view of the
+        // pool would attend foreign K/V.
+        ggml_tensor * read_k = paged_prefill ? staging_k : cache_k;
+        ggml_tensor * read_v = paged_prefill ? staging_v : cache_v;
+        int win_len_padded = padded_kv_len(win_len);
+        if (step_invariant || paged_prefill) {
+            // Never view past the read tensor (its rows may not be 256-aligned).
+            win_len_padded = std::min(win_len_padded, (int)read_k->ne[1]);
+        }
 
         // K and V from cache: a windowed view starting at win_start.
-        ggml_tensor * Kfa = ggml_view_3d(ctx, cache_k,
+        ggml_tensor * Kfa = ggml_view_3d(ctx, read_k,
             head_dim, win_len_padded, n_head_kv,
-            cache_k->nb[1], cache_k->nb[2], cache_k->nb[1] * win_start);
-        ggml_tensor * Vfa = ggml_view_3d(ctx, cache_v,
+            read_k->nb[1], read_k->nb[2], read_k->nb[1] * win_start);
+        ggml_tensor * Vfa = ggml_view_3d(ctx, read_v,
             head_dim, win_len_padded, n_head_kv,
-            cache_v->nb[1], cache_v->nb[2], cache_v->nb[1] * win_start);
+            read_v->nb[1], read_v->nb[2], read_v->nb[1] * win_start);
 
+        ggml_tensor * Qfa = q_segment(0, n_tokens);
+        if (q_fa_out) *q_fa_out = Qfa;
         // A single query needs no causal mask. Multi-token callers supply one.
         attn = ggml_flash_attn_ext(ctx, Qfa, Kfa, Vfa, attn_mask,
                                    kq_scale, 0.0f, 0.0f);
     }
-    // Dense output is [D,Hq,n_tokens]; paged output is [D,n_seq,Hq].
-    // They are layout-equivalent here because the paged path is decode-only
-    // and n_tokens/n_seq is exactly one. A future batched integration must
-    // permute the paged result before this reshape.
+    // Dense output is [D,Hq,n_tokens]; paged output is [D,n_seq,Hq]. They are
+    // layout-equivalent when n_tokens/n_seq is one (classic paged decode);
+    // batched paged decode permutes back to the dense layout above.
 
     // Un-rotate the FA output from FWHT-rotated V space (only when V is TQ3).
     if (out_rotate) {
@@ -899,49 +1167,142 @@ static ggml_tensor * build_delta_net_block(
     const TargetWeights & w,
     const TargetLayer & L,
     ggml_tensor * cur,            // [hidden, n_tokens]
-    ggml_tensor * conv_state,     // [kernel-1, conv_channels] persistent
-    ggml_tensor * ssm_state,      // [head_v_dim, head_v_dim, num_v_heads] persistent
+    ggml_tensor * conv_state,     // [kernel-1, conv_channels, n_seqs] persistent (or slot view)
+    ggml_tensor * ssm_state,      // [head_v_dim, head_v_dim, num_v_heads, n_seqs] persistent (or slot view)
     int n_tokens,
     DeltaNetCapture * cap,        // optional: populated on capture_delta_intermediate
     ggml_tensor * parent_ids,     // optional [n_tokens] i32; tree mode when non-null
-    bool skip_gdn_intermediate
+    bool skip_gdn_intermediate,
+    // Supported shapes are one sequence with any number of timesteps
+    // (prefill/verify), or compact decode with one timestep per mapped row.
+    int n_seqs = 1,
+    // Fused prefill+decode: the first n_fused_prefill tokens are ONE
+    // sequence's prefill chunk running against the staging state slabs;
+    // the remaining n_seqs tokens are the batched one-token-per-slot decode
+    // against the full state tensors. The projections and the output
+    // projection stay whole-batch (each weight read once); only the
+    // conv/recurrence core splits into two already-proven configurations.
+    int n_fused_prefill = 0,
+    ggml_tensor * prefill_conv_state = nullptr,
+    ggml_tensor * prefill_ssm_state = nullptr,
+    ggml_tensor * active_slot_ids = nullptr,
+    ggml_tensor * state_slot_ids = nullptr,
+    bool allow_inplace_state = false
 ) {
     const int head_k_dim   = w.ssm_d_state;
     const int num_k_heads  = w.ssm_n_group;
     const int num_v_heads  = w.ssm_dt_rank;
     const int head_v_dim   = w.ssm_d_inner / w.ssm_dt_rank;
     const int conv_channels = w.ssm_d_inner + 2 * w.ssm_n_group * w.ssm_d_state;
-    const int n_seqs       = 1;
-    const int n_seq_tokens = n_tokens;
+    const bool fused = n_fused_prefill > 0;
+    GGML_ASSERT(n_seqs >= 1);
+    GGML_ASSERT(!fused || (prefill_conv_state && prefill_ssm_state &&
+                           active_slot_ids &&
+                           n_fused_prefill + n_seqs == n_tokens));
+    GGML_ASSERT((active_slot_ids == nullptr) == (state_slot_ids == nullptr));
+    GGML_ASSERT(!active_slot_ids ||
+                (!cap && !parent_ids && n_fused_prefill + n_seqs == n_tokens));
+    if (!fused) {
+        if (active_slot_ids) {
+            GGML_ASSERT(n_tokens == n_seqs);
+        } else {
+            GGML_ASSERT(n_seqs == 1);
+        }
+    }
     const bool can_skip_gdn_intermediate = skip_gdn_intermediate && !parent_ids && !cap;
 
-    // ── qkv_mixed = wqkv @ cur         [10240, n_tokens]
-    ggml_tensor * qkv_mixed = apply_scale2(ctx, ggml_mul_mat(ctx, L.wqkv, cur), L.wqkv_s);
-    qkv_mixed = ggml_reshape_3d(ctx, qkv_mixed, conv_channels, n_seq_tokens, n_seqs);
+    // ── Whole-batch projections ─────────────────────────────────────
+    // qkv_mixed = wqkv @ cur           [10240, n_tokens]
+    ggml_tensor * qkv_2d = apply_scale2(ctx, ggml_mul_mat(ctx, L.wqkv, cur), L.wqkv_s);
 
-    // ── z = wqkv_gate @ cur            [inner, n_tokens]
+    // z = wqkv_gate @ cur              [inner, n_tokens]
     ggml_tensor * z = apply_scale2(ctx, ggml_mul_mat(ctx, L.wqkv_gate, cur), L.wqkv_gate_s);
 
-    // ── beta = ssm_beta @ cur          [dt_rank, n_tokens]
-    ggml_tensor * beta = apply_scale2(ctx, ggml_mul_mat(ctx, L.ssm_beta, cur), L.ssm_beta_s);
-    beta = ggml_reshape_4d(ctx, beta, 1, num_v_heads, n_seq_tokens, n_seqs);
-    beta = ggml_sigmoid(ctx, beta);
+    // beta = sigmoid(ssm_beta @ cur)   [dt_rank, n_tokens]
+    ggml_tensor * beta_2d = apply_scale2(ctx, ggml_mul_mat(ctx, L.ssm_beta, cur), L.ssm_beta_s);
+    beta_2d = ggml_sigmoid(ctx, beta_2d);
 
-    // ── alpha = ssm_alpha @ cur        [dt_rank, n_tokens]
-    //    alpha = alpha + ssm_dt_bias          (per-head bias)
-    //    alpha = softplus(alpha)
-    //    g     = alpha * ssm_a                (-A_log.exp() * softplus)
+    // alpha = ssm_alpha @ cur          [dt_rank, n_tokens]
+    // g     = softplus(alpha + ssm_dt_bias) * ssm_a   (-A_log.exp() * softplus)
     ggml_tensor * alpha = apply_scale2(ctx, ggml_mul_mat(ctx, L.ssm_alpha, cur), L.ssm_alpha_s);
-    alpha = ggml_reshape_3d(ctx, alpha, num_v_heads, n_seq_tokens, n_seqs);
     alpha = ggml_add(ctx, alpha, L.ssm_dt_bias);
     alpha = ggml_softplus(ctx, alpha);
-    ggml_tensor * g_tensor = ggml_mul(ctx, alpha, L.ssm_a);
-    g_tensor = ggml_reshape_4d(ctx, g_tensor, 1, num_v_heads, n_seq_tokens, n_seqs);
+    ggml_tensor * g_2d = ggml_mul(ctx, alpha, L.ssm_a);
+
+    // ── Token-axis segments: one for the classic modes, two when fused ──
+    struct DeltaSeg {
+        int off;                  // first token of the segment
+        int T;                    // timesteps per sequence
+        int S;                    // sequences
+        ggml_tensor * conv_st;
+        ggml_tensor * ssm_st;
+    };
+    DeltaSeg segs[2];
+    int n_segs = 0;
+    if (fused) {
+        segs[n_segs++] = {0, n_fused_prefill, 1,
+                          prefill_conv_state, prefill_ssm_state};
+        segs[n_segs++] = {n_fused_prefill, 1, n_seqs, conv_state, ssm_state};
+    } else {
+        // No general [timesteps x sequences] mode: this is either one
+        // multi-token sequence or one compact token per mapped sequence.
+        const int timesteps = active_slot_ids ? 1 : n_tokens;
+        segs[n_segs++] = {0, timesteps, n_seqs, conv_state, ssm_state};
+    }
+
+    // Column slice of a [C, n_tokens] projection; the tensor itself when the
+    // segment spans the whole batch, so single-segment graphs keep today's
+    // topology exactly.
+    auto seg_cols = [&](ggml_tensor * t, int off, int n) -> ggml_tensor * {
+        if (off == 0 && n == (int)t->ne[1]) return t;
+        return ggml_view_2d(ctx, t, t->ne[0], n, t->nb[1],
+                            (size_t)off * t->nb[1]);
+    };
+
+    ggml_tensor * flat[2] = {nullptr, nullptr};
+    for (int si = 0; si < n_segs; si++) {
+    const DeltaSeg & seg = segs[si];
+    const int n_seq_tokens = seg.T;
+    const int seg_seqs     = seg.S;
+    const int seg_tokens   = seg.T * seg.S;
+    const bool seg_active = active_slot_ids &&
+        ((!fused && si == 0) || (fused && si == 1));
+    // Plain one-token decode has no in-graph consumer of the updated state:
+    // the next graph evaluation is the first read. Write the final state
+    // directly into its persistent slab and avoid materializing/copying a
+    // second S_v x S_v x H_v state. The active-aware path also updates each
+    // mapped physical slab directly; only its negative bucket-padding rows
+    // use the result tensor's retained scratch state region.
+    const bool inplace_state = seg_active ||
+        (allow_inplace_state && can_skip_gdn_intermediate &&
+         !fused && n_seq_tokens == 1);
+
+    ggml_tensor * qkv_mixed = ggml_reshape_3d(ctx,
+        seg_cols(qkv_2d, seg.off, seg_tokens),
+        conv_channels, n_seq_tokens, seg_seqs);
+    ggml_tensor * beta = ggml_reshape_4d(ctx,
+        seg_cols(beta_2d, seg.off, seg_tokens),
+        1, num_v_heads, n_seq_tokens, seg_seqs);
+    ggml_tensor * g_tensor = ggml_reshape_4d(ctx,
+        seg_cols(g_2d, seg.off, seg_tokens),
+        1, num_v_heads, n_seq_tokens, seg_seqs);
 
     // ── Fetch conv state [kernel-1, conv_channels] and prepend to qkv_mixed
     //    along the token axis to form the convolution input.
-    ggml_tensor * conv_states_r = ggml_reshape_3d(ctx, conv_state,
-        w.ssm_d_conv - 1, conv_channels, n_seqs);
+    ggml_tensor * conv_states_r = nullptr;
+    if (seg_active) {
+        const int64_t slab =
+            (int64_t)(w.ssm_d_conv - 1) * conv_channels;
+        ggml_tensor * all_conv = ggml_reshape_2d(
+            ctx, seg.conv_st, slab, seg.conv_st->ne[2]);
+        ggml_tensor * gathered =
+            ggml_get_rows(ctx, all_conv, state_slot_ids);
+        conv_states_r = ggml_reshape_3d(
+            ctx, gathered, w.ssm_d_conv - 1, conv_channels, seg_seqs);
+    } else {
+        conv_states_r = ggml_reshape_3d(ctx, seg.conv_st,
+            w.ssm_d_conv - 1, conv_channels, seg_seqs);
+    }
 
     // qkv_mixed currently is [conv_channels, n_tokens, n_seqs]; we need
     // [n_tokens, conv_channels, n_seqs] to concat on dim 0.
@@ -975,12 +1336,24 @@ static ggml_tensor * build_delta_net_block(
         ggml_build_forward_expand(gf, ggml_cpy(ctx, conv_input, dst));
     }
 
-    // ── Save the last (kernel-1) steps back to conv_state
+    // ── Save the last (kernel-1) steps back to the conv state
     ggml_tensor * last_conv = ggml_view_3d(ctx, conv_input,
-        w.ssm_d_conv - 1, conv_channels, n_seqs,
+        w.ssm_d_conv - 1, conv_channels, seg_seqs,
         conv_input->nb[1], conv_input->nb[2],
         (conv_input->ne[0] - (w.ssm_d_conv - 1)) * ggml_element_size(conv_input));
-    ggml_build_forward_expand(gf, ggml_cpy(ctx, last_conv, conv_state));
+    if (seg_active) {
+        const int64_t slab =
+            (int64_t)(w.ssm_d_conv - 1) * conv_channels;
+        ggml_tensor * compact_last = ggml_reshape_2d(
+            ctx, ggml_cont(ctx, last_conv), slab, seg_seqs);
+        ggml_tensor * all_conv = ggml_reshape_2d(
+            ctx, seg.conv_st, slab, seg.conv_st->ne[2]);
+        ggml_build_forward_expand(
+            gf, ggml_set_rows_masked(
+                    ctx, all_conv, compact_last, active_slot_ids));
+    } else {
+        ggml_build_forward_expand(gf, ggml_cpy(ctx, last_conv, seg.conv_st));
+    }
 
     // ── 1D conv + silu
     //    Tree mode: use the parent-chain-aware variant so sibling nodes gather
@@ -1001,19 +1374,19 @@ static ggml_tensor * build_delta_net_block(
     const size_t row_size = conv_channels * elt;
 
     ggml_tensor * q_c = ggml_view_4d(ctx, conv_out,
-        head_k_dim, num_k_heads, n_seq_tokens, n_seqs,
+        head_k_dim, num_k_heads, n_seq_tokens, seg_seqs,
         head_k_dim * elt,
         row_size,
         row_size * n_seq_tokens,
         q_offset * elt);
     ggml_tensor * k_c = ggml_view_4d(ctx, conv_out,
-        head_k_dim, num_k_heads, n_seq_tokens, n_seqs,
+        head_k_dim, num_k_heads, n_seq_tokens, seg_seqs,
         head_k_dim * elt,
         row_size,
         row_size * n_seq_tokens,
         k_offset * elt);
     ggml_tensor * v_c = ggml_view_4d(ctx, conv_out,
-        head_v_dim, num_v_heads, n_seq_tokens, n_seqs,
+        head_v_dim, num_v_heads, n_seq_tokens, seg_seqs,
         head_v_dim * elt,
         row_size,
         row_size * n_seq_tokens,
@@ -1026,13 +1399,15 @@ static ggml_tensor * build_delta_net_block(
     // Repeat Q and K from num_k_heads to num_v_heads so they match V's layout
     // (only needed if not using the fused op's broadcast support).
     if (num_k_heads != num_v_heads) {
-        q_c = ggml_repeat_4d(ctx, q_c, head_k_dim, num_v_heads, n_seq_tokens, n_seqs);
-        k_c = ggml_repeat_4d(ctx, k_c, head_k_dim, num_v_heads, n_seq_tokens, n_seqs);
+        q_c = ggml_repeat_4d(ctx, q_c, head_k_dim, num_v_heads, n_seq_tokens, seg_seqs);
+        k_c = ggml_repeat_4d(ctx, k_c, head_k_dim, num_v_heads, n_seq_tokens, seg_seqs);
     }
 
     // ── SSM state (recurrent): reshape to [S_v, S_v, H_v, n_seqs]
-    ggml_tensor * s = ggml_reshape_4d(ctx, ssm_state,
-        head_v_dim, head_v_dim, num_v_heads, n_seqs);
+    ggml_tensor * s = seg_active
+        ? seg.ssm_st
+        : ggml_reshape_4d(ctx, seg.ssm_st,
+            head_v_dim, head_v_dim, num_v_heads, seg_seqs);
 
     // ── Fused Gated DeltaNet op — returns packed (output | new_state [| intermediates]).
     //    In tree mode, the kernel uses parent_ids to reload state at DFS
@@ -1075,17 +1450,20 @@ static ggml_tensor * build_delta_net_block(
     }
 
     ggml_tensor * output = nullptr;
-    ggml_tensor * new_state = nullptr;
 
     if (use_chunked) {
         auto r = build_delta_net_chunked(ctx, q_c, k_c, v_c, g_tensor, beta, s);
-        output    = r.output;
-        new_state = r.new_state;
-        goto after_delta_net;
-    }
-
+        output = r.output;
+        // The chunked path writes into the same state slot via its 4D view
+        // `s` (a live view over the state tensor), using the same cpy
+        // pattern the sequential path uses for `new_state`.
+        ggml_build_forward_expand(gf, ggml_cpy(ctx, r.new_state, s));
+    } else {
     ggml_tensor * result;
-    if (parent_ids) {
+    if (seg_active) {
+        result = ggml_gated_delta_net_active_inplace(
+            ctx, q_c, k_c, v_c, g_tensor, beta, s, active_slot_ids);
+    } else if (parent_ids) {
         // Tree verify: _tree_persist wires src[7] internally.
         result = persist_inter
             ? ggml_gated_delta_net_tree_persist(ctx, q_c, k_c, v_c, g_tensor, beta, s, parent_ids, persist_inter)
@@ -1096,7 +1474,9 @@ static ggml_tensor * build_delta_net_block(
         // cache buffer — same mechanism as _tree_persist, but without tree
         // parent_ids. Avoids the legacy result-region cpy (and the OOB it
         // could cause if the result tensor has no embedded intermediate region).
-        result = ggml_gated_delta_net(ctx, q_c, k_c, v_c, g_tensor, beta, s);
+        result = inplace_state
+            ? ggml_gated_delta_net_inplace(ctx, q_c, k_c, v_c, g_tensor, beta, s)
+            : ggml_gated_delta_net(ctx, q_c, k_c, v_c, g_tensor, beta, s);
         if (persist_inter) {
             result->src[7] = persist_inter;
         }
@@ -1106,25 +1486,27 @@ static ggml_tensor * build_delta_net_block(
     }
 
     // Slice output and new_state out of the packed result
-    {
     const int64_t S_v = head_v_dim;
     const int64_t H_v = num_v_heads;
     const size_t r_elt = ggml_element_size(result);
     output = ggml_view_4d(ctx, result,
-        S_v, H_v, n_seq_tokens, n_seqs,
+        S_v, H_v, n_seq_tokens, seg_seqs,
         S_v * r_elt,
         S_v * H_v * r_elt,
         S_v * H_v * n_seq_tokens * r_elt,
         0);
-    new_state = ggml_view_4d(ctx, result,
-        S_v, S_v, H_v, n_seqs,
-        S_v * r_elt,
-        S_v * S_v * r_elt,
-        S_v * S_v * H_v * r_elt,
-        S_v * H_v * n_seq_tokens * n_seqs * r_elt);
+    if (!inplace_state) {
+        ggml_tensor * new_state = ggml_view_4d(ctx, result,
+            S_v, S_v, H_v, seg_seqs,
+            S_v * r_elt,
+            S_v * S_v * r_elt,
+            S_v * S_v * H_v * r_elt,
+            S_v * H_v * n_seq_tokens * seg_seqs * r_elt);
 
-    // Persist new_state back to cache
-    ggml_build_forward_expand(gf, ggml_cpy(ctx, new_state, ssm_state));
+        // Persist new_state back to cache. Both compact active decode and the
+        // plain in-place AR path write state from the GDN kernel directly.
+        ggml_build_forward_expand(gf, ggml_cpy(ctx, new_state, seg.ssm_st));
+    }
 
     // Expose per-step intermediate states for spec-decode rollback. The patched
     // ggml_gated_delta_net kernel appends an intermediate-states region to the
@@ -1151,32 +1533,27 @@ static ggml_tensor * build_delta_net_block(
             "(got type %d); use F16 intermediates (the default) or the tree-verify path.",
             (int)cap->ssm_intermediate_states->type);
     }
-    } // end of block started at `{` before `const int64_t S_v = head_v_dim;`
-
-after_delta_net:
-    // Chunked path writes directly into the same ssm_state slot via its 4D
-    // view `s` (which is a live view over ssm_state), using the same cpy
-    // pattern the sequential path uses for `new_state`. Sequential path's
-    // cpy was already emitted above; guard this second cpy on use_chunked
-    // so we don't double-write.
-    if (use_chunked) {
-        ggml_build_forward_expand(gf, ggml_cpy(ctx, new_state, s));
     }
 
     // ── Gated output norm: rms_norm(output) * silu(z_4d)
-    ggml_tensor * z_4d = ggml_reshape_4d(ctx, z, head_v_dim, num_v_heads, n_seq_tokens, n_seqs);
+    ggml_tensor * z_4d = ggml_reshape_4d(ctx,
+        seg_cols(z, seg.off, seg_tokens),
+        head_v_dim, num_v_heads, n_seq_tokens, seg_seqs);
     ggml_tensor * output_n = ggml_rms_norm(ctx, rms_norm_input_f32(ctx, output), w.rms_eps);
     output_n = ggml_mul(ctx, output_n, L.ssm_norm);
     ggml_tensor * z_silu  = ggml_silu(ctx, z_4d);
     output_n = ggml_mul(ctx, output_n, z_silu);
 
-    // Reshape to [d_inner, n_tokens]
-    ggml_tensor * flat = ggml_reshape_3d(ctx, output_n,
-        head_v_dim * num_v_heads, n_seq_tokens, n_seqs);
+    // Reshape to [d_inner, seg_tokens]
+    flat[si] = ggml_reshape_2d(ctx, output_n,
+        head_v_dim * num_v_heads, seg_tokens);
+    }  // segment loop
 
-    // Output projection
-    ggml_tensor * out = apply_scale2(ctx, ggml_mul_mat(ctx, L.ssm_out, flat), L.ssm_out_s);
-    out = ggml_reshape_2d(ctx, out, w.n_embd, n_seq_tokens * n_seqs);
+    // ── Output projection over the whole batch (one weight read)
+    ggml_tensor * flat_all = (n_segs == 1)
+        ? flat[0] : ggml_concat(ctx, flat[0], flat[1], 1);
+    ggml_tensor * out = apply_scale2(ctx, ggml_mul_mat(ctx, L.ssm_out, flat_all), L.ssm_out_s);
+    out = ggml_reshape_2d(ctx, out, w.n_embd, n_tokens);
     return out;
 }
 
@@ -1308,6 +1685,20 @@ QwenGraphOutputs build_qwen35_graph(
     TargetCache &          cache,
     const QwenGraphInputs & in) {
 
+    const bool needs_staging = cache.n_seq_slots > 1 &&
+        (in.paged_prefill || in.n_prefill_tokens > 0 ||
+         in.prefill_commit);
+    if (needs_staging) {
+        const size_t n_full_attn =
+            (size_t)(w.n_layer / w.full_attention_interval);
+        const size_t n_delta = (size_t)w.n_layer - n_full_attn;
+        if (!staging_set_complete(
+                cache, in.staging_idx, n_full_attn, n_delta)) {
+            set_last_error("invalid or incomplete prefill staging set");
+            return {};
+        }
+    }
+
     const int n_tokens = in.n_tokens;
 
     // 1. Caller supplies pre-embedded inputs via in.inp_embed (CPU lookup done
@@ -1348,18 +1739,27 @@ QwenGraphOutputs build_qwen35_graph(
         if (is_attn) {
             const bool want_q_cap = in.q_capture && cache.q_cap;
             ggml_tensor * q_fa = nullptr;
-            cur = build_full_attn_block(ctx, gf, w, L, cur, in.positions, w.rope_sections,
-                                        cache.attn_k[fa_idx], cache.attn_v[fa_idx],
-                                        in.attn_mask, in.kv_start, n_tokens,
-                                        cache.kv_k_type, cache.kv_v_type,
-                                        cache.kv_k_rotated,
-                                        in.fa_window,
-                                        /*q_tail_capture=*/nullptr,
-                                        /*q_tail_start=*/0,
-                                        in.kv_write_rows,
-                                        want_q_cap ? &q_fa : nullptr,
-                                        in.paged_attention ? cache.paged_block_table : nullptr,
-                                        in.paged_attention ? cache.paged_kv_seq_lens : nullptr);
+            const bool use_staging = in.paged_prefill &&
+            fa_idx < (int)staging_k_for(cache, in.staging_idx).size();
+        const auto & sk_set = staging_k_for(cache, in.staging_idx);
+        const auto & sv_set = staging_v_for(cache, in.staging_idx);
+        cur = build_full_attn_block(ctx, gf, w, L, cur, in.positions, w.rope_sections,
+                                    cache.attn_k[fa_idx], cache.attn_v[fa_idx],
+                                    in.attn_mask, in.kv_start, n_tokens,
+                                    cache.kv_k_type, cache.kv_v_type,
+                                    cache.kv_k_rotated,
+                                    in.fa_window,
+                                    /*q_tail_capture=*/nullptr,
+                                    /*q_tail_start=*/0,
+                                    in.kv_write_rows,
+                                    want_q_cap ? &q_fa : nullptr,
+                                    in.paged_block_table,
+                                    in.paged_kv_seq_lens,
+                                    use_staging ? sk_set[fa_idx] : nullptr,
+                                    use_staging ? sv_set[fa_idx] : nullptr,
+                                    in.paged_max_kv_len,
+                                    in.active_slot_ids,
+                                    in.n_prefill_tokens);
             if (want_q_cap && q_fa) {
                 // Last token's Q, all heads: src [head_dim, 1, n_head] view of
                 // [head_dim, n_tokens, n_head]; dst = q_cap plane fa_idx
@@ -1388,10 +1788,53 @@ QwenGraphOutputs build_qwen35_graph(
                 cap_ptr->ssm_intermediate_states = cache.ssm_intermediate[dn_idx];
                 cap_ptr->conv_input              = cache.conv_input_cache[dn_idx];
             }
+            ggml_tensor * conv_st = cache.conv_state[dn_idx];
+            ggml_tensor * ssm_st  = cache.ssm_state[dn_idx];
+            ggml_tensor * pf_conv = nullptr;
+            ggml_tensor * pf_ssm  = nullptr;
+            const auto & stage_conv = staging_conv_for(cache, in.staging_idx);
+            const auto & stage_ssm  = staging_ssm_for(cache, in.staging_idx);
+            if (in.n_prefill_tokens > 0) {
+                // Fused prefill+decode: the decode segment runs on the full
+                // state tensors; the prefill segment carries its state in
+                // the staging slabs (committed to the slot on prefill_commit).
+                pf_conv = stage_conv[dn_idx];
+                pf_ssm  = stage_ssm[dn_idx];
+            } else if (cache.n_seq_slots > 1 && in.n_seqs == 1 &&
+                       in.paged_prefill) {
+                // Pure prefill chunk against a multi-slot cache: run on the
+                // staging slabs, NOT the slot's own — slots are reused
+                // without a device-side state reset, so the slab may still
+                // hold a previous occupant's state, while staging is zeroed
+                // at admission. The final chunk (prefill_commit) copies
+                // staging into the slot's slabs.
+                conv_st = stage_conv[dn_idx];
+                ssm_st  = stage_ssm[dn_idx];
+            } else if (cache.n_seq_slots > 1 && in.n_seqs == 1 &&
+                       !in.active_slot_ids) {
+                // Single-sequence forward against a multi-slot cache: this
+                // slot's contiguous slab of the state tensors.
+                conv_st = ggml_view_3d(ctx, conv_st,
+                    conv_st->ne[0], conv_st->ne[1], 1,
+                    conv_st->nb[1], conv_st->nb[2],
+                    (size_t)in.seq_slot * conv_st->nb[2]);
+                ssm_st = ggml_view_4d(ctx, ssm_st,
+                    ssm_st->ne[0], ssm_st->ne[1], ssm_st->ne[2], 1,
+                    ssm_st->nb[1], ssm_st->nb[2], ssm_st->nb[3],
+                    (size_t)in.seq_slot * ssm_st->nb[3]);
+            }
             cur = build_delta_net_block(ctx, gf, w, L, cur,
-                                        cache.conv_state[dn_idx], cache.ssm_state[dn_idx],
+                                        conv_st, ssm_st,
                                         n_tokens, cap_ptr, in.parent_ids,
-                                        /*skip_gdn_intermediate=*/true);
+                                        /*skip_gdn_intermediate=*/true,
+                                        in.n_seqs,
+                                        in.n_prefill_tokens,
+                                        pf_conv, pf_ssm,
+                                        in.active_slot_ids,
+                                        in.state_slot_ids,
+                                        /*allow_inplace_state=*/
+                                            !in.paged_prefill &&
+                                            in.n_prefill_tokens == 0);
             dn_idx++;
         }
 
@@ -1462,17 +1905,46 @@ QwenGraphOutputs build_qwen35_graph(
         inpL = cur;
     }
 
+    // Prefill commit: copy the staging conv/ssm slabs into the admitted
+    // slot's slabs. Emitted AFTER every layer, so these nodes execute after
+    // the batched decode state write-back — the decode dummy-row garbage in
+    // the slot's slabs loses to the committed prefill state.
+    if (in.prefill_commit && cache.n_seq_slots > 1) {
+        const auto & stage_conv = staging_conv_for(cache, in.staging_idx);
+        const auto & stage_ssm  = staging_ssm_for(cache, in.staging_idx);
+        for (size_t dn = 0; dn < cache.conv_state.size(); dn++) {
+            ggml_tensor * c_src = stage_conv[dn];
+            ggml_tensor * s_src = stage_ssm[dn];
+            ggml_tensor * c_full = cache.conv_state[dn];
+            ggml_tensor * s_full = cache.ssm_state[dn];
+            if (!c_src || !s_src || !c_full || !s_full) continue;
+            ggml_tensor * c_dst = ggml_view_3d(ctx, c_full,
+                c_full->ne[0], c_full->ne[1], 1,
+                c_full->nb[1], c_full->nb[2],
+                (size_t)in.seq_slot * c_full->nb[2]);
+            ggml_tensor * s_dst = ggml_view_4d(ctx, s_full,
+                s_full->ne[0], s_full->ne[1], s_full->ne[2], 1,
+                s_full->nb[1], s_full->nb[2], s_full->nb[3],
+                (size_t)in.seq_slot * s_full->nb[3]);
+            ggml_build_forward_expand(gf, ggml_cpy(ctx, c_src, c_dst));
+            ggml_build_forward_expand(gf, ggml_cpy(ctx, s_src, s_dst));
+        }
+    }
+
     // 2. Final norm
     ggml_tensor * out = rms_norm_mul(ctx, inpL, w.out_norm, w.rms_eps);
 
-    // 3. LM head — optionally only for the last token (prefill optimization:
-    //    reduces logits from [vocab, n_tokens] to [vocab, 1], saving ~233MB
-    //    scratch at ubatch=384 and eliminating a large matmul).
+    // 3. LM head — optionally only for a tail of the token axis (prefill
+    //    computes just the last row; fused steps compute the decode rows
+    //    plus, on the committing chunk, the prompt's last row. Saves the
+    //    [vocab, n_tokens] matmul and ~233MB scratch at ubatch=384).
     ggml_tensor * logits = nullptr;
     if (w.output) {
-        if (in.last_token_logits_only && n_tokens > 1) {
-            out = ggml_view_2d(ctx, out, hidden, 1, out->nb[1],
-                               (size_t)(n_tokens - 1) * out->nb[1]);
+        if (in.logits_tail_rows > 0 && in.logits_tail_rows < n_tokens) {
+            out = ggml_view_2d(ctx, out, hidden, in.logits_tail_rows,
+                               out->nb[1],
+                               (size_t)(n_tokens - in.logits_tail_rows) *
+                                   out->nb[1]);
         }
         logits = ggml_mul_mat(ctx, w.output, out);
         ggml_set_name(logits, "logits");
@@ -1606,6 +2078,11 @@ bool snapshot_target_cache(const TargetWeights & w,
                            const TargetCache & cache,
                            ggml_backend_t backend,
                            PrefixSnapshot & snap) {
+    if (cache.n_seq_slots > 1) {
+        set_last_error("snapshot_target_cache: multi-slot caches are unsupported");
+        return false;
+    }
+
     const int n_full_attn = w.n_layer / w.full_attention_interval; // 16
     const int n_delta     = w.n_layer - n_full_attn;               // 48
     const int snap_pos    = cache.cur_pos;
@@ -1738,6 +2215,10 @@ bool snapshot_target_cache(const TargetWeights & w,
 }
 
 bool restore_target_cache(const PrefixSnapshot & snap, TargetCache & cache) {
+    if (cache.n_seq_slots > 1) {
+        set_last_error("restore_target_cache: multi-slot caches are unsupported");
+        return false;
+    }
     if (snap.kv_k_type != cache.kv_k_type) {
         set_last_error("restore_target_cache: kv_k_type mismatch");
         return false;

--- a/server/src/server/api_types.h
+++ b/server/src/server/api_types.h
@@ -5,4 +5,16 @@ namespace dflash::common {
 
 enum class ApiFormat { OPENAI_CHAT, ANTHROPIC, RESPONSES, COMPLETIONS };
 
+// Log/status name of a format — shared by the request-tracing logs of the
+// classic worker loop and the concurrent scheduler.
+inline const char * api_format_name(ApiFormat format) {
+    switch (format) {
+    case ApiFormat::OPENAI_CHAT: return "chat";
+    case ApiFormat::ANTHROPIC:   return "anthropic";
+    case ApiFormat::RESPONSES:   return "responses";
+    case ApiFormat::COMPLETIONS: return "completions";
+    default:                     return "unknown";
+    }
+}
+
 }  // namespace dflash::common

--- a/server/src/server/client_send_buffer.h
+++ b/server/src/server/client_send_buffer.h
@@ -1,0 +1,139 @@
+// ClientSendBuffer — buffered non-blocking writer for one client socket.
+//
+// The concurrent scheduler must never block on a client: a stalled SSE
+// reader would head-of-line-block every co-scheduled request's decode.
+// Token chunks and final responses append here; the scheduler drains the
+// buffer with non-blocking sends once per decode iteration and consults
+// the stall policy (no drain progress for a deadline, or a byte cap) to
+// decide when a dead reader should be dropped.
+//
+// The fd is owned by the caller and must already be non-blocking (the HTTP
+// server sets client sockets non-blocking at enqueue time).
+
+#pragma once
+
+#include "socket_handle.h"
+
+#if defined(_WIN32)
+#if !defined(NOMINMAX)
+#define NOMINMAX
+#endif
+#if !defined(WIN32_LEAN_AND_MEAN)
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <winsock2.h>
+#else
+#include <cerrno>
+#include <sys/socket.h>
+#include <sys/types.h>
+#endif
+
+#include <algorithm>
+#include <chrono>
+#include <limits>
+#include <string>
+#include <string_view>
+
+namespace dflash::common {
+
+class ClientSendBuffer {
+public:
+    void append(std::string_view bytes) { buf_.append(bytes); }
+
+    bool empty() const { return off_ == buf_.size(); }
+    size_t pending() const { return buf_.size() - off_; }
+
+    // Drain as much as the socket accepts right now. Never blocks. Returns
+    // false on a hard socket error (peer gone). Records drain progress for
+    // the stall policy and compacts the drained prefix.
+    bool flush(SocketHandle fd) {
+        const size_t off_before = off_;
+        while (off_ < buf_.size()) {
+            const auto n = send_some(fd, buf_.data() + off_,
+                                     buf_.size() - off_);
+            if (n > 0) { off_ += (size_t)n; continue; }
+            if (n < 0) {
+                const int error = send_error();
+                if (send_would_block(error)) break;
+                if (send_was_interrupted(error)) continue;
+            }
+            return false;
+        }
+        const bool made_progress = off_ != off_before;
+        if (off_ == buf_.size()) {
+            buf_.clear();
+            off_ = 0;
+        } else if (off_ > kCompactAt) {
+            buf_.erase(0, off_);
+            off_ = 0;
+        }
+        if (made_progress) {
+            last_progress_ = std::chrono::steady_clock::now();
+        }
+        return true;
+    }
+
+    // True when the reader should be dropped: bytes are pending and either
+    // the buffer exceeds `cap` or nothing drained since `stall` ago. The
+    // deadline does NOT reset while the reader makes no progress — a
+    // trickling reader is bounded by the cap instead.
+    bool should_drop(std::chrono::steady_clock::time_point now,
+                     std::chrono::seconds stall, size_t cap) const {
+        if (empty()) return false;
+        return pending() > cap || now - last_progress_ > stall;
+    }
+
+    // Start (or restart) the stall clock, e.g. at admission.
+    void mark_progress(std::chrono::steady_clock::time_point now) {
+        last_progress_ = now;
+    }
+
+private:
+    static constexpr size_t kCompactAt = 64u << 10;
+
+#if defined(_WIN32)
+    static int send_some(SocketHandle fd, const char * data, size_t len) {
+        const int chunk = static_cast<int>((std::min)(
+            len, static_cast<size_t>((std::numeric_limits<int>::max)())));
+        return ::send(fd, data, chunk, 0);
+    }
+
+    static int send_error() {
+        return WSAGetLastError();
+    }
+
+    static bool send_would_block(int error) {
+        return error == WSAEWOULDBLOCK;
+    }
+
+    static bool send_was_interrupted(int error) {
+        return error == WSAEINTR;
+    }
+#else
+    static ssize_t send_some(SocketHandle fd, const char * data, size_t len) {
+#if defined(MSG_NOSIGNAL)
+        return ::send(fd, data, len, MSG_NOSIGNAL);
+#else
+        return ::send(fd, data, len, 0);
+#endif
+    }
+
+    static int send_error() {
+        return errno;
+    }
+
+    static bool send_would_block(int error) {
+        return error == EAGAIN || error == EWOULDBLOCK;
+    }
+
+    static bool send_was_interrupted(int error) {
+        return error == EINTR;
+    }
+#endif
+
+    std::string buf_;
+    size_t off_ = 0;
+    std::chrono::steady_clock::time_point last_progress_{};
+};
+
+}  // namespace dflash::common

--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -157,6 +157,33 @@ bool sse_chunk_has_done(
     return found;
 }
 
+HeartbeatSendResult try_send_sse_heartbeat(
+        SocketHandle fd, size_t & offset) {
+    constexpr size_t heartbeat_size = sizeof(kSseHeartbeat) - 1;
+    if (offset > heartbeat_size) {
+        offset = 0;
+        return HeartbeatSendResult::Disconnected;
+    }
+    while (offset < heartbeat_size) {
+        const ssize_t n = send(
+            fd, kSseHeartbeat + offset, heartbeat_size - offset,
+            MSG_NOSIGNAL | MSG_DONTWAIT);
+        if (n > 0) {
+            offset += (size_t)n;
+            continue;
+        }
+        if (n < 0) {
+            const int error = sock_errno();
+            if (sock_is_eintr(error)) continue;
+            if (sock_is_eagain(error)) return HeartbeatSendResult::Retry;
+        }
+        offset = 0;
+        return HeartbeatSendResult::Disconnected;
+    }
+    offset = 0;
+    return HeartbeatSendResult::Complete;
+}
+
 }  // namespace http_detail
 
 static std::string context_overflow_message(int max_ctx, int prompt_tokens, int max_output) {
@@ -478,18 +505,6 @@ static std::string generate_id(const char * prefix) {
     return buf;
 }
 
-// Logging helpers shared by route_request() / worker_loop(). Kept static
-// (file-scope) so they don't leak into the public ABI; the chat lifecycle
-// logs that use them are part of #270's request-tracing instrumentation.
-static const char * api_format_name(ApiFormat format) {
-    switch (format) {
-    case ApiFormat::OPENAI_CHAT: return "chat";
-    case ApiFormat::ANTHROPIC:   return "anthropic";
-    case ApiFormat::RESPONSES:   return "responses";
-    default:                     return "unknown";
-    }
-}
-
 static size_t json_array_size(const json & value) {
     return value.is_array() ? value.size() : 0;
 }
@@ -768,6 +783,9 @@ json build_props_body(const ServerConfig & config,
             // (dflash/scripts/bench_http_capability.py) read
             // /props.runtime wholesale into result.json.server_info.
             {"chunk",           config.chunk},
+            {"continuous_batching", {
+                {"admission_coalesce_ms", config.admission_coalesce_ms},
+            }},
             // Device placement strings (e.g. "auto:0", "cuda:0"). Empty
             // string when no draft model is loaded.
             {"target_device",   config.target_device},
@@ -1361,8 +1379,16 @@ int HttpServer::run() {
     std::fprintf(stderr, "[server] listening on http://%s:%d\n",
                  config_.host.c_str(), config_.port);
 
-    // Start worker thread.
-    worker_thread_ = std::thread([this]() { worker_loop(); });
+    // A backend-provided sequence engine replaces the one-request worker
+    // with the concurrent scheduler. Upstream forwarding stays on the
+    // classic path even when the local backend exposes an engine.
+    if (SeqEngine * engine = backend_.seq_engine();
+        engine && config_.pflash_upstream_base.empty()) {
+        worker_thread_ =
+            std::thread([this, engine]() { scheduler_loop(*engine); });
+    } else {
+        worker_thread_ = std::thread([this]() { worker_loop(); });
+    }
 
     // Accept loop.
     while (!stopping_.load()) {
@@ -1945,8 +1971,7 @@ void HttpServer::log_parsed_request(const ParsedRequest & req) const {
 
 void HttpServer::enqueue_request_and_wait(SocketHandle fd, ParsedRequest req) {
     // Set socket non-blocking for send() stall detection during streaming.
-    const int flags = sock_get_flags(fd);
-    if (flags >= 0) sock_set_nonblock(fd);
+    sock_set_nonblock(fd);
 
     ServerJob job;
     job.fd = fd;
@@ -2360,10 +2385,8 @@ json build_responses_api_response(
 
 json build_non_streaming_response(
         const ParsedRequest & req, const GenerateResult & result,
-        int generation_cap, const GenTimings & timings, Tokenizer & tokenizer,
-        SseEmitter & emitter) {
-    const CompletionTokenCounts counts = feed_non_streaming_tokens(
-        result.tokens, tokenizer, emitter);
+        int generation_cap, const GenTimings & timings,
+        const CompletionTokenCounts & counts, SseEmitter & emitter) {
     switch (req.format) {
     case ApiFormat::OPENAI_CHAT:
         return build_openai_completion_response(
@@ -2377,6 +2400,16 @@ json build_non_streaming_response(
     default:
         return {{"text", emitter.accumulated_text()}};
     }
+}
+
+json build_non_streaming_response(
+        const ParsedRequest & req, const GenerateResult & result,
+        int generation_cap, const GenTimings & timings, Tokenizer & tokenizer,
+        SseEmitter & emitter) {
+    const CompletionTokenCounts counts = feed_non_streaming_tokens(
+        result.tokens, tokenizer, emitter);
+    return build_non_streaming_response(
+        req, result, generation_cap, timings, counts, emitter);
 }
 
 // Prompt preparation applies exactly one compression policy: FlowKV for
@@ -3535,6 +3568,74 @@ void HttpServer::configure_generation_io(
     };
 }
 
+bool HttpServer::deliver_generation_token(
+        ServerJob * job, const ParsedRequest & req, SseEmitter & emitter,
+        int32_t token, int & completion_tokens,
+        ClientSendBuffer & send_buffer) {
+    ++completion_tokens;
+
+    std::string text;
+    const TokenDelivery delivery =
+        classify_generated_token(tokenizer_, token, text);
+    if (delivery == TokenDelivery::kSkip) return true;
+
+    // Non-stream replay counts every non-skipped token, including tokens
+    // whose decoded text is empty. Keep concurrent usage accounting aligned;
+    // streaming still has no frame to send for an empty string.
+    if (text.empty() && req.stream) return true;
+
+    const auto chunks = emitter.emit_token(text);
+    if (req.stream && !chunks.empty()) {
+        // Disable silent-prefill heartbeats only once there is a real frame
+        // to buffer. Complete a partial comment ahead of that frame.
+        stop_job_stream(job, &send_buffer);
+        for (const auto & chunk : chunks) {
+            send_buffer.append(chunk);
+        }
+    }
+    return delivery == TokenDelivery::kThinkTag || !emitter.stop_hit();
+}
+
+void HttpServer::send_nonstream_response(
+        const ParsedRequest & req, SocketHandle fd, SseEmitter & emitter,
+        const std::vector<int32_t> & gen_tokens, int n_gen_cap,
+        bool budget_forced_close, bool degenerate_decode_close,
+        const GenTimings & gen_timings,
+        ClientSendBuffer * send_buffer) {
+    CompletionTokenCounts counts;
+    counts.total = (int) gen_tokens.size();
+    emitter.emit_finish(counts.total);
+    const int first_content = emitter.first_content_token_index();
+    const int emitted = emitter.emit_token_count();
+    counts.reasoning = first_content < 0 ? emitted : first_content;
+    counts.content = first_content < 0 ? 0 : emitted - first_content;
+
+    GenerateResult result;
+    result.tokens = gen_tokens;
+    result.budget_forced_close = budget_forced_close;
+    result.degenerate_decode_close = degenerate_decode_close;
+
+    const json response = build_non_streaming_response(
+        req, result, n_gen_cap, gen_timings, counts, emitter);
+
+    const std::string body = response.dump() + "\n";
+    if (send_buffer) {
+        send_buffer->append(
+            format_http_response(200, "application/json", body));
+    } else {
+        send_response(fd, 200, "application/json", body);
+    }
+}
+
+std::array<std::string, 2> HttpServer::sse_error_close_chunks(
+        const std::string & message) {
+    const json err = {{"error", {
+        {"message", message},
+        {"type", "server_error"},
+    }}};
+    return {"data: " + err.dump() + "\n\n", "data: [DONE]\n\n"};
+}
+
 void HttpServer::worker_loop() {
     while (true) {
         ServerJob * job = dequeue();
@@ -3590,11 +3691,9 @@ void HttpServer::process_job(ServerJob * job) {
         std::fprintf(stderr, "[server] request failed: %s\n", message.c_str());
         if (req.stream) {
             stop_job_stream(job);
-            json err = {{"error", {{"message", message}, {"type", "server_error"}}}};
-            const std::string chunk = "data: " + err.dump() + "\n\n";
-            send_job_bytes(job, chunk.data(), chunk.size());
-            const char done[] = "data: [DONE]\n\n";
-            send_job_bytes(job, done, sizeof(done) - 1);
+            for (const std::string & chunk : sse_error_close_chunks(message)) {
+                send_job_bytes(job, chunk.data(), chunk.size());
+            }
         } else {
             send_error(fd, status, message);
         }
@@ -3796,8 +3895,7 @@ void HttpServer::process_job(ServerJob * job) {
             req, result, n_gen_cap, gen_timings, tokenizer_, emitter);
         // Streaming uses non-blocking sends; restore blocking mode before
         // writing a complete JSON response on this shared socket path.
-        const int flags = sock_get_flags(fd);
-        if (flags >= 0) sock_set_block(fd);
+        sock_set_block(fd);
         send_response(fd, 200, "application/json",
                       response.dump() + "\n");
     }
@@ -3880,6 +3978,33 @@ ServerJob * HttpServer::dequeue() {
     if (!queue_head_) queue_tail_ = nullptr;
     j->next = nullptr;
     return j;
+}
+
+ServerJob * HttpServer::try_dequeue() {
+    std::lock_guard<std::mutex> lk(queue_mu_);
+    if (!queue_head_) return nullptr;
+    ServerJob * job = queue_head_;
+    queue_head_ = job->next;
+    if (!queue_head_) queue_tail_ = nullptr;
+    job->next = nullptr;
+    return job;
+}
+
+ServerJob * HttpServer::dequeue_for(
+        std::chrono::steady_clock::duration timeout) {
+    std::unique_lock<std::mutex> lk(queue_mu_);
+    if (!queue_head_ && !stopping_.load() &&
+        timeout > std::chrono::steady_clock::duration::zero()) {
+        queue_cv_.wait_for(lk, timeout, [&] {
+            return queue_head_ != nullptr || stopping_.load();
+        });
+    }
+    if (!queue_head_) return nullptr;
+    ServerJob * job = queue_head_;
+    queue_head_ = job->next;
+    if (!queue_head_) queue_tail_ = nullptr;
+    job->next = nullptr;
+    return job;
 }
 
 // ─── HTTP I/O ───────────────────────────────────────────────────────────
@@ -4024,6 +4149,19 @@ bool HttpServer::send_job_bytes(
     if (job->client_disconnected.load(std::memory_order_acquire)) {
         return false;
     }
+    // A heartbeat may have made a short write on the previous monitor tick.
+    // Finish that comment before writing an SSE data frame so their bytes
+    // cannot be interleaved on the stream.
+    if (job->heartbeat_offset > 0) {
+        constexpr size_t heartbeat_size = sizeof(kSseHeartbeat) - 1;
+        if (!send_all(job->fd, kSseHeartbeat + job->heartbeat_offset,
+                      heartbeat_size - job->heartbeat_offset)) {
+            job->heartbeat_offset = 0;
+            job->client_disconnected.store(true, std::memory_order_release);
+            return false;
+        }
+        job->heartbeat_offset = 0;
+    }
     if (!send_all(job->fd, data, len)) {
         job->client_disconnected.store(true, std::memory_order_release);
         return false;
@@ -4037,12 +4175,21 @@ void HttpServer::start_job_stream(ServerJob * job) {
     if (job->client_disconnected.load(std::memory_order_acquire)) return;
     job->stream_ready = true;
     job->read_close_probe_sent = false;
+    job->heartbeat_offset = 0;
     job->last_stream_write = std::chrono::steady_clock::now();
 }
 
-void HttpServer::stop_job_stream(ServerJob * job) {
+void HttpServer::stop_job_stream(
+        ServerJob * job, ClientSendBuffer * pending_output) {
     std::lock_guard<std::mutex> lock(job->write_mu);
     job->stream_ready = false;
+    if (pending_output && job->heartbeat_offset > 0) {
+        constexpr size_t heartbeat_size = sizeof(kSseHeartbeat) - 1;
+        pending_output->append(std::string_view(
+            kSseHeartbeat + job->heartbeat_offset,
+            heartbeat_size - job->heartbeat_offset));
+        job->heartbeat_offset = 0;
+    }
 }
 
 void HttpServer::maybe_send_job_heartbeat(
@@ -4060,17 +4207,23 @@ void HttpServer::maybe_send_job_heartbeat(
         return;
     }
 
-    if (!send_all(job->fd, kSseHeartbeat, sizeof(kSseHeartbeat) - 1)) {
+    // The scheduler also takes write_mu when it switches from prefill
+    // heartbeats to buffered token output.  Never hold that shared mutex
+    // across send_all()'s 30-second stall window.
+    const auto result = http_detail::try_send_sse_heartbeat(
+        job->fd, job->heartbeat_offset);
+    if (result == http_detail::HeartbeatSendResult::Disconnected) {
         job->client_disconnected.store(true, std::memory_order_release);
         return;
     }
+    if (result == http_detail::HeartbeatSendResult::Retry) return;
     if (probe_read_close) job->read_close_probe_sent = true;
     job->last_stream_write = now;
 }
 
-bool HttpServer::send_response(
-        SocketHandle fd, int status, const std::string & content_type,
-                               const std::string & body) {
+std::string HttpServer::format_http_response(
+        int status, const std::string & content_type,
+        const std::string & body) {
     const char * reason = "OK";
     switch (status) {
         case 200: reason = "OK"; break;
@@ -4094,7 +4247,15 @@ bool HttpServer::send_response(
     header += "Content-Length: " + std::to_string(body.size()) + "\r\n";
     header += "Connection: close\r\n\r\n";
     header += body;
-    return send_all(fd, header.data(), header.size());
+    return header;
+}
+
+bool HttpServer::send_response(
+        SocketHandle fd, int status, const std::string & content_type,
+        const std::string & body) {
+    const std::string payload =
+        format_http_response(status, content_type, body);
+    return send_all(fd, payload.data(), payload.size());
 }
 
 bool HttpServer::send_error(

--- a/server/src/server/http_server.h
+++ b/server/src/server/http_server.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include "socket_handle.h"
+#include "client_send_buffer.h"
 #include "common/model_backend.h"
 #include "tokenizer.h"
 #include "chat_template.h"
@@ -28,9 +29,11 @@
 #include "model_card.h"
 #include "adaptive_keep_ratio.h"
 #include "server_status.h"
+#include "sse_emitter.h"
 #include <nlohmann/json.hpp>
 
 #include <atomic>
+#include <array>
 #include <chrono>
 #include <condition_variable>
 #include <cstdint>
@@ -51,7 +54,6 @@ using json = nlohmann::json;
 
 // ─── Forward declarations ───────────────────────────────────────────────
 struct ServerJob;
-class SseEmitter;
 
 namespace http_detail {
 // Non-consuming peer-state probe used by the client-thread job monitor.
@@ -68,6 +70,16 @@ PeerSocketState inspect_peer_socket(SocketHandle fd);
 // `partial_line` carries an unterminated line across transport chunks.
 bool sse_chunk_has_done(std::string & partial_line,
                         const char * data, size_t size);
+
+// Advance one heartbeat on an already-nonblocking job socket without waiting
+// for writability. `offset` preserves a partial write across monitor ticks.
+// Public for the model-free socket regression test.
+enum class HeartbeatSendResult {
+    Complete,
+    Retry,
+    Disconnected,
+};
+HeartbeatSendResult try_send_sse_heartbeat(SocketHandle fd, size_t & offset);
 }
 
 // ─── Server configuration ───────────────────────────────────────────────
@@ -176,6 +188,9 @@ struct ServerConfig {
     // server_main after CLI parse.
     std::string target_device;
     std::string draft_device;
+    // Idle-to-busy batching window. It is ignored by single-slot engines and
+    // never delays an already decoding request.
+    int admission_coalesce_ms = 20;
 
     // PFlash (speculative prefill compression)
     enum class PflashMode { OFF, AUTO, ALWAYS };
@@ -413,6 +428,36 @@ private:
         ServerJob * job, const ParsedRequest & req, SseEmitter & emitter,
         GenerationOutputState & output, DaemonIO & io);
 
+    // Worker thread, concurrent mode (the backend exposes a SeqEngine):
+    // iteration-level scheduler. Admission is claim-only; this baseline
+    // drains its pending prefill between decode iterations, then advances
+    // active slots together in one batched step.
+    void scheduler_loop(SeqEngine & engine);
+
+    // Non-blocking dequeue used for admission polling between decode steps.
+    ServerJob * try_dequeue();
+    // Bounded wait used only during an idle-to-busy admission window.
+    ServerJob * dequeue_for(
+        std::chrono::steady_clock::duration timeout);
+
+    // Concurrent-scheduler token delivery and shared response construction.
+    // A send buffer keeps slow clients off the shared decode loop.
+    bool deliver_generation_token(
+        ServerJob * job, const ParsedRequest & req, SseEmitter & emitter,
+        int32_t token, int & completion_tokens,
+        ClientSendBuffer & send_buffer);
+    void send_nonstream_response(
+        const ParsedRequest & req, SocketHandle fd, SseEmitter & emitter,
+        const std::vector<int32_t> & gen_tokens, int n_gen_cap,
+        bool budget_forced_close, bool degenerate_decode_close,
+        const GenTimings & gen_timings,
+        ClientSendBuffer * send_buffer = nullptr);
+    std::string format_http_response(
+        int status, const std::string & content_type,
+        const std::string & body);
+    static std::array<std::string, 2> sse_error_close_chunks(
+        const std::string & message);
+
     // Parse HTTP request from socket.
     struct HttpRequest {
         std::string method;
@@ -450,7 +495,8 @@ private:
     bool send_all(SocketHandle fd, const void * data, size_t len);
     bool send_job_bytes(ServerJob * job, const void * data, size_t len);
     void start_job_stream(ServerJob * job);
-    void stop_job_stream(ServerJob * job);
+    void stop_job_stream(ServerJob * job,
+                         ClientSendBuffer * pending_output = nullptr);
     void maybe_send_job_heartbeat(ServerJob * job, bool peer_read_closed);
 
     // Job queue.
@@ -546,9 +592,19 @@ struct ServerJob {
     std::mutex    write_mu;
     bool          stream_ready = false;
     bool          read_close_probe_sent = false;
+    size_t        heartbeat_offset = 0;
     std::chrono::steady_clock::time_point last_stream_write{};
     std::atomic<bool> client_disconnected{false};
     ServerJob *   next = nullptr;
+
+    // Concurrent-scheduler state that survives a pool-full admission retry.
+    // The classic worker leaves these fields untouched.
+    bool          announced = false;
+    bool          sse_started = false;
+    // First concurrent-scheduler attempt; retained across busy deferrals so
+    // server-side prefill/elapsed telemetry does not erase queueing delay.
+    std::chrono::steady_clock::time_point parallel_started_at{};
+    std::unique_ptr<SseEmitter> emitter;
 };
 
 // ─── Parse session_id from a chat-completion JSON body ──────────────────

--- a/server/src/server/scheduler.cpp
+++ b/server/src/server/scheduler.cpp
@@ -1,0 +1,753 @@
+// Concurrent scheduler for --max-concurrency serving: the worker thread's
+// iteration-level loop over a backend's SeqEngine decode slots.
+//
+// Split from http_server.cpp: this TU owns non-blocking admission (one
+// prefill chunk per engine step, fused with the live decode batch), FIFO
+// pool-full deferrals, per-slot streaming through ClientSendBuffer, and
+// retirement. SSE emission, error-close chunks, and HTTP response
+// formatting are shared with the classic worker so both paths emit
+// matching wire formats.
+
+#include "http_server.h"
+#include "common/concurrency/seq_engine.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <thread>
+
+namespace dflash::common {
+
+namespace {
+
+// Per-slot request state for the iteration-level scheduler. Indexed by the
+// engine slot id returned from admit(), so scheduler and engine agree on
+// which engine-owned state record a request owns. This remains the one
+// external phase: sockets stay here, prompt/KV/sampler/progress stay in Qwen.
+struct SchedSlot {
+    ServerJob * job = nullptr;
+    SocketHandle fd = kInvalidSocket;
+    std::unique_ptr<SseEmitter> emitter;
+    bool prefilling = false;
+    uint64_t admission_order = 0;
+    std::chrono::steady_clock::time_point started_at{};
+    std::chrono::steady_clock::time_point decode_started_at{};
+    double prefill_s = 0.0;
+    int n_gen_cap = 0;
+    int completion_tokens = 0;
+    bool client_disconnected = false;
+    bool failed = false;
+    std::string error;
+    bool finished = false;
+    std::vector<int32_t> gen_tokens;   // committed + pending, in order
+    int32_t pending_tok = -1;          // sampled, fed back next step
+    // Buffered client output (see client_send_buffer.h): chunks append here and
+    // a non-blocking flush runs every scheduler iteration, so one slow
+    // reader can never head-of-line-block the shared decode loop.
+    dflash::common::ClientSendBuffer send_buffer;
+    // Thinking-budget force-close, applied scheduler-side before the token
+    // is fed back (mirrors do_ar_decode's maybe_force_close).
+    dflash::common::BudgetHook hook;
+    bool hook_started = false;
+    int  hook_pos = 0;
+    bool budget_forced_close = false;
+    bool degenerate_close = false;
+};
+
+// Outcome of one admission attempt. The three cases differ in who owns the
+// job afterwards: Admitted hands it to a slot, Deferred hands it back to the
+// caller to retry at the head of the line, Retired means the job is already
+// answered and holds nothing.
+enum class AdmissionDisposition {
+    Admitted,  // job owns an engine slot and its first token is on the wire
+    Deferred,  // engine had no room; caller keeps the job and retries it first
+    Retired,   // job finished or failed during admission; no slot was taken
+};
+
+}  // namespace
+
+void HttpServer::scheduler_loop(SeqEngine & engine) {
+    const int n_slots = engine.slot_count();
+    std::vector<SchedSlot> slots((size_t)n_slots);
+    uint64_t next_request_id = 1;
+    uint64_t next_admission_order = 0;
+    // Admission-deferred job (pool blocks/slots exhausted). Kept at the head
+    // of the line so FIFO order survives the deferral.
+    ServerJob * deferred = nullptr;
+    std::chrono::steady_clock::time_point deferred_retry_at{};
+
+    // Degenerate-run guard shared with do_ar_decode: explicit env override,
+    // else 32 when the min-tokens floor is active, else off.
+    static const int repeat_guard = [] {
+        if (const char * s = std::getenv("DFLASH_DEGENERATE_RUN_TOKENS")) {
+            const int v = std::atoi(s);
+            if (v >= 0) return v;
+        }
+        const char * f = std::getenv("DFLASH_MIN_TOKENS");
+        return (f && std::atoi(f) > 0) ? 32 : 0;
+    }();
+
+    // Cached live-slot count — incremented on admit, decremented on retire.
+    // Replaces the O(n_slots) scan that was called 2-3× per iteration.
+    int live_slots = 0;
+
+    int published_live_count = -1;
+    int published_prefill_count = -1;
+    auto publish_live_count = [&]() {
+        int prefilling = 0;
+        for (const SchedSlot & s : slots) {
+            if (s.job && s.prefilling) ++prefilling;
+        }
+        if (live_slots == published_live_count &&
+            prefilling == published_prefill_count) return;
+        published_live_count = live_slots;
+        published_prefill_count = prefilling;
+        if (live_slots > 0) {
+            status_.set_concurrent_requests(live_slots, prefilling);
+        } else status_.set_idle();
+        broadcast_status();
+    };
+
+    auto finish_job = [this](ServerJob * job) {
+        stop_job_stream(job);
+        std::lock_guard<std::mutex> lk(job->mu);
+        job->done = true;
+        job->cv.notify_one();
+    };
+
+    // A stalled reader may buffer at most this much before being dropped.
+    constexpr size_t kMaxSlotSendBuffer = 1u << 20;
+    constexpr auto kClientStallTimeout = std::chrono::seconds(30);
+
+    // Final payloads of retired slots still draining to their sockets. The
+    // job is signalled done only once its bytes are out (or the deadline /
+    // hard error gives up) because the parked client thread closes the fd
+    // the moment it wakes.
+    struct DrainJob {
+        ServerJob * job = nullptr;
+        SocketHandle fd = kInvalidSocket;
+        ClientSendBuffer send_buffer;
+        std::chrono::steady_clock::time_point deadline{};
+    };
+    std::vector<DrainJob> drains;
+
+    auto service_drains = [&]() {
+        if (drains.empty()) return;
+        const auto now = std::chrono::steady_clock::now();
+        for (size_t i = 0; i < drains.size();) {
+            DrainJob & d = drains[i];
+            const size_t pending_before = d.send_buffer.pending();
+            const bool ok = d.send_buffer.flush(d.fd);
+            if (d.send_buffer.pending() < pending_before) {
+                d.deadline = std::chrono::steady_clock::now() +
+                             kClientStallTimeout;
+            }
+            if (!ok || d.send_buffer.empty() || now > d.deadline) {
+                finish_job(d.job);
+                drains[i] = std::move(drains.back());
+                drains.pop_back();
+                continue;
+            }
+            ++i;
+        }
+    };
+
+    auto maybe_force_close = [](SchedSlot & s, int32_t & tok) {
+        if (s.hook.close_token_ids.empty()) return;
+        if (s.hook_started) {
+            if (s.hook_pos < (int)s.hook.close_token_ids.size()) {
+                tok = s.hook.close_token_ids[(size_t)s.hook_pos++];
+            }
+            return;
+        }
+        const int generated = (int)s.gen_tokens.size();
+        const int remaining = s.n_gen_cap - generated;
+        if (remaining <= s.hook.hard_limit_remaining) {
+            const int32_t first_close = s.hook.close_token_ids.front();
+            s.hook_started = true;
+            s.hook_pos = 1;
+            if (tok != first_close) {
+                tok = first_close;
+                s.budget_forced_close = true;
+            }
+        }
+    };
+
+    // Advances one slot by a single sampled token — the post-sample path
+    // shared by the first (prefill-logits) token and every decode-step token.
+    // Note `tok` is by value but not passthrough: maybe_force_close may
+    // *substitute* a close token for it, and that substitute is what gets
+    // recorded, emitted, and fed back. Appends to gen_tokens, streams the
+    // delta into send_buffer, and parks the token in pending_tok as the next
+    // step's input for this slot. Sets s.finished — but never retires the
+    // slot — on EOS, gen cap, stop-sequence hit, or degenerate repetition.
+    auto advance_slot = [&](SchedSlot & s, int32_t tok) {
+        maybe_force_close(s, tok);
+        s.gen_tokens.push_back(tok);
+        const bool cont = deliver_generation_token(
+            s.job, s.job->req, *s.emitter, tok, s.completion_tokens,
+            s.send_buffer);
+        s.pending_tok = tok;
+        if (!cont || engine.token_is_eos(tok) ||
+            (int)s.gen_tokens.size() >= s.n_gen_cap) {
+            s.finished = true;
+            return;
+        }
+        // Single-token run guard (matches do_ar_decode's repeat break).
+        if (repeat_guard > 0 && (int)s.gen_tokens.size() >= repeat_guard) {
+            int run = 1;
+            for (int j = (int)s.gen_tokens.size() - 2; j >= 0; --j) {
+                if (s.gen_tokens[(size_t)j] != tok) break;
+                run++;
+            }
+            if (run >= repeat_guard) {
+                std::fprintf(stderr,
+                    "[parallel] token %d repeated %d times — stopping slot\n",
+                    tok, run);
+                s.degenerate_close = true;
+                s.finished = true;
+                return;
+            }
+        }
+        // Post-close repetition watchdog (periods 12..80), mirrors
+        // do_ar_decode's sweep once the close sequence has fully injected.
+        if (s.hook_started &&
+            s.hook_pos >= (int)s.hook.close_token_ids.size()) {
+            const auto end = s.gen_tokens.end();
+            const int avail = (int)s.gen_tokens.size();
+            for (int P = 12; P <= 80; P++) {
+                if (avail < 2 * P) break;
+                if (std::equal(end - 2 * P, end - P, end - P)) {
+                    std::fprintf(stderr,
+                        "[parallel] post-close period=%d repeated — "
+                        "stopping slot\n", P);
+                    s.degenerate_close = true;
+                    s.finished = true;
+                    return;
+                }
+            }
+        }
+    };
+
+    auto retire_slot = [&](int idx, bool backend_ok) {
+        SchedSlot & s = slots[(size_t)idx];
+        if (!s.job) return;
+        const ParsedRequest & req = s.job->req;
+        // Stop monitor-thread heartbeats before queuing terminal frames.
+        stop_job_stream(s.job, &s.send_buffer);
+        const double decode_s = std::chrono::duration<double>(
+            std::chrono::steady_clock::now() - s.decode_started_at).count();
+        const int prompt_tokens = (int)req.prompt_tokens.size();
+        GenTimings gen_timings{
+            s.prefill_s,
+            decode_s,
+            /*cache_hit=*/false,
+            /*cached_prefix_tokens=*/0,
+            /*prefilled_tokens=*/prompt_tokens,
+            /*effective_prompt_tokens=*/prompt_tokens,
+        };
+
+        if (backend_ok && !s.failed) {
+            PerfRecord perf;
+            perf.prompt_tokens = (int)req.prompt_tokens.size();
+            perf.completion_tokens = s.completion_tokens;
+            perf.prefill_tok_s = s.prefill_s > 0.0
+                ? (double)req.prompt_tokens.size() / s.prefill_s : 0.0;
+            perf.decode_tok_s = decode_s > 0.0
+                ? (double)s.completion_tokens / decode_s : 0.0;
+            status_.record_perf(perf);
+        }
+
+        if (s.failed || !backend_ok) {
+            const std::string message =
+                s.error.empty() ? "generation failed" : s.error;
+            if (!s.client_disconnected) {
+                if (req.stream) {
+                    for (const std::string & chunk :
+                         sse_error_close_chunks(message)) {
+                        s.send_buffer.append(chunk);
+                    }
+                } else {
+                    json err = {{"error", {{"message", message},
+                                           {"type", "invalid_request_error"}}}};
+                    s.send_buffer.append(format_http_response(
+                        500, "application/json", err.dump() + "\n"));
+                }
+            }
+        } else if (req.stream && !s.client_disconnected) {
+            auto final_chunks =
+                s.emitter->emit_finish(s.completion_tokens, &gen_timings);
+            for (const auto & chunk : final_chunks) {
+                s.send_buffer.append(chunk);
+            }
+        } else if (!req.stream && !s.client_disconnected) {
+            send_nonstream_response(req, s.fd, *s.emitter, s.gen_tokens,
+                                    s.n_gen_cap, s.budget_forced_close,
+                                    s.degenerate_close, gen_timings,
+                                    &s.send_buffer);
+        }
+
+        const double elapsed_s = std::chrono::duration<double>(
+            std::chrono::steady_clock::now() - s.started_at).count();
+        const int out_tokens = (int)s.gen_tokens.size();
+        std::fprintf(stderr,
+            "[server] chat DONE %s ok=%s in=%zu out=%d %.1fs %.1f tok/s "
+            "finish=%s slot=%d prefill=%.1fs decode=%.1fs(%.1ftok/s) parallel\n",
+            req.response_id.c_str(),
+            (!s.failed && backend_ok) ? "true" : "false",
+            req.prompt_tokens.size(), out_tokens, elapsed_s,
+            elapsed_s > 0.0 ? out_tokens / elapsed_s : 0.0,
+            s.client_disconnected ? "client_disconnect"
+                                  : s.emitter->finish_reason().c_str(),
+            idx, s.prefill_s, decode_s,
+            decode_s > 0.0 ? out_tokens / decode_s : 0.0);
+
+        engine.retire(idx);
+        // A retirement may have released the blocks the head job needs.
+        deferred_retry_at = {};
+
+        // Hand any undrained bytes to the drain list; the job stays parked
+        // until they are out (or the drain gives up).
+        bool drained = s.client_disconnected;
+        if (!drained) {
+            drained = s.send_buffer.flush(s.fd) ? s.send_buffer.empty() : true;
+        }
+        if (drained) {
+            finish_job(s.job);
+        } else if (s.send_buffer.pending() > kMaxSlotSendBuffer) {
+            // Non-streaming output is materialized only at retirement, after
+            // the live-slot cap check.  Do not park an oversized final
+            // response in drains when the client cannot accept it now.
+            std::fprintf(stderr,
+                "[parallel] slot %d final response exceeds client buffer "
+                "cap -- dropping response\n", idx);
+            finish_job(s.job);
+        } else {
+            DrainJob d;
+            d.job = s.job;
+            d.fd = s.fd;
+            d.send_buffer = std::move(s.send_buffer);
+            d.deadline = std::chrono::steady_clock::now() +
+                         kClientStallTimeout;
+            drains.push_back(std::move(d));
+        }
+        s = SchedSlot{};
+        live_slots--;
+        publish_live_count();
+    };
+
+    auto admit_job = [&](ServerJob * job) -> AdmissionDisposition {
+        const ParsedRequest & req = job->req;
+        if (job->parallel_started_at ==
+                std::chrono::steady_clock::time_point{}) {
+            job->parallel_started_at = std::chrono::steady_clock::now();
+        }
+        const auto started_at = job->parallel_started_at;
+
+        // Same thinking-budget n_gen math as the classic worker loop.
+        const bool budget_active = req.thinking_opt_in;
+        const int effective_think_ceiling = (req.per_req_phase1_cap >= 0)
+            ? req.per_req_phase1_cap
+            : config_.think_max_tokens;
+        const int eff_reply_for_n_gen = (req.per_req_reply_budget >= 0)
+            ? req.per_req_reply_budget
+            : config_.hard_limit_reply_budget;
+        const int n_gen_cap = budget_active
+            ? (std::min)(effective_think_ceiling + eff_reply_for_n_gen,
+                         req.max_output)
+            : req.max_output;
+
+        if (n_gen_cap < 1) {
+            // Degenerate ask: reply with an empty completion, no slot needed.
+            SseEmitter emitter(req.format, req.response_id, req.model,
+                               (int)req.prompt_tokens.size(), req.tools,
+                               &tool_memory_, req.stop_sequences,
+                               req.started_in_thinking);
+            GenTimings t{
+                0.0,
+                0.0,
+                /*cache_hit=*/false,
+                /*cached_prefix_tokens=*/0,
+                /*prefilled_tokens=*/0,
+                /*effective_prompt_tokens=*/(int)req.prompt_tokens.size(),
+            };
+            if (req.stream) {
+                if (send_sse_headers(job)) {
+                    bool ok = true;
+                    for (const auto & c : emitter.emit_start()) {
+                        if (!send_job_bytes(job, c.data(), c.size())) { ok = false; break; }
+                    }
+                    if (ok) {
+                        for (const auto & c : emitter.emit_finish(0, &t)) {
+                            if (!send_job_bytes(job, c.data(), c.size())) break;
+                        }
+                    }
+                }
+            } else {
+                send_nonstream_response(req, job->fd, emitter, {}, n_gen_cap,
+                                        false, false, t);
+            }
+            finish_job(job);
+            return AdmissionDisposition::Retired;
+        }
+
+        if (!job->announced) {
+            job->announced = true;
+            std::fprintf(stderr,
+                "[server] chat START %s format=%s stream=%s prompt_tokens=%zu "
+                "max_tokens=%d live=%d parallel\n",
+                req.response_id.c_str(), api_format_name(req.format),
+                req.stream ? "true" : "false", req.prompt_tokens.size(),
+                req.max_output, live_slots);
+        }
+
+        // Commit the SSE preamble BEFORE the (multi-second) prefill so
+        // streaming clients see the 200 immediately — and so a dead client
+        // is detected before its prefill is paid for. The socket is fresh
+        // (nothing sent yet), so these few hundred bytes cannot stall.
+        // sse_started survives a busy deferral: retries do not resend.
+        if (!job->emitter) {
+            job->emitter = std::make_unique<SseEmitter>(
+                req.format, req.response_id, req.model,
+                (int)req.prompt_tokens.size(), req.tools, &tool_memory_,
+                req.stop_sequences, req.started_in_thinking);
+        }
+        if (req.stream && !job->sse_started) {
+            job->sse_started = true;
+            bool ok = send_sse_headers(job);
+            if (ok) {
+                for (const auto & c : job->emitter->emit_start()) {
+                    if (!send_job_bytes(job, c.data(), c.size())) {
+                        ok = false;
+                        break;
+                    }
+                }
+            }
+            if (!ok) {
+                finish_job(job);
+                return AdmissionDisposition::Retired;
+            }
+            start_job_stream(job);
+        }
+
+        // Admission only claims the slot and queues the prompt. Prefill
+        // advances one chunk per engine step alongside live decode.
+        auto ar = engine.admit(next_request_id, req.prompt_tokens,
+                               req.sampler);
+        if (ar.status == SeqEngine::AdmitResult::Status::busy)
+            return AdmissionDisposition::Deferred;
+        if (ar.status != SeqEngine::AdmitResult::Status::admitted) {
+            std::fprintf(stderr, "[server] admit failed: %s\n",
+                         ar.error.c_str());
+            if (req.stream && job->sse_started) {
+                stop_job_stream(job);
+                // Headers are already on the wire: report in-stream, like
+                // the classic worker's fail_request after SSE start.
+                for (const std::string & chunk : sse_error_close_chunks(
+                         "admission failed: " + ar.error)) {
+                    send_job_bytes(job, chunk.data(), chunk.size());
+                }
+            } else {
+                send_error(job->fd, 500, "admission failed: " + ar.error);
+            }
+            finish_job(job);
+            return AdmissionDisposition::Retired;
+        }
+        next_request_id++;
+
+        SchedSlot & s = slots[(size_t)ar.slot];
+        s = SchedSlot{};
+        s.job = job;
+        s.fd = job->fd;
+        s.prefilling = true;
+        s.admission_order = next_admission_order++;
+        s.started_at = started_at;
+        s.decode_started_at = started_at;  // sane on prefill failure
+        s.n_gen_cap = std::min(
+            n_gen_cap,
+            engine.max_context() - (int)req.prompt_tokens.size() + 1);
+        s.emitter = std::move(job->emitter);
+        s.send_buffer.mark_progress(std::chrono::steady_clock::now());
+        if (budget_active && !config_.think_close_token_ids.empty() &&
+            config_.hard_limit_reply_budget > 0) {
+            s.hook.close_token_ids = config_.think_close_token_ids;
+            s.hook.hard_limit_remaining = eff_reply_for_n_gen;
+        }
+        live_slots++;
+        publish_live_count();
+        return AdmissionDisposition::Admitted;
+    };
+
+    // Scheduler loop. Every iteration walks the same five phases:
+    //
+    //   1. Admit    — fill every available slot (deferred first, then the
+    //                 queue). Their prefills advance inside later steps.
+    //   2. Idle     — nothing live: service drains and loop back, where the
+    //                 admission phase parks in the blocking dequeue.
+    //   3. Step     — advance one pending prefill chunk alongside every
+    //                 decoding slot in one engine pass.
+    //   4. Flush    — non-blocking write of the buffered chunks; readers that
+    //                 stall or overflow their buffer are dropped.
+    //   5. Reap     — service drains, then retire whatever finished this
+    //                 iteration so its blocks are free for the next admit.
+    //
+    // Exits on stopping_ (checked after admission), leaving the teardown
+    // below to answer every client still parked in a slot, drain, or queue.
+    // Hoisted per-iteration buffers — capacity persists across iterations.
+    SeqEngine::StepPlan step_plan;
+    step_plan.decode.reserve((size_t)n_slots);
+    step_plan.prefills.reserve((size_t)n_slots);
+    std::vector<PrefillCandidate> prefill_candidates;
+    prefill_candidates.reserve((size_t)n_slots);
+    size_t prefill_round_robin_start = 0;
+
+    while (true) {
+        // Phase 1 — Admission: deferred job first (FIFO), then the queue.
+        // Blocking dequeue only when idle; between decode steps only a poll.
+        // Engines reject atomically when their current slot, staging, or
+        // reserved-capacity limit is reached, so policy stays model-neutral.
+        auto idle_admission_deadline =
+            std::chrono::steady_clock::time_point{};
+        while (live_slots < n_slots && !stopping_.load()) {
+            // A deferred job owns the front of the line, so nothing else may
+            // be admitted while its retry backoff is still running.
+            if (deferred &&
+                std::chrono::steady_clock::now() < deferred_retry_at) {
+                break;
+            }
+            // Retry the deferred job first; it was already queued ahead of
+            // everything still in the queue.
+            ServerJob * job = deferred;
+            deferred = nullptr;
+            bool woke_from_idle = false;
+            if (!job) {
+                if (live_slots == 0 && drains.empty()) {
+                    // Fully idle: no stream is waiting on us, so give the
+                    // scratch memory back and park in a blocking dequeue.
+                    publish_live_count();
+                    backend_.release_scratch();
+                    job = dequeue();
+                    woke_from_idle = job != nullptr;
+                } else {
+                    // A fresh idle transition may spend its bounded batching
+                    // window here; all ongoing decode paths only poll.
+                    const auto now = std::chrono::steady_clock::now();
+                    if (idle_admission_deadline > now) {
+                        job = dequeue_for(idle_admission_deadline - now);
+                        if (!job) idle_admission_deadline = {};
+                    } else {
+                        job = try_dequeue();
+                    }
+                }
+            }
+            if (!job) break;  // queue empty: go decode what is already live
+            if (job->client_disconnected.load(std::memory_order_acquire)) {
+                finish_job(job);
+                continue;
+            }
+            const AdmissionDisposition outcome = admit_job(job);
+            if (outcome == AdmissionDisposition::Deferred) {
+                deferred = job;
+                deferred_retry_at = std::chrono::steady_clock::now() +
+                                    std::chrono::seconds(1);
+                break;  // wait for a retire to free blocks
+            }
+            if (outcome == AdmissionDisposition::Admitted) {
+                if (woke_from_idle && n_slots > 1 &&
+                    config_.admission_coalesce_ms > 0) {
+                    idle_admission_deadline =
+                        std::chrono::steady_clock::now() +
+                        std::chrono::milliseconds(
+                            config_.admission_coalesce_ms);
+                }
+                continue;  // fill the remaining slots before step()
+            }
+        }
+        if (stopping_.load()) break;
+
+        // Phase 2 — Idle: no slot to step, so only the drains need service.
+        if (live_slots == 0) {
+            service_drains();
+            if (deferred) {
+                // A defensive busy response with no live sequence must not
+                // turn the worker into a tight retry loop. Real capacity
+                // releases clear deferred_retry_at in retire_slot().
+                const auto now = std::chrono::steady_clock::now();
+                if (deferred_retry_at > now) {
+                    std::this_thread::sleep_until(std::min(
+                        deferred_retry_at, now + std::chrono::milliseconds(5)));
+                }
+                continue;
+            }
+            if (!drains.empty()) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(5));
+                continue;             // keep draining; don't block in dequeue
+            }
+            continue;                 // dequeue() blocks in admission
+        }
+
+        // Retire cancellations before spending another model step.
+        for (int i = 0; i < n_slots; ++i) {
+            SchedSlot & s = slots[(size_t)i];
+            if (s.job && s.job->client_disconnected.load(
+                    std::memory_order_acquire)) {
+                s.client_disconnected = true;
+                s.finished = true;
+                retire_slot(i, true);
+            }
+        }
+        if (live_slots == 0) continue;
+
+        // Phase 3 — Build one model-neutral batch plan: every decode row plus
+        // a FIFO, engine-bounded subset of pending prompt work. The engine
+        // lowers this plan into whatever graph/state representation it owns.
+        step_plan.decode.clear();
+        prefill_candidates.clear();
+        for (int i = 0; i < n_slots; i++) {
+            if (slots[(size_t)i].job && !slots[(size_t)i].prefilling) {
+                step_plan.decode.push_back(
+                    {i, slots[(size_t)i].pending_tok});
+            } else if (slots[(size_t)i].job) {
+                prefill_candidates.push_back(
+                    {i, slots[(size_t)i].admission_order});
+            }
+        }
+        const StepPlanLimits step_limits =
+            engine.step_plan_limits((int)step_plan.decode.size());
+        step_plan.prefills = plan_prefill_slices(
+            prefill_candidates, step_limits, prefill_round_robin_start);
+        if (!prefill_candidates.empty()) {
+            ++prefill_round_robin_start;
+        }
+
+        SeqEngine::StepResult step_result = engine.step(step_plan);
+        const std::string protocol_error =
+            validate_step_result(step_plan, step_result, n_slots);
+        if (!protocol_error.empty()) {
+            step_result.decode.clear();
+            step_result.prefills.clear();
+            step_result.error =
+                "engine step protocol violation: " + protocol_error;
+        }
+
+        if (!step_result.ok()) {
+            const std::string & error = step_result.error;
+            std::fprintf(stderr,
+                "[parallel] engine step failed: %s — "
+                "failing all live requests\n", error.c_str());
+            for (int i = 0; i < n_slots; i++) {
+                if (slots[(size_t)i].job) {
+                    slots[(size_t)i].failed = true;
+                    slots[(size_t)i].error = error;
+                    retire_slot(i, false);
+                }
+            }
+            continue;
+        }
+        for (const auto & out : step_result.decode) {
+            if (out.slot < 0 || out.slot >= n_slots) continue;
+            SchedSlot & s = slots[(size_t)out.slot];
+            if (!s.job) continue;
+            if (out.failed) {
+                s.failed = true;
+                s.error = out.error;
+                s.finished = true;
+                continue;
+            }
+            advance_slot(s, out.token);
+        }
+        using PrefillStatus = SeqEngine::PrefillOutput::Status;
+        for (const auto & out : step_result.prefills) {
+            if (out.slot < 0 || out.slot >= n_slots) continue;
+            SchedSlot & s = slots[(size_t)out.slot];
+            if (!s.job) continue;
+            if (out.status == PrefillStatus::failed) {
+                s.failed = true;
+                s.error = out.error;
+                s.finished = true;
+                continue;
+            }
+            if (out.status == PrefillStatus::completed) {
+                s.prefilling = false;
+                publish_live_count();
+                // A prefill lane just became reusable, so the FIFO head may
+                // be admissible even though no KV blocks were retired.
+                deferred_retry_at = {};
+                s.decode_started_at = std::chrono::steady_clock::now();
+                s.prefill_s = std::chrono::duration<double>(
+                    s.decode_started_at - s.started_at).count();
+                advance_slot(s, out.token);
+                continue;
+            }
+        }
+        // Phase 4 — Non-blocking flush of every live slot's chunks. Progress
+        // resets the stall clock; a reader that makes no progress for 30 s
+        // or lets the buffer hit the cap is dropped (its slot retires).
+        {
+            const auto now = std::chrono::steady_clock::now();
+            for (int i = 0; i < n_slots; i++) {
+                SchedSlot & s = slots[(size_t)i];
+                if (!s.job || s.client_disconnected) continue;
+                if (!s.send_buffer.flush(s.fd)) {
+                    s.client_disconnected = true;
+                    s.finished = true;
+                    continue;
+                }
+                if (s.send_buffer.should_drop(now, kClientStallTimeout,
+                                              kMaxSlotSendBuffer)) {
+                    std::fprintf(stderr,
+                        "[parallel] slot %d client stalled — dropping stream\n", i);
+                    s.client_disconnected = true;
+                    s.finished = true;
+                }
+            }
+        }
+        // Phase 5 — Reap: finish the drains, then hand back the blocks of
+        // every slot that ended this iteration so the next admit can use them.
+        service_drains();
+        for (int i = 0; i < n_slots; i++) {
+            if (slots[(size_t)i].job && slots[(size_t)i].finished) {
+                retire_slot(i, true);
+            }
+        }
+    }
+
+    // Shutdown: unblock every parked client thread.
+    for (int i = 0; i < n_slots; i++) {
+        if (slots[(size_t)i].job) {
+            slots[(size_t)i].failed = true;
+            retire_slot(i, false);
+        }
+    }
+    service_drains();
+    for (DrainJob & d : drains) finish_job(d.job);
+    drains.clear();
+    if (deferred) {
+        // admit_job() sends the SSE headers and opening event before asking
+        // the engine for a slot, so a pool-full deferred stream is already
+        // live on the wire. Close that protocol cleanly on shutdown instead
+        // of waking the client thread and letting it truncate the response.
+        const ParsedRequest & req = deferred->req;
+        if (req.stream && deferred->sse_started) {
+            for (const std::string & chunk :
+                 sse_error_close_chunks("server shutting down")) {
+                send_all(deferred->fd, chunk.data(), chunk.size());
+            }
+        } else {
+            send_error(deferred->fd, 503, "server shutting down");
+        }
+        finish_job(deferred);
+    }
+    // Jobs that never reached admission are still parked in their client
+    // threads too. Drain the raw queue before returning so run() does not hit
+    // its client-shutdown timeout and the destructor never has to wake threads
+    // after the server/backend teardown has already started.
+    while (ServerJob * queued = try_dequeue()) {
+        send_error(queued->fd, 503, "server shutting down");
+        finish_job(queued);
+    }
+}
+
+
+}  // namespace dflash::common

--- a/server/src/server/server_main.cpp
+++ b/server/src/server/server_main.cpp
@@ -24,8 +24,10 @@
 #include "common/peer_access.h"
 #include "placement/pflash_placement.h"
 #include "placement/draft_residency.h"
+#include "kvflash_pager.h"
 
 #include <algorithm>
+#include <charconv>
 #include <csignal>
 #include <cstdio>
 #include <cstdlib>
@@ -106,6 +108,13 @@ static void print_usage(const char * prog) {
         "                       from attention at long contexts. Use 0 for tools.\n"
         "  --paged-attention   Use 16-token paged KV blocks for Qwen3.6-27B\n"
         "                       autoregressive decode (experimental)\n"
+        "  --max-concurrency <N>  Maximum concurrent decode sequences\n"
+        "                         (enables paged attention; default: 1)\n"
+        "  --admission-coalesce-ms <N>  Idle-to-busy batching window\n"
+        "                               (default: 20; 0 disables)\n"
+        "  --kv-pool-tokens <N> Total paged K/V pool shared by all\n"
+        "                       --max-concurrency slots, in tokens\n"
+        "                       (default: sized from available device memory)\n"
         "  --model-name <name>  Model name for /v1/models (default: dflash)\n"
         "  --prefix-cache-slots <N>  Prefix cache slots (default: 32, 0 disables)\n"
         "  --prefill-cache-slots <N> Full prompt/prefill cache slots (default: 0)\n"
@@ -353,6 +362,43 @@ int main(int argc, char ** argv) {
             bargs.fa_window = std::atoi(argv[++i]);
         } else if (std::strcmp(argv[i], "--paged-attention") == 0) {
             bargs.paged_attention = true;
+        } else if (std::strcmp(argv[i], "--max-concurrency") == 0 && i + 1 < argc) {
+            const char * value = argv[++i];
+            const char * end = value + std::strlen(value);
+            const auto parsed = std::from_chars(
+                value, end, bargs.max_concurrency);
+            if (parsed.ec != std::errc{} || parsed.ptr != end) {
+                std::fprintf(stderr,
+                    "[server] --max-concurrency must be an integer\n");
+                return 2;
+            }
+        } else if (std::strcmp(argv[i], "--admission-coalesce-ms") == 0 &&
+                   i + 1 < argc) {
+            const char * value = argv[++i];
+            const char * end = value + std::strlen(value);
+            const auto parsed = std::from_chars(
+                value, end, sconfig.admission_coalesce_ms);
+            if (parsed.ec != std::errc{} || parsed.ptr != end) {
+                std::fprintf(stderr,
+                    "[server] --admission-coalesce-ms must be an integer\n");
+                return 2;
+            }
+            if (sconfig.admission_coalesce_ms < 0 ||
+                sconfig.admission_coalesce_ms > 1000) {
+                std::fprintf(stderr,
+                    "[server] --admission-coalesce-ms must be in [0,1000]\n");
+                return 2;
+            }
+        } else if (std::strcmp(argv[i], "--kv-pool-tokens") == 0 && i + 1 < argc) {
+            const char * value = argv[++i];
+            const char * end = value + std::strlen(value);
+            const auto parsed = std::from_chars(
+                value, end, bargs.kv_pool_tokens);
+            if (parsed.ec != std::errc{} || parsed.ptr != end) {
+                std::fprintf(stderr,
+                    "[server] --kv-pool-tokens must be an integer\n");
+                return 2;
+            }
         } else if (std::strcmp(argv[i], "--model-name") == 0 && i + 1 < argc) {
             sconfig.model_name = argv[++i];
         } else if (std::strcmp(argv[i], "--prefix-cache-slots") == 0 && i + 1 < argc) {
@@ -602,6 +648,13 @@ int main(int argc, char ** argv) {
         }
     }
 
+    // Concurrent serving is implemented by the paged engine, so one user-facing
+    // concurrency flag selects the complete serving mode. Keep the feature gate
+    // strict for non-CLI callers that construct BackendArgs directly.
+    if (bargs.max_concurrency > 1) {
+        bargs.paged_attention = true;
+    }
+
     // Ask the factory to resolve model/placement facts and apply its feature
     // admission policy before any setup work. server_main only maps the
     // categorized result to the existing process exit convention.
@@ -613,6 +666,11 @@ int main(int argc, char ** argv) {
     backend_features.routing_stats_requested =
         sconfig.freq_tracking || !sconfig.collect_routing_path.empty();
     backend_features.adaptive_experts_requested = adaptive_experts_set;
+    // Fixed pools are known incompatibilities before model setup. Automatic
+    // sizing needs the backend's real VRAM budget; if it produces a live pool,
+    // the backend rejects the pairing after sizing.
+    backend_features.kvflash_enabled =
+        kvflash_fixed_pool_requested(std::getenv("DFLASH_KVFLASH"));
     const BackendPreparation backend_preparation =
         prepare_backend(bargs, backend_features);
     if (!backend_preparation.ok()) {
@@ -1029,6 +1087,8 @@ int main(int argc, char ** argv) {
     std::fprintf(stderr, "[server] │  peer_access     = %s\n",
                  bargs.device.peer_access ? "ON" : "off");
     std::fprintf(stderr, "[server] │  chunk           = %d\n", bargs.chunk);
+    std::fprintf(stderr, "[server] │  admission_wait  = %d ms\n",
+                 sconfig.admission_coalesce_ms);
     if (arch == "deepseek4") {
         std::fprintf(stderr, "[server] │  ds4_fused      = %s\n",
                      bargs.ds4_fused_decode ? "ON" : "off");

--- a/server/src/server/server_status.h
+++ b/server/src/server/server_status.h
@@ -10,6 +10,7 @@
 #include <chrono>
 #include <functional>
 #include <mutex>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -35,6 +36,7 @@ enum class InferencePhase {
     IDLE,
     PREFILL,
     DECODE,
+    MIXED,
 };
 
 static inline const char * phase_name(InferencePhase p) {
@@ -42,6 +44,7 @@ static inline const char * phase_name(InferencePhase p) {
     case InferencePhase::IDLE:    return "idle";
     case InferencePhase::PREFILL: return "prefill";
     case InferencePhase::DECODE:  return "decode";
+    case InferencePhase::MIXED:   return "mixed";
     default:                      return "unknown";
     }
 }
@@ -67,6 +70,7 @@ public:
                      bool is_stream, const RequestInfo & info) {
         std::lock_guard<std::mutex> lk(mu_);
         phase_ = InferencePhase::PREFILL;
+        active_requests_ = 0;
         prompt_excerpt_ = prompt_excerpt;
         prompt_tokens_ = prompt_tokens;
         completion_tokens_ = 0;
@@ -109,6 +113,27 @@ public:
     void set_idle() {
         std::lock_guard<std::mutex> lk(mu_);
         phase_ = InferencePhase::IDLE;
+        active_requests_ = 0;
+        prompt_excerpt_.clear();
+        draft_tokens_.clear();
+    }
+
+    // Concurrent serving intentionally exposes only aggregate live state.
+    // A single request record/token feed cannot represent multiple slots
+    // without mixing unrelated requests.
+    void set_concurrent_requests(int n, int prefilling) {
+        std::lock_guard<std::mutex> lk(mu_);
+        if (n < 0 || prefilling < 0 || prefilling > n) {
+            throw std::invalid_argument("invalid concurrent request counts");
+        }
+        if (active_requests_ == 0 && n > 0) {
+            started_at_ = std::chrono::steady_clock::now();
+        }
+        active_requests_ = n;
+        phase_ = n == 0 ? InferencePhase::IDLE
+               : prefilling == n ? InferencePhase::PREFILL
+               : prefilling == 0 ? InferencePhase::DECODE
+                                 : InferencePhase::MIXED;
         prompt_excerpt_.clear();
         draft_tokens_.clear();
     }
@@ -136,6 +161,7 @@ public:
         RequestInfo info;
         bool cache_hit = false, pflash = false, spec_decode = false;
         std::string messages_json;
+        int active_requests = 0;
 
         {
             std::lock_guard<std::mutex> lk(mu_);
@@ -152,6 +178,7 @@ public:
             pflash = pflash_;
             spec_decode = spec_decode_;
             messages_json = messages_json_;
+            active_requests = active_requests_;
             if (phase != InferencePhase::IDLE) {
                 elapsed_s = std::chrono::duration<double>(
                     std::chrono::steady_clock::now() - started_at_).count();
@@ -161,8 +188,9 @@ public:
         json j;
         j["phase"] = phase_name(phase);
         j["total_requests"] = total_requests;
+        j["active_requests"] = active_requests;
 
-        if (phase != InferencePhase::IDLE) {
+        if (phase != InferencePhase::IDLE && active_requests == 0) {
             j["current"] = {
                 {"prompt_excerpt", prompt_excerpt},
                 {"prompt_tokens", prompt_tokens},
@@ -226,6 +254,7 @@ private:
     bool pflash_ = false;
     bool spec_decode_ = false;
     std::string messages_json_;
+    int active_requests_ = 0;
 
     // History.
     std::vector<PerfRecord> perf_history_;

--- a/server/src/server/tool_memory.cpp
+++ b/server/src/server/tool_memory.cpp
@@ -14,6 +14,7 @@ ToolMemory::ToolMemory(size_t max_entries, size_t max_bytes)
 void ToolMemory::remember(const std::vector<std::string> & call_ids,
                           const std::string & raw_text) {
     if (disabled() || raw_text.empty()) return;
+    std::lock_guard<std::mutex> lk(mu_);
 
     // Deduplicate call_ids
     std::vector<std::string> unique_ids;
@@ -58,6 +59,7 @@ void ToolMemory::remember(const std::vector<std::string> & call_ids,
 }
 
 std::string ToolMemory::lookup(const std::vector<std::string> & call_ids) {
+    std::lock_guard<std::mutex> lk(mu_);
     std::string result_text;
     bool first = true;
 

--- a/server/src/server/tool_memory.h
+++ b/server/src/server/tool_memory.h
@@ -10,12 +10,16 @@
 
 #include <cstddef>
 #include <list>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
 namespace dflash::common {
 
+// Thread-safe: lookup() is called from HTTP client threads during request
+// parsing while the worker/scheduler thread calls remember() at stream
+// finish, and lookup() mutates the LRU. One mutex covers both.
 class ToolMemory {
 public:
     explicit ToolMemory(size_t max_entries = 50000,
@@ -40,10 +44,12 @@ public:
         size_t current_bytes;
     };
     Stats stats() const {
+        std::lock_guard<std::mutex> lk(mu_);
         return {max_entries_, max_bytes_, by_id_.size(), total_bytes_};
     }
 
 private:
+    mutable std::mutex mu_;
     struct Block {
         size_t      size_bytes;
         size_t      refs = 0;

--- a/server/test/bench_paged_attention.cpp
+++ b/server/test/bench_paged_attention.cpp
@@ -722,9 +722,10 @@ bool run_case(
     }
     if (padding_mask) ggml_set_input(padding_mask);
 
-    ggml_tensor * paged_output = ggml_paged_attn(
+    ggml_tensor * paged_output = ggml_paged_attn_ext(
         ctx.value, q_paged, k_paged, v_paged, table, kv_seq_lens_tensor,
-        1.0f / std::sqrt(static_cast<float>(D)), BLOCK_SIZE, max_context);
+        nullptr, 1.0f / std::sqrt(static_cast<float>(D)), BLOCK_SIZE,
+        max_context);
     ggml_tensor * contiguous_output = ggml_flash_attn_ext(
         ctx.value, q_contiguous, k_contiguous, v_contiguous,
         padding_mask, 1.0f / std::sqrt(static_cast<float>(D)),

--- a/server/test/host_check.h
+++ b/server/test/host_check.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <cstdio>
+#include <cstdlib>
+
+#define CHECK(cond)                                                          \
+    do {                                                                     \
+        g_checks++;                                                          \
+        if (!(cond)) {                                                       \
+            std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__,     \
+                         #cond);                                             \
+            std::exit(1);                                                    \
+        }                                                                    \
+    } while (0)

--- a/server/test/seq_engine_contract.h
+++ b/server/test/seq_engine_contract.h
@@ -1,0 +1,349 @@
+// Host-side executable contract for common/concurrency/seq_engine.h.
+//
+// The checker deliberately knows only logical slots, decode inputs, and
+// scheduler-selected prefill slices. It exercises the largest useful cohort
+// up to two sequences allowed by the advertised limits, mixed
+// decode/prefill, validation failures, retryable blocking, and slot reuse
+// without importing a model graph or cache representation.
+
+#pragma once
+
+#include "common/concurrency/seq_engine.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace dflash::common {
+
+inline std::vector<std::string> check_seq_engine_contract(SeqEngine & engine) {
+    std::vector<std::string> violations;
+    auto require = [&violations](bool ok, const char * message) {
+        if (!ok) violations.emplace_back(message);
+    };
+
+    const int n_slots = engine.slot_count();
+    require(n_slots >= 2,
+            "slot_count() must be at least 2 for the concurrency contract");
+    if (n_slots < 2) return violations;
+
+    const StepPlanLimits idle_limits = engine.step_plan_limits(0);
+    const StepPlanLimits mixed_limits = engine.step_plan_limits(1);
+    const auto supports_one_prefill = [](const StepPlanLimits & limits) {
+        return limits.max_prefill_sequences >= 1 &&
+               limits.max_prefill_tokens_per_sequence >= 1 &&
+               limits.max_prefill_tokens_total >= 1 &&
+               limits.prefill_allocation_quantum >= 1;
+    };
+    require(supports_one_prefill(idle_limits),
+            "idle step_plan_limits() must permit one prefill token");
+    require(supports_one_prefill(mixed_limits),
+            "mixed step_plan_limits() must permit one prefill token");
+    require(engine.max_context() >= 3,
+            "max_context() must fit the contract-check prompts");
+    if (!supports_one_prefill(idle_limits) ||
+        !supports_one_prefill(mixed_limits) || engine.max_context() < 3) {
+        return violations;
+    }
+
+    // Exercise at most two concurrent prefills, but never infer K=2 support
+    // from slot_count(): sequence count and the total-token cap are separate
+    // engine capabilities.
+    const int idle_cohort_size = std::min({
+        2,
+        n_slots,
+        idle_limits.max_prefill_sequences,
+        idle_limits.max_prefill_tokens_total,
+    });
+
+    const SamplerCfg greedy{};
+    SamplerCfg seeded{};
+    seeded.temp = 0.7f;
+    seeded.seed = 20260809;
+
+    std::vector<bool> active((size_t)n_slots, false);
+    std::vector<bool> decoding((size_t)n_slots, false);
+    std::vector<int> remaining((size_t)n_slots, 0);
+    std::vector<int32_t> next_token((size_t)n_slots, -1);
+
+    auto retire_all = [&]() {
+        for (int slot = 0; slot < n_slots; ++slot) {
+            if (active[(size_t)slot]) engine.retire(slot);
+            active[(size_t)slot] = false;
+            decoding[(size_t)slot] = false;
+            remaining[(size_t)slot] = 0;
+        }
+    };
+
+    auto record_admit = [&](uint64_t request_id,
+                            const std::vector<int32_t> & prompt,
+                            const SamplerCfg & sampler) {
+        const SeqEngine::AdmitResult result =
+            engine.admit(request_id, prompt, sampler);
+        const bool admitted =
+            result.status == SeqEngine::AdmitResult::Status::admitted;
+        require(admitted, "admit() must succeed while a slot is free");
+        if (!admitted) return -1;
+        require(result.slot >= 0 && result.slot < n_slots,
+                "admit() returned an unknown slot");
+        if (result.slot < 0 || result.slot >= n_slots) return -1;
+        require(!active[(size_t)result.slot],
+                "admit() reused a live slot");
+        if (active[(size_t)result.slot]) return -1;
+        active[(size_t)result.slot] = true;
+        decoding[(size_t)result.slot] = false;
+        remaining[(size_t)result.slot] = (int)prompt.size();
+        return result.slot;
+    };
+
+    auto slice_limit = [&](const SeqEngine::StepPlan & plan) {
+        return engine.step_plan_limits((int)plan.decode.size())
+            .max_prefill_tokens_per_sequence;
+    };
+
+    // Validate and apply one successful logical step to the checker mirror.
+    // Contract prefills below request one token at a time, so advanced means
+    // exactly one prompt token without reintroducing a progress counter.
+    auto apply_progress = [&](const SeqEngine::StepPlan & plan,
+                              const SeqEngine::StepResult & result) {
+        const std::string protocol_error =
+            validate_step_result(plan, result, n_slots);
+        if (!protocol_error.empty()) {
+            violations.emplace_back(protocol_error);
+            return false;
+        }
+        require(result.ok(), "valid planned work must succeed");
+        if (!result.ok()) return false;
+
+        std::vector<bool> decode_answered((size_t)n_slots, false);
+        std::vector<bool> prefill_answered((size_t)n_slots, false);
+
+        for (const SeqEngine::DecodeOutput & output : result.decode) {
+            require(!output.failed,
+                    "contract-check decode work must not fail");
+            if (output.slot < 0 || output.slot >= n_slots ||
+                output.failed) {
+                continue;
+            }
+            decode_answered[(size_t)output.slot] = true;
+            next_token[(size_t)output.slot] = output.token;
+        }
+
+        using PrefillStatus = SeqEngine::PrefillOutput::Status;
+        for (const SeqEngine::PrefillOutput & output : result.prefills) {
+            require(output.status != PrefillStatus::failed,
+                    "contract-check prefill work must not fail");
+            if (output.slot < 0 || output.slot >= n_slots ||
+                output.status == PrefillStatus::failed) {
+                continue;
+            }
+            auto selected = std::find_if(
+                plan.prefills.begin(), plan.prefills.end(),
+                [&](const PrefillSlice & slice) {
+                    return slice.slot == output.slot;
+                });
+            if (selected == plan.prefills.end()) continue;
+            require(selected->max_tokens == 1,
+                    "contract checker must use unit prefill slices");
+            prefill_answered[(size_t)output.slot] = true;
+            if (output.status == PrefillStatus::advanced) {
+                require(remaining[(size_t)output.slot] > 1,
+                        "prefill reported advanced for its final token");
+                --remaining[(size_t)output.slot];
+            } else {
+                require(remaining[(size_t)output.slot] == 1,
+                        "prefill reported completion before its final token");
+                remaining[(size_t)output.slot] = 0;
+                decoding[(size_t)output.slot] = true;
+                next_token[(size_t)output.slot] = output.token;
+            }
+        }
+
+        for (const SeqEngine::StepInput & input : plan.decode) {
+            if (input.slot >= 0 && input.slot < n_slots) {
+                require(decode_answered[(size_t)input.slot],
+                        "step() left a decoding slot without an output");
+            }
+        }
+        for (const PrefillSlice & slice : plan.prefills) {
+            require(slice.max_tokens > 0 &&
+                        slice.max_tokens <= slice_limit(plan),
+                    "StepPlan prefill slice exceeded engine limits");
+            if (slice.slot >= 0 && slice.slot < n_slots) {
+                require(prefill_answered[(size_t)slice.slot],
+                        "step() left a selected prefill without an output");
+            }
+        }
+        return true;
+    };
+
+    auto execute = [&](const SeqEngine::StepPlan & plan) {
+        return apply_progress(plan, engine.step(plan));
+    };
+
+    auto decode_inputs = [&]() {
+        std::vector<SeqEngine::StepInput> inputs;
+        for (int slot = 0; slot < n_slots; ++slot) {
+            if (active[(size_t)slot] && decoding[(size_t)slot]) {
+                inputs.push_back({slot, next_token[(size_t)slot]});
+            }
+        }
+        return inputs;
+    };
+
+    // Admit the long prompt in the same idle cohort only when the engine can
+    // actually execute two slices. K=1 engines admit it after the short
+    // prompt releases its staging resource, then exercise the same mixed path.
+    const int short_slot = record_admit(1, {11}, greedy);
+    int long_slot = -1;
+    if (idle_cohort_size >= 2) {
+        long_slot = record_admit(2, {21, 22, 23}, seeded);
+    }
+    if (short_slot < 0 || (idle_cohort_size >= 2 && long_slot < 0)) {
+        retire_all();
+        return violations;
+    }
+    if (long_slot >= 0) {
+        require(short_slot != long_slot,
+                "two pending admissions must own distinct slots");
+    }
+
+    SeqEngine::StepPlan first_plan;
+    first_plan.prefills.push_back({short_slot, 1});
+    if (long_slot >= 0) {
+        first_plan.prefills.push_back({long_slot, 1});
+    }
+    if (!execute(first_plan)) {
+        retire_all();
+        return violations;
+    }
+    require(decoding[(size_t)short_slot],
+            "the short prefill must complete in its selected slice");
+
+    if (long_slot < 0) {
+        long_slot = record_admit(2, {21, 22, 23}, seeded);
+        if (long_slot < 0) {
+            retire_all();
+            return violations;
+        }
+    }
+    require(!decoding[(size_t)long_slot] &&
+                remaining[(size_t)long_slot] > 0,
+            "long member must remain pending after the short member completes");
+
+    for (int iteration = 0;
+         remaining[(size_t)long_slot] > 0 && iteration < 8;
+         ++iteration) {
+        SeqEngine::StepPlan mixed;
+        mixed.decode = decode_inputs();
+        const StepPlanLimits limits =
+            engine.step_plan_limits((int)mixed.decode.size());
+        require(supports_one_prefill(limits),
+                "mixed step_plan_limits() must permit continued prefill");
+        if (!supports_one_prefill(limits)) break;
+        mixed.prefills.push_back({long_slot, 1});
+        if (!execute(mixed)) break;
+    }
+    require(remaining[(size_t)long_slot] == 0,
+            "mixed prefill did not complete within bounded progress steps");
+
+    // Full decode coverage, including the token handoff back into the engine.
+    SeqEngine::StepPlan decode_plan;
+    decode_plan.decode = decode_inputs();
+    require(decode_plan.decode.size() == 2,
+            "both completed admissions must enter decode");
+    if (!execute(decode_plan)) {
+        retire_all();
+        return violations;
+    }
+
+    // A full engine is retryable admission pressure, not a request error.
+    if (n_slots == 2) {
+        const SeqEngine::AdmitResult full = engine.admit(3, {31}, greedy);
+        require(full.status == SeqEngine::AdmitResult::Status::busy &&
+                    full.slot < 0,
+                "a full engine must report busy without claiming a slot");
+    }
+
+    // Omitting a decoder or attaching prefill work to a decoding slot is a
+    // terminal plan-validation failure and must not partially advance state.
+    auto require_failed = [&](const SeqEngine::StepPlan & invalid,
+                              const char * message) {
+        const SeqEngine::StepResult result = engine.step(invalid);
+        require(!result.ok(), message);
+        require(!result.error.empty(),
+                "failed step must explain the validation error");
+        require(result.decode.empty() && result.prefills.empty(),
+                "failed step must not report partial progress");
+    };
+
+    SeqEngine::StepPlan omitted;
+    omitted.decode.push_back(decode_plan.decode.front());
+    require_failed(omitted,
+                   "step() must reject a plan that omits a decoding slot");
+
+    SeqEngine::StepPlan invalid_prefill = decode_plan;
+    invalid_prefill.prefills.push_back({short_slot, 1});
+    require_failed(invalid_prefill,
+                   "step() must reject prefill work for a decoding slot");
+
+    // Start fresh and complete the advertised idle cohort in one step. When
+    // K=2 is available, this still catches engines that accidentally retain a
+    // scalar completion/output path.
+    retire_all();
+    const int simultaneous_a = record_admit(10, {41}, greedy);
+    int simultaneous_b = -1;
+    if (idle_cohort_size >= 2) {
+        simultaneous_b = record_admit(11, {51}, seeded);
+    }
+    if (simultaneous_a >= 0 &&
+        (idle_cohort_size < 2 || simultaneous_b >= 0)) {
+        SeqEngine::StepPlan simultaneous;
+        simultaneous.prefills.push_back({simultaneous_a, 1});
+        if (simultaneous_b >= 0) {
+            simultaneous.prefills.push_back({simultaneous_b, 1});
+        }
+        execute(simultaneous);
+        require(decoding[(size_t)simultaneous_a],
+                "selected prefill must report completion");
+        if (simultaneous_b >= 0) {
+            require(decoding[(size_t)simultaneous_b],
+                    "one K=2 step must report simultaneous completions");
+        }
+    }
+
+    // Retire is idempotent, frees capacity, and cancels unfinished prefill.
+    const int freed = simultaneous_a;
+    if (freed >= 0) {
+        engine.retire(freed);
+        engine.retire(freed);
+        active[(size_t)freed] = false;
+        decoding[(size_t)freed] = false;
+        const int replacement = record_admit(12, {61, 62}, greedy);
+        require(replacement >= 0,
+                "admit() must reuse capacity after retire()");
+        if (replacement >= 0) {
+            engine.retire(replacement);
+            engine.retire(replacement);
+            active[(size_t)replacement] = false;
+            decoding[(size_t)replacement] = false;
+            remaining[(size_t)replacement] = 0;
+        }
+    }
+
+    retire_all();
+    const SeqEngine::StepResult idle = engine.step({});
+    require(idle.ok(), "step() with no work must succeed");
+    require(idle.decode.empty() && idle.prefills.empty() &&
+                idle.error.empty(),
+            "idle result must not retain work or errors");
+
+    const int reused = record_admit(13, {71}, greedy);
+    require(reused >= 0,
+            "an engine must admit again after every slot retires");
+    retire_all();
+    return violations;
+}
+
+}  // namespace dflash::common

--- a/server/test/test_batched_gdn.cpp
+++ b/server/test/test_batched_gdn.cpp
@@ -1,0 +1,536 @@
+// Batched-decode correctness foundation: proves the n_seqs batch axis of
+// ggml_gated_delta_net and ggml_ssm_conv is exactly equivalent to running
+// each sequence independently. The concurrent serving path (--max-concurrency N)
+// relies on this: it stacks N single-token decodes on the n_seqs axis of
+// both ops with per-slot state slabs, so any cross-sequence leakage or
+// stride bug here would silently corrupt every parallel stream.
+#include "ggml.h"
+#include "ggml-alloc.h"
+#include "ggml-backend.h"
+#include "ggml-cpu.h"
+#include "ggml-cuda.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <random>
+#include <vector>
+
+namespace {
+
+// qwen35-like shapes scaled down. S_V doubles as head_k_dim: the fused GDN
+// kernel reads q/k rows with the S_v extent, and 32 is a supported kernel
+// specialization (16/32/64/128).
+constexpr int S_V = 32;
+constexpr int N_HEAD = 4;
+constexpr int N_SEQS = 4;
+constexpr int D_CONV = 4;
+// CUDA ssm_conv launches 128-thread blocks and asserts channels % 128 == 0.
+constexpr int CONV_CHANNELS = 128;
+constexpr int N_STEPS = 3;
+constexpr float MAX_ABS_ERROR = 1.0e-5f;
+
+// Single-token decode: n_tokens == 1, so each sequence's slice of every
+// contiguous [.., n_tokens, n_seqs] host buffer is one contiguous chunk.
+constexpr size_t GDN_QKV_PER_SEQ = static_cast<size_t>(S_V) * N_HEAD;
+constexpr size_t GDN_GATE_PER_SEQ = N_HEAD;
+constexpr size_t GDN_STATE_PER_SEQ = static_cast<size_t>(S_V) * S_V * N_HEAD;
+constexpr size_t CONV_IN_PER_SEQ =
+    static_cast<size_t>(D_CONV) * CONV_CHANNELS;  // (d_conv-1) history + 1 token
+constexpr size_t CONV_HIST_PER_SEQ =
+    static_cast<size_t>(D_CONV - 1) * CONV_CHANNELS;
+constexpr size_t CONV_OUT_PER_SEQ = CONV_CHANNELS;
+constexpr size_t CONV_WEIGHT_ELEMS = static_cast<size_t>(D_CONV) * CONV_CHANNELS;
+
+bool check(const char * name, const float * batched, const float * reference,
+           size_t count);
+
+void fill_uniform(std::mt19937 & rng, float lo, float hi,
+                  std::vector<float> & values) {
+    std::uniform_real_distribution<float> dist(lo, hi);
+    for (float & value : values) value = dist(rng);
+}
+
+// One fused GDN decode step over n_seqs sequences (n_tokens == 1 each).
+// Reads the packed result: attn [S_V*N_HEAD per seq] followed by the final
+// state [S_V*S_V*N_HEAD per seq] — the same regions the backend slices.
+bool run_gdn(ggml_backend_t backend, int n_seqs,
+             const float * q, const float * k, const float * v,
+             const float * g, const float * beta, const float * state,
+             float * attn_out, float * state_out,
+             bool inplace = false,
+             const int32_t * active_slot_ids = nullptr,
+             int physical_slots = 0,
+             float * scratch_state_out = nullptr) {
+    if (physical_slots == 0) physical_slots = n_seqs;
+    if (physical_slots < 1 ||
+        (!active_slot_ids && physical_slots != n_seqs)) {
+        return false;
+    }
+    ggml_init_params params{};
+    params.mem_size = 4 * 1024 * 1024;
+    params.no_alloc = true;
+    ggml_context * ctx = ggml_init(params);
+    if (!ctx) return false;
+
+    ggml_tensor * q_t =
+        ggml_new_tensor_4d(ctx, GGML_TYPE_F32, S_V, N_HEAD, 1, n_seqs);
+    ggml_tensor * k_t =
+        ggml_new_tensor_4d(ctx, GGML_TYPE_F32, S_V, N_HEAD, 1, n_seqs);
+    ggml_tensor * v_t =
+        ggml_new_tensor_4d(ctx, GGML_TYPE_F32, S_V, N_HEAD, 1, n_seqs);
+    ggml_tensor * g_t =
+        ggml_new_tensor_4d(ctx, GGML_TYPE_F32, 1, N_HEAD, 1, n_seqs);
+    ggml_tensor * beta_t =
+        ggml_new_tensor_4d(ctx, GGML_TYPE_F32, 1, N_HEAD, 1, n_seqs);
+    ggml_tensor * state_t = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F32, S_V, S_V, N_HEAD, physical_slots);
+    for (ggml_tensor * input : {q_t, k_t, v_t, g_t, beta_t, state_t}) {
+        ggml_set_input(input);
+    }
+    ggml_tensor * active_t = nullptr;
+    if (active_slot_ids) {
+        active_t = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, n_seqs);
+        ggml_set_input(active_t);
+    }
+
+    ggml_tensor * result = active_t
+        ? ggml_gated_delta_net_active_inplace(
+              ctx, q_t, k_t, v_t, g_t, beta_t, state_t, active_t)
+        : inplace
+            ? ggml_gated_delta_net_inplace(
+                  ctx, q_t, k_t, v_t, g_t, beta_t, state_t)
+            : ggml_gated_delta_net(
+                  ctx, q_t, k_t, v_t, g_t, beta_t, state_t);
+    // Decode path compacts the result to [attn | final_state], exactly like
+    // build_delta_net_block with skip_gdn_intermediate.
+    ggml_gated_delta_net_set_skip_intermediate(result, true);
+    const bool state_inplace = inplace || active_t;
+    // Active-slot mode writes persistent state in place, but its result keeps
+    // one state-sized scratch region per batch row for negative padding ids.
+    const bool result_has_state = !inplace || active_t;
+    const size_t expected_result_elems =
+        (GDN_QKV_PER_SEQ + (result_has_state ? GDN_STATE_PER_SEQ : 0)) *
+        n_seqs;
+    if (ggml_nelements(result) != expected_result_elems) {
+        std::fprintf(stderr,
+                     "batched gdn: %s result has %zu elements, expected %zu\n",
+                     state_inplace ? "in-place" : "packed",
+                     static_cast<size_t>(ggml_nelements(result)),
+                     expected_result_elems);
+        ggml_free(ctx);
+        return false;
+    }
+    ggml_set_output(result);
+
+    ggml_cgraph * graph = ggml_new_graph(ctx);
+    ggml_build_forward_expand(graph, result);
+
+    ggml_gallocr_t allocator =
+        ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend));
+    bool ok = ggml_gallocr_alloc_graph(allocator, graph);
+    if (ok) {
+        const size_t qkv_bytes = GDN_QKV_PER_SEQ * n_seqs * sizeof(float);
+        const size_t gate_bytes = GDN_GATE_PER_SEQ * n_seqs * sizeof(float);
+        const size_t state_bytes =
+            GDN_STATE_PER_SEQ * physical_slots * sizeof(float);
+        ggml_backend_tensor_set(q_t, q, 0, qkv_bytes);
+        ggml_backend_tensor_set(k_t, k, 0, qkv_bytes);
+        ggml_backend_tensor_set(v_t, v, 0, qkv_bytes);
+        ggml_backend_tensor_set(g_t, g, 0, gate_bytes);
+        ggml_backend_tensor_set(beta_t, beta, 0, gate_bytes);
+        ggml_backend_tensor_set(state_t, state, 0, state_bytes);
+        if (active_t) {
+            ggml_backend_tensor_set(active_t, active_slot_ids, 0,
+                                    n_seqs * sizeof(active_slot_ids[0]));
+        }
+        ok = ggml_backend_graph_compute(backend, graph) == GGML_STATUS_SUCCESS;
+        if (ok) {
+            const size_t attn_bytes = GDN_QKV_PER_SEQ * n_seqs * sizeof(float);
+            ggml_backend_tensor_get(result, attn_out, 0, attn_bytes);
+            if (state_inplace) {
+                ggml_backend_tensor_get(state_t, state_out, 0, state_bytes);
+            } else {
+                ggml_backend_tensor_get(
+                    result, state_out, attn_bytes, state_bytes);
+            }
+            if (scratch_state_out) {
+                ggml_backend_tensor_get(
+                    result, scratch_state_out, attn_bytes,
+                    GDN_STATE_PER_SEQ * n_seqs * sizeof(float));
+            }
+        }
+    }
+    ggml_gallocr_free(allocator);
+    ggml_free(ctx);
+    return ok;
+}
+
+// One ssm_conv step: sx [d_conv-1 + 1, channels, n_seqs] against shared
+// [d_conv, channels] weights, producing [channels, 1, n_seqs].
+bool run_conv(ggml_backend_t backend, int n_seqs,
+              const float * sx, const float * weights, float * out) {
+    ggml_init_params params{};
+    params.mem_size = 4 * 1024 * 1024;
+    params.no_alloc = true;
+    ggml_context * ctx = ggml_init(params);
+    if (!ctx) return false;
+
+    ggml_tensor * sx_t =
+        ggml_new_tensor_3d(ctx, GGML_TYPE_F32, D_CONV, CONV_CHANNELS, n_seqs);
+    ggml_tensor * w_t =
+        ggml_new_tensor_2d(ctx, GGML_TYPE_F32, D_CONV, CONV_CHANNELS);
+    for (ggml_tensor * input : {sx_t, w_t}) {
+        ggml_set_input(input);
+    }
+
+    ggml_tensor * result = ggml_ssm_conv(ctx, sx_t, w_t);
+    ggml_set_output(result);
+
+    ggml_cgraph * graph = ggml_new_graph(ctx);
+    ggml_build_forward_expand(graph, result);
+
+    ggml_gallocr_t allocator =
+        ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend));
+    bool ok = ggml_gallocr_alloc_graph(allocator, graph);
+    if (ok) {
+        ggml_backend_tensor_set(sx_t, sx, 0,
+                                CONV_IN_PER_SEQ * n_seqs * sizeof(float));
+        ggml_backend_tensor_set(w_t, weights, 0,
+                                CONV_WEIGHT_ELEMS * sizeof(float));
+        ok = ggml_backend_graph_compute(backend, graph) == GGML_STATUS_SUCCESS;
+        if (ok) {
+            ggml_backend_tensor_get(result, out, 0,
+                                    CONV_OUT_PER_SEQ * n_seqs * sizeof(float));
+        }
+    }
+    ggml_gallocr_free(allocator);
+    ggml_free(ctx);
+    return ok;
+}
+
+bool test_masked_set_rows(ggml_backend_t backend) {
+    constexpr int ROW_WIDTH = 4;
+    constexpr int DEST_ROWS = 4;
+    constexpr int SOURCE_ROWS = 3;
+
+    ggml_init_params params{};
+    params.mem_size = 2 * 1024 * 1024;
+    params.no_alloc = true;
+    ggml_context * ctx = ggml_init(params);
+    if (!ctx) return false;
+
+    ggml_tensor * destination = ggml_new_tensor_2d(
+        ctx, GGML_TYPE_F32, ROW_WIDTH, DEST_ROWS);
+    ggml_tensor * source = ggml_new_tensor_2d(
+        ctx, GGML_TYPE_F32, ROW_WIDTH, SOURCE_ROWS);
+    ggml_tensor * row_ids = ggml_new_tensor_1d(
+        ctx, GGML_TYPE_I32, SOURCE_ROWS);
+    for (ggml_tensor * input : {destination, source, row_ids}) {
+        ggml_set_input(input);
+    }
+    ggml_tensor * result =
+        ggml_set_rows_masked(ctx, destination, source, row_ids);
+    ggml_set_output(result);
+    ggml_cgraph * graph = ggml_new_graph(ctx);
+    ggml_build_forward_expand(graph, result);
+
+    ggml_gallocr_t allocator =
+        ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend));
+    bool ok = ggml_gallocr_alloc_graph(allocator, graph);
+    std::vector<float> destination_data(ROW_WIDTH * DEST_ROWS);
+    std::vector<float> source_data(ROW_WIDTH * SOURCE_ROWS);
+    for (size_t i = 0; i < destination_data.size(); ++i) {
+        destination_data[i] = 100.0f + static_cast<float>(i);
+    }
+    for (size_t i = 0; i < source_data.size(); ++i) {
+        source_data[i] = 200.0f + static_cast<float>(i);
+    }
+    const std::vector<int32_t> ids{2, -1, 0};
+    if (ok) {
+        ggml_backend_tensor_set(destination, destination_data.data(), 0,
+                                destination_data.size() * sizeof(float));
+        ggml_backend_tensor_set(source, source_data.data(), 0,
+                                source_data.size() * sizeof(float));
+        ggml_backend_tensor_set(row_ids, ids.data(), 0,
+                                ids.size() * sizeof(ids[0]));
+        ok = ggml_backend_graph_compute(backend, graph) == GGML_STATUS_SUCCESS;
+    }
+    if (ok) {
+        std::vector<float> actual(destination_data.size());
+        std::vector<float> expected = destination_data;
+        ggml_backend_tensor_get(result, actual.data(), 0,
+                                actual.size() * sizeof(float));
+        std::copy_n(source_data.data(), ROW_WIDTH,
+                    expected.data() + 2 * ROW_WIDTH);
+        std::copy_n(source_data.data() + 2 * ROW_WIDTH, ROW_WIDTH,
+                    expected.data());
+        ok = check("masked state scatter", actual.data(), expected.data(),
+                   actual.size());
+    }
+
+    ggml_gallocr_free(allocator);
+    ggml_free(ctx);
+    return ok;
+}
+
+bool check(const char * name, const float * batched, const float * reference,
+           size_t count) {
+    float max_abs_diff = 0.0f;
+    bool finite = true;
+    for (size_t i = 0; i < count; ++i) {
+        if (!std::isfinite(batched[i]) || !std::isfinite(reference[i])) {
+            finite = false;
+            break;
+        }
+        max_abs_diff =
+            std::max(max_abs_diff, std::fabs(batched[i] - reference[i]));
+    }
+    const bool ok = finite && max_abs_diff < MAX_ABS_ERROR;
+    std::printf("batched gdn %-24s max_abs=%.6g %s\n", name,
+                finite ? max_abs_diff : INFINITY, ok ? "PASS" : "FAIL");
+    return ok;
+}
+
+// Fresh random single-token inputs for all N_SEQS sequences. Ranges follow
+// what the model block feeds the fused op: q/k are L2-normalized (order-one
+// entries), beta is a sigmoid in (0,1), and g = -A.exp()*softplus(alpha) is
+// negative so exp(g) <= 1 keeps the recurrence contractive.
+struct GdnStep {
+    std::vector<float> q, k, v, g, beta;
+
+    explicit GdnStep(std::mt19937 & rng)
+        : q(GDN_QKV_PER_SEQ * N_SEQS), k(GDN_QKV_PER_SEQ * N_SEQS),
+          v(GDN_QKV_PER_SEQ * N_SEQS), g(GDN_GATE_PER_SEQ * N_SEQS),
+          beta(GDN_GATE_PER_SEQ * N_SEQS) {
+        fill_uniform(rng, -1.0f, 1.0f, q);
+        fill_uniform(rng, -1.0f, 1.0f, k);
+        fill_uniform(rng, -1.0f, 1.0f, v);
+        fill_uniform(rng, -1.0f, 0.0f, g);
+        fill_uniform(rng, 0.05f, 0.95f, beta);
+    }
+};
+
+// Runs one decode step batched (n_seqs = N_SEQS) and per-sequence
+// (N_SEQS calls with n_seqs = 1) from the SAME carried states, compares
+// attn and final state, then advances both state copies for the next step.
+bool step_and_compare(ggml_backend_t backend, const char * label,
+                      const GdnStep & step,
+                      std::vector<float> & state_batched,
+                      std::vector<float> & state_reference,
+                      bool inplace_batched) {
+    std::vector<float> attn_batched(GDN_QKV_PER_SEQ * N_SEQS);
+    std::vector<float> attn_reference(GDN_QKV_PER_SEQ * N_SEQS);
+    std::vector<float> next_batched(GDN_STATE_PER_SEQ * N_SEQS);
+    std::vector<float> next_reference(GDN_STATE_PER_SEQ * N_SEQS);
+
+    bool ok = run_gdn(backend, N_SEQS, step.q.data(), step.k.data(),
+                      step.v.data(), step.g.data(), step.beta.data(),
+                      state_batched.data(), attn_batched.data(),
+                      next_batched.data(), inplace_batched);
+    for (int seq = 0; ok && seq < N_SEQS; ++seq) {
+        ok = run_gdn(backend, 1,
+                     step.q.data() + seq * GDN_QKV_PER_SEQ,
+                     step.k.data() + seq * GDN_QKV_PER_SEQ,
+                     step.v.data() + seq * GDN_QKV_PER_SEQ,
+                     step.g.data() + seq * GDN_GATE_PER_SEQ,
+                     step.beta.data() + seq * GDN_GATE_PER_SEQ,
+                     state_reference.data() + seq * GDN_STATE_PER_SEQ,
+                     attn_reference.data() + seq * GDN_QKV_PER_SEQ,
+                     next_reference.data() + seq * GDN_STATE_PER_SEQ);
+    }
+    if (!ok) {
+        std::fprintf(stderr, "batched gdn %s: compute failed\n", label);
+        return false;
+    }
+
+    char name[64];
+    std::snprintf(name, sizeof(name), "%s attn", label);
+    ok = check(name, attn_batched.data(), attn_reference.data(),
+               attn_batched.size());
+    std::snprintf(name, sizeof(name), "%s state", label);
+    ok = check(name, next_batched.data(), next_reference.data(),
+               next_batched.size()) && ok;
+
+    // Carry each side's own output so a state-propagation bug compounds
+    // across steps instead of being masked by a shared copy.
+    state_batched = std::move(next_batched);
+    state_reference = std::move(next_reference);
+    return ok;
+}
+
+bool test_gdn_sequential(ggml_backend_t backend, std::mt19937 & rng,
+                         bool inplace_batched) {
+    std::vector<float> state(GDN_STATE_PER_SEQ * N_SEQS);
+    fill_uniform(rng, -0.5f, 0.5f, state);
+    std::vector<float> state_batched = state;
+    std::vector<float> state_reference = state;
+
+    bool ok = true;
+    for (int step_idx = 0; step_idx < N_STEPS; ++step_idx) {
+        char label[32];
+        std::snprintf(label, sizeof(label), "%s step%d",
+                      inplace_batched ? "inplace" : "packed", step_idx);
+        const GdnStep step(rng);
+        ok = step_and_compare(backend, label, step, state_batched,
+                              state_reference, inplace_batched) && ok;
+    }
+    return ok;
+}
+
+bool test_gdn_active_slots(ggml_backend_t backend, std::mt19937 & rng) {
+    // Three physical server slots round up to a four-row graph bucket.
+    // Negative and out-of-range rows both use scratch state without
+    // touching any physical slab.
+    constexpr int physical_slots = 3;
+    const std::vector<int32_t> active_slot_ids{2, -1, physical_slots, 0};
+    const GdnStep step(rng);
+    std::vector<float> initial_state(GDN_STATE_PER_SEQ * physical_slots);
+    fill_uniform(rng, -0.5f, 0.5f, initial_state);
+
+    std::vector<float> attn_active(GDN_QKV_PER_SEQ * N_SEQS);
+    std::vector<float> state_active(initial_state.size());
+    std::vector<float> scratch_active(GDN_STATE_PER_SEQ * N_SEQS);
+    bool ok = run_gdn(
+        backend, N_SEQS, step.q.data(), step.k.data(), step.v.data(),
+        step.g.data(), step.beta.data(), initial_state.data(),
+        attn_active.data(), state_active.data(), /*inplace=*/false,
+        active_slot_ids.data(), physical_slots, scratch_active.data());
+    if (!ok) {
+        std::fprintf(stderr, "batched gdn active slots: compute failed\n");
+        return false;
+    }
+
+    std::vector<float> expected_state = initial_state;
+    for (int row = 0; row < N_SEQS; ++row) {
+        const int slot = active_slot_ids[row];
+
+        std::vector<float> attn_reference(GDN_QKV_PER_SEQ);
+        std::vector<float> state_reference(GDN_STATE_PER_SEQ);
+        std::vector<float> zero_state(GDN_STATE_PER_SEQ, 0.0f);
+        const float * row_state = slot >= 0 && slot < physical_slots
+            ? initial_state.data() + slot * GDN_STATE_PER_SEQ
+            : zero_state.data();
+        ok = run_gdn(
+            backend, 1,
+            step.q.data() + row * GDN_QKV_PER_SEQ,
+            step.k.data() + row * GDN_QKV_PER_SEQ,
+            step.v.data() + row * GDN_QKV_PER_SEQ,
+            step.g.data() + row * GDN_GATE_PER_SEQ,
+            step.beta.data() + row * GDN_GATE_PER_SEQ,
+            row_state,
+            attn_reference.data(), state_reference.data()) && ok;
+
+        char label[48];
+        std::snprintf(label, sizeof(label), "active row%d slot%d attn",
+                      row, slot);
+        ok = check(label,
+                   attn_active.data() + row * GDN_QKV_PER_SEQ,
+                   attn_reference.data(), GDN_QKV_PER_SEQ) && ok;
+        if (slot >= 0 && slot < physical_slots) {
+            std::copy(state_reference.begin(), state_reference.end(),
+                      expected_state.begin() + slot * GDN_STATE_PER_SEQ);
+        } else {
+            std::snprintf(label, sizeof(label), "active row%d scratch", row);
+            ok = check(label,
+                       scratch_active.data() + row * GDN_STATE_PER_SEQ,
+                       state_reference.data(), GDN_STATE_PER_SEQ) && ok;
+        }
+    }
+
+    ok = check("active physical state", state_active.data(),
+               expected_state.data(), state_active.size()) && ok;
+    return ok;
+}
+
+bool test_conv(ggml_backend_t backend, std::mt19937 & rng) {
+    std::vector<float> weights(CONV_WEIGHT_ELEMS);
+    fill_uniform(rng, -0.5f, 0.5f, weights);
+
+    // Per-sequence conv history, carried on the host exactly like the
+    // backend's conv_state slots: each step prepends the (d_conv-1)-row
+    // history to the new token, convolves, then shifts the token in.
+    std::vector<float> history(CONV_HIST_PER_SEQ * N_SEQS);
+    fill_uniform(rng, -1.0f, 1.0f, history);
+
+    bool ok = true;
+    for (int step_idx = 0; step_idx < N_STEPS; ++step_idx) {
+        std::vector<float> token(static_cast<size_t>(CONV_CHANNELS) * N_SEQS);
+        fill_uniform(rng, -1.0f, 1.0f, token);
+
+        // sx rows per channel: [h0, h1, h2, new_token]
+        std::vector<float> sx(CONV_IN_PER_SEQ * N_SEQS);
+        for (int seq = 0; seq < N_SEQS; ++seq) {
+            for (int channel = 0; channel < CONV_CHANNELS; ++channel) {
+                float * row = sx.data() + seq * CONV_IN_PER_SEQ +
+                              static_cast<size_t>(channel) * D_CONV;
+                const float * hist = history.data() + seq * CONV_HIST_PER_SEQ +
+                                     static_cast<size_t>(channel) * (D_CONV - 1);
+                for (int j = 0; j < D_CONV - 1; ++j) row[j] = hist[j];
+                row[D_CONV - 1] = token[seq * CONV_CHANNELS + channel];
+            }
+        }
+
+        std::vector<float> out_batched(CONV_OUT_PER_SEQ * N_SEQS);
+        std::vector<float> out_reference(CONV_OUT_PER_SEQ * N_SEQS);
+        bool computed =
+            run_conv(backend, N_SEQS, sx.data(), weights.data(),
+                     out_batched.data());
+        for (int seq = 0; computed && seq < N_SEQS; ++seq) {
+            computed = run_conv(backend, 1, sx.data() + seq * CONV_IN_PER_SEQ,
+                                weights.data(),
+                                out_reference.data() + seq * CONV_OUT_PER_SEQ);
+        }
+        if (!computed) {
+            std::fprintf(stderr, "batched gdn conv step%d: compute failed\n",
+                         step_idx);
+            return false;
+        }
+
+        char name[32];
+        std::snprintf(name, sizeof(name), "conv step%d", step_idx);
+        ok = check(name, out_batched.data(), out_reference.data(),
+                   out_batched.size()) && ok;
+
+        // Shift the new token into the history window.
+        for (int seq = 0; seq < N_SEQS; ++seq) {
+            for (int channel = 0; channel < CONV_CHANNELS; ++channel) {
+                float * hist = history.data() + seq * CONV_HIST_PER_SEQ +
+                               static_cast<size_t>(channel) * (D_CONV - 1);
+                for (int j = 0; j < D_CONV - 2; ++j) hist[j] = hist[j + 1];
+                hist[D_CONV - 2] = token[seq * CONV_CHANNELS + channel];
+            }
+        }
+    }
+    return ok;
+}
+
+}  // namespace
+
+int main(int argc, char ** argv) {
+    const bool cpu = argc == 2 && std::strcmp(argv[1], "--cpu") == 0;
+    if (argc > 2 || (argc == 2 && !cpu)) {
+        std::fprintf(stderr, "usage: %s [--cpu]\n", argv[0]);
+        return 2;
+    }
+    ggml_backend_t backend = cpu
+        ? ggml_backend_cpu_init()
+        : ggml_backend_cuda_init(0);
+    if (!backend) {
+        std::fprintf(stderr, "%s backend unavailable\n", cpu ? "CPU" : "GPU");
+        return 1;
+    }
+
+    std::mt19937 rng(20260728);
+    bool ok = test_gdn_sequential(backend, rng, /*inplace_batched=*/false);
+    ok = test_gdn_sequential(backend, rng, /*inplace_batched=*/true) && ok;
+    ok = test_gdn_active_slots(backend, rng) && ok;
+    ok = test_conv(backend, rng) && ok;
+    ok = test_masked_set_rows(backend) && ok;
+
+    ggml_backend_free(backend);
+    return ok ? 0 : 1;
+}

--- a/server/test/test_client_send_buffer.cpp
+++ b/server/test/test_client_send_buffer.cpp
@@ -1,0 +1,150 @@
+// Host-side unit test for ClientSendBuffer (concurrent scheduler writer).
+//
+// Uses a socketpair with a shrunken send buffer to exercise partial drains,
+// backpressure, the stall policy, and hard-error detection.
+
+#include "server/client_send_buffer.h"
+#include "host_check.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fcntl.h>
+#include <string>
+#include <sys/socket.h>
+#include <unistd.h>
+
+using namespace dflash::common;
+using clock_t_ = std::chrono::steady_clock;
+using std::chrono::seconds;
+
+static int g_checks = 0;
+
+static void make_pair(int fds[2]) {
+    CHECK(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+    // Non-blocking writer (matches the HTTP server's client sockets) and a
+    // small send buffer so a few KB reliably back-pressures.
+    CHECK(fcntl(fds[0], F_SETFL, O_NONBLOCK) == 0);
+    const int sndbuf = 4096;
+    CHECK(setsockopt(fds[0], SOL_SOCKET, SO_SNDBUF,
+                     &sndbuf, sizeof(sndbuf)) == 0);
+}
+
+static std::string drain_peer(int fd) {
+    std::string got;
+    char tmp[4096];
+    for (;;) {
+        const ssize_t n = recv(fd, tmp, sizeof(tmp), MSG_DONTWAIT);
+        if (n <= 0) break;
+        got.append(tmp, (size_t)n);
+    }
+    return got;
+}
+
+int main() {
+    // Happy path: everything fits the socket buffer in one flush.
+    {
+        int fds[2];
+        make_pair(fds);
+        ClientSendBuffer buffer;
+        CHECK(buffer.empty());
+        buffer.append("hello ");
+        buffer.append("world");
+        CHECK(buffer.pending() == 11);
+        CHECK(buffer.flush(fds[0]));
+        CHECK(buffer.empty());
+        CHECK(drain_peer(fds[1]) == "hello world");
+        close(fds[0]);
+        close(fds[1]);
+    }
+
+    // Backpressure: a payload larger than the socket buffer drains across
+    // flushes as the peer reads, and never blocks.
+    {
+        int fds[2];
+        make_pair(fds);
+        ClientSendBuffer buffer;
+        std::string payload(256 * 1024, '\0');
+        for (size_t i = 0; i < payload.size(); ++i) {
+            payload[i] = static_cast<char>((i * 131 + 17) & 0xff);
+        }
+        buffer.append(payload);
+        CHECK(buffer.flush(fds[0]));
+        CHECK(!buffer.empty());          // socket buffer full, remainder pending
+        std::string got;
+        for (int i = 0; i < 1000 && !buffer.empty(); i++) {
+            got += drain_peer(fds[1]);
+            CHECK(buffer.flush(fds[0]));
+        }
+        got += drain_peer(fds[1]);
+        CHECK(buffer.empty());
+        CHECK(got == payload);
+        close(fds[0]);
+        close(fds[1]);
+    }
+
+    // A single flush that sends past the compaction threshold but leaves a
+    // tail must still count as progress. Compaction normalizes off_ back to
+    // zero, so progress cannot be inferred from the post-compaction offset.
+    {
+        int fds[2];
+        CHECK(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+        CHECK(fcntl(fds[0], F_SETFL, O_NONBLOCK) == 0);
+        const int sndbuf = 256 * 1024;
+        CHECK(setsockopt(fds[0], SOL_SOCKET, SO_SNDBUF,
+                         &sndbuf, sizeof(sndbuf)) == 0);
+
+        ClientSendBuffer buffer;
+        const std::string payload(2 * 1024 * 1024, 'p');
+        buffer.append(payload);
+        buffer.mark_progress(clock_t_::now() - seconds(3600));
+        CHECK(buffer.flush(fds[0]));
+        CHECK(!buffer.empty());
+        CHECK(payload.size() - buffer.pending() > (64u << 10));
+        CHECK(!buffer.should_drop(clock_t_::now(), seconds(30),
+                                  payload.size()));
+        close(fds[0]);
+        close(fds[1]);
+    }
+
+    // Stall policy: pending bytes with no progress trip the deadline and the
+    // cap; an empty send buffer never drops; progress resets the clock.
+    {
+        int fds[2];
+        make_pair(fds);
+        ClientSendBuffer buffer;
+        const auto t0 = clock_t_::now();
+        buffer.mark_progress(t0);
+        CHECK(!buffer.should_drop(t0 + seconds(3600), seconds(30), 1u << 20));
+
+        buffer.append(std::string(64 * 1024, 'y'));
+        CHECK(buffer.flush(fds[0]));     // fills the 4 KB socket buffer, stalls
+        CHECK(!buffer.empty());
+        CHECK(!buffer.should_drop(clock_t_::now(), seconds(30), 1u << 20));
+        CHECK(buffer.should_drop(clock_t_::now() + seconds(31), seconds(30),
+                                 1u << 20));
+        CHECK(buffer.should_drop(clock_t_::now(), seconds(30), /*cap=*/1024));
+
+        // Reader progress resets the deadline.
+        drain_peer(fds[1]);
+        CHECK(buffer.flush(fds[0]));
+        CHECK(!buffer.should_drop(clock_t_::now() + seconds(29), seconds(30),
+                                  1u << 20));
+        close(fds[0]);
+        close(fds[1]);
+    }
+
+    // Hard error: peer closed -> flush returns false.
+    {
+        int fds[2];
+        make_pair(fds);
+        close(fds[1]);
+        ClientSendBuffer buffer;
+        buffer.append("doomed");
+        CHECK(!buffer.flush(fds[0]));
+        close(fds[0]);
+    }
+
+    std::printf("OK test_client_send_buffer (%d checks)\n", g_checks);
+    return 0;
+}

--- a/server/test/test_dflash.cpp
+++ b/server/test/test_dflash.cpp
@@ -1266,7 +1266,7 @@ int main(int argc, char ** argv) {
                                    /*capture=*/false,
                                    /*capture_delta_intermediate=*/false,
                                    /*fa_window=*/0,
-                                   /*last_token_logits_only=*/false,
+                                   /*logits_tail_rows=*/0,
                                    g_kq_stride_pad)) {
                 std::fprintf(stderr, "profile build N=%d failed\n", n); return 1;
             }
@@ -1373,7 +1373,7 @@ int main(int argc, char ** argv) {
                                    /*capture=*/false,
                                    /*capture_delta_intermediate=*/false,
                                    /*fa_window=*/g_fa_window,
-                                   /*last_token_logits_only=*/false,
+                                   /*logits_tail_rows=*/0,
                                    g_kq_stride_pad)) {
                 std::fprintf(stderr, "[time-breakdown] build failed for %s\n", sc.label);
                 step_graph_destroy(tsg);
@@ -1458,7 +1458,7 @@ int main(int argc, char ** argv) {
                                    /*capture=*/true,
                                    /*capture_delta_intermediate=*/true,
                                    /*fa_window=*/g_fa_window,
-                                   /*last_token_logits_only=*/false,
+                                   /*logits_tail_rows=*/0,
                                    g_kq_stride_pad)) {
                 std::fprintf(stderr, "[time-breakdown] verify+capture build failed ctx=%d\n", ctx);
                 step_graph_destroy(vsg);
@@ -2076,7 +2076,7 @@ int main(int argc, char ** argv) {
                                         start, nt, with_m, true,
                                         /*capture_delta_intermediate=*/false,
                                         /*fa_window=*/0,
-                                        /*last_token_logits_only=*/false,
+                                        /*logits_tail_rows=*/0,
                                         g_kq_stride_pad)) {
                     std::fprintf(stderr, "prefill build @%d\n", start); return -1;
                 }
@@ -2117,7 +2117,7 @@ int main(int argc, char ** argv) {
                                int32_t pos, int fa_w, float * logits_out) -> bool {
             if (!build_target_step(dsg, w, cache, backend,
                                     kv_start, 1, false, true, false, fa_w,
-                                    /*last_token_logits_only=*/false,
+                                    /*logits_tail_rows=*/0,
                                     g_kq_stride_pad)) {
                 std::fprintf(stderr, "decode build failed\n"); return false;
             }
@@ -2874,7 +2874,7 @@ int main(int argc, char ** argv) {
                                 /*with_mask=*/true, /*capture=*/true,
                                 /*capture_delta_intermediate=*/false,
                                 /*fa_window=*/g_fa_window,
-                                /*last_token_logits_only=*/true,
+                                /*logits_tail_rows=*/1,
                                 g_kq_stride_pad)) {
             // Issue #114: gallocr OOM. Free all prefix snapshots so the next
             // request has VRAM headroom; abort this request cleanly in daemon
@@ -2926,7 +2926,7 @@ int main(int argc, char ** argv) {
                                 /*with_mask=*/pf_with_mask, /*capture=*/true,
                                 /*capture_delta_intermediate=*/false,
                                 /*fa_window=*/g_fa_window,
-                                /*last_token_logits_only=*/true,
+                                /*logits_tail_rows=*/1,
                                 g_kq_stride_pad)) {
             std::fprintf(stderr, "prefill build @%d failed (OOM)\n", start);
             for (int _i = 0; _i < PREFIX_CACHE_SLOTS; _i++) free_prefix_snapshot(prefix_snapshots[_i]);
@@ -2978,7 +2978,7 @@ int main(int argc, char ** argv) {
             if (daemon_mode) { stream_emit(-1); goto _req_aborted_oom; } else return 1;
         }
 
-        // Logits are [vocab, 1] (last_token_logits_only), read from offset 0.
+        // Logits are [vocab, 1] (logits_tail_rows=1), read from offset 0.
         pf_logits_buf.assign(vocab, 0.0f);
         ggml_backend_tensor_get(sg.logits, pf_logits_buf.data(), 0,
                                 sizeof(float) * vocab);
@@ -3791,7 +3791,7 @@ int main(int argc, char ** argv) {
                                     /*with_mask=*/true, /*capture=*/true,
                                     /*capture_delta_intermediate=*/fast_rollback,
                                     verify_fa_window,
-                                    /*last_token_logits_only=*/false,
+                                    /*logits_tail_rows=*/0,
                                     g_kq_stride_pad)) {
                 std::fprintf(stderr, "verify build failed\n"); return 1;
             }
@@ -3854,7 +3854,7 @@ int main(int argc, char ** argv) {
                                         /*with_mask=*/false, /*capture=*/true,
                                         /*capture_delta_intermediate=*/false,
                                         /*fa_window=*/0,
-                                        /*last_token_logits_only=*/false,
+                                        /*logits_tail_rows=*/0,
                                         g_kq_stride_pad)) {
                     std::fprintf(stderr, "seq verify build %d failed\n", i); return 1;
                 }
@@ -4072,7 +4072,7 @@ int main(int argc, char ** argv) {
                                     committed, commit_n,
                                     replay_with_mask, /*capture=*/true,
                                     false, replay_fa_window,
-                                    /*last_token_logits_only=*/false,
+                                    /*logits_tail_rows=*/0,
                                     g_kq_stride_pad)) {
                 std::fprintf(stderr, "replay build failed\n"); return 1;
             }

--- a/server/test/test_feature_gate.cpp
+++ b/server/test/test_feature_gate.cpp
@@ -392,6 +392,11 @@ void test_feature_gate_paged_attention_requires_plain_ar_decode() {
     CHECK(!gate_result(
         base, "qwen35", PlacementBackend::Cuda, pflash).empty());
 
+    BackendFeatureConfig kvflash;
+    kvflash.kvflash_enabled = true;
+    CHECK(!gate_result(
+        base, "qwen35", PlacementBackend::Cuda, kvflash).empty());
+
     // The pool rounds max_ctx up to whole blocks, so both ends of the range
     // are rejected: nothing to allocate, and rounding that overflows int.
     BackendArgs empty_ctx = base;
@@ -416,6 +421,75 @@ void test_feature_gate_paged_attention_requires_plain_ar_decode() {
         args->paged_attention = false;
         CHECK(gate_result(*args, "qwen35", PlacementBackend::Cuda).empty());
     }
+}
+
+void test_feature_gate_parallel_and_kv_pool_rules() {
+    // A valid paged qwen35 monolithic launch is the baseline every rule
+    // below perturbs.
+    BackendArgs paged;
+    paged.model_path = "/nonexistent/model.gguf";
+    paged.paged_attention = true;
+
+    // --max-concurrency is validated even without any other flag: zero decode
+    // slots is meaningless on every backend.
+    BackendArgs plain;
+    plain.model_path = "/nonexistent/model.gguf";
+    plain.max_concurrency = 0;
+    CHECK(!gate_result(plain, "qwen35", PlacementBackend::Cuda).empty());
+    plain.max_concurrency = 1;
+    CHECK(gate_result(plain, "qwen35", PlacementBackend::Cuda).empty());
+
+    // More than one slot exists only in the paged qwen35 backend.
+    BackendArgs dense;
+    dense.model_path = "/nonexistent/model.gguf";
+    dense.max_concurrency = 2;
+    CHECK(!gate_result(dense, "qwen35", PlacementBackend::Cuda).empty());
+
+    BackendArgs parallel = paged;
+    parallel.max_concurrency = 2;
+    CHECK(gate_result(parallel, "qwen35", PlacementBackend::Cuda).empty());
+
+    // Slot counts need not be powers of two. Decode graph buckets pad via
+    // active_slot_ids rather than changing the physical slot allocation.
+    parallel.max_concurrency = 3;
+    CHECK(gate_result(parallel, "qwen35", PlacementBackend::Cuda).empty());
+
+    // 64 slots is the top of the supported range.
+    parallel.max_concurrency = 64;
+    CHECK(gate_result(parallel, "qwen35", PlacementBackend::Cuda).empty());
+    parallel.max_concurrency = 65;
+    CHECK(!gate_result(parallel, "qwen35", PlacementBackend::Cuda).empty());
+
+    // --kv-pool-tokens sizes the shared pool, so it needs slots to share.
+    BackendArgs pool = paged;
+    pool.kv_pool_tokens = 4096;
+    CHECK(!gate_result(pool, "qwen35", PlacementBackend::Cuda).empty());
+    pool.max_concurrency = 2;
+    CHECK(gate_result(pool, "qwen35", PlacementBackend::Cuda).empty());
+
+    // The pool must hold at least one block, and stay addressable with int
+    // after rounding up to whole blocks.
+    pool.kv_pool_tokens = PAGED_BLOCK_SIZE - 1;
+    CHECK(!gate_result(pool, "qwen35", PlacementBackend::Cuda).empty());
+    pool.kv_pool_tokens = PAGED_BLOCK_SIZE;
+    CHECK(gate_result(pool, "qwen35", PlacementBackend::Cuda).empty());
+    const long long max_pool_tokens =
+        ((long long)INT_MAX - PAGED_BLOCK_SIZE) /
+        PAGED_BLOCK_SIZE * PAGED_BLOCK_SIZE;
+    pool.kv_pool_tokens = max_pool_tokens + 1;
+    CHECK(!gate_result(pool, "qwen35", PlacementBackend::Cuda).empty());
+    pool.kv_pool_tokens = max_pool_tokens;
+    CHECK(gate_result(pool, "qwen35", PlacementBackend::Cuda).empty());
+
+    // The automatic pool is memory-derived, so a logical slot/context product
+    // larger than the physical tensor address space is legal.
+    BackendArgs overflow = paged;
+    overflow.max_concurrency = 2;
+    overflow.device.max_ctx = 1 << 30;
+    CHECK(gate_result(overflow, "qwen35", PlacementBackend::Cuda).empty());
+    // An explicit addressable pool remains accepted as well.
+    overflow.kv_pool_tokens = 1 << 20;
+    CHECK(gate_result(overflow, "qwen35", PlacementBackend::Cuda).empty());
 }
 
 // ── Inert-flag warnings ─────────────────────────────────────────────────
@@ -570,6 +644,7 @@ TEST_CASE(FeatureGateFixture, feature_gate_suite) {
     test_feature_gate_layer_split_requires_supported_arch();
     test_feature_gate_paged_attention_requires_qwen35_monolithic();
     test_feature_gate_paged_attention_requires_plain_ar_decode();
+    test_feature_gate_parallel_and_kv_pool_rules();
     test_feature_warnings_silent_when_supported();
     test_feature_warnings_report_inert_draft();
     test_feature_warnings_report_inert_decode_tunables();

--- a/server/test/test_generate.cpp
+++ b/server/test/test_generate.cpp
@@ -9,9 +9,12 @@
 //
 // Usage:
 //   test_generate <qwen35.gguf> <prompt_ids.bin> <n_gen> <out_ids.bin>
+//   test_generate --seq-engine-contract <qwen35.gguf> [slots]
 
 #include "dflash27b.h"
 #include "internal.h"
+#include "qwen35/qwen35_backend.h"
+#include "seq_engine_contract.h"
 
 #include "ggml.h"
 #include "ggml-alloc.h"
@@ -48,7 +51,7 @@
 
 using namespace dflash::common;
 
-struct StepGraph {
+struct GenerateStepGraph {
     ggml_context *    ctx = nullptr;
     ggml_cgraph *     gf  = nullptr;
     ggml_gallocr_t    alloc = nullptr;
@@ -61,7 +64,7 @@ struct StepGraph {
 // `kv_start` updates drive the correct KV cache slot. The graph is cheap to
 // rebuild — all the weights + KV cache stay persistent.
 static bool build_step_graph(
-    StepGraph & sg,
+    GenerateStepGraph & sg,
     const TargetWeights & w,
     TargetCache & cache,
     ggml_backend_t backend,
@@ -104,7 +107,7 @@ static bool build_step_graph(
     return ggml_gallocr_alloc_graph(sg.alloc, sg.gf);
 }
 
-static std::vector<int32_t> read_int32_file(const std::string & path) {
+static std::vector<int32_t> read_generate_tokens(const std::string & path) {
     std::ifstream f(path, std::ios::binary | std::ios::ate);
     if (!f) return {};
     auto sz = (size_t)f.tellg();
@@ -114,17 +117,79 @@ static std::vector<int32_t> read_int32_file(const std::string & path) {
     return out;
 }
 
-static bool write_int32_file(const std::string & path, const std::vector<int32_t> & v) {
+static bool write_generate_tokens(const std::string & path,
+                                  const std::vector<int32_t> & v) {
     std::ofstream f(path, std::ios::binary);
     if (!f) return false;
     f.write((const char *)v.data(), v.size() * sizeof(int32_t));
     return (bool)f;
 }
 
+static int run_seq_engine_contract(const char * gguf_path, int slots) {
+    if (slots < 2 || slots > 64) {
+        std::fprintf(stderr, "slots must be in [2, 64], got %d\n", slots);
+        return 2;
+    }
+
+    // Keep this mode independent of a caller's KVFlash environment: paged
+    // attention and KVFlash are intentionally mutually exclusive. Prevent
+    // arbitrary raw token IDs from ending the checker before its three
+    // batched steps have exercised state carry.
+    unsetenv("DFLASH_KVFLASH");
+    setenv("DFLASH_MIN_TOKENS", "8", 1);
+
+    Qwen35Config cfg;
+    cfg.target_path = gguf_path;
+    cfg.device.gpu = 0;
+    cfg.device.max_ctx = 256;
+    cfg.draft_gpu = 0;
+    cfg.paged_attention = true;
+    cfg.max_concurrency = slots;
+
+    Qwen35Backend backend(cfg);
+    if (!backend.init()) {
+        std::fprintf(stderr, "seq-engine backend init failed: %s\n",
+                     dflash27b_last_error());
+        return 1;
+    }
+
+    SeqEngine * engine = backend.seq_engine();
+    if (!engine) {
+        std::fprintf(stderr,
+                     "seq-engine backend did not expose a concurrent engine\n");
+        return 1;
+    }
+
+    const std::vector<std::string> violations =
+        check_seq_engine_contract(*engine);
+    for (const std::string & violation : violations) {
+        std::fprintf(stderr, "seq-engine contract: %s\n", violation.c_str());
+    }
+    if (!violations.empty()) return 1;
+
+    std::printf("seq-engine contract passed against Qwen35Backend (%d slots)\n",
+                slots);
+    return 0;
+}
+
 int main(int argc, char ** argv) {
+    if (argc >= 2 &&
+        std::strcmp(argv[1], "--seq-engine-contract") == 0) {
+        if (argc < 3 || argc > 4) {
+            std::fprintf(stderr,
+                "usage: %s --seq-engine-contract <qwen35.gguf> [slots]\n",
+                argv[0]);
+            return 2;
+        }
+        const int slots = argc == 4 ? std::atoi(argv[3]) : 4;
+        return run_seq_engine_contract(argv[2], slots);
+    }
+
     if (argc < 5) {
         std::fprintf(stderr,
-            "usage: %s <qwen35.gguf> <prompt_ids.bin> <n_gen> <out_ids.bin>\n", argv[0]);
+            "usage: %s <qwen35.gguf> <prompt_ids.bin> <n_gen> <out_ids.bin>\n"
+            "       %s --seq-engine-contract <qwen35.gguf> [slots]\n",
+            argv[0], argv[0]);
         return 2;
     }
     const char * gguf_path   = argv[1];
@@ -187,7 +252,7 @@ int main(int argc, char ** argv) {
         return 1;
     }
 
-    auto prompt = read_int32_file(prompt_path);
+    auto prompt = read_generate_tokens(prompt_path);
     if (prompt.empty()) { std::fprintf(stderr, "empty prompt bin\n"); return 1; }
     std::printf("[prompt] %zu tokens: ", prompt.size());
     for (auto t : prompt) std::printf("%d ", t);
@@ -204,7 +269,7 @@ int main(int argc, char ** argv) {
     const int hidden = DFLASH27B_TARGET_HIDDEN;
     std::vector<float> embed_buf(hidden);
 
-    StepGraph sg;
+    GenerateStepGraph sg;
 
     // ── Helper: run one step given current token + absolute position
     auto run_step = [&](int32_t tok, int pos) -> int32_t {
@@ -273,7 +338,7 @@ int main(int argc, char ** argv) {
     for (int i = 0; i < n_gen; i++) std::printf("%d ", all_tokens[prompt.size() + i]);
     std::printf("\n");
 
-    write_int32_file(out_path, all_tokens);
+    write_generate_tokens(out_path, all_tokens);
     std::printf("[out] wrote %zu tokens to %s\n", all_tokens.size(), out_path);
 
     if (sg.alloc) ggml_gallocr_free(sg.alloc);

--- a/server/test/test_kvflash.cpp
+++ b/server/test/test_kvflash.cpp
@@ -278,7 +278,7 @@ struct BatchStepper {
         gi.n_tokens    = NB;
         gi.kv_start    = pool - NB;      // span = whole pool
         gi.kv_write_rows = kv_write_rows;
-        gi.last_token_logits_only = true;
+        gi.logits_tail_rows = 1;
         QwenGraphOutputs go = build_qwen35_graph(ctx, gf, *w, *cache, gi);
         if (!go.logits) return false;
         logits = go.logits;

--- a/server/test/test_kvflash_pool_sizing.cpp
+++ b/server/test/test_kvflash_pool_sizing.cpp
@@ -20,6 +20,11 @@ struct KvflashPoolSizingFixture {};
 }
 
 TEST_CASE(KvflashPoolSizingFixture, kvflash_pool_sizing_suite) {
+    REQUIRE(!kvflash_fixed_pool_requested(nullptr));
+    REQUIRE(!kvflash_fixed_pool_requested("0"));
+    REQUIRE(!kvflash_fixed_pool_requested("auto"));
+    REQUIRE(kvflash_fixed_pool_requested("4096"));
+
     {
         const luce_test::ScopedEnvVar kvflash_off("DFLASH_KVFLASH", "0");
         REQUIRE(kvflash_pool_from_env(131072) == 0);

--- a/server/test/test_paged_attention.cpp
+++ b/server/test/test_paged_attention.cpp
@@ -58,7 +58,7 @@ std::vector<int32_t> make_block_table(
     std::vector<int32_t> result(
         static_cast<size_t>(test_case.max_blocks) * n_seq, -1);
 
-    // 37 is coprime with both cases' live-block counts, so this maps every
+    // 37 is coprime with the test cases' live-block counts, so this maps every
     // logical page to a unique shuffled physical page.
     int ordinal = 0;
     for (int seq = 0; seq < n_seq; ++seq) {
@@ -125,14 +125,19 @@ std::vector<float> reference_attention(
         int physical_blocks,
         const std::vector<float> & q,
         const std::vector<float> & k,
-        const std::vector<float> & v) {
+        const std::vector<float> & v,
+        const std::vector<int32_t> * active_slot_ids = nullptr) {
     std::vector<float> output(q.size(), 0.0f);
     const float scale = 1.0f / std::sqrt(static_cast<float>(D));
     const int q_per_kv = N_HEAD / N_HEAD_KV;
-    const int n_seq = static_cast<int>(test_case.kv_seq_lens.size());
+    const int n_seq = active_slot_ids
+        ? static_cast<int>(active_slot_ids->size())
+        : static_cast<int>(test_case.kv_seq_lens.size());
 
     for (int seq = 0; seq < n_seq; ++seq) {
-        const int kv_seq_len = clamped_seq_len(test_case, seq);
+        const int physical_seq = active_slot_ids ? (*active_slot_ids)[seq] : seq;
+        if (physical_seq < 0) continue;
+        const int kv_seq_len = clamped_seq_len(test_case, physical_seq);
         for (int head = 0; head < N_HEAD; ++head) {
             const int kv_head = head / q_per_kv;
             const float * q_row =
@@ -143,7 +148,7 @@ std::vector<float> reference_attention(
             for (int token = 0; token < kv_seq_len; ++token) {
                 const int block =
                     block_table[
-                        seq * test_case.max_blocks + token / BLOCK_SIZE];
+                        physical_seq * test_case.max_blocks + token / BLOCK_SIZE];
                 if (!block_is_valid(block, physical_blocks)) {
                     // Mirrors the kernel: invalid blocks contribute nothing.
                     scores[token] = -INFINITY;
@@ -170,7 +175,7 @@ std::vector<float> reference_attention(
             for (int token = 0; token < kv_seq_len; ++token) {
                 const int block =
                     block_table[
-                        seq * test_case.max_blocks + token / BLOCK_SIZE];
+                        physical_seq * test_case.max_blocks + token / BLOCK_SIZE];
                 if (!block_is_valid(block, physical_blocks)) continue;
                 const int physical = block * BLOCK_SIZE + token % BLOCK_SIZE;
                 const float * v_row =
@@ -189,8 +194,12 @@ std::vector<float> reference_attention(
 bool run_case(ggml_backend_t backend,
               const TestCase & test_case,
               ggml_type k_type,
-              ggml_type v_type) {
-    const int n_seq = static_cast<int>(test_case.kv_seq_lens.size());
+              ggml_type v_type,
+              const std::vector<int32_t> * active_slot_ids = nullptr) {
+    const int physical_n_seq = static_cast<int>(test_case.kv_seq_lens.size());
+    const int n_seq = active_slot_ids
+        ? static_cast<int>(active_slot_ids->size())
+        : physical_n_seq;
     const int physical_blocks = count_physical_blocks(test_case);
     const int pool_tokens = physical_blocks * BLOCK_SIZE;
     const std::vector<int32_t> block_table =
@@ -210,18 +219,25 @@ bool run_case(ggml_backend_t backend,
         ggml_new_tensor_3d(ctx, v_type, D, pool_tokens, N_HEAD_KV);
     ggml_tensor * table =
         ggml_new_tensor_2d(
-            ctx, GGML_TYPE_I32, test_case.max_blocks, n_seq);
+            ctx, GGML_TYPE_I32, test_case.max_blocks, physical_n_seq);
     ggml_tensor * kv_seq_lens =
-        ggml_new_tensor_1d(ctx, GGML_TYPE_I32, n_seq);
+        ggml_new_tensor_1d(ctx, GGML_TYPE_I32, physical_n_seq);
     for (ggml_tensor * input : {q, k, v, table, kv_seq_lens}) {
         ggml_set_input(input);
     }
 
-    ggml_tensor * output = ggml_paged_attn(
-        ctx, q, k, v, table, kv_seq_lens,
-        1.0f / std::sqrt(static_cast<float>(D)), BLOCK_SIZE,
-        *std::max_element(test_case.kv_seq_lens.begin(),
-                          test_case.kv_seq_lens.end()));
+    ggml_tensor * active = nullptr;
+    if (active_slot_ids) {
+        active = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, n_seq);
+        ggml_set_input(active);
+    }
+
+    const float scale = 1.0f / std::sqrt(static_cast<float>(D));
+    const int max_kv_seq_len = *std::max_element(
+        test_case.kv_seq_lens.begin(), test_case.kv_seq_lens.end());
+    ggml_tensor * output = ggml_paged_attn_ext(
+        ctx, q, k, v, table, kv_seq_lens, active,
+        scale, BLOCK_SIZE, max_kv_seq_len);
     ggml_set_output(output);
     ggml_cgraph * graph = ggml_new_graph(ctx);
     ggml_build_forward_expand(graph, output);
@@ -270,6 +286,11 @@ bool run_case(ggml_backend_t backend,
             kv_seq_lens, test_case.kv_seq_lens.data(), 0,
             test_case.kv_seq_lens.size() *
                 sizeof(test_case.kv_seq_lens[0]));
+        if (active_slot_ids) {
+            ggml_backend_tensor_set(
+                active, active_slot_ids->data(), 0,
+                active_slot_ids->size() * sizeof((*active_slot_ids)[0]));
+        }
         ok = ggml_backend_graph_compute(backend, graph) == GGML_STATUS_SUCCESS;
     }
 
@@ -281,7 +302,7 @@ bool run_case(ggml_backend_t backend,
         const std::vector<float> expected =
             reference_attention(
                 test_case, block_table, pool_tokens, physical_blocks,
-                q_data, k_reference, v_reference);
+                q_data, k_reference, v_reference, active_slot_ids);
         max_abs_error = 0.0f;
         for (size_t i = 0; i < actual.size(); ++i) {
             if (!std::isfinite(actual[i])) {
@@ -294,8 +315,9 @@ bool run_case(ggml_backend_t backend,
         ok = ok && max_abs_error < MAX_ABS_ERROR;
     }
 
-    std::printf("paged attention %-11s K=%-4s V=%-4s max_abs=%.6g %s\n",
+    std::printf("paged attention %-11s K=%-4s V=%-4s active=%s max_abs=%.6g %s\n",
                 test_case.name, ggml_type_name(k_type), ggml_type_name(v_type),
+                active_slot_ids ? "yes" : "no",
                 max_abs_error, ok ? "PASS" : "FAIL");
     ggml_gallocr_free(allocator);
     ggml_free(ctx);
@@ -323,8 +345,8 @@ bool rejects_unlaunchable_gqa(ggml_backend_t backend) {
         ggml_new_tensor_2d(ctx, GGML_TYPE_I32, 1, 1);
     ggml_tensor * kv_seq_lens =
         ggml_new_tensor_1d(ctx, GGML_TYPE_I32, 1);
-    ggml_tensor * output = ggml_paged_attn(
-        ctx, q, k, v, table, kv_seq_lens,
+    ggml_tensor * output = ggml_paged_attn_ext(
+        ctx, q, k, v, table, kv_seq_lens, nullptr,
         1.0f / std::sqrt(static_cast<float>(D)), BLOCK_SIZE, 1);
 
     const bool rejected = !ggml_backend_supports_op(backend, output);
@@ -356,6 +378,15 @@ void run_paged_attention_case(const TestCase & test_case) {
     ggml_backend_free(backend);
 }
 
+void run_active_slot_case(const TestCase & test_case,
+                          const std::vector<int32_t> & active_slot_ids) {
+    ggml_backend_t backend = ggml_backend_cuda_init(0);
+    REQUIRE_NOT_NULL(backend);
+    CHECK(run_case(backend, test_case, GGML_TYPE_F16, GGML_TYPE_F16,
+                   &active_slot_ids));
+    ggml_backend_free(backend);
+}
+
 };
 TEST_CASE(PagedAttention, PartitionedPathMatchesReference) {
     run_paged_attention_case({
@@ -377,4 +408,24 @@ TEST_CASE(PagedAttention, DirectPathMatchesReference) {
         {0, 1, 15, 16, 17, 257, 511},
         false,
     });
+}
+
+TEST_CASE(PagedAttention, ActiveSlotsMatchReference) {
+    run_active_slot_case({
+        "active-slots",
+        65,
+        {-7, 1, 15, 16, 17, 31, 33, 257, 511, 1025, 2000},
+        true,
+    }, {10, 9, -1, 4});
+}
+
+TEST_CASE(PagedAttention, CompactThreeSlotBucketMatchesReference) {
+    // Three physical slots round up to a four-row graph bucket. The final row
+    // is padding and maps to no physical block-table column.
+    run_active_slot_case({
+        "compact-3",
+        2,
+        {1, 17, 31},
+        false,
+    }, {2, 1, 0, -1});
 }

--- a/server/test/test_paged_kv_pool.cpp
+++ b/server/test/test_paged_kv_pool.cpp
@@ -2,7 +2,8 @@
 
 #define GENERATE_UNIT_TEST_MAIN
 #include "CppUnitTestFramework.hpp"
-#include "../src/common/paged_kv_pool.h"
+#include "common/concurrency/paged_kv_pool.h"
+#include "../src/common/paged_attention_config.h"
 
 #include <initializer_list>
 #include <limits>
@@ -50,17 +51,23 @@ static bool state_unchanged(PagedKvPool & pool,
     const auto after = sequence(pool, handle);
     return after.kv_seq_len == before.kv_seq_len &&
            after.block_table == before.block_table &&
+           after.reserved_block_count == before.reserved_block_count &&
            pool.free_block_count() == free_before;
 }
 
 // True when every handle-taking operation rejects `handle` as stale.
 static bool all_ops_stale(PagedKvPool & pool, PagedKvSequenceHandle handle) {
     PagedKvSequenceSnapshot snapshot;
+    uint32_t owned_blocks = 0;
     return pool.append(handle, 1).status == PagedKvStatus::StaleHandle &&
            pool.append(handle, 1, /*only_first_last_slots=*/true).status ==
                PagedKvStatus::StaleHandle &&
+           pool.reserve_capacity(handle, 16) ==
+               PagedKvStatus::StaleHandle &&
            pool.release(handle) == PagedKvStatus::StaleHandle &&
-           pool.sequence(handle, snapshot) == PagedKvStatus::StaleHandle;
+           pool.sequence(handle, snapshot) == PagedKvStatus::StaleHandle &&
+           pool.owned_block_count(handle, owned_blocks) ==
+               PagedKvStatus::StaleHandle;
 }
 
 TEST_CASE(PagedKvPoolFixture, block_boundaries) {
@@ -101,6 +108,126 @@ TEST_CASE(PagedKvPoolFixture, nondefault_block_size) {
     CHECK(append.write_slots[6].block_offset == 6);
     CHECK(append.write_slots[7].physical_block == 1);
     CHECK(append.write_slots[14].physical_token_index == 14);
+}
+
+TEST_CASE(PagedKvPoolFixture, reserved_acquire_feeds_chunked_append) {
+    PagedKvPool pool(/*physical_block_count=*/6,
+                     /*max_sequences=*/3, /*block_size=*/16);
+    PagedKvSequenceHandle handle;
+    CHECK(pool.acquire_reserved(77, /*token_capacity=*/40, handle) ==
+          PagedKvStatus::Ok);
+    CHECK(pool.active_sequence_count() == 1);
+    CHECK(pool.free_block_count() == 3);
+
+    auto snapshot = sequence(pool, handle);
+    CHECK(snapshot.kv_seq_len == 0);
+    CHECK(snapshot.block_table.empty());
+    CHECK(snapshot.reserved_block_count == 3);
+    uint32_t owned_blocks = 0;
+    CHECK(pool.owned_block_count(handle, owned_blocks) == PagedKvStatus::Ok);
+    CHECK(owned_blocks == 3);
+
+    const auto first = pool.append(handle, 17);
+    CHECK(first.status == PagedKvStatus::Ok);
+    CHECK(equals(sequence(pool, handle).block_table, {0, 1}));
+    CHECK(sequence(pool, handle).reserved_block_count == 1);
+    CHECK(pool.owned_block_count(handle, owned_blocks) == PagedKvStatus::Ok);
+    CHECK(owned_blocks == 3);
+    // Consuming a reservation never changes globally available capacity.
+    CHECK(pool.free_block_count() == 3);
+
+    const auto tail = pool.append(handle, 23);
+    CHECK(tail.status == PagedKvStatus::Ok);
+    snapshot = sequence(pool, handle);
+    CHECK(snapshot.kv_seq_len == 40);
+    CHECK(equals(snapshot.block_table, {0, 1, 2}));
+    CHECK(snapshot.reserved_block_count == 0);
+    CHECK(pool.free_block_count() == 3);
+    CHECK(pool.owned_block_count(handle, owned_blocks) == PagedKvStatus::Ok);
+    CHECK(owned_blocks == 3);
+
+    CHECK(pool.release(handle) == PagedKvStatus::Ok);
+    CHECK(pool.free_block_count() == 6);
+}
+
+TEST_CASE(PagedKvPoolFixture, reserved_acquire_is_atomic_and_isolated) {
+    PagedKvPool pool(/*physical_block_count=*/4,
+                     /*max_sequences=*/3, /*block_size=*/16);
+    PagedKvSequenceHandle first;
+    CHECK(pool.acquire_reserved(1, /*token_capacity=*/48, first) ==
+          PagedKvStatus::Ok);
+    CHECK(pool.free_block_count() == 1);
+
+    PagedKvSequenceHandle unchanged{77, 88};
+    CHECK(pool.acquire_reserved(2, /*token_capacity=*/32, unchanged) ==
+          PagedKvStatus::BlocksExhausted);
+    CHECK(unchanged.slot == 77);
+    CHECK(unchanged.generation == 88);
+    CHECK(pool.active_sequence_count() == 1);
+    CHECK(pool.free_block_count() == 1);
+
+    // Unreserved work cannot steal the first sequence's promised pages.
+    const auto second = acquire(pool, 2);
+    CHECK(pool.append(second, 32).status == PagedKvStatus::BlocksExhausted);
+    CHECK(pool.append(first, 48).status == PagedKvStatus::Ok);
+    CHECK(equals(sequence(pool, first).block_table, {0, 1, 2}));
+
+    CHECK(pool.release(first) == PagedKvStatus::Ok);
+    CHECK(pool.free_block_count() == 4);
+    CHECK(pool.release(second) == PagedKvStatus::Ok);
+
+    // Retirement also returns reservations that prefill never consumed.
+    PagedKvSequenceHandle unused;
+    CHECK(pool.acquire_reserved(3, /*token_capacity=*/32, unused) ==
+          PagedKvStatus::Ok);
+    CHECK(pool.free_block_count() == 2);
+    CHECK(sequence(pool, unused).reserved_block_count == 2);
+    CHECK(pool.release(unused) == PagedKvStatus::Ok);
+    CHECK(pool.free_block_count() == 4);
+}
+
+TEST_CASE(PagedKvPoolFixture, capacity_top_up_is_atomic_and_private) {
+    PagedKvPool pool(/*physical_block_count=*/3,
+                     /*max_sequences=*/2, /*block_size=*/16);
+    const auto first = acquire(pool, 1);
+    const auto second = acquire(pool, 2);
+    CHECK(pool.append(first, 16).status == PagedKvStatus::Ok);
+    CHECK(pool.append(second, 16).status == PagedKvStatus::Ok);
+    CHECK(pool.free_block_count() == 1);
+
+    // Asking for two more blocks fails atomically: neither the logical length
+    // nor either ownership view changes.
+    CHECK(state_unchanged(pool, first, [&] {
+        CHECK(pool.reserve_capacity(first, /*token_capacity=*/48) ==
+              PagedKvStatus::BlocksExhausted);
+    }));
+
+    // A one-page top-up succeeds without advancing logical state or exposing
+    // a block-table entry.
+    CHECK(pool.reserve_capacity(first, /*token_capacity=*/32) ==
+          PagedKvStatus::Ok);
+    auto first_state = sequence(pool, first);
+    CHECK(first_state.kv_seq_len == 16);
+    CHECK(equals(first_state.block_table, {0}));
+    CHECK(first_state.reserved_block_count == 1);
+    CHECK(pool.free_block_count() == 0);
+
+    // The other sequence cannot steal the promised page; its own state stays
+    // unchanged while the owner can consume the reservation.
+    CHECK(state_unchanged(pool, second, [&] {
+        CHECK(pool.append(second, 1).status ==
+              PagedKvStatus::BlocksExhausted);
+    }));
+    CHECK(pool.append(first, 1).status == PagedKvStatus::Ok);
+    first_state = sequence(pool, first);
+    CHECK(equals(first_state.block_table, {0, 2}));
+    CHECK(first_state.reserved_block_count == 0);
+
+    // Top-ups are monotonic no-ops when the sequence already owns enough.
+    CHECK(state_unchanged(pool, first, [&] {
+        CHECK(pool.reserve_capacity(first, /*token_capacity=*/17) ==
+              PagedKvStatus::Ok);
+    }));
 }
 
 TEST_CASE(PagedKvPoolFixture, zero_token_append_is_a_no_op) {
@@ -272,4 +399,36 @@ TEST_CASE(PagedKvPoolFixture, invalid_arguments) {
         CHECK(overflow.status == PagedKvStatus::InvalidArgument);
         CHECK(overflow.write_slots.empty());
     }));
+}
+
+TEST_CASE(PagedKvPoolFixture, auto_pool_sizing) {
+    PagedKvAutoBudget budget;
+    budget.free_bytes = 10'000;
+    budget.fixed_cache_bytes = 1'000;
+    budget.reserve_bytes = 1'000;
+    budget.bytes_per_token = 10;
+    // Memory could hold 800 tokens, but four 128-token logical contexts cap
+    // the useful physical pool at 512.
+    CHECK(paged_kv_auto_pool_tokens(128, 4, budget) == 512);
+
+    budget.free_bytes = 5'000;
+    // 300 raw tokens round down to 288 (18 whole blocks).
+    CHECK(paged_kv_auto_pool_tokens(128, 4, budget) == 288);
+    budget.free_bytes = 1'999;
+    CHECK(paged_kv_auto_pool_tokens(128, 4, budget) == 0);
+    budget.free_bytes = 5'000;
+    budget.bytes_per_token = 0;
+    CHECK(paged_kv_auto_pool_tokens(128, 4, budget) == 0);
+
+    // A representative 24 GiB-card post-weight budget can keep one 32K
+    // context plus oversubscription headroom without allocating 16 x 32K.
+    budget.free_bytes = 10LL * 1024 * 1024 * 1024;
+    budget.fixed_cache_bytes = 4LL * 1024 * 1024 * 1024;
+    budget.reserve_bytes = 1536LL * 1024 * 1024;
+    budget.bytes_per_token = 64 * 1024;
+    const int64_t headline =
+        paged_kv_auto_pool_tokens(32768, 16, budget);
+    CHECK(headline == 73728);
+    CHECK(headline >= 32768);
+    CHECK(headline < 16LL * 32768);
 }

--- a/server/test/test_qwen35_tensor_parallel.cpp
+++ b/server/test/test_qwen35_tensor_parallel.cpp
@@ -12,6 +12,7 @@ using namespace CppUnitTestFramework;
 namespace {
 struct Qwen35TensorParallelFixture : CommonFixture {
     using CommonFixture::CommonFixture;
+    void expect_staging_cache_lifecycle(ggml_context * ctx);
 };
 }
 
@@ -31,12 +32,38 @@ static bool expect_split(const TargetWeights & weights,
         (state.ne[0] + state.ne[1]) * state.nr[0] == tensor->ne[axis];
 }
 
+void Qwen35TensorParallelFixture::expect_staging_cache_lifecycle(
+        ggml_context * ctx) {
+    ggml_tensor * primary =
+        ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 1);
+    ggml_tensor * extra =
+        ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 1);
+
+    TargetCache cache;
+    cache.prefill_staging.resize(2);
+    cache.prefill_staging[0] = {{primary}, {primary}, {primary}, {primary}};
+    cache.prefill_staging[1] = {{extra}, {extra}, {extra}, {extra}};
+
+    CHECK(staging_k_for(cache, 0).at(0) == primary);
+    CHECK(staging_k_for(cache, 1).at(0) == extra);
+    CHECK(staging_k_for(cache, -1).empty());
+    CHECK(staging_k_for(cache, 2).empty());
+    CHECK(staging_v_for(cache, -1).empty());
+    CHECK(staging_ssm_for(cache, 2).empty());
+    CHECK(staging_conv_for(cache, 2).empty());
+
+    free_target_cache(cache);
+    CHECK(cache.prefill_staging.empty());
+}
+
 TEST_CASE(Qwen35TensorParallelFixture, tensor_parallel_split_state) {
     ggml_init_params params{};
     params.mem_size = 32 * ggml_tensor_overhead();
     params.no_alloc = true;
     ggml_context * ctx = ggml_init(params);
     REQUIRE(ctx != nullptr);
+
+    expect_staging_cache_lifecycle(ctx);
 
     TargetWeights weights;
 

--- a/server/test/test_seq_batch_plan.cpp
+++ b/server/test/test_seq_batch_plan.cpp
@@ -1,0 +1,190 @@
+#include "common/concurrency/seq_engine.h"
+#include "host_check.h"
+
+#include <cstdio>
+#include <limits>
+#include <vector>
+
+using namespace dflash::common;
+
+static int g_checks = 0;
+
+int main() {
+    const std::vector<PrefillCandidate> pending{
+        {7, 30}, {2, 10}, {5, 20}, {1, 40},
+    };
+
+    StepPlanLimits idle_limits{/*max sequences=*/2,
+                               /*per sequence=*/2048,
+                               /*total=*/4096,
+                               /*allocation quantum=*/512};
+    StepPlanLimits mixed_limits{/*max sequences=*/2,
+                                /*per sequence=*/512,
+                                /*total=*/1024,
+                                /*allocation quantum=*/512};
+
+    auto idle = plan_prefill_slices(
+        pending, idle_limits);
+    CHECK(idle.size() == 2);
+    CHECK(idle[0].slot == 2);
+    CHECK(idle[1].slot == 5);
+    CHECK(idle[0].max_tokens == 2048);
+    CHECK(idle[1].max_tokens == 2048);
+
+    auto mixed = plan_prefill_slices(
+        pending, mixed_limits);
+    CHECK(mixed.size() == 2);
+    CHECK(mixed[0].max_tokens == 512);
+    CHECK(mixed[1].max_tokens == 512);
+
+    mixed_limits.max_prefill_tokens_per_sequence = 256;
+    mixed_limits.max_prefill_tokens_total = 512;
+    mixed = plan_prefill_slices(pending, mixed_limits);
+    CHECK(mixed.size() == 2);
+    CHECK(mixed[0].max_tokens == 256);
+    CHECK(mixed[1].max_tokens == 256);
+
+    mixed_limits.max_prefill_tokens_total = 301;
+    mixed = plan_prefill_slices(pending, mixed_limits);
+    CHECK(mixed.size() == 2);
+    CHECK(mixed[0].slot == 2);
+    CHECK(mixed[0].max_tokens == 256);
+    CHECK(mixed[1].slot == 5);
+    CHECK(mixed[1].max_tokens == 45);
+
+    auto rotated = plan_prefill_slices(
+        pending, mixed_limits, /*round_robin_start=*/1);
+    CHECK(rotated.size() == 2);
+    CHECK(rotated[0].slot == 2 && rotated[0].max_tokens == 45);
+    CHECK(rotated[1].slot == 5 && rotated[1].max_tokens == 256);
+
+    // A budget smaller than one quantum advances one lane; rotation prevents
+    // the oldest lane from winning every step.
+    mixed_limits.max_prefill_tokens_total = 200;
+    auto clamped0 = plan_prefill_slices(
+        pending, mixed_limits, 0);
+    auto clamped1 = plan_prefill_slices(
+        pending, mixed_limits, 1);
+    CHECK(clamped0.size() == 1 && clamped0[0].slot == 2 &&
+          clamped0[0].max_tokens == 200);
+    CHECK(clamped1.size() == 1 && clamped1[0].slot == 5 &&
+          clamped1[0].max_tokens == 200);
+
+    // The packed Qwen policy fills all eight idle lanes with one 512-token
+    // segment, while a mixed step rotates four such segments fairly.
+    const std::vector<PrefillCandidate> packed{
+        {0, 0}, {1, 1}, {2, 2}, {3, 3},
+        {4, 4}, {5, 5}, {6, 6}, {7, 7},
+    };
+    StepPlanLimits packed_mixed{/*max sequences=*/8,
+                                /*per sequence=*/512,
+                                /*total=*/2048,
+                                /*allocation quantum=*/512};
+    auto packed0 = plan_prefill_slices(packed, packed_mixed, 0);
+    CHECK(packed0.size() == 4);
+    for (int i = 0; i < 4; ++i) {
+        CHECK(packed0[(size_t)i].slot == i);
+        CHECK(packed0[(size_t)i].max_tokens == 512);
+    }
+    auto packed4 = plan_prefill_slices(packed, packed_mixed, 4);
+    CHECK(packed4.size() == 4);
+    for (int i = 0; i < 4; ++i) {
+        CHECK(packed4[(size_t)i].slot == i + 4);
+        CHECK(packed4[(size_t)i].max_tokens == 512);
+    }
+
+    packed_mixed.prefill_allocation_quantum = 0;
+    CHECK(plan_prefill_slices(packed, packed_mixed).empty());
+
+    mixed_limits.max_prefill_tokens_per_sequence = 0;
+    CHECK(plan_prefill_slices(
+        pending, mixed_limits).empty());
+
+    idle_limits.max_prefill_sequences = 0;
+    CHECK(plan_prefill_slices(
+        pending, idle_limits).empty());
+    CHECK(plan_prefill_slices({}, idle_limits).empty());
+
+    StepPlanLimits large_limits{/*max sequences=*/2,
+                                /*per sequence=*/std::numeric_limits<int>::max(),
+                                /*total=*/std::numeric_limits<int>::max(),
+                                /*allocation quantum=*/std::numeric_limits<int>::max()};
+    auto large = plan_prefill_slices(pending, large_limits);
+    CHECK(large.size() == 1);
+    CHECK(large[0].slot == 2);
+    CHECK(large[0].max_tokens == std::numeric_limits<int>::max());
+
+    // The same model-neutral layer validates engine row ownership before the
+    // scheduler mutates socket/request state.
+    SeqEngine::StepPlan work;
+    work.decode = {{0, 7}};
+    work.prefills = {{1, 4}};
+
+    SeqEngine::StepResult good;
+    good.decode.push_back({0, 11, false, {}});
+    good.prefills.push_back({
+        1, SeqEngine::PrefillOutput::Status::advanced, -1, {}});
+    CHECK(validate_step_result(work, good, 2).empty());
+
+    SeqEngine::StepResult complete = good;
+    complete.prefills[0] = {
+        1, SeqEngine::PrefillOutput::Status::completed, 12, {}};
+    CHECK(validate_step_result(work, complete, 2).empty());
+
+    SeqEngine::StepResult missing_decode = good;
+    missing_decode.decode.clear();
+    CHECK(!validate_step_result(work, missing_decode, 2).empty());
+
+    SeqEngine::StepResult duplicate_decode = good;
+    duplicate_decode.decode.push_back({0, 12, false, {}});
+    CHECK(!validate_step_result(work, duplicate_decode, 2).empty());
+
+    SeqEngine::StepResult missing_prefill = good;
+    missing_prefill.prefills.clear();
+    CHECK(!validate_step_result(work, missing_prefill, 2).empty());
+
+    // A selected prefill may terminate with a per-request error; the
+    // scheduler retires only that slot.
+    SeqEngine::StepResult prefill_failure = good;
+    prefill_failure.prefills[0] = {
+        1, SeqEngine::PrefillOutput::Status::failed, -1, "prefill failed"};
+    CHECK(validate_step_result(work, prefill_failure, 2).empty());
+
+    SeqEngine::StepResult bad_row_failure = prefill_failure;
+    bad_row_failure.prefills.back().error.clear();
+    CHECK(!validate_step_result(work, bad_row_failure, 2).empty());
+
+    SeqEngine::StepResult unknown_prefill = good;
+    unknown_prefill.prefills[0].status =
+        static_cast<SeqEngine::PrefillOutput::Status>(-1);
+    CHECK(!validate_step_result(work, unknown_prefill, 2).empty());
+
+    SeqEngine::StepResult bad_decode = good;
+    bad_decode.decode[0] = {0, -1, true, {}};
+    CHECK(!validate_step_result(work, bad_decode, 2).empty());
+
+    SeqEngine::StepResult failed_with_token = good;
+    failed_with_token.decode[0] = {0, 12, true, "decode failed"};
+    CHECK(!validate_step_result(work, failed_with_token, 2).empty());
+
+    SeqEngine::StepResult success_with_error = good;
+    success_with_error.decode[0].error = "contradictory diagnostic";
+    CHECK(!validate_step_result(work, success_with_error, 2).empty());
+
+    SeqEngine::StepResult failed;
+    failed.error = "device compute failed";
+    CHECK(validate_step_result(work, failed, 2).empty());
+    failed.decode.push_back({0, -1, true, "partial"});
+    CHECK(!validate_step_result(work, failed, 2).empty());
+
+    SeqEngine::StepResult idle_result;
+    CHECK(validate_step_result({}, idle_result, 2).empty());
+    CHECK(!validate_step_result(work, idle_result, 2).empty());
+
+    SeqEngine::StepPlan duplicate_plan = work;
+    duplicate_plan.decode.push_back({0, 8});
+    CHECK(!validate_step_result(duplicate_plan, good, 2).empty());
+
+    std::printf("test_seq_batch_plan: %d checks passed\n", g_checks);
+    return 0;
+}

--- a/server/test/test_seq_engine_contract.cpp
+++ b/server/test/test_seq_engine_contract.cpp
@@ -1,0 +1,323 @@
+// Host-only mutation test for the model-neutral SeqEngine contract.
+
+#include "seq_engine_contract.h"
+#include "host_check.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace dflash::common;
+
+static int g_checks = 0;
+
+struct Faults {
+    bool hard_error_when_full = false;
+    bool reuse_live_slot = false;
+    bool drop_decode_output = false;
+    bool serialize_prefills = false;
+    bool accept_omitted_decode = false;
+    bool accept_invalid_prefill = false;
+    bool lose_other_pending = false;
+    bool overconsume_prefill = false;
+    bool drop_second_completion = false;
+    bool retire_leaks = false;
+};
+
+struct FakeCapabilities {
+    StepPlanLimits idle{2, 2, 4};
+    StepPlanLimits mixed{2, 1, 2};
+};
+
+class FakeSeqEngine final : public SeqEngine {
+public:
+    explicit FakeSeqEngine(int count, Faults faults = {},
+                           FakeCapabilities capabilities = {})
+        : slots_((size_t)count), faults_(faults),
+          capabilities_(capabilities) {}
+
+    int slot_count() const override { return (int)slots_.size(); }
+    int max_context() const override { return 128; }
+    StepPlanLimits step_plan_limits(int decode_rows) const override {
+        return decode_rows > 0 ? capabilities_.mixed : capabilities_.idle;
+    }
+    bool token_is_eos(int32_t token) const override { return token == 2; }
+
+    AdmitResult admit(uint64_t,
+                      const std::vector<int32_t> & prompt,
+                      const SamplerCfg &) override {
+        AdmitResult result;
+        if (prompt.empty() || prompt.size() > (size_t)max_context()) {
+            result.error = "invalid prompt";
+            return result;
+        }
+
+        int chosen = -1;
+        if (faults_.reuse_live_slot) {
+            chosen = 0;
+        } else {
+            for (size_t i = 0; i < slots_.size(); ++i) {
+                if (!slots_[i].active) {
+                    chosen = (int)i;
+                    break;
+                }
+            }
+        }
+        if (chosen < 0) {
+            result.status = faults_.hard_error_when_full
+                ? AdmitResult::Status::failed
+                : AdmitResult::Status::busy;
+            result.error = "all slots are live";
+            return result;
+        }
+
+        Slot & slot = slots_[(size_t)chosen];
+        slot.active = true;
+        slot.prefilling = true;
+        slot.remaining = (int)prompt.size();
+        slot.fed.clear();
+        result.status = AdmitResult::Status::admitted;
+        result.slot = chosen;
+        return result;
+    }
+
+    StepResult step(const StepPlan & plan) override {
+        StepResult result;
+        std::string validation_error;
+        if (!valid_decode(plan, validation_error) &&
+            !faults_.accept_omitted_decode) {
+            result.error = validation_error;
+            return result;
+        }
+        if (!valid_prefills(plan, validation_error) &&
+            !faults_.accept_invalid_prefill) {
+            result.error = validation_error;
+            return result;
+        }
+
+        size_t decode_count = plan.decode.size();
+        if (faults_.drop_decode_output && plan.prefills.empty() &&
+            decode_count == 2) {
+            --decode_count;
+        }
+        for (size_t i = 0; i < decode_count; ++i) {
+            const StepInput & input = plan.decode[i];
+            if (input.slot < 0 || input.slot >= slot_count()) continue;
+            Slot & slot = slots_[(size_t)input.slot];
+            slot.fed.push_back(input.token);
+            result.decode.push_back({
+                input.slot,
+                100 + input.slot + (int32_t)slot.fed.size(),
+                false, {},
+            });
+        }
+
+        std::vector<int> completed_this_step;
+        for (size_t i = 0; i < plan.prefills.size(); ++i) {
+            if (faults_.serialize_prefills && i > 0) continue;
+            const PrefillSlice & slice = plan.prefills[i];
+            if (slice.slot < 0 || slice.slot >= slot_count()) continue;
+            Slot & slot = slots_[(size_t)slice.slot];
+            if (!slot.active || !slot.prefilling || slot.remaining <= 0) {
+                continue;
+            }
+            int consumed = std::min(slice.max_tokens, slot.remaining);
+            if (faults_.overconsume_prefill) consumed = slice.max_tokens + 1;
+            slot.remaining -= consumed;
+            if (slot.remaining <= 0) {
+                slot.prefilling = false;
+                completed_this_step.push_back(slice.slot);
+                const bool omit = faults_.drop_second_completion && i > 0;
+                if (!omit) {
+                    result.prefills.push_back({
+                        slice.slot, PrefillOutput::Status::completed,
+                        100 + slice.slot, {},
+                    });
+                }
+            } else {
+                result.prefills.push_back({
+                    slice.slot, PrefillOutput::Status::advanced, -1, {},
+                });
+            }
+        }
+
+        if (faults_.lose_other_pending && !completed_this_step.empty()) {
+            for (Slot & slot : slots_) {
+                if (slot.active && slot.prefilling) slot.prefilling = false;
+            }
+        }
+
+        return result;
+    }
+
+    void retire(int slot) override {
+        if (slot < 0 || slot >= slot_count() || faults_.retire_leaks) return;
+        slots_[(size_t)slot] = Slot{};
+    }
+
+private:
+    struct Slot {
+        bool active = false;
+        bool prefilling = false;
+        int remaining = 0;
+        std::vector<int32_t> fed;
+    };
+
+    int decoding_count() const {
+        int count = 0;
+        for (const Slot & slot : slots_) {
+            if (slot.active && !slot.prefilling) ++count;
+        }
+        return count;
+    }
+
+    bool valid_decode(const StepPlan & plan, std::string & error) const {
+        std::vector<bool> seen(slots_.size(), false);
+        if ((int)plan.decode.size() != decoding_count()) {
+            error = "plan omits a decoding slot";
+            return false;
+        }
+        for (const StepInput & input : plan.decode) {
+            if (input.slot < 0 || input.slot >= slot_count() ||
+                seen[(size_t)input.slot] || input.token < 0 ||
+                !slots_[(size_t)input.slot].active ||
+                slots_[(size_t)input.slot].prefilling) {
+                error = "invalid decode input";
+                return false;
+            }
+            seen[(size_t)input.slot] = true;
+        }
+        for (int slot = 0; slot < slot_count(); ++slot) {
+            if (slots_[(size_t)slot].active &&
+                !slots_[(size_t)slot].prefilling &&
+                !seen[(size_t)slot]) {
+                error = "plan omits a decoding slot";
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool valid_prefills(const StepPlan & plan, std::string & error) const {
+        const StepPlanLimits limits =
+            step_plan_limits((int)plan.decode.size());
+        const int token_limit = limits.max_prefill_tokens_per_sequence;
+        if ((int)plan.prefills.size() > limits.max_prefill_sequences) {
+            error = "too many prefills";
+            return false;
+        }
+        std::vector<bool> seen(slots_.size(), false);
+        int total_tokens = 0;
+        for (const PrefillSlice & slice : plan.prefills) {
+            if (slice.slot < 0 || slice.slot >= slot_count() ||
+                seen[(size_t)slice.slot] || slice.max_tokens <= 0 ||
+                slice.max_tokens > token_limit ||
+                !slots_[(size_t)slice.slot].active ||
+                !slots_[(size_t)slice.slot].prefilling) {
+                error = "invalid prefill slice";
+                return false;
+            }
+            seen[(size_t)slice.slot] = true;
+            total_tokens += slice.max_tokens;
+            if (total_tokens > limits.max_prefill_tokens_total) {
+                error = "too many total prefill tokens";
+                return false;
+            }
+        }
+        return true;
+    }
+
+    std::vector<Slot> slots_;
+    Faults faults_;
+    FakeCapabilities capabilities_;
+};
+
+static void print_violations(const char * label,
+                             const std::vector<std::string> & violations) {
+    for (const std::string & violation : violations) {
+        std::fprintf(stderr, "  [%s] %s\n", label, violation.c_str());
+    }
+}
+
+static bool mentions(const std::vector<std::string> & violations,
+                     const char * needle) {
+    return std::any_of(
+        violations.begin(), violations.end(),
+        [&](const std::string & violation) {
+            return violation.find(needle) != std::string::npos;
+        });
+}
+
+int main() {
+    for (const int slots : {2, 4}) {
+        FakeSeqEngine engine(slots);
+        const auto violations = check_seq_engine_contract(engine);
+        if (!violations.empty()) print_violations("conforming", violations);
+        CHECK(violations.empty());
+    }
+
+    {
+        FakeCapabilities capabilities;
+        capabilities.idle = {1, 2, 2};
+        capabilities.mixed = {1, 1, 1};
+        FakeSeqEngine engine(2, {}, capabilities);
+        const auto violations = check_seq_engine_contract(engine);
+        if (!violations.empty()) print_violations("conforming-k1", violations);
+        CHECK(violations.empty());
+    }
+
+    {
+        FakeCapabilities capabilities;
+        capabilities.idle = {2, 2, 2};
+        capabilities.mixed = {1, 1, 1};
+        FakeSeqEngine engine(2, {}, capabilities);
+        const auto violations = check_seq_engine_contract(engine);
+        if (!violations.empty()) {
+            print_violations("conforming-width-dependent", violations);
+        }
+        CHECK(violations.empty());
+    }
+
+    struct Case {
+        const char * label;
+        bool Faults::*fault;
+        const char * expected;
+    };
+    const Case cases[] = {
+        {"hard-error-full", &Faults::hard_error_when_full, "full engine"},
+        {"reuse-live", &Faults::reuse_live_slot, "reused a live slot"},
+        {"drop-decode", &Faults::drop_decode_output, "omitted an output"},
+        {"serialize-prefill", &Faults::serialize_prefills,
+         "omitted an output"},
+        {"accept-omitted", &Faults::accept_omitted_decode,
+         "omits a decoding slot"},
+        {"accept-invalid-prefill", &Faults::accept_invalid_prefill,
+         "prefill work for a decoding slot"},
+        {"lose-pending", &Faults::lose_other_pending,
+         "valid planned work must succeed"},
+        {"overconsume", &Faults::overconsume_prefill,
+         "completion before its final token"},
+        {"scalar-completion", &Faults::drop_second_completion,
+         "omitted an output"},
+        {"retire-leak", &Faults::retire_leaks,
+         "succeed while a slot is free"},
+    };
+
+    for (const Case & test : cases) {
+        Faults faults;
+        faults.*test.fault = true;
+        FakeSeqEngine engine(2, faults);
+        const auto violations = check_seq_engine_contract(engine);
+        if (!mentions(violations, test.expected)) {
+            std::fprintf(stderr,
+                         "FAIL %s: expected violation containing '%s'\n",
+                         test.label, test.expected);
+            print_violations(test.label, violations);
+        }
+        CHECK(mentions(violations, test.expected));
+    }
+
+    std::printf("test_seq_engine_contract: %d checks passed\n", g_checks);
+    return 0;
+}

--- a/server/test/test_seq_slot_manager.cpp
+++ b/server/test/test_seq_slot_manager.cpp
@@ -1,0 +1,428 @@
+// Host-side unit test for Qwen35SlotManager (concurrent decode slots).
+//
+// Mirrors test_paged_kv_pool: no model, ggml, or GPU required. Covers the
+// admission checks, atomic prompt-plus-headroom reservation, rolling decode
+// protection, block-table deltas, exhaustion atomicity, and pool-handle
+// lifecycle across retire.
+
+#include "qwen35/concurrency/qwen35_slot_manager.h"
+#include "host_check.h"
+
+#include <cstdio>
+#include <cstdlib>
+
+using namespace dflash::common;
+
+static int g_checks = 0;
+
+static SamplerCfg greedy_sampler() {
+    return SamplerCfg{};
+}
+
+static std::vector<int32_t> prompt_tokens(int count) {
+    return std::vector<int32_t>((size_t)count, 1);
+}
+
+static SeqEngine::AdmitResult admit(
+        Qwen35SlotManager & manager, uint64_t request_id,
+        const std::vector<int32_t> & prompt, const SamplerCfg & sampler) {
+    static int next_staging_lease = 0;
+    return manager.admit(
+        request_id, prompt, sampler, next_staging_lease++);
+}
+
+static bool is_admitted(const SeqEngine::AdmitResult & result) {
+    return result.status == SeqEngine::AdmitResult::Status::admitted;
+}
+
+static bool is_busy(const SeqEngine::AdmitResult & result) {
+    return result.status == SeqEngine::AdmitResult::Status::busy;
+}
+
+int main() {
+    // 8 blocks x 16 tokens = 128 pool tokens, 2 slots, per-seq max_ctx 64.
+    {
+        PagedKvPool pool(/*physical_block_count=*/8, /*max_sequences=*/2,
+                         /*block_size=*/16);
+        Qwen35SlotManager mgr(pool, /*max_ctx=*/64);
+        CHECK(mgr.slot_count() == 2);
+        CHECK(mgr.max_context() == 64);
+        CHECK(!mgr.is_active(0) && !mgr.is_active(1));
+
+        // Invalid asks are hard errors, not busy.
+        CHECK(!is_admitted(admit(mgr, 1, prompt_tokens(0), greedy_sampler())));
+        CHECK(!is_admitted(admit(mgr, 1, prompt_tokens(65), greedy_sampler())));
+        CHECK(!mgr.is_active(0) && !mgr.is_active(1));
+        CHECK(pool.active_sequence_count() == 0);
+
+        // Admission reserves the prompt's two blocks plus its next decode page
+        // without advancing logical length; chunked append consumes only the
+        // prompt portion of that private reservation.
+        const std::vector<int32_t> admitted_prompt = prompt_tokens(20);
+        auto a = admit(mgr, 1, admitted_prompt, greedy_sampler());
+        CHECK(is_admitted(a) && !is_busy(a));
+        CHECK(a.slot == 0);
+        CHECK(pool.free_block_count() == 5);
+        CHECK(mgr.is_active(0));
+        CHECK(mgr.slot(0).sample_history == admitted_prompt);
+
+        // Prompt allocation follows the chunks actually scheduled. The first
+        // ten rows open block 0; the next ten consume its tail and open block
+        // 1, returning only that block-table delta.
+        auto p0 = mgr.append_prefill(a.slot, 10);
+        CHECK(p0.ok);
+        CHECK(p0.rows.size() == 10 && p0.rows.front() == 0 &&
+              p0.rows.back() == 9);
+        CHECK(p0.first_new_block == 0 && p0.new_blocks.size() == 1 &&
+              p0.new_blocks[0] == 0);
+        CHECK(pool.free_block_count() == 5);
+        auto p1 = mgr.append_prefill(a.slot, 10);
+        CHECK(p1.ok);
+        CHECK(p1.rows.size() == 10 && p1.rows.front() == 10 &&
+              p1.rows.back() == 19);
+        CHECK(p1.first_new_block == 1 && p1.new_blocks.size() == 1 &&
+              p1.new_blocks[0] == 1);
+        CHECK(pool.free_block_count() == 5);
+        mgr.commit_prefill(0);
+        CHECK(mgr.slot(0).cur_pos == 20);
+
+        // Decode appends: row allocation + sample_history; cur_pos advances
+        // separately after the step's compute.
+        auto st = mgr.append_token(0, /*fed_token=*/42);
+        CHECK(st.ok);
+        CHECK(st.position == 20);
+        CHECK(st.physical_row == 20);     // tail of the prompt's last block
+        CHECK(st.new_block < 0 && st.new_block_index < 0);
+        CHECK(mgr.slot(0).cur_pos == 20);
+        CHECK(mgr.slot(0).sample_history.size() == 21 &&
+              mgr.slot(0).sample_history.back() == 42);
+        mgr.commit_step(0);
+        CHECK(mgr.slot(0).cur_pos == 21);
+
+        // Second admission lands in slot 1 with non-identity rows.
+        auto b = admit(mgr, 2, prompt_tokens(20), greedy_sampler());
+        CHECK(is_admitted(b) && b.slot == 1);
+        auto pb = mgr.append_prefill(b.slot, 20);
+        CHECK(pb.ok && pb.rows.front() != 0);
+        mgr.commit_prefill(1);
+
+        // Third admission: no free slot -> busy.
+        auto c = admit(mgr, 3, prompt_tokens(8), greedy_sampler());
+        CHECK(!is_admitted(c) && is_busy(c));
+
+        // Retire frees the slot AND the pool blocks.
+        const uint32_t free_before = pool.free_block_count();
+        mgr.retire(0);
+        CHECK(!mgr.is_active(0));
+        CHECK(pool.free_block_count() > free_before);
+        CHECK(mgr.is_active(1));
+
+        // The freed slot admits again.
+        auto d = admit(mgr, 3, prompt_tokens(8), greedy_sampler());
+        CHECK(is_admitted(d) && d.slot == 0);
+
+        // Inactive-slot calls are safe no-ops.
+        mgr.retire(0);
+        mgr.retire(0);
+        CHECK(!mgr.append_prefill(0, 1).ok);
+        CHECK(!mgr.append_token(0, 1).ok);
+        mgr.commit_step(0);
+        mgr.retire(-1);
+        mgr.retire(99);
+    }
+
+    // A physically impossible headroom page does not make an otherwise useful
+    // prompt impossible: this one-block pool falls back to prompt-only.
+    {
+        PagedKvPool pool(/*physical_block_count=*/1,
+                         /*max_sequences=*/2, /*block_size=*/16);
+        Qwen35SlotManager mgr(pool, /*max_ctx=*/128);
+        auto a = admit(mgr, 1, prompt_tokens(8), greedy_sampler());
+        CHECK(is_admitted(a));
+        CHECK(pool.free_block_count() == 0);
+        CHECK(mgr.append_prefill(a.slot, 8).ok);
+        CHECK(pool.free_block_count() == 0);
+    }
+
+    // Busy-vs-never-fits classification against a small pool.
+    {
+        // 4 blocks x 16 = 64 pool tokens, 2 slots, max_ctx 64.
+        PagedKvPool pool(4, 2, /*block_size=*/16);
+        Qwen35SlotManager mgr(pool, 64);
+
+        // A near-limit prompt needs no additional physical page before max_ctx.
+        auto exact = admit(mgr, 1, prompt_tokens(60), greedy_sampler());
+        CHECK(is_admitted(exact) && mgr.max_context() == 64);
+        CHECK(pool.free_block_count() == 0);
+        CHECK(mgr.append_prefill(exact.slot, 60).ok);
+        mgr.retire(exact.slot);
+
+        // Occupy most of the pool, then a second request that WOULD fit an
+        // empty pool reports busy (blocks held by a live sequence).
+        auto big = admit(mgr, 2, prompt_tokens(48), greedy_sampler());  // 3 prompt + 1 headroom
+        CHECK(is_admitted(big));
+        CHECK(mgr.append_prefill(big.slot, 48).ok);
+        auto blocked = admit(mgr, 3, prompt_tokens(32), greedy_sampler());  // 2 blocks
+        CHECK(!is_admitted(blocked) && is_busy(blocked));
+        mgr.retire(big.slot);
+        auto now_fits = admit(mgr, 3, prompt_tokens(32), greedy_sampler());
+        CHECK(is_admitted(now_fits));
+    }
+
+    // Never-fits: a prompt beyond the WHOLE pool is a hard error, not
+    // busy — waiting for a drain could never help.
+    {
+        // 4 blocks x 16 = 64 pool tokens, but max_ctx allows asking for more.
+        PagedKvPool pool(4, 2, /*block_size=*/16);
+        Qwen35SlotManager mgr(pool, /*max_ctx=*/128);
+        auto never = admit(mgr, 1, prompt_tokens(100), greedy_sampler());
+        CHECK(!is_admitted(never) && !is_busy(never));   // prompt 100 > pool 64
+        CHECK(pool.active_sequence_count() == 0);
+
+        // Impossibility wins over temporary slot pressure: do not queue an
+        // oversized prompt merely because every sequence slot is occupied.
+        auto live = admit(mgr, 2, prompt_tokens(16), greedy_sampler());
+        CHECK(is_admitted(live));
+        auto live2 = admit(mgr, 3, prompt_tokens(16), greedy_sampler());
+        CHECK(is_admitted(live2));
+        auto still_never = admit(mgr, 4, prompt_tokens(100), greedy_sampler());
+        CHECK(!is_admitted(still_never) && !is_busy(still_never));
+    }
+
+    // Aggregate prompt reservations prevent two partial prefills from
+    // consuming the same capacity and reaching a no-progress deadlock.
+    {
+        PagedKvPool pool(/*physical_block_count=*/4,
+                         /*max_sequences=*/3, /*block_size=*/16);
+        Qwen35SlotManager mgr(pool, /*max_ctx=*/64);
+        auto a = admit(mgr, 1, prompt_tokens(48), greedy_sampler());
+        CHECK(is_admitted(a));
+        CHECK(pool.free_block_count() == 0);
+
+        // The second prompt fits the whole pool, but cannot reserve its prompt
+        // plus headroom while the first request owns all four pages. It never
+        // becomes a second partially-filled live slot.
+        auto later = admit(mgr, 2, prompt_tokens(32), greedy_sampler());
+        CHECK(!is_admitted(later) && is_busy(later));
+        CHECK(pool.active_sequence_count() == 1);
+
+        auto first_chunk = mgr.append_prefill(a.slot, 16);
+        CHECK(first_chunk.ok);
+        CHECK(pool.free_block_count() == 0);
+        // Consuming a reserved page does not make it available to another
+        // admission, and appending past the admitted prompt is a hard error.
+        later = admit(mgr, 2, prompt_tokens(32), greedy_sampler());
+        CHECK(!is_admitted(later) && is_busy(later));
+        auto too_much = mgr.append_prefill(a.slot, 33);
+        CHECK(!too_much.ok);
+        auto final_chunk = mgr.append_prefill(a.slot, 32);
+        CHECK(final_chunk.ok);
+        mgr.commit_prefill(a.slot);
+
+        mgr.retire(a.slot);
+        CHECK(pool.free_block_count() == 4);
+        later = admit(mgr, 2, prompt_tokens(32), greedy_sampler());
+        CHECK(is_admitted(later));
+        mgr.retire(later.slot);
+    }
+
+    // When the entire physical pool cannot hold one prompt page plus one decode
+    // page, admission falls back to prompt-only and exhaustion stays retryable.
+    {
+        PagedKvPool pool(/*physical_block_count=*/1,
+                         /*max_sequences=*/1, /*block_size=*/16);
+        Qwen35SlotManager mgr(pool, /*max_ctx=*/32);
+        auto a = admit(mgr, 1, prompt_tokens(16), greedy_sampler());
+        CHECK(is_admitted(a));
+        CHECK(mgr.append_prefill(a.slot, 16).ok);
+        mgr.commit_prefill(a.slot);
+        auto decode_blocked = mgr.append_token(a.slot, 77);
+        CHECK(!decode_blocked.ok && decode_blocked.busy);
+        CHECK(mgr.slot(a.slot).sample_history == prompt_tokens(16));
+        CHECK(mgr.slot(a.slot).cur_pos == 16);
+    }
+
+    // Rolling headroom has priority over younger admission. Even when a
+    // decoder consumes its reserved page while the pool is full, blocks freed
+    // later are topped up for that decoder before a new prompt can claim them.
+    {
+        PagedKvPool pool(/*physical_block_count=*/4,
+                         /*max_sequences=*/2, /*block_size=*/16);
+        Qwen35SlotManager mgr(pool, /*max_ctx=*/48);
+        auto older = admit(mgr, 1, prompt_tokens(16), greedy_sampler());
+        auto peer = admit(mgr, 2, prompt_tokens(16), greedy_sampler());
+        CHECK(is_admitted(older) && is_admitted(peer));
+        CHECK(pool.free_block_count() == 0);
+        CHECK(mgr.append_prefill(older.slot, 16).ok);
+        CHECK(mgr.append_prefill(peer.slot, 16).ok);
+        mgr.commit_prefill(older.slot);
+        mgr.commit_prefill(peer.slot);
+
+        // Enter the initially reserved next page. No block is free yet to
+        // replenish a third page, but this decode token still succeeds.
+        auto enter_second = mgr.append_token(older.slot, 70);
+        CHECK(enter_second.ok && enter_second.new_block >= 0);
+        mgr.commit_step(older.slot);
+        PagedKvSequenceSnapshot snapshot;
+        CHECK(pool.sequence(mgr.slot(older.slot).handle, snapshot) ==
+              PagedKvStatus::Ok);
+        CHECK(snapshot.block_table.size() == 2);
+        CHECK(snapshot.reserved_block_count == 0);
+
+        // Retirement frees two pages. A younger admission first restores the
+        // older decoder's third-page reserve, then reports busy because only
+        // one page remains for its own two-page admission.
+        mgr.retire(peer.slot);
+        CHECK(pool.free_block_count() == 2);
+        auto younger = admit(mgr, 3, prompt_tokens(16), greedy_sampler());
+        CHECK(!is_admitted(younger) && is_busy(younger));
+        CHECK(pool.sequence(mgr.slot(older.slot).handle, snapshot) ==
+              PagedKvStatus::Ok);
+        CHECK(snapshot.reserved_block_count == 1);
+        CHECK(pool.free_block_count() == 1);
+
+        // The protected third page remains consumable at the next boundary.
+        for (int i = 0; i < 15; ++i) {
+            CHECK(mgr.append_token(older.slot, 71 + i).ok);
+            mgr.commit_step(older.slot);
+        }
+        auto enter_third = mgr.append_token(older.slot, 99);
+        CHECK(enter_third.ok && enter_third.new_block >= 0);
+        mgr.commit_step(older.slot);
+
+        mgr.retire(older.slot);
+        younger = admit(mgr, 3, prompt_tokens(16), greedy_sampler());
+        CHECK(is_admitted(younger));
+    }
+
+    // A row whose current append fits its existing page must not consume the
+    // last free block as speculative future headroom before a later row that
+    // needs that block for its current append. Rolling top-up is therefore an
+    // admission-wide operation, never a side effect of append_token().
+    {
+        PagedKvPool pool(/*physical_block_count=*/5,
+                         /*max_sequences=*/3, /*block_size=*/4);
+        Qwen35SlotManager mgr(pool, /*max_ctx=*/16);
+        auto first = admit(mgr, 1, prompt_tokens(4), greedy_sampler());
+        auto boundary = admit(mgr, 2, prompt_tokens(4), greedy_sampler());
+        CHECK(is_admitted(first) && is_admitted(boundary));
+
+        PagedKvSequenceHandle blocker;
+        CHECK(pool.acquire_reserved(99, /*token_capacity=*/4, blocker) ==
+              PagedKvStatus::Ok);
+        CHECK(pool.free_block_count() == 0);
+        CHECK(mgr.append_prefill(first.slot, 4).ok);
+        CHECK(mgr.append_prefill(boundary.slot, 4).ok);
+        mgr.commit_prefill(first.slot);
+        mgr.commit_prefill(boundary.slot);
+
+        auto first_second_page = mgr.append_token(first.slot, 10);
+        CHECK(first_second_page.ok && first_second_page.new_block_index == 1);
+        mgr.commit_step(first.slot);  // position 5, inside its second page
+        for (int i = 0; i < 4; ++i) {
+            CHECK(mgr.append_token(boundary.slot, 20 + i).ok);
+            mgr.commit_step(boundary.slot);
+        }
+        CHECK(mgr.slot(boundary.slot).cur_pos == 8);  // needs page 3 next
+
+        CHECK(pool.release(blocker) == PagedKvStatus::Ok);
+        CHECK(pool.free_block_count() == 1);
+        CHECK(mgr.append_token(first.slot, 30).ok);
+        CHECK(pool.free_block_count() == 1);
+        auto boundary_append = mgr.append_token(boundary.slot, 31);
+        CHECK(boundary_append.ok && boundary_append.new_block_index == 2);
+        CHECK(pool.free_block_count() == 0);
+    }
+
+    // Context exhaustion: append_token refuses past max_ctx.
+    {
+        PagedKvPool pool(4, 1, /*block_size=*/16);
+        Qwen35SlotManager mgr(pool, /*max_ctx=*/17);
+        auto a = admit(mgr, 1, prompt_tokens(16), greedy_sampler());
+        CHECK(is_admitted(a));
+        CHECK(mgr.append_prefill(a.slot, 16).ok);
+        mgr.commit_prefill(0);
+        auto s1 = mgr.append_token(0, 7);   // position 16 (== max_ctx-1)
+        CHECK(s1.ok && s1.position == 16);
+        CHECK(s1.new_block == 1 && s1.new_block_index == 1);
+        mgr.commit_step(0);
+        auto s2 = mgr.append_token(0, 8);   // cur_pos == max_ctx -> refuse
+        CHECK(!s2.ok);
+    }
+
+    // Prefilling lifecycle: an admitted slot stays out of the decode batch
+    // until commit_prefill() makes its first sampled token available.
+    {
+        PagedKvPool pool(8, 2, /*block_size=*/16);
+        Qwen35SlotManager mgr(pool, 64);
+        auto a = admit(mgr, 1, prompt_tokens(20), greedy_sampler());
+        CHECK(is_admitted(a));
+        CHECK(mgr.is_prefilling(a.slot));
+        CHECK(mgr.is_active(a.slot));
+        CHECK(mgr.decoding_count() == 0);
+        CHECK(!mgr.append_token(a.slot, 42).ok);
+
+        CHECK(mgr.append_prefill(a.slot, 20).ok);
+        mgr.commit_prefill(a.slot);
+        CHECK(!mgr.is_prefilling(a.slot));
+        CHECK(mgr.decoding_count() == 1);
+        CHECK(mgr.append_token(a.slot, 42).ok);
+        CHECK(!mgr.append_prefill(a.slot, 1).ok);
+
+        // A second admission can prefill while the first slot decodes.
+        auto b = admit(mgr, 2, prompt_tokens(20), greedy_sampler());
+        CHECK(is_admitted(b));
+        CHECK(mgr.is_active(a.slot) && mgr.is_active(b.slot));
+        CHECK(mgr.decoding_count() == 1);
+
+        // Retiring during prefill clears the state before slot reuse.
+        mgr.retire(b.slot);
+        CHECK(!mgr.is_prefilling(b.slot));
+        auto c = admit(mgr, 3, prompt_tokens(8), greedy_sampler());
+        CHECK(is_admitted(c) && c.slot == b.slot);
+        CHECK(mgr.is_prefilling(c.slot));
+    }
+
+    // Seeded sampling RNG is deterministic per admission. The sampler alone
+    // decides: a seed is honoured exactly when needs_logit_processing() says
+    // the slot actually draws, so there is no way to ask for seeded sampling
+    // and be given argmax (or the reverse).
+    {
+        PagedKvPool pool(4, 1, /*block_size=*/16);
+        Qwen35SlotManager mgr(pool, 64);
+        SamplerCfg cfg = greedy_sampler();
+        cfg.temp = 0.7f;            // needs_logit_processing() -> true
+        cfg.seed = 1234;
+        CHECK(cfg.needs_logit_processing());
+        auto a = admit(mgr, 1, prompt_tokens(4), cfg);
+        CHECK(is_admitted(a));
+        const uint64_t first = mgr.slot(0).rng();
+        mgr.retire(0);
+        auto b = admit(mgr, 2, prompt_tokens(4), cfg);
+        CHECK(is_admitted(b));
+        CHECK(mgr.slot(0).rng() == first);
+
+        // A different seed is a different stream.
+        mgr.retire(0);
+        cfg.seed = 5678;
+        auto c = admit(mgr, 3, prompt_tokens(4), cfg);
+        CHECK(is_admitted(c));
+        CHECK(mgr.slot(0).rng() != first);
+    }
+
+    // A greedy sampler never draws, so its seed is irrelevant and admission
+    // must not depend on one being present.
+    {
+        PagedKvPool pool(4, 1, /*block_size=*/16);
+        Qwen35SlotManager mgr(pool, 64);
+        SamplerCfg cfg = greedy_sampler();
+        cfg.seed = 1234;
+        CHECK(!cfg.needs_logit_processing());
+        auto a = admit(mgr, 1, prompt_tokens(4), cfg);
+        CHECK(is_admitted(a));
+        CHECK(!mgr.slot(0).sampler.needs_logit_processing());
+    }
+
+    std::printf("OK test_seq_slot_manager (%d checks)\n", g_checks);
+    return 0;
+}

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -44,6 +44,7 @@
 
 #include <filesystem>
 #include <cmath>
+#include <cerrno>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -98,6 +99,13 @@ struct ServerUnitFixture {};
     } \
 } while (0)
 
+TEST_CASE(ServerUnitFixture, test_api_format_names_are_total) {
+    CHECK(std::string(api_format_name(ApiFormat::OPENAI_CHAT)) == "chat");
+    CHECK(std::string(api_format_name(ApiFormat::ANTHROPIC)) == "anthropic");
+    CHECK(std::string(api_format_name(ApiFormat::RESPONSES)) == "responses");
+    CHECK(std::string(api_format_name(ApiFormat::COMPLETIONS)) == "completions");
+}
+
 TEST_CASE(ServerUnitFixture, test_daemon_io_external_cancellation_latches) {
     bool cancel = false;
     DaemonIO io;
@@ -141,6 +149,47 @@ TEST_CASE(ServerUnitFixture, test_http_peer_socket_probe_preserves_half_close) {
     sockets[0] = -1;
     TEST_ASSERT(http_detail::inspect_peer_socket(closed_fd) ==
                 http_detail::PeerSocketState::Disconnected);
+    close(sockets[1]);
+}
+
+TEST_CASE(ServerUnitFixture, test_http_heartbeat_never_waits_for_stalled_peer) {
+    int sockets[2] = {-1, -1};
+    TEST_ASSERT(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
+    TEST_ASSERT(fcntl(sockets[0], F_SETFL, O_NONBLOCK) == 0);
+    const int sndbuf = 4096;
+    TEST_ASSERT(setsockopt(sockets[0], SOL_SOCKET, SO_SNDBUF,
+                           &sndbuf, sizeof(sndbuf)) == 0);
+
+    const std::string fill(4096, 'x');
+    ssize_t sent = 0;
+    do {
+        sent = send(sockets[0], fill.data(), fill.size(), MSG_NOSIGNAL);
+    } while (sent > 0);
+    TEST_ASSERT(sent < 0 && (errno == EAGAIN || errno == EWOULDBLOCK));
+
+    const auto started = std::chrono::steady_clock::now();
+    size_t heartbeat_offset = 0;
+    TEST_ASSERT(http_detail::try_send_sse_heartbeat(
+                    sockets[0], heartbeat_offset) ==
+                http_detail::HeartbeatSendResult::Retry);
+    TEST_ASSERT(heartbeat_offset < sizeof(": keep-alive\n\n") - 1);
+    const auto elapsed = std::chrono::steady_clock::now() - started;
+    TEST_ASSERT(elapsed < std::chrono::milliseconds(100));
+
+    // Once the peer drains, retrying completes the same heartbeat rather than
+    // treating temporary backpressure as a disconnect.
+    char drained[8192];
+    while (recv(sockets[1], drained, sizeof(drained), MSG_DONTWAIT) > 0) {}
+    TEST_ASSERT(http_detail::try_send_sse_heartbeat(
+                    sockets[0], heartbeat_offset) ==
+                http_detail::HeartbeatSendResult::Complete);
+    TEST_ASSERT(heartbeat_offset == 0);
+    const std::string expected = ": keep-alive\n\n";
+    TEST_ASSERT(recv(sockets[1], drained, sizeof(drained), 0) ==
+                (ssize_t)expected.size());
+    TEST_ASSERT(std::memcmp(drained, expected.data(), expected.size()) == 0);
+
+    close(sockets[0]);
     close(sockets[1]);
 }
 #endif
@@ -2245,6 +2294,38 @@ TEST_CASE(ServerUnitFixture, test_pflash_config_defaults) {
     TEST_ASSERT(cfg.pflash_drafter_path.empty());
     TEST_ASSERT(!cfg.pflash_skip_park);
     TEST_ASSERT(cfg.draft_residency == DraftResidencyPolicy::Auto);
+}
+
+TEST_CASE(ServerUnitFixture, test_concurrent_status_is_aggregate_only) {
+    ServerStatus status;
+    ServerStatus::RequestInfo info;
+    info.model = "classic-model";
+    status.set_running("classic prompt", 12, true, info);
+    json snapshot = status.to_json();
+    TEST_ASSERT(snapshot["active_requests"] == 0);
+    TEST_ASSERT(snapshot["current"]["model"] == "classic-model");
+
+    status.set_concurrent_requests(2, 2);
+    snapshot = status.to_json();
+    TEST_ASSERT(snapshot["phase"] == "prefill");
+    TEST_ASSERT(snapshot["active_requests"] == 2);
+    TEST_ASSERT(snapshot["current"].is_null());
+
+    status.set_concurrent_requests(2, 1);
+    snapshot = status.to_json();
+    TEST_ASSERT(snapshot["phase"] == "mixed");
+    TEST_ASSERT(snapshot["active_requests"] == 2);
+
+    status.set_concurrent_requests(2, 0);
+    snapshot = status.to_json();
+    TEST_ASSERT(snapshot["phase"] == "decode");
+    TEST_ASSERT(snapshot["active_requests"] == 2);
+
+    status.set_idle();
+    snapshot = status.to_json();
+    TEST_ASSERT(snapshot["phase"] == "idle");
+    TEST_ASSERT(snapshot["active_requests"] == 0);
+    TEST_ASSERT(snapshot["current"].is_null());
 }
 
 TEST_CASE(ServerUnitFixture, test_pflash_config_modes) {
@@ -4633,7 +4714,6 @@ TEST_CASE(ServerUnitFixture, test_props_model_card_wholesale_sidecar) {
     PrefixCache  pc(0, tok);
     ToolMemory   tm;
     json body = build_props_body(cfg, pc, tm);
-
     TEST_ASSERT(body.contains("model_card"));
     TEST_ASSERT(!body["model_card"].is_null());
     // `source` is the upstream URL, NOT the filepath. The filepath label
@@ -4746,6 +4826,7 @@ TEST_CASE(ServerUnitFixture, test_props_runtime_shape) {
     cfg.chunk           = 512;
     cfg.target_device   = "auto:0";
     cfg.draft_device    = "auto:0";
+    TEST_ASSERT(cfg.admission_coalesce_ms == 20);
 
     Tokenizer    tok;
     PrefixCache  pc(0, tok);
@@ -4764,12 +4845,17 @@ TEST_CASE(ServerUnitFixture, test_props_runtime_shape) {
     TEST_ASSERT(rt["chunk"].get<int>()                   == 512);
     TEST_ASSERT(rt["target_device"].get<std::string>()   == "auto:0");
     TEST_ASSERT(rt["draft_device"].get<std::string>()    == "auto:0");
+    TEST_ASSERT(rt["continuous_batching"]["admission_coalesce_ms"]
+                    .get<int>() == 20);
     TEST_ASSERT(body["pflash"]["draft_residency"].get<std::string>() == "persistent");
 
     // draft_device is null when no draft model is loaded.
     cfg.draft_device.clear();
+    cfg.admission_coalesce_ms = 7;
     body = build_props_body(cfg, pc, tm);
     TEST_ASSERT(body["runtime"]["draft_device"].is_null());
+    TEST_ASSERT(body["runtime"]["continuous_batching"]
+                    ["admission_coalesce_ms"].get<int>() == 7);
 }
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/server/tests/test_server_parallel.py
+++ b/server/tests/test_server_parallel.py
@@ -1,0 +1,589 @@
+#!/usr/bin/env python3
+"""End-to-end integration tests for concurrent serving (--max-concurrency N).
+
+Exercises the qwen35 paged-attention slot engine: true decode overlap across
+streams, per-request state isolation, sequential-vs-concurrent consistency,
+SSE interleaving, over-subscription (queueing beyond slot count), concurrent
+non-streaming completions, and non-pausing admission.
+
+Usage:
+    # Start server first with concurrent serving enabled:
+    ./server/build/dflash_server <qwen36-model.gguf> --port 9099 \
+        --paged-attention --max-concurrency 3
+
+    # Then run tests:
+    python3 server/tests/test_server_parallel.py \
+        --base-url http://127.0.0.1:9099 --max-concurrency 3
+
+The non-power-of-two default is intentional: three physical slots produce a
+four-row compact decode bucket, with the final row mapped to padding. This
+guards the distinction between graph bucket width and physical slot count.
+
+Note: batched decode may legally differ from single-request decode at the
+token level (GEMM reduction order can flip near-tie tokens), so all answer
+checks are content-level (the expected number appears), never exact-match.
+"""
+
+import argparse
+import json
+import re
+import sys
+import threading
+import time
+import urllib.request
+import urllib.error
+
+
+def make_math_prompts(count: int):
+    """Deterministic arithmetic prompts with distinct 3-digit answers.
+
+    Sums start at 111 and step by 3 so that no answer is within +/-2 of
+    another (greedy reasoning that decomposes a sum won't casually emit a
+    neighboring stream's answer), and for small counts the operands stay
+    2-digit while every answer is 3-digit, so an answer never collides with
+    an operand echoed from another prompt.
+    """
+    prompts = []
+    for i in range(count):
+        s = 111 + 3 * i
+        a = s // 2
+        b = s - a
+        prompts.append((f"What is {a}+{b}? Answer with just the number.", str(s)))
+    return prompts
+
+
+def make_long_prompts(count: int):
+    """Prompts that force long, multi-chunk generations, so overlap and
+    interleave are observable. Each stream counts a distinct range; the
+    expected marker is the range start (always emitted early)."""
+    prompts = []
+    for i in range(count):
+        start = 100 + 50 * i
+        end = start + 40
+        prompts.append((
+            f"Count from {start} to {end}, separated by commas, "
+            f"no other text.", str(start)))
+    return prompts
+
+
+def contains_number(text: str, number: str) -> bool:
+    """True if `number` appears in `text` as a standalone number
+    (not embedded in a longer digit run)."""
+    return re.search(rf"(?<![0-9]){re.escape(number)}(?![0-9])", text) is not None
+
+
+class ParallelTestSuite:
+    def __init__(self, base_url: str, parallel: int):
+        self.base = base_url.rstrip("/")
+        self.parallel = parallel
+        self.passed = 0
+        self.failed = 0
+        self.skipped = 0
+
+    def _req(self, method: str, path: str, body: dict | None = None,
+             stream: bool = False, timeout: float = 300.0):
+        url = self.base + path
+        data = json.dumps(body).encode() if body else None
+        headers = {"Content-Type": "application/json"} if body else {}
+        req = urllib.request.Request(url, data=data, headers=headers, method=method)
+        resp = urllib.request.urlopen(req, timeout=timeout)
+        if stream:
+            return resp  # caller reads lines
+        return json.loads(resp.read().decode())
+
+    def _check(self, name: str, ok: bool, detail: str = ""):
+        if ok:
+            self.passed += 1
+            print(f"  ✅ {name}")
+        else:
+            self.failed += 1
+            print(f"  ❌ {name}: {detail}")
+
+    def _skip(self, name: str, reason: str):
+        self.skipped += 1
+        print(f"  ⏭️  {name}: {reason}")
+
+    # ── Request workers ──────────────────────────────────────────────────
+
+    def _chat_body(self, prompt: str, max_tokens: int, stream: bool) -> dict:
+        return {
+            "model": "dflash",
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": max_tokens,
+            "temperature": 0.0,
+            "stream": stream,
+        }
+
+    def _stream_worker(self, idx: int, prompt: str, max_tokens: int,
+                       results: list, barrier: threading.Barrier | None = None,
+                       timeline: list | None = None,
+                       timeline_lock=None,
+                       timeout: float = 600.0):
+        """Run one streaming chat completion; record content and chunk timing."""
+        r = {"ok": False, "error": None, "content": "", "reasoning": "",
+             "first_chunk_t": None, "finish_t": None, "n_chunks": 0}
+        results[idx] = r
+        try:
+            if barrier is not None:
+                barrier.wait(timeout=60)
+            resp = self._req("POST", "/v1/chat/completions",
+                             self._chat_body(prompt, max_tokens, stream=True),
+                             stream=True, timeout=timeout)
+            for line in resp:
+                line = line.decode().strip()
+                if not line:
+                    continue
+                if line == "data: [DONE]":
+                    break
+                if not line.startswith("data: "):
+                    continue
+                chunk = json.loads(line[6:])
+                choices = chunk.get("choices") or [{}]
+                delta = choices[0].get("delta", {})
+                got_piece = False
+                if delta.get("reasoning_content"):
+                    r["reasoning"] += delta["reasoning_content"]
+                    got_piece = True
+                if delta.get("content"):
+                    r["content"] += delta["content"]
+                    got_piece = True
+                if got_piece:
+                    now = time.monotonic()
+                    r["n_chunks"] += 1
+                    if r["first_chunk_t"] is None:
+                        r["first_chunk_t"] = now
+                    if timeline is not None:
+                        with timeline_lock:
+                            timeline.append((now, idx))
+            r["finish_t"] = time.monotonic()
+            resp.close()
+            r["ok"] = True
+        except urllib.error.HTTPError as e:
+            body = e.read().decode(errors="replace")
+            r["error"] = f"HTTP {e.code}: {body[:300]}"
+        except Exception as e:
+            r["error"] = f"{type(e).__name__}: {e}"
+
+    def _nonstream_worker(self, idx: int, prompt: str, max_tokens: int,
+                          results: list, barrier: threading.Barrier | None = None,
+                          start_delay: float = 0.0,
+                          timeout: float = 600.0):
+        """Run one non-streaming chat completion."""
+        r = {"ok": False, "error": None, "content": "", "reasoning": "",
+             "usage": {}}
+        results[idx] = r
+        try:
+            if barrier is not None:
+                barrier.wait(timeout=60)
+            if start_delay > 0:
+                time.sleep(start_delay)
+            resp = self._req("POST", "/v1/chat/completions",
+                             self._chat_body(prompt, max_tokens, stream=False),
+                             timeout=timeout)
+            msg = resp["choices"][0]["message"]
+            r["content"] = msg.get("content") or ""
+            r["reasoning"] = msg.get("reasoning_content") or ""
+            r["usage"] = resp.get("usage", {})
+            r["ok"] = True
+        except urllib.error.HTTPError as e:
+            body = e.read().decode(errors="replace")
+            r["error"] = f"HTTP {e.code}: {body[:300]}"
+        except Exception as e:
+            r["error"] = f"{type(e).__name__}: {e}"
+
+    def _run_workers(self, worker, count: int, per_request_kwargs: list,
+                     join_timeout: float = 900.0):
+        """Launch `count` worker threads through a start barrier; return results."""
+        results: list = [None] * count
+        barrier = threading.Barrier(count)
+        threads = []
+        for i in range(count):
+            t = threading.Thread(target=worker,
+                                 args=(i,), kwargs={**per_request_kwargs[i],
+                                                    "results": results,
+                                                    "barrier": barrier},
+                                 daemon=True)
+            threads.append(t)
+            t.start()
+        for t in threads:
+            t.join(timeout=join_timeout)
+        return results
+
+    def _launch_streams(self, prompts, max_tokens: int,
+                        timeline: list | None = None,
+                        join_timeout: float = 900.0):
+        """Fire len(prompts) streaming requests simultaneously."""
+        timeline_lock = threading.Lock() if timeline is not None else None
+        kwargs = [{"prompt": p, "max_tokens": max_tokens,
+                   "timeline": timeline, "timeline_lock": timeline_lock}
+                  for p, _ in prompts]
+        return self._run_workers(self._stream_worker, len(prompts), kwargs,
+                                 join_timeout=join_timeout)
+
+    def _launch_nonstream(self, prompts, max_tokens: int,
+                          join_timeout: float = 900.0):
+        """Fire len(prompts) non-streaming requests simultaneously."""
+        kwargs = [{"prompt": p, "max_tokens": max_tokens} for p, _ in prompts]
+        return self._run_workers(self._nonstream_worker, len(prompts), kwargs,
+                                 join_timeout=join_timeout)
+
+    def _all_completed(self, results, label: str) -> bool:
+        """Check every worker result; report per-request failures."""
+        all_ok = True
+        for i, r in enumerate(results):
+            if r is None:
+                self._check(f"{label} request {i+1} completes", False,
+                            "worker did not finish (timeout)")
+                all_ok = False
+            elif not r["ok"]:
+                self._check(f"{label} request {i+1} completes", False, r["error"])
+                all_ok = False
+        if all_ok:
+            self._check(f"all {len(results)} {label} requests complete "
+                        "with 200", True)
+        return all_ok
+
+    @staticmethod
+    def _combined(r) -> str:
+        return r["reasoning"] + "\n" + r["content"]
+
+    # ── Tests ────────────────────────────────────────────────────────────
+
+    def test_parallel_streaming(self):
+        """N simultaneous streams must overlap and their chunks interleave."""
+        n = self.parallel
+        print(f"\n[PAR-1] Streaming overlap + interleave — "
+              f"{n} simultaneous requests")
+        if n == 1:
+            self._skip("streaming overlap + interleave",
+                       "--max-concurrency 1: concurrency is not expected; "
+                       "run with --max-concurrency > 1")
+            return
+        prompts = make_long_prompts(n)
+        timeline: list = []
+        t0 = time.monotonic()
+        results = self._launch_streams(prompts, max_tokens=192,
+                                       timeline=timeline)
+        elapsed = time.monotonic() - t0
+        if not self._all_completed(results, "streaming"):
+            return
+
+        missing = [i + 1 for i, r in enumerate(results)
+                   if r["first_chunk_t"] is None]
+        self._check("every stream produced at least one chunk",
+                    not missing, f"streams with no chunks: {missing}")
+        if missing:
+            return
+
+        latest_first = max(r["first_chunk_t"] for r in results)
+        earliest_finish = min(r["finish_t"] for r in results)
+        rel = [(f"s{i+1}: first={r['first_chunk_t']-t0:.2f}s "
+                f"finish={r['finish_t']-t0:.2f}s")
+               for i, r in enumerate(results)]
+        self._check("all first chunks arrive before earliest finish "
+                    "(true overlap, not serialization)",
+                    latest_first < earliest_finish,
+                    f"latest first chunk at {latest_first-t0:.2f}s, earliest "
+                    f"finish at {earliest_finish-t0:.2f}s; {'; '.join(rel)}")
+        print(f"    → {n} streams completed in {elapsed:.1f}s; "
+              f"latest first chunk {latest_first-t0:.2f}s, "
+              f"earliest finish {earliest_finish-t0:.2f}s")
+
+        seq = [idx for _, idx in sorted(timeline)]
+        distinct = len(set(seq))
+        runs = 1 + sum(1 for a, b in zip(seq, seq[1:]) if a != b) if seq else 0
+        self._check("chunks arrived from at least two streams", distinct >= 2,
+                    f"streams seen: {sorted(set(seq))}")
+        # If every stream's chunks formed one contiguous block, runs would
+        # equal distinct; interleaving means some stream owns >= 2 runs.
+        self._check("chunks from different streams interleave",
+                    runs > distinct,
+                    f"{len(seq)} chunks arrived in {runs} contiguous runs "
+                    f"across {distinct} streams (fully serialized order)")
+        print(f"    → {len(seq)} chunks, {distinct} streams, {runs} runs")
+
+    def test_parallel_isolation(self):
+        """Concurrent streams with distinct prompts: each answer belongs to
+        its own prompt, none leaks into another stream (state isolation)."""
+        n = self.parallel
+        print(f"\n[PAR-2] Isolation — {n} concurrent distinct prompts")
+        prompts = make_math_prompts(n)
+        results = self._launch_streams(prompts, max_tokens=512)
+        if not self._all_completed(results, "streaming"):
+            return
+
+        answers = [ans for _, ans in prompts]
+        for i, r in enumerate(results):
+            # Positive: own answer somewhere in reasoning+content.
+            self._check(f"stream {i+1} contains its own answer {answers[i]}",
+                        contains_number(self._combined(r), answers[i]),
+                        f"content={r['content']!r} "
+                        f"reasoning={r['reasoning'][:200]!r}")
+            # Negative: no other stream's answer in the final content
+            # (content only — reasoning legitimately echoes this prompt's
+            # operands and intermediate sums, content is just the number).
+            leaked = [answers[j] for j in range(n)
+                      if j != i and contains_number(r["content"], answers[j])]
+            self._check(f"stream {i+1} contains no other stream's answer",
+                        not leaked,
+                        f"leaked answers {leaked} in content={r['content']!r}")
+
+    def test_parallel_nonstream(self):
+        """A prompt answered correctly alone must still be answered correctly
+        when decoded inside an N-way concurrent non-streaming batch. Also
+        validates every concurrent answer and its completion-token usage.
+        Content-level match only — batched GEMM reduction order may legally
+        flip near-tie tokens, so exact token equality is NOT required."""
+        n = self.parallel
+        print(f"\n[PAR-3] Sequential + concurrent non-streaming consistency")
+        prompts = make_math_prompts(n)
+        probe_prompt, probe_answer = prompts[0]
+
+        # Solo run.
+        solo = [None]
+        self._nonstream_worker(0, probe_prompt, 512, solo)
+        if not solo[0]["ok"]:
+            self._check("solo request completes", False, solo[0]["error"])
+            return
+        self._check("solo request completes", True)
+        solo_ok = contains_number(self._combined(solo[0]), probe_answer)
+        self._check(f"solo answer contains {probe_answer}", solo_ok,
+                    f"content={solo[0]['content']!r} "
+                    f"reasoning={solo[0]['reasoning'][:200]!r}")
+        print(f"    → solo content: {solo[0]['content']!r}")
+
+        # Same prompt inside an N-way concurrent batch.
+        results = self._launch_nonstream(prompts, max_tokens=512)
+        if not self._all_completed(results, "non-streaming"):
+            return
+        conc = results[0]
+        print(f"    → concurrent content: {conc['content']!r}")
+        if solo[0]["content"] != conc["content"]:
+            print("    → note: solo/concurrent contents differ at token level "
+                  "(allowed — batched reduction order)")
+        for i, r in enumerate(results):
+            ans = prompts[i][1]
+            self._check(f"request {i+1} contains its answer {ans}",
+                        contains_number(self._combined(r), ans),
+                        f"content={r['content']!r} "
+                        f"reasoning={r['reasoning'][:200]!r}")
+            completion_tokens = r["usage"].get("completion_tokens", 0)
+            self._check(f"request {i+1} usage.completion_tokens > 0",
+                        completion_tokens > 0,
+                        f"usage={r['usage']}")
+            prompt_tokens = r["usage"].get("prompt_tokens", 0)
+            timings = r["usage"].get("timings", {})
+            self._check(
+                f"request {i+1} timings account for the full prompt",
+                prompt_tokens > 0
+                and timings.get("prefilled_tokens") == prompt_tokens
+                and timings.get("effective_prompt_tokens") == prompt_tokens,
+                f"usage={r['usage']}")
+
+    def test_parallel_more_than_slots(self):
+        """2*N requests at once: extras must queue behind the N slots and
+        all must finish with correct answers."""
+        n = self.parallel
+        count = 2 * n
+        print(f"\n[PAR-4] Over-subscription — {count} requests on {n} slots")
+        prompts = make_math_prompts(count)
+        t0 = time.monotonic()
+        results = self._launch_nonstream(prompts, max_tokens=512,
+                                         join_timeout=1800.0)
+        elapsed = time.monotonic() - t0
+        if not self._all_completed(results, "non-streaming"):
+            return
+        for i, r in enumerate(results):
+            ans = prompts[i][1]
+            self._check(f"request {i+1} contains its answer {ans}",
+                        contains_number(self._combined(r), ans),
+                        f"content={r['content']!r} "
+                        f"reasoning={r['reasoning'][:200]!r}")
+        print(f"    → {count} requests completed in {elapsed:.1f}s")
+
+    def test_unequal_prefill_staging_leases(self):
+        """A multi-chunk prefill must keep its staging identity after an
+        earlier short prefill commits and leaves the FIFO head."""
+        print("\n[PAR-5] Unequal prefills retain isolated staging state")
+        if self.parallel < 2:
+            self._skip("unequal prefill staging lease",
+                       "--max-concurrency 1: multiple staging sets unavailable")
+            return
+
+        short_prompt = "What is 55+56? Answer with just the number."
+        filler = "\n".join(
+            f"record {i}: alpha beta gamma delta epsilon zeta eta theta"
+            for i in range(360))
+        long_prompt = (
+            f"Read and then ignore these padding records:\n{filler}\n"
+            "What is 4500+4501? Answer with just the number.")
+
+        # Launch both requests close together, with the short request first in
+        # FIFO order. It should finish first while the long request retains
+        # staging set 1.
+        kwargs = [
+            {"prompt": short_prompt, "max_tokens": 512,
+             "start_delay": 0.0},
+            {"prompt": long_prompt, "max_tokens": 512,
+             "start_delay": 0.001},
+        ]
+        results = self._run_workers(
+            self._nonstream_worker, 2, kwargs, join_timeout=1800.0)
+        if not self._all_completed(results, "unequal-prefill"):
+            return
+
+        self._check(
+            "short prefill answers 111",
+            contains_number(self._combined(results[0]), "111"),
+            f"content={results[0]['content']!r}")
+        self._check(
+            "long prefill answers 9001 after the short prefill commits",
+            contains_number(self._combined(results[1]), "9001"),
+            f"content={results[1]['content']!r} "
+            f"reasoning={results[1]['reasoning'][:200]!r}")
+        long_prompt_tokens = results[1]["usage"].get("prompt_tokens", 0)
+        self._check(
+            "long prompt crosses the 2048-token initial prefill chunk",
+            long_prompt_tokens > 2048,
+            f"usage={results[1]['usage']}")
+
+    def test_parallel_prefill_no_pause(self):
+        """A long admission must not pause a stream that is already decoding."""
+        n = self.parallel
+        print("\n[PAR-7] Prefill/decode fusion — decode continues during "
+              "a long prefill")
+        if n == 1:
+            self._skip("prefill no-pause",
+                       "--max-concurrency 1: fusion not applicable, skipping")
+            return
+
+        # Stream A starts alone and reaches steady decode before B arrives.
+        a_prompt, _ = make_long_prompts(1)[0]
+        timeline: list = []
+        timeline_lock = threading.Lock()
+        a_res: list = [None]
+        a_thread = threading.Thread(
+            target=self._stream_worker, args=(0, a_prompt, 320, a_res),
+            kwargs={"timeline": timeline, "timeline_lock": timeline_lock},
+            daemon=True)
+        a_thread.start()
+        deadline = time.monotonic() + 180
+        while time.monotonic() < deadline:
+            ra = a_res[0]
+            if ra is not None and (ra["n_chunks"] >= 3 or ra["error"]):
+                break
+            time.sleep(0.05)
+        ra = a_res[0]
+        if ra is None or ra["error"] or ra["n_chunks"] < 3:
+            self._check("stream A reaches steady decode", False,
+                        "no chunks" if ra is None else
+                        (ra["error"] or f"only {ra['n_chunks']} chunks"))
+            return
+        self._check("stream A reaches steady decode", True)
+
+        # Stream B has several 512-token prefill chunks. Answer 167 cannot
+        # collide with the filler item indices (0..139).
+        filler = "\n".join(
+            f"item {i}: the quick brown fox jumps over the lazy dog"
+            for i in range(140))
+        b_prompt = (f"Here is a list:\n{filler}\n"
+                    "Ignore the list entirely. What is 83+84? "
+                    "Answer with just the number.")
+        b_res: list = [None]
+        b_started = time.monotonic()
+        b_thread = threading.Thread(
+            target=self._stream_worker, args=(0, b_prompt, 512, b_res),
+            daemon=True)
+        b_thread.start()
+        b_thread.join(timeout=900)
+        a_thread.join(timeout=900)
+
+        rb = b_res[0]
+        if rb is None or not rb["ok"] or rb["first_chunk_t"] is None:
+            self._check("stream B completes", False,
+                        "no result" if rb is None else str(rb["error"]))
+            return
+        self._check("stream B completes", True)
+        self._check("stream B answers 167",
+                    contains_number(self._combined(rb), "167"),
+                    f"content={rb['content']!r}")
+
+        # Blocking admission leaves the prefill-dominated first 70% of B's
+        # TTFT window empty. Fused steps keep producing A outputs there.
+        window = rb["first_chunk_t"] - b_started
+        early_end = b_started + 0.7 * window
+        with timeline_lock:
+            a_early = [t for t, idx in timeline
+                       if idx == 0 and b_started <= t <= early_end]
+        ra = a_res[0]
+        if ra["finish_t"] is not None and ra["finish_t"] < early_end:
+            self._skip("A kept emitting during B's prefill",
+                       "stream A finished before B's window closed")
+            return
+        self._check("stream A kept emitting during B's prefill window",
+                    len(a_early) >= 2,
+                    f"A emitted {len(a_early)} chunks in the first "
+                    f"{0.7 * window:.2f}s of B's {window:.2f}s "
+                    "prefill window")
+
+    # ── Run all ──────────────────────────────────────────────────────────
+
+    def run_all(self):
+        print("=" * 60)
+        print("Parallel Serving Tests")
+        print(f"Target: {self.base} (parallel={self.parallel})")
+        print("=" * 60)
+
+        self.test_parallel_streaming()
+        self.test_parallel_isolation()
+        self.test_parallel_nonstream()
+        self.test_parallel_more_than_slots()
+        self.test_unequal_prefill_staging_leases()
+        self.test_parallel_prefill_no_pause()
+
+        print("\n" + "=" * 60)
+        total = self.passed + self.failed + self.skipped
+        print(f"Results: {self.passed}/{total} passed, {self.failed} failed"
+              + (f", {self.skipped} skipped" if self.skipped else ""))
+        return 0 if self.failed == 0 else 1
+
+
+# ─── Main ────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Concurrent serving tests for dflash_server "
+                    "(run against a server started with "
+                    "--paged-attention --max-concurrency N)")
+    parser.add_argument("--base-url", default="http://127.0.0.1:9099",
+                        help="Server base URL")
+    parser.add_argument("--max-concurrency", type=int, default=3,
+                        help="N: --max-concurrency value used to start the server")
+    args = parser.parse_args()
+
+    if not (1 <= args.max_concurrency <= 64):
+        print("ERROR: --max-concurrency must be in [1, 64], "
+              f"got {args.max_concurrency}")
+        sys.exit(2)
+
+    # Preflight: server must already be running.
+    base = args.base_url.rstrip("/")
+    try:
+        r = urllib.request.urlopen(base + "/health", timeout=10)
+        health = json.loads(r.read().decode())
+        if health.get("status") != "ok":
+            print(f"ERROR: server unhealthy: {health}")
+            sys.exit(2)
+    except Exception as e:
+        print(f"ERROR: server not reachable at {base}: {e}")
+        print("Start it first, e.g.:")
+        print(f"  ./server/build/dflash_server <model.gguf> --port 9099 "
+              f"--paged-attention --max-concurrency {args.max_concurrency}")
+        sys.exit(2)
+
+    suite = ParallelTestSuite(base, args.max_concurrency)
+    sys.exit(suite.run_all())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Dependency

Builds on #555, which provides the paged K/V allocator, paged-attention operator, and single-request Qwen paged-decode foundation.

## Summary

Adds concurrent paged serving for Qwen behind the existing paged-attention path.

- Introduces model-neutral `SeqEngine`, `StepPlan`, and `StepResult` contracts.
- Adds scheduler-owned admission, fair automatic prefill distribution, request retirement, cancellation handling, and slow-client buffering.
- Derives idle and mixed prefill capacity from engine-advertised limits instead of exposing scheduler-internal token-budget flags.
- Batches live Qwen decode rows and supports fused prefill/decode lowering.
- Stores recurrent state per sequence with explicit row-to-slot mapping.
- Reserves prompt capacity atomically and derives paged-K/V capacity from available memory.
- Adds host, kernel, contract, and end-to-end parallel-serving coverage.
- Extends CI to exercise concurrent-serving kernels while retaining current DeepSeek4 coverage.

## Impact

Multiple requests can share one Qwen backend without run-to-completion serialization. Slot lifecycle, paged K/V ownership, recurrent state, sampling state, and response delivery remain isolated per request.

The normal serving interface stays small: users select maximum concurrency and may override K/V pool capacity, while the engine supplies appropriate idle and mixed prefill limits automatically.

## Validation

- `git diff --check`
- `test_seq_batch_plan`: 41 checks passed
- Full HIP `test_server_unit` target built successfully for `gfx1151`
- Focused server configuration and `/props` tests passed
- CUDA configuration from current `main`
- Focused CUDA build progressed through the modified core and concurrent-serving kernel sources without errors; the full GPU template build was not completed locally

## TODO future

- shared paged prefixes

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
