### PR TITLE
fix(test): map no-device error for HIP

### DIFF
--- a/server/test/ds4_test_gpu_runtime.h
+++ b/server/test/ds4_test_gpu_runtime.h
@@ -14,6 +14,9 @@
 
 #if defined(GGML_USE_HIP)
 #include "vendors/hip.h"
+#ifndef cudaErrorNoDevice
+#define cudaErrorNoDevice hipErrorNoDevice
+#endif
 #elif defined(GGML_USE_MUSA)
 #include "vendors/musa.h"
 #else


### PR DESCRIPTION
## Summary

- map `cudaErrorNoDevice` to `hipErrorNoDevice` in the shared GPU test runtime header
- restore ROCm compilation for tests that use CUDA-compatible runtime names

## Root cause

The runtime-skip check added for GPU tests uses `cudaErrorNoDevice`. CUDA defines that symbol directly, but the HIP vendor shim does not provide the corresponding compatibility mapping, so both gfx1151 and gfx1201 CI jobs fail during compilation before tests run.

## Impact

ROCm test targets compile with the same portable CUDA-style spelling already used throughout the shared test runtime. CUDA and MUSA paths are unchanged.

## Validation

- `git diff --check`
- configured the HIP build with ROCm 7.2.4 for `gfx1151`
- built `test_rocmfp3_mix_registry` successfully
- ran `ctest -R rocmfp3_mix_registry` on Radeon 8060S: 1/1 passed

Fixes the failure in https://github.com/Luce-Org/lucebox/actions/runs/32022612224/job/95369811039