### PR TITLE
feat(server): parse <function_calls> and <invoke> XML tool emissions

### DIFF
--- a/server/src/server/sse_emitter.cpp
+++ b/server/src/server/sse_emitter.cpp
@@ -16,6 +16,14 @@ static const char THINK_CLOSE[] = "</think>";
 static constexpr size_t THINK_OPEN_LEN  = 7;
 static constexpr size_t THINK_CLOSE_LEN = 8;
 
+static std::string trim_ws(const std::string & v) {
+    const char * ws = " \t\r\n";
+    const size_t a = v.find_first_not_of(ws);
+    if (a == std::string::npos) return std::string();
+    const size_t b = v.find_last_not_of(ws);
+    return v.substr(a, b - a + 1);
+}
+
 static bool has_request_tools(const json & tools) {
     return tools.is_array() && !tools.empty();
 }
@@ -83,6 +91,7 @@ SseEmitter::SseEmitter(ApiFormat format,
     , tools_(tools)
     , tool_memory_(tool_memory)
     , mode_(started_in_thinking ? StreamMode::REASONING : StreamMode::CONTENT)
+    , tool_entry_mode_(started_in_thinking ? StreamMode::REASONING : StreamMode::CONTENT)
     , active_kind_(started_in_thinking ? "thinking" : "text")
     , stop_sequences_(stop_sequences)
     , created_at_(unix_timestamp())
@@ -305,71 +314,48 @@ std::vector<std::string> SseEmitter::emit_token(const std::string & raw_piece) {
                 checked_think_prefix_ = true;
             }
 
-            size_t idx = window_.find(THINK_CLOSE);
-            if (idx != std::string::npos) {
-                std::string pre = window_.substr(0, idx);
+            size_t think_close_idx = window_.find(THINK_CLOSE);
+            size_t tool_idx = std::string::npos;
+            bool tool_hit = has_request_tools(tools_) &&
+                            find_tool_syntax_start(window_, tools_, tool_idx);
+
+            struct Hit { size_t pos; int type; };  // 1=think_close, 2=tool
+            std::vector<Hit> hits;
+            if (think_close_idx != std::string::npos) hits.push_back({think_close_idx, 1});
+            if (tool_hit)                             hits.push_back({tool_idx, 2});
+
+            if (!hits.empty()) {
+                std::sort(hits.begin(), hits.end(),
+                          [](const Hit & a, const Hit & b) { return a.pos < b.pos; });
+                auto & h = hits[0];
+                std::string pre = window_.substr(0, h.pos);
                 if (!pre.empty()) {
                     reasoning_text_ += pre;
-                    // Emit reasoning delta
-                    switch (format_) {
-                    case ApiFormat::OPENAI_CHAT:
-                        out.push_back(format_openai_delta({{"reasoning_content", pre}}));
-                        break;
-                    case ApiFormat::ANTHROPIC: {
-                        if (active_kind_ != "thinking") {
-                            out.push_back(sse_event("content_block_stop",
-                                json({{"type", "content_block_stop"}, {"index", block_index_}}).dump()));
-                            block_index_++;
-                            active_kind_ = "thinking";
-                            json new_block = {{"type", "thinking"}, {"thinking", ""}};
-                            out.push_back(sse_event("content_block_start",
-                                json({{"type", "content_block_start"}, {"index", block_index_},
-                                      {"content_block", new_block}}).dump()));
-                        }
-                        out.push_back(sse_event("content_block_delta",
-                            json({{"type", "content_block_delta"}, {"index", block_index_},
-                                  {"delta", {{"type", "thinking_delta"}, {"thinking", pre}}}}).dump()));
-                        break;
-                    }
-                    case ApiFormat::RESPONSES:
-                        // Responses API doesn't stream reasoning — it's stripped
-                        break;
-                    default: break;
-                    }
+                    emit_reasoning_delta(out, pre);
                 }
-                window_ = window_.substr(idx + THINK_CLOSE_LEN);
-                mode_ = StreamMode::CONTENT;
+
+                if (h.type == 1) {
+                    window_ = window_.substr(h.pos + THINK_CLOSE_LEN);
+                    mode_ = StreamMode::CONTENT;
+                } else {
+                    // Tool-call syntax inside reasoning
+                    tool_buffer_ = window_.substr(h.pos);
+                    window_.clear();
+                    tool_entry_mode_ = StreamMode::REASONING;
+                    mode_ = StreamMode::TOOL_BUFFER;
+                }
                 continue;
             }
-            // No close tag yet — emit safe prefix if window is large enough
-            if (window_.size() > std::max(BASE_HOLDBACK, stop_holdback_)) {
-                size_t cut = utf8_safe_len(window_, window_.size() - std::max(BASE_HOLDBACK, stop_holdback_));
+
+            // No close tag or tool start yet — emit safe prefix if window is large enough
+            const size_t holdback = has_request_tools(tools_)
+                ? std::max({BASE_HOLDBACK, stop_holdback_, tool_syntax_holdback(tools_)})
+                : std::max(BASE_HOLDBACK, stop_holdback_);
+            if (window_.size() > holdback) {
+                size_t cut = utf8_safe_len(window_, window_.size() - holdback);
                 if (cut == 0) break;  // not enough complete chars yet
                 std::string safe = window_.substr(0, cut);
-                reasoning_text_ += safe;
-                switch (format_) {
-                case ApiFormat::OPENAI_CHAT:
-                    out.push_back(format_openai_delta({{"reasoning_content", safe}}));
-                    break;
-                case ApiFormat::ANTHROPIC:
-                    if (active_kind_ != "thinking") {
-                        out.push_back(sse_event("content_block_stop",
-                            json({{"type", "content_block_stop"}, {"index", block_index_}}).dump()));
-                        block_index_++;
-                        active_kind_ = "thinking";
-                        json new_block = {{"type", "thinking"}, {"thinking", ""}};
-                        out.push_back(sse_event("content_block_start",
-                            json({{"type", "content_block_start"}, {"index", block_index_},
-                                  {"content_block", new_block}}).dump()));
-                    }
-                    out.push_back(sse_event("content_block_delta",
-                        json({{"type", "content_block_delta"}, {"index", block_index_},
-                              {"delta", {{"type", "thinking_delta"}, {"thinking", safe}}}}).dump()));
-                    break;
-                case ApiFormat::RESPONSES:
-                    break;
-                default: break;
-                }
+                emit_reasoning_delta(out, safe);
                 window_ = window_.substr(cut);
             }
             break;
@@ -411,6 +397,7 @@ std::vector<std::string> SseEmitter::emit_token(const std::string & raw_piece) {
                 // until finish so the parser can validate it.
                 tool_buffer_ = window_.substr(h.pos);
                 window_.clear();
+                tool_entry_mode_ = StreamMode::CONTENT;
                 mode_ = StreamMode::TOOL_BUFFER;
             }
             continue;
@@ -421,6 +408,7 @@ std::vector<std::string> SseEmitter::emit_token(const std::string & raw_piece) {
             tool_buffer_ = window_;
             tool_buffer_fallback_to_content_ = true;
             window_.clear();
+            tool_entry_mode_ = StreamMode::CONTENT;
             mode_ = StreamMode::TOOL_BUFFER;
             continue;
         }
@@ -497,6 +485,35 @@ void SseEmitter::emit_content_delta(std::vector<std::string> & out,
     }
 }
 
+void SseEmitter::emit_reasoning_delta(std::vector<std::string> & out, const std::string & text) {
+    if (text.empty()) return;
+    reasoning_text_ += text;
+    switch (format_) {
+    case ApiFormat::OPENAI_CHAT:
+        out.push_back(format_openai_delta({{"reasoning_content", text}}));
+        break;
+    case ApiFormat::ANTHROPIC:
+        if (active_kind_ != "thinking") {
+            if (!active_kind_.empty()) {
+                out.push_back(sse_event("content_block_stop",
+                    json({{"type", "content_block_stop"}, {"index", block_index_}}).dump()));
+                block_index_++;
+            }
+            active_kind_ = "thinking";
+            json new_block = {{"type", "thinking"}, {"thinking", ""}};
+            out.push_back(sse_event("content_block_start",
+                json({{"type", "content_block_start"}, {"index", block_index_},
+                      {"content_block", new_block}}).dump()));
+        }
+        out.push_back(sse_event("content_block_delta",
+            json({{"type", "content_block_delta"}, {"index", block_index_},
+                  {"delta", {{"type", "thinking_delta"}, {"thinking", text}}}}).dump()));
+        break;
+    default:
+        break;
+    }
+}
+
 // ─── emit_finish ────────────────────────────────────────────────────────
 
 std::vector<std::string> SseEmitter::emit_finish(int completion_tokens,
@@ -505,17 +522,15 @@ std::vector<std::string> SseEmitter::emit_finish(int completion_tokens,
 
     // Flush remaining window
     if (mode_ == StreamMode::REASONING && !window_.empty()) {
-        reasoning_text_ += window_;
-        switch (format_) {
-        case ApiFormat::OPENAI_CHAT:
-            out.push_back(format_openai_delta({{"reasoning_content", window_}}));
-            break;
-        case ApiFormat::ANTHROPIC:
-            out.push_back(sse_event("content_block_delta",
-                json({{"type", "content_block_delta"}, {"index", block_index_},
-                      {"delta", {{"type", "thinking_delta"}, {"thinking", window_}}}}).dump()));
-            break;
-        default: break;
+        size_t tool_idx = std::string::npos;
+        if (has_request_tools(tools_) && find_tool_syntax_start(window_, tools_, tool_idx)) {
+            std::string pre = window_.substr(0, tool_idx);
+            emit_reasoning_delta(out, pre);
+            tool_buffer_ = window_.substr(tool_idx);
+            tool_entry_mode_ = StreamMode::REASONING;
+            mode_ = StreamMode::TOOL_BUFFER;
+        } else {
+            emit_reasoning_delta(out, window_);
         }
     } else if (mode_ == StreamMode::CONTENT && !window_.empty()) {
         // Zero-argument Laguna calls in the stripped form are just the bare
@@ -544,6 +559,7 @@ std::vector<std::string> SseEmitter::emit_finish(int completion_tokens,
                         // path accepts (it emits name-only bodies as
                         // zero-argument calls).
                         tool_buffer_ = "<tool_call>" + tail + "</tool_call>";
+                        tool_entry_mode_ = StreamMode::CONTENT;
                         mode_ = StreamMode::TOOL_BUFFER;
                         zero_arg_call = true;
                         break;
@@ -574,10 +590,31 @@ std::vector<std::string> SseEmitter::emit_finish(int completion_tokens,
                 tool_memory_->remember(ids, accumulated_raw_);
             }
 
-            // Emit any cleaned text from the tool buffer
+            // Emit any cleaned text from the tool buffer. If the buffer contains </think>,
+            // split at </think> and route the prefix to reasoning before emitting the remainder as content.
             if (!parsed.cleaned_text.empty()) {
-                accumulated_content_ += parsed.cleaned_text;
-                emit_content_delta(out, parsed.cleaned_text);
+                size_t think_close_pos = parsed.cleaned_text.find(THINK_CLOSE);
+                if (think_close_pos != std::string::npos) {
+                    std::string reasoning_part = parsed.cleaned_text.substr(0, think_close_pos);
+                    std::string content_part = parsed.cleaned_text.substr(think_close_pos + THINK_CLOSE_LEN);
+                    emit_reasoning_delta(out, reasoning_part);
+                    if (!content_part.empty()) {
+                        if (first_content_token_index_ < 0) {
+                            first_content_token_index_ = reasoning_text_.empty() ? 0 : std::max(0, emit_token_count_ - 1);
+                        }
+                        accumulated_content_ += content_part;
+                        emit_content_delta(out, content_part);
+                    }
+                } else if (tool_entry_mode_ == StreamMode::REASONING) {
+                    // Tool call was inside unclosed <think>; suffix remains reasoning.
+                    emit_reasoning_delta(out, parsed.cleaned_text);
+                } else {
+                    if (first_content_token_index_ < 0) {
+                        first_content_token_index_ = reasoning_text_.empty() ? 0 : std::max(0, emit_token_count_ - 1);
+                    }
+                    accumulated_content_ += parsed.cleaned_text;
+                    emit_content_delta(out, parsed.cleaned_text);
+                }
             }
 
             fr = "tool_calls";

--- a/server/src/server/sse_emitter.h
+++ b/server/src/server/sse_emitter.h
@@ -140,6 +140,8 @@ private:
 
     // Emit a content delta (format-specific).
     void emit_content_delta(std::vector<std::string> & out, const std::string & text);
+    // Emit a reasoning delta (format-specific).
+    void emit_reasoning_delta(std::vector<std::string> & out, const std::string & text);
 
     // SSE data line
     static std::string sse_data(const std::string & json_str);
@@ -153,6 +155,7 @@ private:
     ToolMemory * tool_memory_;
 
     StreamMode   mode_;
+    StreamMode   tool_entry_mode_ = StreamMode::CONTENT;
     std::string  window_;           // holdback buffer
     std::string  tool_buffer_;      // accumulated tool text
     bool         tool_buffer_fallback_to_content_ = false;

--- a/server/src/server/tool_parser.cpp
+++ b/server/src/server/tool_parser.cpp
@@ -55,6 +55,7 @@ static std::string generate_call_id() {
 
 static const char TOOL_OPEN[] = "<tool_call>";
 static const char FUNCTION_CALL_OPEN[] = "<function_call>";
+static const char FUNCTION_CALLS_OPEN[] = "<function_calls>";
 static const char FUNCTION_OPEN[] = "<function=";
 static const char BARE_FUNCTION_OPEN[] = "<function>";
 static const char FUNCTION_SPACE_OPEN[] = "<function ";
@@ -106,6 +107,7 @@ bool find_tool_syntax_start(const std::string & text, const json & tools,
     while (idx != std::string::npos) {
         if (text.compare(idx, sizeof(TOOL_OPEN) - 1, TOOL_OPEN) == 0 ||
             text.compare(idx, sizeof(FUNCTION_CALL_OPEN) - 1, FUNCTION_CALL_OPEN) == 0 ||
+            text.compare(idx, sizeof(FUNCTION_CALLS_OPEN) - 1, FUNCTION_CALLS_OPEN) == 0 ||
             text.compare(idx, sizeof(FUNCTION_OPEN) - 1, FUNCTION_OPEN) == 0 ||
             text.compare(idx, sizeof(BARE_FUNCTION_OPEN) - 1, BARE_FUNCTION_OPEN) == 0 ||
             text.compare(idx, sizeof(FUNCTION_SPACE_OPEN) - 1,
@@ -136,8 +138,9 @@ bool find_tool_syntax_start(const std::string & text, const json & tools,
 }
 
 size_t tool_syntax_holdback(const json & tools) {
-    // Longest fixed opener is `<parameter name=` (16 bytes).
+    // Retain longest fixed openers: `<parameter name=` (16B), `<function_calls>` (16B).
     size_t holdback = std::max({sizeof(ATTRIBUTE_PARAMETER_OPEN) - 2,
+                                sizeof(FUNCTION_CALLS_OPEN) - 2,
                                 sizeof(FUNCTION_CALL_OPEN) - 2,
                                 sizeof(BARE_FUNCTION_OPEN) - 2});
     if (!tools.is_array()) return holdback;
@@ -151,54 +154,89 @@ size_t tool_syntax_holdback(const json & tools) {
     return holdback;
 }
 
+// Find matching function definition in tools array.
+static const json * find_tool_definition(const json & tools, const std::string & name) {
+    if (tools.is_null() || !tools.is_array() || tools.empty()) return nullptr;
+    for (const auto & t : tools) {
+        if (!t.is_object()) continue;
+        if (t.contains("function") && t["function"].is_object()) {
+            if (t["function"].value("name", "") == name) {
+                return &t["function"];
+            }
+        } else if (t.value("name", "") == name) {
+            return &t;
+        }
+    }
+    return nullptr;
+}
+
 // Check if a function name is in the allowed tools list.
 static bool tool_allowed(const json & tools, const std::string & name) {
     if (tools.is_null() || !tools.is_array() || tools.empty()) return true;
-    for (const auto & t : tools) {
-        const auto & fn = t.contains("function") ? t["function"] : t;
-        if (fn.is_object() && fn.value("name", "") == name) return true;
-    }
-    return false;
+    return find_tool_definition(tools, name) != nullptr;
 }
 
 // Find parameter schema properties for a function.
 static json find_tool_properties(const json & tools, const std::string & name) {
-    if (tools.is_null() || !tools.is_array()) return json::object();
-    for (const auto & t : tools) {
-        const auto & fn = t.contains("function") ? t["function"] : t;
-        if (!fn.is_object() || fn.value("name", "") != name) continue;
-        if (fn.contains("parameters") && fn["parameters"].is_object()) {
-            const auto & params = fn["parameters"];
-            if (params.contains("properties") && params["properties"].is_object()) {
-                return params["properties"];
+    const json * fn = find_tool_definition(tools, name);
+    if (!fn) return json::object();
+    const json & schema = fn->contains("parameters") ? (*fn)["parameters"]
+                        : fn->contains("input_schema") ? (*fn)["input_schema"]
+                        : json();
+    if (schema.is_object() && schema.contains("properties") && schema["properties"].is_object()) {
+        return schema["properties"];
+    }
+    return json::object();
+}
+
+static bool tool_has_missing_required(const json & tools,
+                                      const std::string & name,
+                                      const json & args) {
+    const json * fn = find_tool_definition(tools, name);
+    if (!fn) return false;
+    const json & schema = fn->contains("parameters") ? (*fn)["parameters"]
+                        : fn->contains("input_schema") ? (*fn)["input_schema"]
+                        : json();
+    if (schema.is_object() && schema.contains("required") && schema["required"].is_array()) {
+        for (const auto & req : schema["required"]) {
+            if (req.is_string() && !args.contains(req.get<std::string>())) {
+                return true;
             }
         }
     }
-    return json::object();
+    return false;
 }
 
 // Convert a string value to its JSON-schema-typed equivalent.
 static json convert_param_value(const std::string & val, const std::string & key,
                                 const json & props) {
-    if (val == "null") return nullptr;
-    if (!props.contains(key)) return val;
+    if (!props.is_object() || !props.contains(key)) return val;
 
     const auto & cfg = props[key];
     std::string ptype = "string";
+    bool allows_null = false;
     if (cfg.is_object() && cfg.contains("type")) {
         const auto & t = cfg["type"];
         if (t.is_string()) {
             ptype = t.get<std::string>();
+            if (ptype == "null") allows_null = true;
         } else if (t.is_array()) {
-            // JSON Schema allows "type": ["string","null"]; take the first
-            // non-null string entry instead of throwing.
+            // JSON Schema allows "type": ["integer","null"]; find non-null type
+            // and record whether null is permitted.
             for (const auto & e : t) {
-                if (e.is_string() && e.get<std::string>() != "null") {
-                    ptype = e.get<std::string>();
-                    break;
+                if (e.is_string()) {
+                    if (e.get<std::string>() == "null") allows_null = true;
+                    else if (ptype == "string") ptype = e.get<std::string>();
                 }
             }
         }
+    }
+    if (cfg.is_object() && cfg.value("nullable", false)) {
+        allows_null = true;
+    }
+
+    if (val == "null") {
+        return allows_null ? json(nullptr) : json(val);
     }
 
     // string types
@@ -356,6 +394,30 @@ static const std::regex & re_function_call() {
 
 static const std::regex & re_bare_function_json() {
     static std::regex r(R"(<function>([\s\S]*?)</function>)");
+    return r;
+}
+
+static const std::regex & re_function_calls_block() {
+    static std::regex r(R"(<function_calls>([\s\S]*?)</function_calls>)");
+    return r;
+}
+
+static const std::regex & re_invoke_xml() {
+    static std::regex r(
+        R"re(<invoke\s+(?:name|tool)\s*=\s*(?:"([A-Za-z_][\w.\-]*)"|'([A-Za-z_][\w.\-]*)'|([A-Za-z_][\w.\-]*))\s*>([\s\S]*?)</invoke>)re");
+    return r;
+}
+
+static std::string extract_matched_invoke_name(const std::smatch & m) {
+    if (m[1].matched) return m[1].str();
+    if (m[2].matched) return m[2].str();
+    if (m[3].matched) return m[3].str();
+    return "";
+}
+
+static const std::regex & re_invoke_param_xml() {
+    static std::regex r(
+        R"re(<(param|parameter)(?:\s+name\s*=\s*(?:"([A-Za-z_][\w.\-]*)"|'([A-Za-z_][\w.\-]*)'|([A-Za-z_][\w.\-]*))|=([A-Za-z_][\w.\-]*))\s*>([\s\S]*?)</\1>)re");
     return r;
 }
 
@@ -556,6 +618,60 @@ static bool parse_complete_parameter_body(const std::string & body,
     }
 
     return found_param && trim_ws(body.substr(cursor)).empty();
+}
+
+static bool parse_invoke_body(const std::string & body,
+                             const std::string & fn_name,
+                             const json & tools,
+                             json & out_args) {
+    const json props = find_tool_properties(tools, fn_name);
+    out_args = json::object();
+    const std::string trimmed = trim_ws(body);
+    if (trimmed.empty()) {
+        return !tool_has_missing_required(tools, fn_name, out_args);
+    }
+
+    // 1. Match inline JSON body inside <invoke>
+    if (trimmed.front() == '{' && trimmed.back() == '}') {
+        try {
+            json obj = json::parse(trimmed);
+            if (obj.is_object()) {
+                for (auto & [k, v] : obj.items()) {
+                    if (v.is_string()) {
+                        out_args[k] = convert_param_value(v.get<std::string>(), k, props);
+                    } else {
+                        out_args[k] = v;
+                    }
+                }
+                return !tool_has_missing_required(tools, fn_name, out_args);
+            }
+        } catch (...) {}
+    }
+
+    // 2. Match XML parameters: <param name="...">, <parameter name="...">, <param=...>, <parameter=...>
+    size_t cursor = 0;
+    bool found_param = false;
+    auto pbegin = std::sregex_iterator(body.begin(), body.end(), re_invoke_param_xml());
+    auto pend = std::sregex_iterator();
+    for (auto pit = pbegin; pit != pend; ++pit) {
+        const size_t pos = pit->position();
+        if (!trim_ws(body.substr(cursor, pos - cursor)).empty()) return false;
+
+        std::string key;
+        for (int g : {2, 3, 4, 5}) {
+            if ((*pit)[g].matched) { key = (*pit)[g].str(); break; }
+        }
+        if (key.empty() || out_args.contains(key)) return false;
+
+        out_args[key] = convert_param_value(trim_ws((*pit)[6].str()), key, props);
+        found_param = true;
+        cursor = pos + pit->length();
+    }
+    if (found_param && trim_ws(body.substr(cursor)).empty()) {
+        return !tool_has_missing_required(tools, fn_name, out_args);
+    }
+
+    return false;
 }
 
 // ─── JSON tool call parser ──────────────────────────────────────────────
@@ -807,6 +923,8 @@ static bool parse_function_sig_args(const std::string & arg_text, json & out_arg
     }
     return true;
 }
+
+
 
 // ─── Main parser ────────────────────────────────────────────────────────
 
@@ -1171,6 +1289,50 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
                     add_call(name, args, pos, pos + it->length());
                 }
             } catch (...) {}
+        }
+    }
+
+    // Pattern 4d: <function_calls><invoke name="NAME">...<param name="K">V</param>...</invoke></function_calls>
+    {
+        auto fbegin = std::sregex_iterator(text.begin(), text.end(), re_function_calls_block());
+        auto fend = std::sregex_iterator();
+        for (auto fit = fbegin; fit != fend; ++fit) {
+            const size_t bstart = fit->position();
+            const size_t bend = bstart + fit->length();
+            if (overlaps(removals, bstart)) continue;
+
+            const std::string block_content = (*fit)[1].str();
+            auto begin = std::sregex_iterator(block_content.begin(), block_content.end(), re_invoke_xml());
+            auto end = std::sregex_iterator();
+            std::vector<std::pair<std::string, json>> block_calls;
+            bool valid = true;
+            size_t cursor = 0;
+
+            for (auto it = begin; it != end; ++it) {
+                const size_t rel_pos = it->position();
+                if (!trim_ws(block_content.substr(cursor, rel_pos - cursor)).empty()) {
+                    valid = false;
+                    break;
+                }
+                const std::string fn_name = extract_matched_invoke_name(*it);
+                if (fn_name.empty() || !tool_allowed(tools, fn_name)) {
+                    valid = false;
+                    break;
+                }
+                json args;
+                if (!parse_invoke_body((*it)[4].str(), fn_name, tools, args)) {
+                    valid = false;
+                    break;
+                }
+                block_calls.push_back({fn_name, std::move(args)});
+                cursor = rel_pos + it->length();
+            }
+
+            if (valid && !block_calls.empty() && trim_ws(block_content.substr(cursor)).empty()) {
+                for (auto & bc : block_calls) {
+                    add_call(bc.first, bc.second, bstart, bend);
+                }
+            }
         }
     }
 

--- a/server/src/server/tool_parser.h
+++ b/server/src/server/tool_parser.h
@@ -1,6 +1,6 @@
 // Tool call parser — extracts structured tool calls from generated text.
 //
-// Supports 11 detection patterns:
+// Supports 12 detection patterns:
 //   1. <tool_call><function=name>...</function></tool_call>  (Qwen XML)
 //   2. <function=name>...</function>                          (bare function XML)
 //   3. <function=name(k="v")></function>                      (function signature)
@@ -12,6 +12,7 @@
 //   9. call:<ns>?<verb>{relaxed-JSON-args}                    (gemma plain-text)
 //  10. Bare JSON objects  {"name":..., "arguments":...}       (raw JSON)
 //  11. Whole-response JSON args for one declared tool          {"arg":...}
+//  12. <function_calls><invoke name=name>...</invoke>         (agent invoke XML)
 
 #pragma once
 

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -466,6 +466,41 @@ TEST_CASE(ServerUnitFixture, test_emitter_started_in_thinking_without_open_tag) 
     TEST_ASSERT(all.find("\"content\":\"Thinking Process") == std::string::npos);
 }
 
+TEST_CASE(ServerUnitFixture, test_emitter_started_in_thinking_with_function_calls_no_think_close) {
+    auto em = make_emitter(ApiFormat::OPENAI_CHAT, read_tools(), true);
+    auto c1 = em.emit_token("Let me read the key files.\n\n");
+    auto c2 = em.emit_token("<function_calls>\n  <invoke name=\"read\">\n    <param name=\"path\">README.md</param>\n  </invoke>\n</function_calls>");
+    auto fin = em.emit_finish(2);
+
+    std::string all = concat(c1) + concat(c2) + concat(fin);
+    TEST_ASSERT(em.tool_calls().size() == 1);
+    if (!em.tool_calls().empty()) {
+        TEST_ASSERT(em.tool_calls()[0].name == "read");
+        TEST_ASSERT(json::parse(em.tool_calls()[0].arguments)["path"] == "README.md");
+    }
+    TEST_ASSERT(em.reasoning_text().find("Let me read the key files.") != std::string::npos);
+    TEST_ASSERT(em.reasoning_text().find("<invoke") == std::string::npos);
+    TEST_ASSERT(em.reasoning_text().find("<function_calls>") == std::string::npos);
+    TEST_ASSERT(em.accumulated_text().empty());
+    TEST_ASSERT(all.find("\"finish_reason\":\"tool_calls\"") != std::string::npos);
+}
+
+TEST_CASE(ServerUnitFixture, test_emitter_tool_call_inside_think_block_does_not_leak_think_close) {
+    auto em = make_emitter(ApiFormat::OPENAI_CHAT, read_tools(), false);
+    auto c1 = em.emit_token("<think>Planning files.\n");
+    auto c2 = em.emit_token("<function_calls>\n  <invoke name=\"read\">\n    <param name=\"path\">README.md</param>\n  </invoke>\n</function_calls>\nMore reasoning before close.\n</think>\nHere is the answer.");
+    auto fin = em.emit_finish(2);
+
+    std::string all = concat(c1) + concat(c2) + concat(fin);
+    TEST_ASSERT(em.tool_calls().size() == 1);
+    TEST_ASSERT(em.reasoning_text().find("Planning files.") != std::string::npos);
+    TEST_ASSERT(em.reasoning_text().find("More reasoning before close.") != std::string::npos);
+    TEST_ASSERT(em.accumulated_text().find("</think>") == std::string::npos);
+    TEST_ASSERT(em.accumulated_text().find("More reasoning") == std::string::npos);
+    TEST_ASSERT(em.accumulated_text().find("Here is the answer.") != std::string::npos);
+    TEST_ASSERT(all.find("\"finish_reason\":\"tool_calls\"") != std::string::npos);
+}
+
 TEST_CASE(ServerUnitFixture, test_reasoning_unclosed_think) {
     auto r = parse_reasoning("<think>still thinking no close",
                              true, false);
@@ -772,6 +807,363 @@ TEST_CASE(ServerUnitFixture, test_parse_space_function_tool_xml_rejects_malforme
     auto unknown_result = parse_tool_calls(unknown, read_tools());
     TEST_ASSERT(unknown_result.tool_calls.empty());
     TEST_ASSERT(unknown_result.cleaned_text == unknown);
+}
+
+TEST_CASE(ServerUnitFixture, test_parse_function_calls_multi_invoke_xml) {
+    const std::string text =
+        "Hello! I'm happy to help you analyze this project and propose improvements.\n\n"
+        "Let me first read the remaining key files to fully understand the project.\n\n"
+        "<function_calls>\n"
+        "  <invoke name=\"read\">\n"
+        "    <param name=\"path\">README.md</param>\n"
+        "  </invoke>\n"
+        "  <invoke name=\"read\">\n"
+        "    <param name=\"path\">server.go</param>\n"
+        "  </invoke>\n"
+        "  <invoke name=\"read\">\n"
+        "    <param name=\"path\">internal/rfid/reader_test.go</param>\n"
+        "  </invoke>\n"
+        "  <invoke name=\"read\">\n"
+        "    <param name=\"path\">internal/rfidops/ops_test.go</param>\n"
+        "  </invoke>\n"
+        "</function_calls>";
+
+    auto result = parse_tool_calls(text, read_tools());
+    TEST_ASSERT(result.tool_calls.size() == 4);
+    if (result.tool_calls.size() == 4) {
+        TEST_ASSERT(result.tool_calls[0].name == "read");
+        TEST_ASSERT(json::parse(result.tool_calls[0].arguments)["path"] == "README.md");
+        TEST_ASSERT(result.tool_calls[1].name == "read");
+        TEST_ASSERT(json::parse(result.tool_calls[1].arguments)["path"] == "server.go");
+        TEST_ASSERT(result.tool_calls[2].name == "read");
+        TEST_ASSERT(json::parse(result.tool_calls[2].arguments)["path"] == "internal/rfid/reader_test.go");
+        TEST_ASSERT(result.tool_calls[3].name == "read");
+        TEST_ASSERT(json::parse(result.tool_calls[3].arguments)["path"] == "internal/rfidops/ops_test.go");
+    }
+    TEST_ASSERT(result.cleaned_text ==
+                "Hello! I'm happy to help you analyze this project and propose improvements.\n\n"
+                "Let me first read the remaining key files to fully understand the project.");
+}
+
+TEST_CASE(ServerUnitFixture, test_parse_function_calls_pi_agent_multi_invoke) {
+    const std::string text =
+        " Hello! I'm happy to help you analyze this project and propose improvements.\n\n"
+        " Let me read the remaining key files I haven't seen yet to fully understand the codebase.\n\n"
+        " <function_calls>\n"
+        "   <invoke name=\"read\">\n"
+        "     <param name=\"path\">README.md</param>\n"
+        "   </invoke>\n"
+        "   <invoke name=\"read\">\n"
+        "     <param name=\"path\">server.go</param>\n"
+        "   </invoke>\n"
+        "   <invoke name=\"read\">\n"
+        "     <param name=\"path\">internal/rfid/reader_test.go</param>\n"
+        "   </invoke>\n"
+        "   <invoke name=\"read\">\n"
+        "     <param name=\"path\">internal/rfidops/ops_test.go</param>\n"
+        "   </invoke>\n"
+        " </function_calls>";
+
+    auto result = parse_tool_calls(text, read_tools());
+    TEST_ASSERT(result.tool_calls.size() == 4);
+    if (result.tool_calls.size() == 4) {
+        TEST_ASSERT(result.tool_calls[0].name == "read");
+        TEST_ASSERT(json::parse(result.tool_calls[0].arguments)["path"] == "README.md");
+        TEST_ASSERT(result.tool_calls[1].name == "read");
+        TEST_ASSERT(json::parse(result.tool_calls[1].arguments)["path"] == "server.go");
+        TEST_ASSERT(result.tool_calls[2].name == "read");
+        TEST_ASSERT(json::parse(result.tool_calls[2].arguments)["path"] == "internal/rfid/reader_test.go");
+        TEST_ASSERT(result.tool_calls[3].name == "read");
+        TEST_ASSERT(json::parse(result.tool_calls[3].arguments)["path"] == "internal/rfidops/ops_test.go");
+    }
+    TEST_ASSERT(result.cleaned_text ==
+                "Hello! I'm happy to help you analyze this project and propose improvements.\n\n"
+                " Let me read the remaining key files I haven't seen yet to fully understand the codebase.");
+}
+
+TEST_CASE(ServerUnitFixture, test_parse_function_calls_invoke_xml) {
+    const std::string text =
+        "Reading configuration:\n"
+        "<function_calls>\n"
+        "<invoke name=\"read\">\n"
+        "  <param name=\"path\">server.go</param>\n"
+        "  <param name=\"offset\">10</param>\n"
+        "  <param name=\"limit\">50</param>\n"
+        "</invoke>\n"
+        "</function_calls>";
+
+    auto result = parse_tool_calls(text, read_tools());
+    TEST_ASSERT(result.tool_calls.size() == 1);
+    if (!result.tool_calls.empty()) {
+        TEST_ASSERT(result.tool_calls[0].name == "read");
+        auto args = json::parse(result.tool_calls[0].arguments);
+        TEST_ASSERT(args["path"] == "server.go");
+        TEST_ASSERT(args["offset"] == 10);
+        TEST_ASSERT(args["limit"] == 50);
+    }
+    TEST_ASSERT(result.cleaned_text == "Reading configuration:");
+}
+
+static json anthropic_read_tools() {
+    return json::array({
+        {{"name", "read"},
+         {"input_schema", {
+             {"type", "object"},
+             {"properties", {
+                 {"path", {{"type", "string"}}},
+                 {"offset", {{"type", "integer"}}},
+                 {"limit", {{"type", "integer"}}}
+             }},
+             {"required", json::array({"path"})}
+         }}}
+    });
+}
+
+TEST_CASE(ServerUnitFixture, test_find_tool_syntax_start_function_calls) {
+    size_t pos = 0;
+    TEST_ASSERT(find_tool_syntax_start("Thought\n<function_calls>\n<invoke", json(), pos));
+    TEST_ASSERT(pos == 8);
+
+    size_t pos2 = 0;
+    TEST_ASSERT(find_tool_syntax_start("Here:\n<function_calls><invoke name=\"read\">", json(), pos2));
+    TEST_ASSERT(pos2 == 6);
+
+    // Natural-language prose starting with <invoke should not trigger tool opener
+    size_t pos3 = 0;
+    TEST_ASSERT(!find_tool_syntax_start("We should <invoke the changes now", json(), pos3));
+}
+
+TEST_CASE(ServerUnitFixture, test_parse_invoke_json_body_coerces_types) {
+    const std::string text =
+        "<function_calls>\n"
+        "<invoke name=\"read\">\n"
+        "  {\"path\": \"server.go\", \"offset\": \"10\", \"limit\": \"50\"}\n"
+        "</invoke>\n"
+        "</function_calls>";
+
+    auto result = parse_tool_calls(text, read_tools());
+    TEST_ASSERT(result.tool_calls.size() == 1);
+    if (!result.tool_calls.empty()) {
+        TEST_ASSERT(result.tool_calls[0].name == "read");
+        auto args = json::parse(result.tool_calls[0].arguments);
+        TEST_ASSERT(args["path"] == "server.go");
+        TEST_ASSERT(args["offset"] == 10);
+        TEST_ASSERT(args["limit"] == 50);
+    }
+    TEST_ASSERT(result.cleaned_text.empty());
+}
+
+TEST_CASE(ServerUnitFixture, test_parse_invoke_json_body_preserves_string_null) {
+    const std::string text =
+        "<function_calls>\n"
+        "<invoke name=\"read\">\n"
+        "  {\"path\": \"null\", \"offset\": \"10\"}\n"
+        "</invoke>\n"
+        "</function_calls>";
+
+    auto result = parse_tool_calls(text, read_tools());
+    TEST_ASSERT(result.tool_calls.size() == 1);
+    if (!result.tool_calls.empty()) {
+        TEST_ASSERT(result.tool_calls[0].name == "read");
+        auto args = json::parse(result.tool_calls[0].arguments);
+        TEST_ASSERT(args["path"] == "null");
+        TEST_ASSERT(args["offset"] == 10);
+    }
+}
+
+
+TEST_CASE(ServerUnitFixture, test_parse_invoke_json_body_union_type) {
+    json tools = json::array({
+        {
+            {"type", "function"},
+            {"function", {
+                {"name", "search"},
+                {"parameters", {
+                    {"type", "object"},
+                    {"properties", {
+                        {"limit", {{"type", json::array({"integer", "null"})}}},
+                        {"query", {{"type", "string"}}}
+                    }}
+                }}
+            }}
+        }
+    });
+
+    const std::string text1 =
+        "<function_calls>\n"
+        "<invoke name=\"search\">\n"
+        "  {\"query\": \"test\", \"limit\": \"20\"}\n"
+        "</invoke>\n"
+        "</function_calls>";
+
+    auto result1 = parse_tool_calls(text1, tools);
+    TEST_ASSERT(result1.tool_calls.size() == 1);
+    if (!result1.tool_calls.empty()) {
+        auto args = json::parse(result1.tool_calls[0].arguments);
+        TEST_ASSERT(args["query"] == "test");
+        TEST_ASSERT(args["limit"] == 20);
+    }
+
+    const std::string text2 =
+        "<function_calls>\n"
+        "<invoke name=\"search\">\n"
+        "  {\"query\": \"null\", \"limit\": \"null\"}\n"
+        "</invoke>\n"
+        "</function_calls>";
+
+    auto result2 = parse_tool_calls(text2, tools);
+    TEST_ASSERT(result2.tool_calls.size() == 1);
+    if (!result2.tool_calls.empty()) {
+        auto args = json::parse(result2.tool_calls[0].arguments);
+        TEST_ASSERT(args["query"] == "null");
+        TEST_ASSERT(args["limit"].is_null());
+    }
+}
+
+TEST_CASE(ServerUnitFixture, test_emitter_tool_call_inside_unclosed_think_block_routes_to_reasoning) {
+    auto em = make_emitter(ApiFormat::OPENAI_CHAT, read_tools(), false);
+    auto c1 = em.emit_token("<think>Planning files.\n");
+    auto c2 = em.emit_token("<function_calls>\n  <invoke name=\"read\">\n    <param name=\"path\">README.md</param>\n  </invoke>\n</function_calls>\nStill thinking about what to do next without close tag.");
+    auto fin = em.emit_finish(2);
+
+    std::string all = concat(c1) + concat(c2) + concat(fin);
+    TEST_ASSERT(em.tool_calls().size() == 1);
+    TEST_ASSERT(em.reasoning_text().find("Planning files.") != std::string::npos);
+    TEST_ASSERT(em.reasoning_text().find("Still thinking about what to do next") != std::string::npos);
+    TEST_ASSERT(em.accumulated_text().empty());
+    TEST_ASSERT(all.find("\"finish_reason\":\"tool_calls\"") != std::string::npos);
+}
+
+TEST_CASE(ServerUnitFixture, test_parse_invoke_anthropic_input_schema) {
+    const std::string text =
+        "<function_calls>\n"
+        "<invoke name=\"read\">\n"
+        "  <param name=\"path\">app.py</param>\n"
+        "  <param name=\"offset\">5</param>\n"
+        "  <param name=\"limit\">25</param>\n"
+        "</invoke>\n"
+        "</function_calls>";
+
+    auto result = parse_tool_calls(text, anthropic_read_tools());
+    TEST_ASSERT(result.tool_calls.size() == 1);
+    if (!result.tool_calls.empty()) {
+        TEST_ASSERT(result.tool_calls[0].name == "read");
+        auto args = json::parse(result.tool_calls[0].arguments);
+        TEST_ASSERT(args["path"] == "app.py");
+        TEST_ASSERT(args["offset"] == 5);
+        TEST_ASSERT(args["limit"] == 25);
+    }
+    TEST_ASSERT(result.cleaned_text.empty());
+}
+
+TEST_CASE(ServerUnitFixture, test_parse_invoke_rejects_empty_or_malformed_body) {
+    // Required parameter missing in empty body
+    const std::string empty_body = "<function_calls><invoke name=\"read\"></invoke></function_calls>";
+    auto empty_result = parse_tool_calls(empty_body, read_tools());
+    TEST_ASSERT(empty_result.tool_calls.empty());
+    TEST_ASSERT(empty_result.cleaned_text == empty_body);
+
+    // Required parameter missing in non-empty XML body (offset present, but required path missing)
+    const std::string missing_req_xml =
+        "<function_calls><invoke name=\"read\"><param name=\"offset\">10</param></invoke></function_calls>";
+    auto missing_req_result = parse_tool_calls(missing_req_xml, read_tools());
+    TEST_ASSERT(missing_req_result.tool_calls.empty());
+    TEST_ASSERT(missing_req_result.cleaned_text == missing_req_xml);
+
+    // Required parameter missing in inline JSON body
+    const std::string missing_req_json =
+        "<function_calls><invoke name=\"read\">{\"offset\": 10}</invoke></function_calls>";
+    auto missing_req_json_result = parse_tool_calls(missing_req_json, read_tools());
+    TEST_ASSERT(missing_req_json_result.tool_calls.empty());
+    TEST_ASSERT(missing_req_json_result.cleaned_text == missing_req_json);
+
+    // Mismatched parameter tags (<param> closed by </parameter>)
+    const std::string mismatched_tags =
+        "<function_calls><invoke name=\"read\"><param name=\"path\">foo.go</parameter></invoke></function_calls>";
+    auto mismatched_result = parse_tool_calls(mismatched_tags, read_tools());
+    TEST_ASSERT(mismatched_result.tool_calls.empty());
+    TEST_ASSERT(mismatched_result.cleaned_text == mismatched_tags);
+
+    // Malformed body with unclosed junk
+    const std::string malformed_body =
+        "<function_calls><invoke name=\"read\"><param name=\"path\">foo.go</unclosed junk</invoke></function_calls>";
+    auto malformed_result = parse_tool_calls(malformed_body, read_tools());
+    TEST_ASSERT(malformed_result.tool_calls.empty());
+    TEST_ASSERT(malformed_result.cleaned_text == malformed_body);
+}
+
+TEST_CASE(ServerUnitFixture, test_parse_function_calls_partial_block_retains_unparsed) {
+    const std::string text =
+        "<function_calls>\n"
+        "  <invoke name=\"read\">\n"
+        "    <param name=\"path\">valid.go</param>\n"
+        "  </invoke>\n"
+        "  <invoke name=\"read\">\n"
+        "    <param name=\"path\">broken.go</unclosed junk\n"
+        "  </invoke>\n"
+        "</function_calls>";
+
+    auto result = parse_tool_calls(text, read_tools());
+    TEST_ASSERT(result.tool_calls.empty());
+    // Unparsed invoke should leave entire text untouched
+    TEST_ASSERT(result.cleaned_text == text);
+}
+
+TEST_CASE(ServerUnitFixture, test_parse_invoke_attribute_quotes) {
+    // Valid double quotes
+    auto r1 = parse_tool_calls("<function_calls><invoke name=\"read\"><param name=\"path\">foo.go</param></invoke></function_calls>", read_tools());
+    TEST_ASSERT(r1.tool_calls.size() == 1);
+    TEST_ASSERT(r1.cleaned_text.empty());
+
+    // Valid single quotes
+    auto r2 = parse_tool_calls("<function_calls><invoke name='read'><param name='path'>foo.go</param></invoke></function_calls>", read_tools());
+    TEST_ASSERT(r2.tool_calls.size() == 1);
+    TEST_ASSERT(r2.cleaned_text.empty());
+
+    // Valid unquoted attribute
+    auto r3 = parse_tool_calls("<function_calls><invoke name=read><param name=path>foo.go</param></invoke></function_calls>", read_tools());
+    TEST_ASSERT(r3.tool_calls.size() == 1);
+    TEST_ASSERT(r3.cleaned_text.empty());
+
+    // Valid invoke with >4 whitespace characters
+    auto r3b = parse_tool_calls("<function_calls><invoke        name=\"read\"><param name=\"path\">foo.go</param></invoke></function_calls>", read_tools());
+    TEST_ASSERT(r3b.tool_calls.size() == 1);
+    TEST_ASSERT(r3b.cleaned_text.empty());
+
+    // Unclosed double quote on invoke name
+    const std::string unclosed1 = "<function_calls><invoke name=\"read><param name=\"path\">foo.go</param></invoke></function_calls>";
+    auto r4 = parse_tool_calls(unclosed1, read_tools());
+    TEST_ASSERT(r4.tool_calls.empty());
+    TEST_ASSERT(r4.cleaned_text == unclosed1);
+
+    // Unclosed single quote on invoke name
+    const std::string unclosed2 = "<function_calls><invoke name='read><param name='path'>foo.go</param></invoke></function_calls>";
+    auto r5 = parse_tool_calls(unclosed2, read_tools());
+    TEST_ASSERT(r5.tool_calls.empty());
+    TEST_ASSERT(r5.cleaned_text == unclosed2);
+
+    // Unclosed double quote on param name
+    const std::string unclosed3 = "<function_calls><invoke name=\"read\"><param name=\"path>foo.go</param></invoke></function_calls>";
+    auto r6 = parse_tool_calls(unclosed3, read_tools());
+    TEST_ASSERT(r6.tool_calls.empty());
+    TEST_ASSERT(r6.cleaned_text == unclosed3);
+}
+
+TEST_CASE(ServerUnitFixture, test_parse_function_calls_empty_block_stripped) {
+    const std::string empty_fc = "<function_calls>\n   \n</function_calls>";
+    auto result = parse_tool_calls(empty_fc, read_tools());
+    TEST_ASSERT(result.tool_calls.empty());
+    TEST_ASSERT(result.cleaned_text == empty_fc);
+}
+
+TEST_CASE(ServerUnitFixture, test_parse_function_calls_unclosed_block) {
+    // Missing </function_calls> - unclosed <function_calls> remains untouched
+    const std::string text =
+        "<function_calls>\n"
+        "<invoke name=\"read\"><param name=\"path\">foo.go</param></invoke>";
+    auto result = parse_tool_calls(text, read_tools());
+    TEST_ASSERT(result.tool_calls.empty());
+    TEST_ASSERT(result.cleaned_text == text);
 }
 
 TEST_CASE(ServerUnitFixture, test_parse_json_tool_call) {


### PR DESCRIPTION
## Summary
Adds support for Claude/Anthropic/Agentic XML tool call emissions using `<function_calls><invoke name="..."><param name="...">...</param></invoke></function_calls>` as well as standalone `<invoke name="...">` blocks.

## Motivation
When models (such as DeepSeek-V4 or agentic fine-tunes) emit multiple parallel tool calls (e.g. reading multiple files in a batch), they frequently emit `<function_calls><invoke name="read"><param name="path">...</param></invoke>...</function_calls>`. Previously, these XML blocks were unparsed and leaked directly into visible assistant text.

## Changes
1. **Parser Pattern 12 (`tool_parser.cpp`):**
   - Added `re_function_calls_block()` and `re_invoke_xml()` to extract tool names and parameters from `<invoke>` tags.
   - Supports parameter formats: `<param name="...">...\</param>`, `<parameter name="...">...\</parameter>`, `<param=...>`, and inline JSON bodies.
   - Automatically coerces arguments against declared tool JSON schemas via `convert_param_value`.
   - Removes `<function_calls>...</function_calls>` and `<invoke>...</invoke>` blocks from visible output without stripping surrounding natural language.
2. **Opener Detection & Holdback (`find_tool_syntax_start` / `tool_syntax_holdback`):**
   - Added `<function_calls>` and `<invoke` openers to streaming holdback so streamed tool calls are properly intercepted before reaching the client.
3. **Unit Tests (`test_server_unit.cpp`):**
   - `test_parse_function_calls_multi_invoke_xml`: Verifies multi-file `<invoke>` parsing and text stripping.
   - `test_parse_bare_invoke_xml`: Verifies standalone `<invoke>` with multiple arguments.
   - `test_find_tool_syntax_start_invoke`: Verifies opener offsets.

## Verification
- Built with `-DCMAKE_BUILD_TYPE=RelWithDebInfo` on ROCm/HIP.
- Unit tests: 364/364 passed (100%).
- Verified live with DeepSeek-V4-Flash and `pi` agent.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

