### PR TITLE
fix(hip): restrict wavefront guard to device pass

### DIFF
--- a/server/src/flashprefill_kernels.hip.cu
+++ b/server/src/flashprefill_kernels.hip.cu
@@ -29,12 +29,15 @@
 // which is a 32-lane instruction. A wave64 target would need a different WMMA
 // instruction and fragment layout, not a warp-width tweak, so we fail the build
 // loudly rather than emit silently-wrong results. All currently declared AMD
-// targets (gfx1100 / gfx1151, RDNA3) are wave32. __AMDGCN_WAVEFRONT_SIZE(__) is
-// defined only in the device compile pass.
-#if defined(__AMDGCN_WAVEFRONT_SIZE__) && (__AMDGCN_WAVEFRONT_SIZE__ != 32)
+// targets (gfx1100 / gfx1151, RDNA3) are wave32. Check the compiler-provided
+// wavefront macros only in the device pass: some ROCm versions expose a
+// host-side definition that is not an integer constant expression.
+#if defined(__HIP_DEVICE_COMPILE__) && __HIP_DEVICE_COMPILE__
+#  if defined(__AMDGCN_WAVEFRONT_SIZE__) && (__AMDGCN_WAVEFRONT_SIZE__ != 32)
 #  error "flashprefill_kernels.hip.cu requires a 32-lane wavefront (RDNA v_wmma_f32_16x16x16 fragment layout). Build for a wave32 target (gfx10/gfx11) or provide a wave64 WMMA rewrite."
-#elif !defined(__AMDGCN_WAVEFRONT_SIZE__) && defined(__AMDGCN_WAVEFRONT_SIZE) && (__AMDGCN_WAVEFRONT_SIZE != 32)
+#  elif !defined(__AMDGCN_WAVEFRONT_SIZE__) && defined(__AMDGCN_WAVEFRONT_SIZE) && (__AMDGCN_WAVEFRONT_SIZE != 32)
 #  error "flashprefill_kernels.hip.cu requires a 32-lane wavefront (RDNA v_wmma_f32_16x16x16 fragment layout). Build for a wave32 target (gfx10/gfx11) or provide a wave64 WMMA rewrite."
+#  endif
 #endif
 
 namespace dflash::common {


### PR DESCRIPTION
## Summary

Restrict the rocWMMA wavefront-size compile-time check to the HIP device pass.

Some ROCm 7.1 host passes expose `__AMDGCN_WAVEFRONT_SIZE` without making it an integer constant expression. Evaluating it in a preprocessor arithmetic condition then rejects an otherwise valid gfx1151 build. The device pass still performs the existing wave32 safety check, so wave64 targets continue to fail loudly.

Published qualification patch: [`lucebox-rocm71-host-wavefront.patch`](https://github.com/pepuscz/strix-halo-deepseek-v4-flash/blob/main/patches/lucebox-rocm71-host-wavefront.patch)

## Validation

- `git diff --check`
- ROCm 7.1.1 / gfx1151 qualified build completed with this guard
- The patch changes only preprocessor scope; kernel code and device-pass validation are unchanged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

