### PR TITLE
feat(server): parse <function_calls> XML tool emissions

### DIFF
--- a/server/src/server/sse_emitter.cpp
+++ b/server/src/server/sse_emitter.cpp
@@ -286,9 +286,22 @@ std::vector<std::string> SseEmitter::emit_token(const std::string & raw_piece) {
     while (true) {
         if (mode_ == StreamMode::TOOL_BUFFER) {
             if (tool_from_reasoning_ && first_content_token_index_ < 0) {
-                if (window_.find(THINK_CLOSE) != std::string::npos ||
-                    (tool_buffer_ + window_).find(THINK_CLOSE) != std::string::npos) {
-                    first_content_token_index_ = emit_token_count_ - 1;
+                const std::string full = tool_buffer_ + window_;
+                const size_t fc_close = full.find("</function_calls>");
+                if (fc_close != std::string::npos) {
+                    const size_t search_start = fc_close + std::strlen("</function_calls>");
+                    const size_t think_close = full.find(THINK_CLOSE, search_start);
+                    if (think_close != std::string::npos) {
+                        const size_t after_think = think_close + THINK_CLOSE_LEN;
+                        if (after_think < full.size() &&
+                            full.find_first_not_of(" \t\r\n", after_think) != std::string::npos) {
+                            // The current token already carries content after </think>
+                            first_content_token_index_ = emit_token_count_ - 1;
+                        } else {
+                            // First real content token starts on the next token
+                            first_content_token_index_ = emit_token_count_;
+                        }
+                    }
                 }
             }
             tool_buffer_ += window_;

--- a/server/src/server/sse_emitter.cpp
+++ b/server/src/server/sse_emitter.cpp
@@ -285,6 +285,12 @@ std::vector<std::string> SseEmitter::emit_token(const std::string & raw_piece) {
     // State machine loop — processes the window
     while (true) {
         if (mode_ == StreamMode::TOOL_BUFFER) {
+            if (tool_from_reasoning_ && first_content_token_index_ < 0) {
+                if (window_.find(THINK_CLOSE) != std::string::npos ||
+                    (tool_buffer_ + window_).find(THINK_CLOSE) != std::string::npos) {
+                    first_content_token_index_ = emit_token_count_ - 1;
+                }
+            }
             tool_buffer_ += window_;
             window_.clear();
             break;
@@ -618,11 +624,11 @@ std::vector<std::string> SseEmitter::emit_finish(int completion_tokens,
             if (!parsed.cleaned_text.empty()) {
                 size_t think_close = parsed.cleaned_text.find(THINK_CLOSE);
                 if (think_close != std::string::npos) {
-                    if (first_content_token_index_ == -1) {
-                        first_content_token_index_ = emit_token_count_;
-                    }
                     std::string reasoning = parsed.cleaned_text.substr(0, think_close);
                     std::string content = parsed.cleaned_text.substr(think_close + THINK_CLOSE_LEN);
+                    if (first_content_token_index_ == -1) {
+                        first_content_token_index_ = content.empty() ? emit_token_count_ : std::max(0, emit_token_count_ - 1);
+                    }
                     if (!reasoning.empty()) {
                         reasoning_text_ += reasoning;
                         if (format_ == ApiFormat::OPENAI_CHAT) {

--- a/server/src/server/sse_emitter.cpp
+++ b/server/src/server/sse_emitter.cpp
@@ -306,7 +306,11 @@ std::vector<std::string> SseEmitter::emit_token(const std::string & raw_piece) {
             }
 
             size_t idx = window_.find(THINK_CLOSE);
-            if (idx != std::string::npos) {
+            size_t tool_idx = std::string::npos;
+            bool tool_hit = has_request_tools(tools_) &&
+                            find_tool_syntax_start(window_, tools_, tool_idx);
+
+            if (idx != std::string::npos && (tool_idx == std::string::npos || idx < tool_idx)) {
                 std::string pre = window_.substr(0, idx);
                 if (!pre.empty()) {
                     reasoning_text_ += pre;
@@ -339,6 +343,38 @@ std::vector<std::string> SseEmitter::emit_token(const std::string & raw_piece) {
                 }
                 window_ = window_.substr(idx + THINK_CLOSE_LEN);
                 mode_ = StreamMode::CONTENT;
+                continue;
+            }
+            if (tool_hit) {
+                std::string pre = window_.substr(0, tool_idx);
+                if (!pre.empty()) {
+                    reasoning_text_ += pre;
+                    switch (format_) {
+                    case ApiFormat::OPENAI_CHAT:
+                        out.push_back(format_openai_delta({{"reasoning_content", pre}}));
+                        break;
+                    case ApiFormat::ANTHROPIC: {
+                        if (active_kind_ != "thinking") {
+                            out.push_back(sse_event("content_block_stop",
+                                json({{"type", "content_block_stop"}, {"index", block_index_}}).dump()));
+                            block_index_++;
+                            active_kind_ = "thinking";
+                            json new_block = {{"type", "thinking"}, {"thinking", ""}};
+                            out.push_back(sse_event("content_block_start",
+                                json({{"type", "content_block_start"}, {"index", block_index_},
+                                      {"content_block", new_block}}).dump()));
+                        }
+                        out.push_back(sse_event("content_block_delta",
+                            json({{"type", "content_block_delta"}, {"index", block_index_},
+                                  {"delta", {{"type", "thinking_delta"}, {"thinking", pre}}}}).dump()));
+                        break;
+                    }
+                    default: break;
+                    }
+                }
+                tool_buffer_ = window_.substr(tool_idx);
+                window_.clear();
+                mode_ = StreamMode::TOOL_BUFFER;
                 continue;
             }
             // No close tag yet — emit safe prefix if window is large enough
@@ -576,8 +612,24 @@ std::vector<std::string> SseEmitter::emit_finish(int completion_tokens,
 
             // Emit any cleaned text from the tool buffer
             if (!parsed.cleaned_text.empty()) {
-                accumulated_content_ += parsed.cleaned_text;
-                emit_content_delta(out, parsed.cleaned_text);
+                size_t think_close = parsed.cleaned_text.find(THINK_CLOSE);
+                if (think_close != std::string::npos) {
+                    std::string reasoning = parsed.cleaned_text.substr(0, think_close);
+                    std::string content = parsed.cleaned_text.substr(think_close + THINK_CLOSE_LEN);
+                    if (!reasoning.empty()) {
+                        reasoning_text_ += reasoning;
+                        if (format_ == ApiFormat::OPENAI_CHAT) {
+                            out.push_back(format_openai_delta({{"reasoning_content", reasoning}}));
+                        }
+                    }
+                    if (!content.empty()) {
+                        accumulated_content_ += content;
+                        emit_content_delta(out, content);
+                    }
+                } else {
+                    accumulated_content_ += parsed.cleaned_text;
+                    emit_content_delta(out, parsed.cleaned_text);
+                }
             }
 
             fr = "tool_calls";

--- a/server/src/server/sse_emitter.cpp
+++ b/server/src/server/sse_emitter.cpp
@@ -13,6 +13,7 @@ namespace dflash::common {
 
 static const char THINK_OPEN[]  = "<think>";
 static const char THINK_CLOSE[] = "</think>";
+static const char FUNCTION_CALLS_OPEN[] = "<function_calls>";
 static constexpr size_t THINK_OPEN_LEN  = 7;
 static constexpr size_t THINK_CLOSE_LEN = 8;
 
@@ -308,7 +309,7 @@ std::vector<std::string> SseEmitter::emit_token(const std::string & raw_piece) {
             size_t idx = window_.find(THINK_CLOSE);
             size_t tool_idx = std::string::npos;
             bool tool_hit = has_request_tools(tools_) &&
-                            find_tool_syntax_start(window_, tools_, tool_idx);
+                            (tool_idx = window_.find(FUNCTION_CALLS_OPEN)) != std::string::npos;
 
             if (idx != std::string::npos && (tool_idx == std::string::npos || idx < tool_idx)) {
                 std::string pre = window_.substr(0, idx);
@@ -373,6 +374,7 @@ std::vector<std::string> SseEmitter::emit_token(const std::string & raw_piece) {
                     }
                 }
                 tool_buffer_ = window_.substr(tool_idx);
+                tool_from_reasoning_ = true;
                 window_.clear();
                 mode_ = StreamMode::TOOL_BUFFER;
                 continue;
@@ -446,6 +448,7 @@ std::vector<std::string> SseEmitter::emit_token(const std::string & raw_piece) {
                 // Tool-call syntax. Keep the full tag/function text buffered
                 // until finish so the parser can validate it.
                 tool_buffer_ = window_.substr(h.pos);
+                tool_from_reasoning_ = false;
                 window_.clear();
                 mode_ = StreamMode::TOOL_BUFFER;
             }
@@ -455,6 +458,7 @@ std::vector<std::string> SseEmitter::emit_token(const std::string & raw_piece) {
         if (accumulated_content_.find_first_not_of(" \t\n\r") == std::string::npos &&
             starts_with_potential_bare_json_tool(window_, tools_)) {
             tool_buffer_ = window_;
+            tool_from_reasoning_ = false;
             tool_buffer_fallback_to_content_ = true;
             window_.clear();
             mode_ = StreamMode::TOOL_BUFFER;
@@ -614,17 +618,53 @@ std::vector<std::string> SseEmitter::emit_finish(int completion_tokens,
             if (!parsed.cleaned_text.empty()) {
                 size_t think_close = parsed.cleaned_text.find(THINK_CLOSE);
                 if (think_close != std::string::npos) {
+                    if (first_content_token_index_ == -1) {
+                        first_content_token_index_ = emit_token_count_;
+                    }
                     std::string reasoning = parsed.cleaned_text.substr(0, think_close);
                     std::string content = parsed.cleaned_text.substr(think_close + THINK_CLOSE_LEN);
                     if (!reasoning.empty()) {
                         reasoning_text_ += reasoning;
                         if (format_ == ApiFormat::OPENAI_CHAT) {
                             out.push_back(format_openai_delta({{"reasoning_content", reasoning}}));
+                        } else if (format_ == ApiFormat::ANTHROPIC) {
+                            if (active_kind_ != "thinking") {
+                                out.push_back(sse_event("content_block_stop",
+                                    json({{"type", "content_block_stop"}, {"index", block_index_}}).dump()));
+                                block_index_++;
+                                active_kind_ = "thinking";
+                                json new_block = {{"type", "thinking"}, {"thinking", ""}};
+                                out.push_back(sse_event("content_block_start",
+                                    json({{"type", "content_block_start"}, {"index", block_index_},
+                                          {"content_block", new_block}}).dump()));
+                            }
+                            out.push_back(sse_event("content_block_delta",
+                                json({{"type", "content_block_delta"}, {"index", block_index_},
+                                      {"delta", {{"type", "thinking_delta"}, {"thinking", reasoning}}}}).dump()));
                         }
                     }
                     if (!content.empty()) {
                         accumulated_content_ += content;
                         emit_content_delta(out, content);
+                    }
+                } else if (tool_from_reasoning_) {
+                    reasoning_text_ += parsed.cleaned_text;
+                    if (format_ == ApiFormat::OPENAI_CHAT) {
+                        out.push_back(format_openai_delta({{"reasoning_content", parsed.cleaned_text}}));
+                    } else if (format_ == ApiFormat::ANTHROPIC) {
+                        if (active_kind_ != "thinking") {
+                            out.push_back(sse_event("content_block_stop",
+                                json({{"type", "content_block_stop"}, {"index", block_index_}}).dump()));
+                            block_index_++;
+                            active_kind_ = "thinking";
+                            json new_block = {{"type", "thinking"}, {"thinking", ""}};
+                            out.push_back(sse_event("content_block_start",
+                                json({{"type", "content_block_start"}, {"index", block_index_},
+                                      {"content_block", new_block}}).dump()));
+                        }
+                        out.push_back(sse_event("content_block_delta",
+                            json({{"type", "content_block_delta"}, {"index", block_index_},
+                                  {"delta", {{"type", "thinking_delta"}, {"thinking", parsed.cleaned_text}}}}).dump()));
                     }
                 } else {
                     accumulated_content_ += parsed.cleaned_text;

--- a/server/src/server/sse_emitter.h
+++ b/server/src/server/sse_emitter.h
@@ -153,6 +153,7 @@ private:
     ToolMemory * tool_memory_;
 
     StreamMode   mode_;
+    bool         tool_from_reasoning_ = false;
     std::string  window_;           // holdback buffer
     std::string  tool_buffer_;      // accumulated tool text
     bool         tool_buffer_fallback_to_content_ = false;

--- a/server/src/server/tool_parser.cpp
+++ b/server/src/server/tool_parser.cpp
@@ -55,6 +55,7 @@ static std::string generate_call_id() {
 
 static const char TOOL_OPEN[] = "<tool_call>";
 static const char FUNCTION_CALL_OPEN[] = "<function_call>";
+static const char FUNCTION_CALLS_OPEN[] = "<function_calls>";
 static const char FUNCTION_OPEN[] = "<function=";
 static const char BARE_FUNCTION_OPEN[] = "<function>";
 static const char FUNCTION_SPACE_OPEN[] = "<function ";
@@ -106,6 +107,7 @@ bool find_tool_syntax_start(const std::string & text, const json & tools,
     while (idx != std::string::npos) {
         if (text.compare(idx, sizeof(TOOL_OPEN) - 1, TOOL_OPEN) == 0 ||
             text.compare(idx, sizeof(FUNCTION_CALL_OPEN) - 1, FUNCTION_CALL_OPEN) == 0 ||
+            text.compare(idx, sizeof(FUNCTION_CALLS_OPEN) - 1, FUNCTION_CALLS_OPEN) == 0 ||
             text.compare(idx, sizeof(FUNCTION_OPEN) - 1, FUNCTION_OPEN) == 0 ||
             text.compare(idx, sizeof(BARE_FUNCTION_OPEN) - 1, BARE_FUNCTION_OPEN) == 0 ||
             text.compare(idx, sizeof(FUNCTION_SPACE_OPEN) - 1,
@@ -138,6 +140,7 @@ bool find_tool_syntax_start(const std::string & text, const json & tools,
 size_t tool_syntax_holdback(const json & tools) {
     // Longest fixed opener is `<parameter name=` (16 bytes).
     size_t holdback = std::max({sizeof(ATTRIBUTE_PARAMETER_OPEN) - 2,
+                                sizeof(FUNCTION_CALLS_OPEN) - 2,
                                 sizeof(FUNCTION_CALL_OPEN) - 2,
                                 sizeof(BARE_FUNCTION_OPEN) - 2});
     if (!tools.is_array()) return holdback;
@@ -1174,6 +1177,59 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
         }
     }
 
+    // Pattern 4d: <function_calls><invoke name="NAME">...<param name="K">V</param>...</invoke></function_calls>
+    {
+        static const std::regex re_block(R"(<function_calls>([\s\S]*?)</function_calls>)");
+        static const std::regex re_invoke(R"(<invoke\s+(?:name|tool)\s*=\s*["']?([A-Za-z_][\w.\-]*)["']?\s*>([\s\S]*?)</invoke>)");
+        static const std::regex re_param(R"(<(param|parameter)\s+name\s*=\s*["']?([A-Za-z_][\w.\-]*)["']?\s*>([\s\S]*?)</\1>)");
+
+        auto fbegin = std::sregex_iterator(text.begin(), text.end(), re_block);
+        auto fend = std::sregex_iterator();
+        for (auto fit = fbegin; fit != fend; ++fit) {
+            size_t bstart = fit->position();
+            size_t bend = bstart + fit->length();
+            if (overlaps(removals, bstart)) continue;
+
+            std::string block_content = (*fit)[1].str();
+            auto begin = std::sregex_iterator(block_content.begin(), block_content.end(), re_invoke);
+            auto end = std::sregex_iterator();
+            std::vector<std::pair<std::string, json>> block_calls;
+
+            for (auto it = begin; it != end; ++it) {
+                std::string fn_name = (*it)[1].str();
+                if (!tool_allowed(tools, fn_name)) continue;
+                std::string body = trim_ws((*it)[2].str());
+                json args = json::object();
+                if (!body.empty() && body.front() == '{') {
+                    json raw_args = json::parse(body, nullptr, false);
+                    if (raw_args.is_discarded() || !raw_args.is_object()) continue;
+                    json props = find_tool_properties(tools, fn_name);
+                    for (auto & [k, v] : raw_args.items()) {
+                        if (v.is_string()) {
+                            args[k] = convert_param_value(v.get<std::string>(), k, props);
+                        } else {
+                            args[k] = v;
+                        }
+                    }
+                } else {
+                    auto pbegin = std::sregex_iterator(body.begin(), body.end(), re_param);
+                    auto pend = std::sregex_iterator();
+                    for (auto pit = pbegin; pit != pend; ++pit) {
+                        std::string k = (*pit)[2].str();
+                        std::string v = trim_ws((*pit)[3].str());
+                        args[k] = convert_param_value(v, k, find_tool_properties(tools, fn_name));
+                    }
+                }
+                block_calls.push_back({fn_name, std::move(args)});
+            }
+
+            if (!block_calls.empty()) {
+                for (auto & bc : block_calls) {
+                    add_call(bc.first, bc.second, bstart, bend);
+                }
+            }
+        }
+    }
 
 
     // Pattern 5: call:<ns>?<verb>{relaxed-JSON args}

--- a/server/src/server/tool_parser.cpp
+++ b/server/src/server/tool_parser.cpp
@@ -176,6 +176,12 @@ static json find_tool_properties(const json & tools, const std::string & name) {
                 return params["properties"];
             }
         }
+        if (fn.contains("input_schema") && fn["input_schema"].is_object()) {
+            const auto & params = fn["input_schema"];
+            if (params.contains("properties") && params["properties"].is_object()) {
+                return params["properties"];
+            }
+        }
     }
     return json::object();
 }
@@ -183,8 +189,7 @@ static json find_tool_properties(const json & tools, const std::string & name) {
 // Convert a string value to its JSON-schema-typed equivalent.
 static json convert_param_value(const std::string & val, const std::string & key,
                                 const json & props) {
-    if (val == "null") return nullptr;
-    if (!props.contains(key)) return val;
+    if (!props.contains(key)) return val == "null" ? nullptr : json(val);
 
     const auto & cfg = props[key];
     std::string ptype = "string";
@@ -206,6 +211,7 @@ static json convert_param_value(const std::string & val, const std::string & key
 
     // string types
     if (ptype == "string" || ptype == "str" || ptype == "enum") return val;
+    if (val == "null") return nullptr;
 
     // integer types
     if (ptype.substr(0, 3) == "int" || ptype == "integer") {
@@ -1212,13 +1218,20 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
                         }
                     }
                 } else {
+                    size_t cursor = 0;
+                    bool valid_body = true;
                     auto pbegin = std::sregex_iterator(body.begin(), body.end(), re_param);
                     auto pend = std::sregex_iterator();
                     for (auto pit = pbegin; pit != pend; ++pit) {
+                        size_t ppos = pit->position();
+                        if (!trim_ws(body.substr(cursor, ppos - cursor)).empty()) { valid_body = false; break; }
                         std::string k = (*pit)[2].str();
+                        if (args.contains(k)) { valid_body = false; break; }
                         std::string v = trim_ws((*pit)[3].str());
                         args[k] = convert_param_value(v, k, find_tool_properties(tools, fn_name));
+                        cursor = ppos + pit->length();
                     }
+                    if (!valid_body || (!args.empty() && !trim_ws(body.substr(cursor)).empty())) continue;
                 }
                 block_calls.push_back({fn_name, std::move(args)});
             }

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -5704,3 +5704,57 @@ TEST_CASE(ServerUnitFixture, test_qwen35_embedded_mtp_target_layer_count) {
         "laguna", 65, 1, target_layers, error));
     TEST_ASSERT(target_layers == 65);
 }
+
+TEST_CASE(ServerUnitFixture, test_parse_function_calls_invoke_xml) {
+    const std::string text =
+        "Reading configuration:\n"
+        "<function_calls>\n"
+        "<invoke name=\"read\">\n"
+        "  <param name=\"path\">server.go</param>\n"
+        "  <param name=\"offset\">10</param>\n"
+        "  <param name=\"limit\">50</param>\n"
+        "</invoke>\n"
+        "</function_calls>";
+
+    auto result = parse_tool_calls(text, read_tools());
+    TEST_ASSERT(result.tool_calls.size() == 1);
+    if (!result.tool_calls.empty()) {
+        TEST_ASSERT(result.tool_calls[0].name == "read");
+        auto args = json::parse(result.tool_calls[0].arguments);
+        TEST_ASSERT(args["path"] == "server.go");
+        TEST_ASSERT(args["offset"] == 10);
+        TEST_ASSERT(args["limit"] == 50);
+    }
+    TEST_ASSERT(result.cleaned_text == "Reading configuration:");
+}
+
+TEST_CASE(ServerUnitFixture, test_parse_function_calls_invoke_json) {
+    const std::string text =
+        "<function_calls>\n"
+        "<invoke name=\"read\">\n"
+        "  {\"path\": \"app.py\", \"offset\": \"5\"}\n"
+        "</invoke>\n"
+        "</function_calls>";
+
+    auto result = parse_tool_calls(text, read_tools());
+    TEST_ASSERT(result.tool_calls.size() == 1);
+    if (!result.tool_calls.empty()) {
+        TEST_ASSERT(result.tool_calls[0].name == "read");
+        auto args = json::parse(result.tool_calls[0].arguments);
+        TEST_ASSERT(args["path"] == "app.py");
+        TEST_ASSERT(args["offset"] == 5);
+    }
+    TEST_ASSERT(result.cleaned_text.empty());
+}
+
+TEST_CASE(ServerUnitFixture, test_emitter_function_calls_inside_reasoning) {
+    auto em = make_emitter(ApiFormat::OPENAI_CHAT, read_tools(), false);
+    auto c1 = em.emit_token("<think>Analyzing build files.\n");
+    auto c2 = em.emit_token("<function_calls>\n  <invoke name=\"read\">\n    <param name=\"path\">CMakeLists.txt</param>\n  </invoke>\n</function_calls>\n</think>");
+    auto fin = em.emit_finish(2);
+
+    std::string all = concat(c1) + concat(c2) + concat(fin);
+    TEST_ASSERT(em.tool_calls().size() == 1);
+    TEST_ASSERT(em.reasoning_text().find("Analyzing build files.") != std::string::npos);
+    TEST_ASSERT(all.find("\"finish_reason\":\"tool_calls\"") != std::string::npos);
+}

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -5804,3 +5804,18 @@ TEST_CASE(ServerUnitFixture, test_emitter_function_calls_unclosed_think_flushes_
     TEST_ASSERT(all.find("\"finish_reason\":\"tool_calls\"") != std::string::npos);
 }
 
+TEST_CASE(ServerUnitFixture, test_emitter_function_calls_content_tokens_accounting) {
+    auto em = make_emitter(ApiFormat::OPENAI_CHAT, read_tools(), false);
+    em.emit_token("<think>Analyzing build configuration.\n");
+    em.emit_token("<function_calls>\n  <invoke name=\"read\">\n    <param name=\"path\">CMakeLists.txt</param>\n  </invoke>\n</function_calls>\n");
+    em.emit_token("</think>\n");
+    em.emit_token("Here is the build summary.");
+    em.emit_finish(4);
+
+    TEST_ASSERT(em.tool_calls().size() == 1);
+    TEST_ASSERT(em.first_content_token_index() == 2);
+    TEST_ASSERT(em.emit_token_count() == 4);
+    TEST_ASSERT(em.emit_token_count() - em.first_content_token_index() == 2);
+}
+
+

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -5758,3 +5758,49 @@ TEST_CASE(ServerUnitFixture, test_emitter_function_calls_inside_reasoning) {
     TEST_ASSERT(em.reasoning_text().find("Analyzing build files.") != std::string::npos);
     TEST_ASSERT(all.find("\"finish_reason\":\"tool_calls\"") != std::string::npos);
 }
+
+TEST_CASE(ServerUnitFixture, test_parse_function_calls_anthropic_input_schema) {
+    json anthropic_tools = json::array({
+        {
+            {"name", "read"},
+            {"description", "Read a file"},
+            {"input_schema", {
+                {"type", "object"},
+                {"properties", {
+                    {"path", {{"type", "string"}}},
+                    {"offset", {{"type", "integer"}}}
+                }}
+            }}
+        }
+    });
+
+    const std::string text =
+        "<function_calls>\n"
+        "<invoke name=\"read\">\n"
+        "  <param name=\"path\">main.cpp</param>\n"
+        "  <param name=\"offset\">42</param>\n"
+        "</invoke>\n"
+        "</function_calls>";
+
+    auto result = parse_tool_calls(text, anthropic_tools);
+    TEST_ASSERT(result.tool_calls.size() == 1);
+    if (!result.tool_calls.empty()) {
+        auto args = json::parse(result.tool_calls[0].arguments);
+        TEST_ASSERT(args["path"] == "main.cpp");
+        TEST_ASSERT(args["offset"] == 42);
+    }
+}
+
+TEST_CASE(ServerUnitFixture, test_emitter_function_calls_unclosed_think_flushes_reasoning) {
+    auto em = make_emitter(ApiFormat::OPENAI_CHAT, read_tools(), false);
+    auto c1 = em.emit_token("<think>Analyzing build files without closing tag.\n");
+    auto c2 = em.emit_token("<function_calls>\n  <invoke name=\"read\">\n    <param name=\"path\">CMakeLists.txt</param>\n  </invoke>\n</function_calls>");
+    auto fin = em.emit_finish(2);
+
+    std::string all = concat(c1) + concat(c2) + concat(fin);
+    TEST_ASSERT(em.tool_calls().size() == 1);
+    TEST_ASSERT(em.reasoning_text().find("Analyzing build files without closing tag.") != std::string::npos);
+    TEST_ASSERT(em.accumulated_text().find("Analyzing build files") == std::string::npos);
+    TEST_ASSERT(all.find("\"finish_reason\":\"tool_calls\"") != std::string::npos);
+}
+

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -5806,16 +5806,37 @@ TEST_CASE(ServerUnitFixture, test_emitter_function_calls_unclosed_think_flushes_
 
 TEST_CASE(ServerUnitFixture, test_emitter_function_calls_content_tokens_accounting) {
     auto em = make_emitter(ApiFormat::OPENAI_CHAT, read_tools(), false);
+    // Token 0: reasoning
     em.emit_token("<think>Analyzing build configuration.\n");
+    // Token 1: function_calls
     em.emit_token("<function_calls>\n  <invoke name=\"read\">\n    <param name=\"path\">CMakeLists.txt</param>\n  </invoke>\n</function_calls>\n");
+    // Token 2: close think
     em.emit_token("</think>\n");
+    // Token 3: content
     em.emit_token("Here is the build summary.");
     em.emit_finish(4);
 
     TEST_ASSERT(em.tool_calls().size() == 1);
-    TEST_ASSERT(em.first_content_token_index() == 2);
+    TEST_ASSERT(em.first_content_token_index() == 3);
     TEST_ASSERT(em.emit_token_count() == 4);
-    TEST_ASSERT(em.emit_token_count() - em.first_content_token_index() == 2);
+    TEST_ASSERT(em.emit_token_count() - em.first_content_token_index() == 1);
 }
+
+TEST_CASE(ServerUnitFixture, test_emitter_function_calls_param_with_literal_think_close) {
+    auto em = make_emitter(ApiFormat::OPENAI_CHAT, read_tools(), false);
+    // Token 0: reasoning
+    em.emit_token("<think>Searching for tag.\n");
+    // Token 1: parameter with literal </think> inside
+    em.emit_token("<function_calls>\n  <invoke name=\"read\">\n    <param name=\"path\">test_</think>.cpp</param>\n  </invoke>\n</function_calls>\n");
+    // Token 2: real close think + trailing content in same token
+    em.emit_token("</think> Found file.");
+    em.emit_finish(3);
+
+    TEST_ASSERT(em.tool_calls().size() == 1);
+    TEST_ASSERT(em.first_content_token_index() == 2);
+    TEST_ASSERT(em.emit_token_count() == 3);
+    TEST_ASSERT(em.emit_token_count() - em.first_content_token_index() == 1);
+}
+
 
 


### PR DESCRIPTION
## Summary

Adds support for parsing `<function_calls><invoke name="...">...</invoke></function_calls>` tool call containers emitted by DeepSeek models during multi-tool and file-reading operations.

### Changes
1. **Tool Parser (`tool_parser.cpp`)**:
   - Registers `<function_calls>` opener in `find_tool_syntax_start` and holdback calculation.
   - Adds Pattern 4d to parse `<function_calls>` containers, extracting XML `<param name="...">...</param>` and inline JSON bodies.
   - Coerces string parameters according to JSON Schema property definitions.
2. **Streaming Emitter (`sse_emitter.cpp`)**:
   - Intercepts `<function_calls>` occurring in `StreamMode::REASONING` to buffer tool calls without leaking into reasoning stream.
   - In `emit_finish`, splits `parsed.cleaned_text` across `</think>` to maintain clean separation between reasoning and content deltas.
3. **Unit Tests (`test_server_unit.cpp`)**:
   - Adds unit tests covering XML parameter extraction, inline JSON bodies, and thinking-mode streaming.

### Verification
- 364 / 364 unit tests pass (`ctest -R test_server_unit`).
- Verified live streaming inference with `DeepSeek-V4-Flash-ROCMFP2-STRIX` on ROCm hardware.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

