### PR TITLE
NVLink fix for PR625

### DIFF
--- a/server/deps/llama.cpp/ggml/src/ggml-backend-meta.cpp
+++ b/server/deps/llama.cpp/ggml/src/ggml-backend-meta.cpp
@@ -825,6 +825,18 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
     };
 
     auto handle_ssm_conv = [&](const std::vector<ggml_backend_meta_split_state> & src_ss) -> ggml_backend_meta_split_state {
+        // Step / SpecLA variants (ggml_ssm_conv_step, ggml_ssm_conv_specla):
+        // x [C,T,S] -> out [C,T,S]; the channel axis stays axis 0, while the
+        // weight [K,C] and conv_state [K-1,C,S] carry the same channel
+        // partition on axis 1. The axis layout (not the op_params flag, whose
+        // encoding differs between the step and SpecLA variants) determines
+        // the split.
+        if (tensor->src[2] != nullptr &&
+            src_ss[0].axis == GGML_BACKEND_SPLIT_AXIS_0 &&
+            src_ss[1].axis == GGML_BACKEND_SPLIT_AXIS_1 &&
+            src_ss[2].axis == GGML_BACKEND_SPLIT_AXIS_1) {
+            return {GGML_BACKEND_SPLIT_AXIS_0, {0}, 1, {1}};
+        }
         if (src_ss[0].axis == src_ss[1].axis) {
             if (src_ss[0].axis == GGML_BACKEND_SPLIT_AXIS_0) {
                 return {GGML_BACKEND_SPLIT_AXIS_1, {0}, 1, {1}};

--- a/server/deps/llama.cpp/ggml/src/ggml-backend-meta.cpp
+++ b/server/deps/llama.cpp/ggml/src/ggml-backend-meta.cpp
@@ -830,11 +830,16 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
         // weight [K,C] and conv_state [K-1,C,S] carry the same channel
         // partition on axis 1. The axis layout (not the op_params flag, whose
         // encoding differs between the step and SpecLA variants) determines
-        // the split.
+        // the split. The mode is asserted after the layout match so a future
+        // tree/dynamic-conv layout collision fails loudly instead of being
+        // silently treated as Step/SpecLA.
         if (tensor->src[2] != nullptr &&
             src_ss[0].axis == GGML_BACKEND_SPLIT_AXIS_0 &&
             src_ss[1].axis == GGML_BACKEND_SPLIT_AXIS_1 &&
             src_ss[2].axis == GGML_BACKEND_SPLIT_AXIS_1) {
+            const int mode = ggml_get_op_params_i32(tensor, 0);
+            GGML_ASSERT(mode == 1 || mode == 2);
+            GGML_ASSERT(tensor->src[2]->type == GGML_TYPE_F32);
             return {GGML_BACKEND_SPLIT_AXIS_0, {0}, 1, {1}};
         }
         if (src_ss[0].axis == src_ss[1].axis) {

--- a/server/src/qwen35/qwen35_backend.cpp
+++ b/server/src/qwen35/qwen35_backend.cpp
@@ -26,6 +26,7 @@
 #include "qwen3/qwen3_kvflash_scorer.h"
 
 #include "ggml-cuda.h"
+#include "ggml-backend-impl.h"
 #include "common/snapshot_backend.h"
 #include "pflash_ggml_adapter.h"
 #include "flashprefill.h"
@@ -2456,6 +2457,33 @@ static float qwen35_dspark_confidence_threshold() {
     return kThreshold;
 }
 
+// Resolve the target lm_head to a tensor whose data is readable on the
+// draft backend. In tensor-parallel mode the lm_head is a meta tensor whose
+// data pointer is a placeholder; the real data is mirrored (a full copy) on
+// every rank. Return the simple tensor of the rank that matches the draft
+// GPU (a local read on the draft backend), else nullptr so the caller falls
+// back to the host chain.
+static ggml_tensor * resolve_fused_lm_head(ggml_tensor * lm_head,
+                                           const DevicePlacement & device,
+                                           int draft_gpu) {
+    if (!lm_head) return nullptr;
+    if (!lm_head->buffer ||
+        !ggml_backend_buft_is_meta(ggml_backend_buffer_get_type(lm_head->buffer))) {
+        return lm_head;  // simple tensor: data pointer is real, use as-is
+    }
+    // Meta tensor: the lm_head is mirrored (full copy) on every rank. Read
+    // it from the rank that matches the draft GPU so the fused graph does a
+    // local read on the draft backend.
+    for (size_t j = 0; j < device.layer_split_gpus.size(); ++j) {
+        if (device.layer_split_gpus[j] == draft_gpu) {
+            ggml_tensor * simple = ggml_backend_meta_simple_tensor(lm_head, j);
+            return (simple && simple->data) ? simple : nullptr;
+        }
+    }
+    // Draft GPU is not a target rank; fall back to the host chain.
+    return nullptr;
+}
+
 // Adaptive speculation policy: a spec step (draft + heads + width-q verify)
 // costs about DFLASH_QWEN35_SPEC_STEP_RATIO plain-decode steps, so it only
 // pays off while the drafter gets more than (ratio - 1) of its tokens
@@ -3025,11 +3053,20 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
                 if (fused_dspark) {
                     // One graph for every candidate: markov-corrected tokens
                     // plus (when gated) the confidence score per position.
+                    // The lm_head must be readable on the draft backend; in
+                    // tensor-parallel mode that is the simple tensor of the
+                    // rank matching the draft GPU (lm_head is mirrored on
+                    // every rank).
                     std::vector<float> conf_scores;
-                    ds_ok = dspark_markov_correct_greedy_chain_fused(
-                        dw_, draft_backend_, target->lm_head_tensor(),
-                        local_hidden.data(), q_len, last_tok, draft_tok,
-                        conf_threshold > 0.0f ? &conf_scores : nullptr);
+                    ggml_tensor * fused_lm_head =
+                        resolve_fused_lm_head(target->lm_head_tensor(),
+                                              cfg_.device, cfg_.draft_gpu);
+                    if (fused_lm_head) {
+                        ds_ok = dspark_markov_correct_greedy_chain_fused(
+                            dw_, draft_backend_, fused_lm_head,
+                            local_hidden.data(), q_len, last_tok, draft_tok,
+                            conf_threshold > 0.0f ? &conf_scores : nullptr);
+                    }
                     if (ds_ok && conf_threshold > 0.0f) {
                         // Truncate the chain at the first low-confidence
                         // position: draft_tok[0] is the seed, candidate i
@@ -3220,11 +3257,16 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
                         std::fprintf(stderr,
                             "[qwen35-spec] DSpark Markov head active for DDTree candidates\n");
                     }
-                    topk_ok = dspark_markov_project_topk(dw_, draft_backend_,
-                                                         target->lm_head_tensor(),
-                                                         local_hidden.data(), q_len, K,
-                                                         cfg_.ddtree_temp, last_tok,
-                                                         top_lp, top_ids);
+                    ggml_tensor * fused_lm_head =
+                        resolve_fused_lm_head(target->lm_head_tensor(),
+                                              cfg_.device, cfg_.draft_gpu);
+                    if (fused_lm_head) {
+                        topk_ok = dspark_markov_project_topk(dw_, draft_backend_,
+                                                             fused_lm_head,
+                                                             local_hidden.data(), q_len, K,
+                                                             cfg_.ddtree_temp, last_tok,
+                                                             top_lp, top_ids);
+                    }
                 }
                 if (!topk_ok &&
                     !target->project_hidden_to_topk(local_hidden.data(), q_len, K,

--- a/server/src/qwen35/qwen35_backend.cpp
+++ b/server/src/qwen35/qwen35_backend.cpp
@@ -2466,10 +2466,29 @@ static float qwen35_dspark_confidence_threshold() {
 static ggml_tensor * resolve_fused_lm_head(ggml_tensor * lm_head,
                                            const DevicePlacement & device,
                                            int draft_gpu) {
-    if (!lm_head) return nullptr;
-    if (!lm_head->buffer ||
-        !ggml_backend_buft_is_meta(ggml_backend_buffer_get_type(lm_head->buffer))) {
-        return lm_head;  // simple tensor: data pointer is real, use as-is
+    if (!lm_head || !lm_head->buffer) return nullptr;
+    const ggml_backend_buffer_type_t lm_head_buft =
+        ggml_backend_buffer_get_type(lm_head->buffer);
+    if (!ggml_backend_buft_is_meta(lm_head_buft)) {
+        // A simple tensor is safe only when it is local to the draft backend,
+        // or when peer access was successfully enabled for the actual target
+        // and draft GPU pair. The configuration flag alone is not proof that
+        // the hardware/driver accepted peer access.
+        const ggml_backend_dev_t tensor_dev =
+            ggml_backend_buft_get_device(lm_head_buft);
+        const ggml_backend_dev_t draft_dev =
+            ggml_backend_buft_get_device(
+                ggml_backend_cuda_buffer_type(draft_gpu));
+        if (tensor_dev != draft_dev) {
+            const ggml_backend_dev_t target_dev =
+                ggml_backend_buft_get_device(
+                    ggml_backend_cuda_buffer_type(device.gpu));
+            if (tensor_dev != target_dev ||
+                !cross_device_peer_memcpy_ok(device.gpu, draft_gpu)) {
+                return nullptr;
+            }
+        }
+        return lm_head;
     }
     // Meta tensor: the lm_head is mirrored (full copy) on every rank. Read
     // it from the rank that matches the draft GPU so the fused graph does a
@@ -2477,7 +2496,9 @@ static ggml_tensor * resolve_fused_lm_head(ggml_tensor * lm_head,
     for (size_t j = 0; j < device.layer_split_gpus.size(); ++j) {
         if (device.layer_split_gpus[j] == draft_gpu) {
             ggml_tensor * simple = ggml_backend_meta_simple_tensor(lm_head, j);
-            return (simple && simple->data) ? simple : nullptr;
+            if (!simple || !simple->data) return nullptr;
+            GGML_ASSERT(ggml_are_same_shape(simple, lm_head));
+            return simple;
         }
     }
     // Draft GPU is not a target rank; fall back to the host chain.

--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -3270,7 +3270,9 @@ HttpServer::GenerationCacheState HttpServer::prepare_generation_cache(
     // `forced_cut > restored` true on every tool-heavy turn, the pin branch
     // keeps targeting the already-cached head, and the cache never deepens
     // past the head pin (full conversation re-prefilled each turn).
-    const int logical_prefix_len = cache.prefix_len;
+    const int pre_overwrite_prefix_len = cache.prefix_len;
+    int logical_prefix_len =
+        cache.using_restore ? pre_overwrite_prefix_len : 0;
     if (cache.using_restore) {
         const int snapshot_length =
             backend_.snapshot_cur_pos(cache.cache_slot);
@@ -3335,6 +3337,8 @@ HttpServer::GenerationCacheState HttpServer::prepare_generation_cache(
                 cache.prefix_len = cold_boundary;
                 cache.using_restore = true;
                 cache.disk_hit = true;
+                // This restore was created after the pre-overwrite capture.
+                logical_prefix_len = cold_boundary;
                 std::fprintf(stderr,
                     "[disk-cache] cold prefix saved, restoring from %d\n",
                     cold_boundary);

--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -3263,6 +3263,14 @@ HttpServer::GenerationCacheState HttpServer::prepare_generation_cache(
 
     // Edited or summarized histories can be shorter than the stored KV.
     // Such snapshots cannot be diff-prefilled safely.
+    // The logical entry length (what the PrefixCache believes is cached, e.g.
+    // the tools-head pin at 3620) can exceed the chunk-aligned KV position the
+    // backend actually restored (e.g. 3584). Deepen decisions must compare
+    // against the logical length; otherwise that chunk gap keeps
+    // `forced_cut > restored` true on every tool-heavy turn, the pin branch
+    // keeps targeting the already-cached head, and the cache never deepens
+    // past the head pin (full conversation re-prefilled each turn).
+    const int logical_prefix_len = cache.prefix_len;
     if (cache.using_restore) {
         const int snapshot_length =
             backend_.snapshot_cur_pos(cache.cache_slot);
@@ -3342,7 +3350,7 @@ HttpServer::GenerationCacheState HttpServer::prepare_generation_cache(
     auto prepare_inline = [&]() {
         const auto prepared_snapshot = prefix_cache_.prepare_inline_snap(
             effective_prompt,
-            cache.using_restore ? cache.prefix_len : 0,
+            cache.using_restore ? logical_prefix_len : 0,
             prefer_tools_boundary,
             forced_cut);
         cache.snap_slot = prepared_snapshot.first;

--- a/server/src/server/prefix_cache.cpp
+++ b/server/src/server/prefix_cache.cpp
@@ -218,6 +218,20 @@ int select_inline_snapshot_boundary(const std::vector<int> & boundaries,
     return target > restored_prefix_len ? target : 0;
 }
 
+bool should_force_inline_snapshot_boundary(
+        const std::vector<int> & boundaries,
+        int prompt_len,
+        int restored_prefix_len,
+        bool prefer_tools_boundary,
+        int forced_cut) {
+    const bool tools_pin_restored =
+        prefer_tools_boundary && !boundaries.empty() &&
+        restored_prefix_len >= boundaries.front();
+    return !tools_pin_restored &&
+           forced_cut > restored_prefix_len &&
+           forced_cut <= prompt_len;
+}
+
 // ─── PrefixCache ────────────────────────────────────────────────────────
 
 PrefixCache::PrefixCache(int cap, const Tokenizer & tokenizer)
@@ -333,8 +347,9 @@ std::pair<int, int> PrefixCache::prepare_inline_snap(
     auto candidates = find_all_boundaries(prompt_ids, markers_);
     int target_cut = 0;
     bool forced = false;
-    if (forced_cut > restored_prefix_len &&
-        forced_cut <= (int)prompt_ids.size()) {
+    if (should_force_inline_snapshot_boundary(
+            candidates, (int)prompt_ids.size(), restored_prefix_len,
+            prefer_tools_boundary, forced_cut)) {
         target_cut = forced_cut;
         forced = true;
     } else {

--- a/server/src/server/prefix_cache.h
+++ b/server/src/server/prefix_cache.h
@@ -74,6 +74,16 @@ int select_inline_snapshot_boundary(const std::vector<int> & boundaries,
                                     int restored_prefix_len = 0,
                                     bool prefer_tools_boundary = false);
 
+// Return true when a PPP forced cut should override normal boundary
+// selection. Once the tools head is already restored, forcing the pin again
+// prevents the cache from deepening into the conversation.
+bool should_force_inline_snapshot_boundary(
+    const std::vector<int> & boundaries,
+    int prompt_len,
+    int restored_prefix_len,
+    bool prefer_tools_boundary,
+    int forced_cut);
+
 // ─── Prefix cache entry ─────────────────────────────────────────────────
 
 struct FullCacheEntry {

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -2220,6 +2220,29 @@ TEST_CASE(ServerUnitFixture, test_inline_snapshot_prefers_tools_boundary_until_r
     TEST_ASSERT(select_inline_snapshot_boundary({100}, 100, true) == 0);
 }
 
+TEST_CASE(ServerUnitFixture, test_forced_tools_pin_yields_to_deepen_after_restore) {
+    const std::vector<int> boundaries = {100, 240, 380, 520};
+
+    // Cold request: the PPP cut pins the tools/identity head.
+    TEST_ASSERT(should_force_inline_snapshot_boundary(
+        boundaries, 600, 0, true, 110));
+
+    // Once the tools boundary is restored, normal selection must deepen to a
+    // later conversation boundary instead of forcing the nearby pin again.
+    TEST_ASSERT(!should_force_inline_snapshot_boundary(
+        boundaries, 600, 100, true, 110));
+    TEST_ASSERT(select_inline_snapshot_boundary(boundaries, 100, true) == 380);
+
+    // Without tools preference, a still-unrestored forced cut retains its
+    // original behavior.
+    TEST_ASSERT(should_force_inline_snapshot_boundary(
+        boundaries, 600, 100, false, 110));
+    TEST_ASSERT(!should_force_inline_snapshot_boundary(
+        boundaries, 600, 110, false, 110));
+    TEST_ASSERT(!should_force_inline_snapshot_boundary(
+        boundaries, 100, 0, false, 110));
+}
+
 TEST_CASE(ServerUnitFixture, test_ppp_master_toggle_gates_tools_boundary_pinning) {
     TEST_ASSERT(ppp_prefers_tools_boundary(true, true));
     TEST_ASSERT(!ppp_prefers_tools_boundary(false, true));


### PR DESCRIPTION
Branch `work/625-nvlink-fix-clean` (fork of `Luce-Org/lucebox`), tracking
#625. Fixed two first-generate crashes on the 2x3090 NVLink tensor-split
bench bed that blocked every spec path. Worked on by Qwen 3.8 (Lucebox) +
DeepSeek V4 Flash, reviewed by GPT-5.6 and 0x Alpha

| crash | symptom | commit |
|---|---|---|
| AR + all configs | `GGML_ASSERT(ret.axis != GGML_BACKEND_SPLIT_AXIS_UNKNOWN)` at `ggml-backend-meta.cpp:570/556`, op=SSM_CONV, during tensor-split graph alloc | `2aed638b` |
| DSPARK fused | illegal memory access (placeholder pointer `0x2000000000000000`) in fused spec decode under tensor split | `9b968fc5` |

### Fixes

- `2aed638b` ggml-meta: split SSM_CONV step/SpecLA by axis layout, not
  `op_params`. `handle_ssm_conv` now dispatches on the actual src axis layout;
  the fused step mode returns the same conv_out state layout as the proven
  non-fused path (previously fell into `handle_generic` -> `SPLIT_AXIS_UNKNOWN`
  -> assert).
- `9b968fc5` fix(qwen35): resolve fused DSpark lm_head to draft-GPU simple
  tensor. Under tensor split the target lm_head is a meta tensor (placeholder
  data pointer); `resolve_fused_lm_head()` returns the simple tensor of the rank
  whose `layer_split_gpus[j] == draft_gpu` (lm_head is a full-copy mirror on
  every rank -> local read is valid), else nullptr -> host-chain fallback.
  Applied at both draft-backend call sites (fused greedy chain + DDTree topk) —
  the same latent leak existed in both. Partially a port of the deployed
  perf-line fix `fd7b294`.
- `997a36c4` fix(server): deepen prefix cache past the tools-head pin on
  tool-heavy turns (a prefix-cache/perf fix, not an NVLink crash). The
  inline-snap deepen decision compared the chunk-aligned restored KV position to
  the forced cut; on tool-heavy turns the logical length sits just above the
  chunk gap (e.g. logical 3620 vs restored 3584) so `forced_cut > restored`
  stayed true and the pin kept re-targeting the already-cached head — the full
  conversation was re-prefilled every turn. Now captures the logical entry
  length (`cache.prefix_len` before the restore block overwrites it with the
  snapshot position) and feeds that to the deepen decision. 9-line dataflow
  change in `http_server.cpp`.

### Verification (2x RTX 3090 + NVLink, `--target-split-mode tensor --peer-access`, Q4_0 KV, greedy, verify-width 8; prompt 24538 tok, 1024 gen)

| cell | rep1 | rep2 | accept | crash |
|---|---|---|---|---|
| AR | 36.9 t/s | 36.6 | — | 0 |
| DSPARK | 31.4 | 31.3 | 0.164 | 0 |
| DFLASH2 | **79.6** | **79.7** | **0.569** | 0 |

- DFLASH2 = 2.16x AR on NVLink, above the llama.cpp 1.7-2.0x speculative
  reference.
- AR A/B value-correct: fused vs `DFLASH_QWEN35_NO_FUSED_KERNELS=1` produce
  byte-identical completions.
- NVLink genuinely engaged: `target_split=tensor peer_access=ON`, 4x links.
- Pre-fix AR (SSM_CONV assert) and DSPARK (illegal memory access) both crashed;
  post-fix all cells complete, zero crash lines.

### Status (2026-08-24)

Rebased onto latest #625 (`qwen38-dspark @ 46b1d6a0`, +5 commits past the
earlier sync) — clean rebase, no conflicts. The two crash fixes are now
`2aed638b` + `9b968fc5`; the prefix-cache deepen fix `997a36c4` is the 3rd commit
beyond 625. Force-pushed to the fork (`feab01b` -> `997a36c4`).

Rebuilt image `lucebox-hub:pr637-sync-cuda12` (arches 86;120); `test_server_unit`
393/393 pass. Deployed to the 2x3090 service (`lucebox-3090s`, host port 8001,
tensor-parallel, `--max-ctx 262144`), healthy; the 5090 service was left on the
previous image. Live prefix-cache check confirms the deepen fix: across three
synthetic tool-heavy turns `cached_prefix` went 0 -> 512 -> 1024 and prefill
dropped 1040 -> 786 -> 380 tok; the inline snap committed at logical 1280 (past
the chunk-aligned 1024) — exactly the case the fix targets.

Open items (not blocking):
1. DSPARK 31.4 vs old perf-line 39.0 — ~20% gap (FEAT_CAP default 4096 vs 8192,
   quant/prompt mix). Speed-parity work item, tracked separately.
2. Q8_0-vs-Q6_K target bench — deferred until a Q8_0 target file is available on
   the bench host.
3. Independent axis-correctness review of the two crash fixes — in flight.
4. Confirm the prefix-cache deepen under real ~150K-token pi traffic on the
   3090s (the synthetic check used ~1.4K-token prompts).

## PR #533 — Performance update

Rebuilt and tested the rebased head `06b9600` with the same 26,758-token
OpenClaw payload and deterministic 1,024-token continuation used for the
earlier PR measurements.

| Configuration | PP | TG |
|---|---:|---:|
| RTX 5090 | **2,170.9 tok/s** | **110.6 tok/s** |
| 2x RTX 3090 TP + NVLink | **1,048.5 tok/s** | **76.2 tok/s** |

Both runs were prefix-cache misses, generated all 1,024 requested tokens, and
completed without CUDA, OOM, or server errors. The generated output for each
configuration matched its corresponding reduced-power run byte for byte.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

