### PR TITLE
fix(qwen35): size mixed concurrent target-step graphs

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -1117,6 +1117,13 @@ if(DFLASH27B_TESTS)
         target_link_libraries(test_qwen35_roctx PRIVATE ${CMAKE_DL_LIBS})
         list(APPEND _raw_unit_test_targets test_qwen35_roctx)
     endif()
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_qwen35_graph_sizing.cpp")
+        add_executable(test_qwen35_graph_sizing
+            test/test_qwen35_graph_sizing.cpp)
+        target_include_directories(test_qwen35_graph_sizing PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src)
+        list(APPEND _raw_unit_test_targets test_qwen35_graph_sizing)
+    endif()
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_ggml_rmsnorm_batch.cpp")
         add_executable(test_ggml_rmsnorm_batch test/test_ggml_rmsnorm_batch.cpp)
         target_include_directories(test_ggml_rmsnorm_batch PRIVATE ${DFLASH27B_SRC_INCLUDE_DIRS})

--- a/server/src/qwen35/graph_builders.cpp
+++ b/server/src/qwen35/graph_builders.cpp
@@ -4,6 +4,7 @@
 #include "delta_net_specla.h"
 
 #include "ggml-alloc.h"
+#include "graph_sizing.h"
 
 #include <algorithm>
 #include <cstdint>
@@ -495,7 +496,9 @@ bool build_target_step(
         ggml_set_input(sg.logits_row_indices);
     }
 
-    sg.gf = ggml_new_graph_custom(sg.ctx, 16384, false);
+    const size_t graph_capacity = qwen35_target_graph_capacity(
+        n_prefill_segments, compact_slots);
+    sg.gf = ggml_new_graph_custom(sg.ctx, graph_capacity, false);
 
     // Step-invariant KV write: only when topology can't vary per step.
     // DFLASH_QWEN35_NO_KVPAD=1 restores the legacy cpy append + exact-length

--- a/server/src/qwen35/graph_sizing.h
+++ b/server/src/qwen35/graph_sizing.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <cstddef>
+
+namespace dflash::common {
+
+// The historical 16K target graph holds up to eight independent recurrent
+// segments. Packed mixed prefill adds one more segment for compact decode:
+// on Qwen3.6-27B, eight prefills build 15,061 nodes, while adding decode builds
+// 16,741 and overflows the old limit. Each additional segment contributes
+// 1,680 nodes (35 nodes in each of 48 DeltaNet layers), so reserve 2K per
+// segment beyond the proven eight-segment baseline. This keeps today's common
+// shapes at the old capacity while scaling linearly for K=16/32 and beyond.
+inline size_t qwen35_target_graph_capacity(
+        int n_prefill_segments, bool compact_decode) {
+    constexpr size_t kBaseCapacity = 16384;
+    constexpr int kBaseRecurrentSegments = 8;
+    constexpr size_t kGrowthPerSegment = 2048;
+
+    const int prefill_segments = n_prefill_segments > 0
+        ? n_prefill_segments
+        : 0;
+    const int recurrent_segments =
+        prefill_segments + (compact_decode ? 1 : 0);
+    if (recurrent_segments <= kBaseRecurrentSegments) {
+        return kBaseCapacity;
+    }
+    return kBaseCapacity +
+        (size_t)(recurrent_segments - kBaseRecurrentSegments) *
+            kGrowthPerSegment;
+}
+
+} // namespace dflash::common

--- a/server/test/test_qwen35_graph_sizing.cpp
+++ b/server/test/test_qwen35_graph_sizing.cpp
@@ -1,0 +1,37 @@
+#include "qwen35/graph_sizing.h"
+
+#include <cstdio>
+
+using namespace dflash::common;
+
+namespace {
+int failures = 0;
+
+#define CHECK(condition) do { if (!(condition)) { ++failures; \
+    std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #condition); \
+} } while (0)
+} // namespace
+
+int main() {
+    constexpr size_t old_capacity = 16384;
+    constexpr size_t measured_eight_prefill_nodes = 15061;
+    constexpr size_t measured_eight_prefill_decode_nodes = 16741;
+
+    CHECK(qwen35_target_graph_capacity(8, false) == old_capacity);
+    CHECK(measured_eight_prefill_nodes < old_capacity);
+
+    // C16 regression: eight prompts can prefill while earlier prompts decode.
+    // The compact decode recurrence is the ninth independent segment.
+    const size_t mixed_c16_capacity =
+        qwen35_target_graph_capacity(8, true);
+    CHECK(measured_eight_prefill_decode_nodes > old_capacity);
+    CHECK(mixed_c16_capacity == 18432);
+    CHECK(mixed_c16_capacity > measured_eight_prefill_decode_nodes);
+    CHECK(mixed_c16_capacity - measured_eight_prefill_decode_nodes == 1691);
+
+    // Preserve linear headroom when the prefill cohort itself grows.
+    CHECK(qwen35_target_graph_capacity(16, true) == 34816);
+    CHECK(qwen35_target_graph_capacity(32, true) == 67584);
+
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Problem

The Qwen target-step builder always allocates a 16,384-node graph. That is large enough for eight independent recurrent segments, but the default C16 continuous-serving path can legally schedule eight packed prefills plus compact decode in one traversal.

That ninth recurrent segment builds 16,741 nodes and aborts during graph construction. This reproduces on `main` with the normal continuous-decode scheduler; it is not caused by an experimental policy.

## Fix

- Keep the existing 16,384-node capacity through eight recurrent segments.
- Add 2,048 nodes of capacity for each recurrent segment beyond eight.
- Size the target-step graph from packed-prefill segment count plus compact decode.
- Add a host regression test for the C16 mixed shape and larger future cohorts.

The observed C16 schedule now receives an 18,432-node graph. Common shapes at or below eight recurrent segments retain the existing capacity.

## Scope

This PR is now only the graph-sizing correctness fix. The prefill-first scheduling experiment was removed after warmed three-repeat gfx1151 screening showed only a 1-3% C16 TTFT gain, a C8 TTFT regression, and materially worse overlap ITL. The existing invariant that every normal decode plan covers the complete live cohort remains unchanged.

## Validation

- Graph-sizing regression passed.
- Scheduler plan: 62 checks passed.
- Sequence-engine contract: 14 checks passed.
- Complete server unit suite: 382/382 passed.
- HIP server and focused targets rebuilt successfully.
- `git diff --check` passed.