### PR TITLE
feat(server): simplify tool parser and SSE emitter for DeepSeek V4 and streaming (Stage 2)

### DIFF
--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -3799,7 +3799,7 @@ void HttpServer::send_nonstream_response(
         ClientSendBuffer * send_buffer) {
     CompletionTokenCounts counts;
     counts.total = (int) gen_tokens.size();
-    emitter.emit_finish(counts.total);
+    emitter.emit_finish(counts.total, nullptr, n_gen_cap);
     const int first_content = emitter.first_content_token_index();
     const int emitted = emitter.emit_token_count();
     counts.reasoning = first_content < 0 ? emitted : first_content;
@@ -4082,7 +4082,7 @@ void HttpServer::process_job(ServerJob * job) {
         client_disconnected = true;
     }
     if (req.stream && !client_disconnected) {
-        auto final_chunks = emitter.emit_finish(completion_tokens, &gen_timings);
+        auto final_chunks = emitter.emit_finish(completion_tokens, &gen_timings, n_gen_cap);
         remember_agent_turn(
             req, prepared, cache, result, emitter, completion_tokens,
             visible_output_seen, client_disconnected,

--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -2347,21 +2347,20 @@ json build_anthropic_response(
         });
     }
     for (const auto & tool_call : emitter.tool_calls()) {
-        // Anthropic expects `input` as an object; arguments arrive as a
-        // JSON-encoded string. Fall back to an empty object on bad JSON.
-        json input;
-        try {
-            input = tool_call.arguments.empty()
-                ? json::object()
-                : json::parse(tool_call.arguments);
-        } catch (const std::exception &) {
-            input = json::object();
+        json input = json::object();
+        if (!tool_call.arguments.empty()) {
+            json parsed = json::parse(tool_call.arguments, nullptr, false);
+            if (!parsed.is_discarded() && parsed.is_object()) {
+                input = std::move(parsed);
+            } else {
+                input = {{"_raw", tool_call.arguments}};
+            }
         }
         content.push_back({
             {"type", "tool_use"},
             {"id", tool_call.id},
             {"name", tool_call.name},
-            {"input", input},
+            {"input", std::move(input)},
         });
     }
 

--- a/server/src/server/scheduler.cpp
+++ b/server/src/server/scheduler.cpp
@@ -283,7 +283,7 @@ void HttpServer::scheduler_loop(SeqEngine & engine) {
             }
         } else if (req.stream && !s.client_disconnected) {
             auto final_chunks =
-                s.emitter->emit_finish(s.completion_tokens, &gen_timings);
+                s.emitter->emit_finish(s.completion_tokens, &gen_timings, s.n_gen_cap);
             for (const auto & chunk : final_chunks) {
                 s.send_buffer.append(chunk);
             }
@@ -390,7 +390,7 @@ void HttpServer::scheduler_loop(SeqEngine & engine) {
                         if (!send_job_bytes(job, c.data(), c.size())) { ok = false; break; }
                     }
                     if (ok) {
-                        for (const auto & c : emitter.emit_finish(0, &t)) {
+                        for (const auto & c : emitter.emit_finish(0, &t, n_gen_cap)) {
                             if (!send_job_bytes(job, c.data(), c.size())) break;
                         }
                     }

--- a/server/src/server/sse_emitter.cpp
+++ b/server/src/server/sse_emitter.cpp
@@ -580,7 +580,8 @@ void SseEmitter::emit_content_delta(std::vector<std::string> & out,
 // ─── emit_finish ────────────────────────────────────────────────────────
 
 std::vector<std::string> SseEmitter::emit_finish(int completion_tokens,
-                                                 const GenTimings * timings) {
+                                                 const GenTimings * timings,
+                                                 int generation_cap) {
     std::vector<std::string> out;
 
     // A tail still pending at end-of-stream is a genuinely truncated
@@ -814,6 +815,11 @@ std::vector<std::string> SseEmitter::emit_finish(int completion_tokens,
         }
     }
 
+    if (fr == "stop" && !stop_hit_ && generation_cap >= 0 && completion_tokens >= generation_cap) {
+        fr = "length";
+    }
+    finish_reason_ = fr;
+
     // Format-specific final events
     switch (format_) {
     case ApiFormat::OPENAI_CHAT: {
@@ -854,9 +860,10 @@ std::vector<std::string> SseEmitter::emit_finish(int completion_tokens,
         }
         // stop_reason reflects the model's actual finish: "tool_use" when
         // any tool calls were emitted (downstream SDKs pivot on this to feed
-        // tool_result back), else "end_turn". Stop-sequence hits also report
-        // "end_turn" (Anthropic has no dedicated reason for that case).
-        const char * stop_reason = tool_calls_.empty() ? "end_turn" : "tool_use";
+        // tool_result back), else "end_turn" or "max_tokens".
+        const char * stop_reason = tool_calls_.empty()
+            ? (fr == "length" ? "max_tokens" : "end_turn")
+            : "tool_use";
         json anth_usage = {{"output_tokens", completion_tokens}};
         if (timings) {
             anth_usage["timings"] = build_timings_json(*timings, completion_tokens);
@@ -946,8 +953,7 @@ std::vector<std::string> SseEmitter::emit_finish(int completion_tokens,
 }
 
 std::string SseEmitter::finish_reason() const {
-    if (!tool_calls_.empty()) return "tool_calls";
-    return "stop";
+    return finish_reason_;
 }
 
 }  // namespace dflash::common

--- a/server/src/server/sse_emitter.cpp
+++ b/server/src/server/sse_emitter.cpp
@@ -13,7 +13,6 @@ namespace dflash::common {
 
 static const char THINK_OPEN[]  = "<think>";
 static const char THINK_CLOSE[] = "</think>";
-static const char FUNCTION_CALLS_OPEN[] = "<function_calls>";
 static constexpr size_t THINK_OPEN_LEN  = 7;
 static constexpr size_t THINK_CLOSE_LEN = 8;
 
@@ -349,38 +348,13 @@ std::vector<std::string> SseEmitter::emit_token(const std::string & raw_piece) {
             size_t idx = window_.find(THINK_CLOSE);
             size_t tool_idx = std::string::npos;
             bool tool_hit = has_request_tools(tools_) &&
-                            (tool_idx = window_.find(FUNCTION_CALLS_OPEN)) != std::string::npos;
+                            find_tool_syntax_start(window_, tools_, tool_idx);
 
             if (idx != std::string::npos && (tool_idx == std::string::npos || idx < tool_idx)) {
                 std::string pre = window_.substr(0, idx);
                 if (!pre.empty()) {
                     reasoning_text_ += pre;
-                    // Emit reasoning delta
-                    switch (format_) {
-                    case ApiFormat::OPENAI_CHAT:
-                        out.push_back(format_openai_delta({{"reasoning_content", pre}}));
-                        break;
-                    case ApiFormat::ANTHROPIC: {
-                        if (active_kind_ != "thinking") {
-                            out.push_back(sse_event("content_block_stop",
-                                json({{"type", "content_block_stop"}, {"index", block_index_}}).dump()));
-                            block_index_++;
-                            active_kind_ = "thinking";
-                            json new_block = {{"type", "thinking"}, {"thinking", ""}};
-                            out.push_back(sse_event("content_block_start",
-                                json({{"type", "content_block_start"}, {"index", block_index_},
-                                      {"content_block", new_block}}).dump()));
-                        }
-                        out.push_back(sse_event("content_block_delta",
-                            json({{"type", "content_block_delta"}, {"index", block_index_},
-                                  {"delta", {{"type", "thinking_delta"}, {"thinking", pre}}}}).dump()));
-                        break;
-                    }
-                    case ApiFormat::RESPONSES:
-                        // Responses API doesn't stream reasoning — it's stripped
-                        break;
-                    default: break;
-                    }
+                    emit_reasoning_delta(out, pre);
                 }
                 window_ = window_.substr(idx + THINK_CLOSE_LEN);
                 mode_ = StreamMode::CONTENT;
@@ -390,28 +364,7 @@ std::vector<std::string> SseEmitter::emit_token(const std::string & raw_piece) {
                 std::string pre = window_.substr(0, tool_idx);
                 if (!pre.empty()) {
                     reasoning_text_ += pre;
-                    switch (format_) {
-                    case ApiFormat::OPENAI_CHAT:
-                        out.push_back(format_openai_delta({{"reasoning_content", pre}}));
-                        break;
-                    case ApiFormat::ANTHROPIC: {
-                        if (active_kind_ != "thinking") {
-                            out.push_back(sse_event("content_block_stop",
-                                json({{"type", "content_block_stop"}, {"index", block_index_}}).dump()));
-                            block_index_++;
-                            active_kind_ = "thinking";
-                            json new_block = {{"type", "thinking"}, {"thinking", ""}};
-                            out.push_back(sse_event("content_block_start",
-                                json({{"type", "content_block_start"}, {"index", block_index_},
-                                      {"content_block", new_block}}).dump()));
-                        }
-                        out.push_back(sse_event("content_block_delta",
-                            json({{"type", "content_block_delta"}, {"index", block_index_},
-                                  {"delta", {{"type", "thinking_delta"}, {"thinking", pre}}}}).dump()));
-                        break;
-                    }
-                    default: break;
-                    }
+                    emit_reasoning_delta(out, pre);
                 }
                 tool_buffer_ = window_.substr(tool_idx);
                 tool_from_reasoning_ = true;
@@ -420,34 +373,13 @@ std::vector<std::string> SseEmitter::emit_token(const std::string & raw_piece) {
                 continue;
             }
             // No close tag yet — emit safe prefix if window is large enough
-            if (window_.size() > std::max(BASE_HOLDBACK, stop_holdback_)) {
-                size_t cut = utf8_safe_len(window_, window_.size() - std::max(BASE_HOLDBACK, stop_holdback_));
+            const size_t holdback = std::max(tool_syntax_holdback(tools_), stop_holdback_);
+            if (window_.size() > holdback) {
+                size_t cut = utf8_safe_len(window_, window_.size() - holdback);
                 if (cut == 0) break;  // not enough complete chars yet
                 std::string safe = window_.substr(0, cut);
                 reasoning_text_ += safe;
-                switch (format_) {
-                case ApiFormat::OPENAI_CHAT:
-                    out.push_back(format_openai_delta({{"reasoning_content", safe}}));
-                    break;
-                case ApiFormat::ANTHROPIC:
-                    if (active_kind_ != "thinking") {
-                        out.push_back(sse_event("content_block_stop",
-                            json({{"type", "content_block_stop"}, {"index", block_index_}}).dump()));
-                        block_index_++;
-                        active_kind_ = "thinking";
-                        json new_block = {{"type", "thinking"}, {"thinking", ""}};
-                        out.push_back(sse_event("content_block_start",
-                            json({{"type", "content_block_start"}, {"index", block_index_},
-                                  {"content_block", new_block}}).dump()));
-                    }
-                    out.push_back(sse_event("content_block_delta",
-                        json({{"type", "content_block_delta"}, {"index", block_index_},
-                              {"delta", {{"type", "thinking_delta"}, {"thinking", safe}}}}).dump()));
-                    break;
-                case ApiFormat::RESPONSES:
-                    break;
-                default: break;
-                }
+                emit_reasoning_delta(out, safe);
                 window_ = window_.substr(cut);
             }
             break;
@@ -577,6 +509,120 @@ void SseEmitter::emit_content_delta(std::vector<std::string> & out,
     }
 }
 
+// ─── Reasoning delta emission (format-specific) ─────────────────────────
+
+void SseEmitter::emit_reasoning_delta(std::vector<std::string> & out,
+                                      const std::string & text) {
+    if (text.empty()) return;
+
+    switch (format_) {
+    case ApiFormat::OPENAI_CHAT:
+        out.push_back(format_openai_delta({{"reasoning_content", text}}));
+        break;
+
+    case ApiFormat::ANTHROPIC:
+        if (active_kind_ != "thinking") {
+            out.push_back(sse_event("content_block_stop",
+                json({{"type", "content_block_stop"}, {"index", block_index_}}).dump()));
+            block_index_++;
+            active_kind_ = "thinking";
+            json new_block = {{"type", "thinking"}, {"thinking", ""}};
+            out.push_back(sse_event("content_block_start",
+                json({{"type", "content_block_start"}, {"index", block_index_},
+                      {"content_block", new_block}}).dump()));
+        }
+        out.push_back(sse_event("content_block_delta",
+            json({{"type", "content_block_delta"}, {"index", block_index_},
+                  {"delta", {{"type", "thinking_delta"}, {"thinking", text}}}}).dump()));
+        break;
+
+    case ApiFormat::RESPONSES:
+        break;
+
+    default:
+        break;
+    }
+}
+
+// ─── find_top_level_think_close ─────────────────────────────────────────
+
+static size_t find_top_level_think_close(const std::string & buf, const json & tools) {
+    static const char * const STANDARD_TOOL_CLOSES[] = {
+        "</tool_call>", "</function_call>", "</function_calls>", "</function calls>",
+        "</function>", "</funcname>", "</parameter>", "</parameters>", "</tool_code>",
+        "</invoke>", "</arguments>", "</params>"
+    };
+
+    std::vector<std::string> close_tags;
+    for (const char * tag : STANDARD_TOOL_CLOSES) {
+        close_tags.push_back(tag);
+    }
+    if (tools.is_array()) {
+        for (const auto & t : tools) {
+            const auto & fn = t.contains("function") ? t["function"] : t;
+            if (fn.is_object()) {
+                std::string name = fn.value("name", "");
+                if (!name.empty()) {
+                    close_tags.push_back("</" + name + ">");
+                }
+            }
+        }
+    }
+
+    // Find the end of the last verified tool envelope closing tag
+    size_t last_tool_close_end = 0;
+    for (const auto & tag : close_tags) {
+        size_t pos = buf.find(tag);
+        while (pos != std::string::npos) {
+            last_tool_close_end = std::max(last_tool_close_end, pos + tag.size());
+            pos = buf.find(tag, pos + tag.size());
+        }
+    }
+
+    if (last_tool_close_end > 0) {
+        return buf.find(THINK_CLOSE, last_tool_close_end);
+    }
+
+    // No tool closing tag was found. Check each </think> candidate to ensure
+    // it is not inside an unclosed quote, XML attribute, or parameter body.
+    size_t cursor = 0;
+    while ((cursor = buf.find(THINK_CLOSE, cursor)) != std::string::npos) {
+        // Check quotes before cursor
+        bool in_single_quote = false;
+        bool in_double_quote = false;
+        for (size_t i = 0; i < cursor; i++) {
+            if (buf[i] == '\\' && i + 1 < cursor) {
+                i++;
+                continue;
+            }
+            if (buf[i] == '\'' && !in_double_quote) in_single_quote = !in_single_quote;
+            else if (buf[i] == '"' && !in_single_quote) in_double_quote = !in_double_quote;
+        }
+        if (in_single_quote || in_double_quote) {
+            cursor += THINK_CLOSE_LEN;
+            continue;
+        }
+
+        // Check if remaining suffix contains leftover XML closing tags
+        std::string suffix = buf.substr(cursor + THINK_CLOSE_LEN);
+        bool has_leftover_close = false;
+        for (const auto & tag : close_tags) {
+            if (suffix.find(tag) != std::string::npos) {
+                has_leftover_close = true;
+                break;
+            }
+        }
+        if (has_leftover_close) {
+            cursor += THINK_CLOSE_LEN;
+            continue;
+        }
+
+        return cursor;
+    }
+
+    return std::string::npos;
+}
+
 // ─── emit_finish ────────────────────────────────────────────────────────
 
 std::vector<std::string> SseEmitter::emit_finish(int completion_tokens,
@@ -596,17 +642,7 @@ std::vector<std::string> SseEmitter::emit_finish(int completion_tokens,
     // Flush remaining window
     if (mode_ == StreamMode::REASONING && !window_.empty()) {
         reasoning_text_ += window_;
-        switch (format_) {
-        case ApiFormat::OPENAI_CHAT:
-            out.push_back(format_openai_delta({{"reasoning_content", window_}}));
-            break;
-        case ApiFormat::ANTHROPIC:
-            out.push_back(sse_event("content_block_delta",
-                json({{"type", "content_block_delta"}, {"index", block_index_},
-                      {"delta", {{"type", "thinking_delta"}, {"thinking", window_}}}}).dump()));
-            break;
-        default: break;
-        }
+        emit_reasoning_delta(out, window_);
     } else if (mode_ == StreamMode::CONTENT && !window_.empty()) {
         // Zero-argument Laguna calls in the stripped form are just the bare
         // declared tool name at end of output (the <tool_call> wrapper is
@@ -675,23 +711,7 @@ std::vector<std::string> SseEmitter::emit_finish(int completion_tokens,
                     }
                     if (!reasoning.empty()) {
                         reasoning_text_ += reasoning;
-                        if (format_ == ApiFormat::OPENAI_CHAT) {
-                            out.push_back(format_openai_delta({{"reasoning_content", reasoning}}));
-                        } else if (format_ == ApiFormat::ANTHROPIC) {
-                            if (active_kind_ != "thinking") {
-                                out.push_back(sse_event("content_block_stop",
-                                    json({{"type", "content_block_stop"}, {"index", block_index_}}).dump()));
-                                block_index_++;
-                                active_kind_ = "thinking";
-                                json new_block = {{"type", "thinking"}, {"thinking", ""}};
-                                out.push_back(sse_event("content_block_start",
-                                    json({{"type", "content_block_start"}, {"index", block_index_},
-                                          {"content_block", new_block}}).dump()));
-                            }
-                            out.push_back(sse_event("content_block_delta",
-                                json({{"type", "content_block_delta"}, {"index", block_index_},
-                                      {"delta", {{"type", "thinking_delta"}, {"thinking", reasoning}}}}).dump()));
-                        }
+                        emit_reasoning_delta(out, reasoning);
                     }
                     if (!content.empty()) {
                         accumulated_content_ += content;
@@ -699,23 +719,7 @@ std::vector<std::string> SseEmitter::emit_finish(int completion_tokens,
                     }
                 } else if (tool_from_reasoning_) {
                     reasoning_text_ += parsed.cleaned_text;
-                    if (format_ == ApiFormat::OPENAI_CHAT) {
-                        out.push_back(format_openai_delta({{"reasoning_content", parsed.cleaned_text}}));
-                    } else if (format_ == ApiFormat::ANTHROPIC) {
-                        if (active_kind_ != "thinking") {
-                            out.push_back(sse_event("content_block_stop",
-                                json({{"type", "content_block_stop"}, {"index", block_index_}}).dump()));
-                            block_index_++;
-                            active_kind_ = "thinking";
-                            json new_block = {{"type", "thinking"}, {"thinking", ""}};
-                            out.push_back(sse_event("content_block_start",
-                                json({{"type", "content_block_start"}, {"index", block_index_},
-                                      {"content_block", new_block}}).dump()));
-                        }
-                        out.push_back(sse_event("content_block_delta",
-                            json({{"type", "content_block_delta"}, {"index", block_index_},
-                                  {"delta", {{"type", "thinking_delta"}, {"thinking", parsed.cleaned_text}}}}).dump()));
-                    }
+                    emit_reasoning_delta(out, parsed.cleaned_text);
                 } else {
                     accumulated_content_ += parsed.cleaned_text;
                     emit_content_delta(out, parsed.cleaned_text);
@@ -807,11 +811,25 @@ std::vector<std::string> SseEmitter::emit_finish(int completion_tokens,
             emit_content_delta(out, tool_buffer_);
         } else {
             // Tool syntax was detected but no valid call parsed. Do not leak
-            // malformed/incomplete XML back to the user as assistant text.
+            // malformed/incomplete XML back to the user or reasoning channel.
             std::fprintf(stderr,
                 "[server] tool_call parse failed; suppressing buffered tool text "
                 "request_id=%s format=%d bytes=%zu\n",
                 request_id_.c_str(), (int)format_, tool_buffer_.size());
+
+            if (tool_from_reasoning_) {
+                size_t think_close = find_top_level_think_close(tool_buffer_, tools_);
+                if (think_close != std::string::npos) {
+                    std::string content = tool_buffer_.substr(think_close + THINK_CLOSE_LEN);
+                    if (!content.empty()) {
+                        if (first_content_token_index_ == -1) {
+                            first_content_token_index_ = std::max(0, emit_token_count_ - 1);
+                        }
+                        accumulated_content_ += content;
+                        emit_content_delta(out, content);
+                    }
+                }
+            }
         }
     }
 

--- a/server/src/server/sse_emitter.h
+++ b/server/src/server/sse_emitter.h
@@ -88,7 +88,8 @@ public:
     // the pre-timings API for unit tests that don't exercise that
     // shape.
     std::vector<std::string> emit_finish(int completion_tokens,
-                                         const GenTimings * timings = nullptr);
+                                         const GenTimings * timings = nullptr,
+                                         int generation_cap = -1);
 
     // Get the finish_reason for non-streaming responses.
     std::string finish_reason() const;
@@ -192,6 +193,7 @@ private:
     bool         stop_hit_ = false;
 
     int64_t      created_at_;
+    std::string  finish_reason_ = "stop";
 
     // Responses API IDs
     std::string  msg_item_id_;

--- a/server/src/server/sse_emitter.h
+++ b/server/src/server/sse_emitter.h
@@ -146,6 +146,9 @@ private:
     // Emit a content delta (format-specific).
     void emit_content_delta(std::vector<std::string> & out, const std::string & text);
 
+    // Emit a reasoning/thinking delta (format-specific).
+    void emit_reasoning_delta(std::vector<std::string> & out, const std::string & text);
+
     // SSE data line
     static std::string sse_data(const std::string & json_str);
     static std::string sse_event(const std::string & type, const std::string & json_str);

--- a/server/src/server/tool_parser.cpp
+++ b/server/src/server/tool_parser.cpp
@@ -569,82 +569,59 @@ static bool parse_complete_parameter_body(const std::string & body,
 
 // ─── JSON tool call parser ──────────────────────────────────────────────
 
+static bool parse_arg_string_or_obj(const json & val, json & out_args,
+                                    std::string & out_raw_args) {
+    if (val.is_object()) {
+        out_args = val;
+        out_raw_args = val.dump();
+        return true;
+    }
+    if (val.is_string()) {
+        out_raw_args = val.get<std::string>();
+        json parsed = json::parse(out_raw_args, nullptr, false);
+        if (!parsed.is_discarded() && parsed.is_object()) {
+            out_args = std::move(parsed);
+        } else {
+            out_args = json::object();
+        }
+        return true;
+    }
+    return false;
+}
+
 // Parse the named JSON tool-call envelopes emitted by supported chat models.
-static bool parse_json_tool_call(const json & obj, std::string & out_name, json & out_args) {
+static bool parse_json_tool_call(const json & obj, std::string & out_name,
+                                 json & out_args, std::string & out_raw_args) {
     if (!obj.is_object()) return false;
 
-    std::string name;
-    json args;
-
     if (obj.contains("name") && obj["name"].is_string()) {
-        name = obj["name"].get<std::string>();
-        if (obj.contains("arguments")) {
-            if (obj["arguments"].is_object()) {
-                args = obj["arguments"];
-            } else if (obj["arguments"].is_string()) {
-                try { args = json::parse(obj["arguments"].get<std::string>()); }
-                catch (...) { return false; }
-            } else {
-                return false;
-            }
-        } else if (obj.contains("parameters")) {
-            if (obj["parameters"].is_object()) {
-                args = obj["parameters"];
-            } else if (obj["parameters"].is_string()) {
-                try { args = json::parse(obj["parameters"].get<std::string>()); }
-                catch (...) { return false; }
-            } else {
-                return false;
-            }
+        out_name = obj["name"].get<std::string>();
+        for (const char * k : {"arguments", "parameters", "args", "params", "input"}) {
+            if (obj.contains(k)) return parse_arg_string_or_obj(obj[k], out_args, out_raw_args);
         }
-    } else if (obj.contains("function") && obj["function"].is_string()) {
-        name = obj["function"].get<std::string>();
-        if (!obj.contains("parameters")) {
-            return false;
-        }
-        if (obj["parameters"].is_object()) {
-            args = obj["parameters"];
-        } else if (obj["parameters"].is_string()) {
-            try { args = json::parse(obj["parameters"].get<std::string>()); }
-            catch (...) { return false; }
-        } else {
-            return false;
-        }
-    } else if ((obj.contains("function") && obj["function"].is_object()) ||
-               (obj.contains("function_call") &&
-                obj["function_call"].is_object())) {
-        const auto & fn = obj.contains("function")
-            ? obj["function"]
-            : obj["function_call"];
-        if (!fn.contains("name") || !fn["name"].is_string()) return false;
-        name = fn["name"].get<std::string>();
-        if (fn.contains("arguments")) {
-            if (fn["arguments"].is_object()) {
-                args = fn["arguments"];
-            } else if (fn["arguments"].is_string()) {
-                try { args = json::parse(fn["arguments"].get<std::string>()); }
-                catch (...) { return false; }
-            } else {
-                return false;
-            }
-        } else if (fn.contains("parameters")) {
-            if (fn["parameters"].is_object()) {
-                args = fn["parameters"];
-            } else if (fn["parameters"].is_string()) {
-                try { args = json::parse(fn["parameters"].get<std::string>()); }
-                catch (...) { return false; }
-            } else {
-                return false;
-            }
-        }
-    } else {
         return false;
     }
 
-    if (name.empty() || !args.is_object()) return false;
-    out_name = name;
-    out_args = args;
-    return true;
+    if (obj.contains("function") && obj["function"].is_string()) {
+        out_name = obj["function"].get<std::string>();
+        for (const char * k : {"parameters", "arguments", "args", "params", "input"}) {
+            if (obj.contains(k)) return parse_arg_string_or_obj(obj[k], out_args, out_raw_args);
+        }
+        return false;
+    }
+
+    for (const char * sub : {"function", "function_call", "tool_call"}) {
+        if (obj.contains(sub) && obj[sub].is_object()) {
+            return parse_json_tool_call(obj[sub], out_name, out_args, out_raw_args);
+        }
+    }
+
+    return false;
+}
+
+static bool parse_json_tool_call(const json & obj, std::string & out_name, json & out_args) {
+    std::string raw;
+    return parse_json_tool_call(obj, out_name, out_args, raw);
 }
 
 static bool is_ws(char c) {
@@ -834,6 +811,25 @@ static bool parse_function_sig_args(const std::string & arg_text, json & out_arg
     return true;
 }
 
+static bool extract_raw_json_tool_fallback(const std::string & text,
+                                           std::string & out_name,
+                                           std::string & out_raw_args) {
+    static const std::regex re_name(R"re("(?:name|function|tool)"\s*:\s*"([A-Za-z_][\w.\-]*)")re");
+    static const std::regex re_args_open(R"re("(?:arguments|parameters|args|params|input)"\s*:\s*\{)re");
+
+    std::smatch mn, ma;
+    if (std::regex_search(text, mn, re_name) && std::regex_search(text, ma, re_args_open)) {
+        out_name = mn[1].str();
+        size_t brace_open = ma.position() + ma.length() - 1;
+        size_t brace_close = balanced_braces_end(text, brace_open);
+        if (brace_close != std::string::npos) {
+            out_raw_args = text.substr(brace_open, brace_close - brace_open);
+            return true;
+        }
+    }
+    return false;
+}
+
 // ─── Main parser ────────────────────────────────────────────────────────
 
 ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
@@ -842,12 +838,13 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
     std::vector<std::pair<size_t, ToolCall>> positioned_calls;
 
     auto add_call = [&](const std::string & fn_name, const json & args,
-                        size_t start, size_t end) {
+                        size_t start, size_t end,
+                        const std::string & raw_args = "") {
         if (!tool_allowed(tools, fn_name)) return;
         ToolCall tc;
         tc.id = generate_call_id();
         tc.name = fn_name;
-        tc.arguments = args.dump();
+        tc.arguments = raw_args.empty() ? args.dump() : raw_args;
         positioned_calls.emplace_back(start, std::move(tc));
         removals.push_back({start, end});
     };
@@ -1158,20 +1155,19 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
             size_t pos = it->position();
             if (overlaps(removals, pos)) continue;
             std::string inner = (*it)[1].str();
-            // trim
             size_t s = inner.find_first_not_of(" \t\n\r");
             if (s != std::string::npos) inner = inner.substr(s);
             size_t e = inner.find_last_not_of(" \t\n\r");
             if (e != std::string::npos) inner = inner.substr(0, e + 1);
-            try {
-                json obj = json::parse(inner);
-                std::string name;
-                json args;
-                if (parse_json_tool_call(obj, name, args)) {
-                    size_t pos = it->position();
-                    add_call(name, args, pos, pos + it->length());
-                }
-            } catch (...) {}
+            json obj = json::parse(inner, nullptr, false);
+            std::string name;
+            json args;
+            std::string raw_args;
+            if (!obj.is_discarded() && parse_json_tool_call(obj, name, args, raw_args)) {
+                add_call(name, args, pos, pos + it->length(), raw_args);
+            } else if (extract_raw_json_tool_fallback(inner, name, raw_args)) {
+                add_call(name, json::object(), pos, pos + it->length(), raw_args);
+            }
         }
     }
 
@@ -1183,24 +1179,23 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
             size_t pos = it->position();
             if (overlaps(removals, pos)) continue;
             std::string inner = (*it)[1].str();
-            // trim
             size_t s = inner.find_first_not_of(" \t\n\r");
             if (s != std::string::npos) inner = inner.substr(s);
             size_t e = inner.find_last_not_of(" \t\n\r");
             if (e != std::string::npos) inner = inner.substr(0, e + 1);
-            try {
-                json obj = json::parse(inner);
-                std::string name;
-                json args;
-                if (parse_json_tool_call(obj, name, args)) {
-                    size_t pos = it->position();
-                    add_call(name, args, pos, pos + it->length());
-                }
-            } catch (...) {}
+            json obj = json::parse(inner, nullptr, false);
+            std::string name;
+            json args;
+            std::string raw_args;
+            if (!obj.is_discarded() && parse_json_tool_call(obj, name, args, raw_args)) {
+                add_call(name, args, pos, pos + it->length(), raw_args);
+            } else if (extract_raw_json_tool_fallback(inner, name, raw_args)) {
+                add_call(name, json::object(), pos, pos + it->length(), raw_args);
+            }
         }
     }
 
-    // Pattern 4d: <function_calls><invoke name="NAME">...<param name="K">V</param>...</invoke></function_calls>
+    // Pattern 4d: <function_calls> containing <invoke> blocks or JSON lines
     {
         static const std::regex re_block(R"(<function_calls>([\s\S]*?)</function_calls>)");
         static const std::regex re_invoke(R"(<invoke\s+(?:name|tool)\s*=\s*["']?([A-Za-z_][\w.\-]*)["']?\s*>([\s\S]*?)</invoke>)");
@@ -1214,29 +1209,40 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
             if (overlaps(removals, bstart)) continue;
 
             std::string block_content = (*fit)[1].str();
+            size_t inner_start = fit->position(1);
+            struct CallMatch { std::string name; json args; std::string raw_args; size_t start, end; };
+            std::vector<CallMatch> block_calls;
+
+            // 1. Try <invoke> tags
             auto begin = std::sregex_iterator(block_content.begin(), block_content.end(), re_invoke);
             auto end = std::sregex_iterator();
-            std::vector<std::pair<std::string, json>> block_calls;
-
             for (auto it = begin; it != end; ++it) {
                 std::string fn_name = (*it)[1].str();
                 if (!tool_allowed(tools, fn_name)) continue;
                 std::string body = trim_ws((*it)[2].str());
                 json args = json::object();
+                std::string raw_args;
                 if (!body.empty() && body.front() == '{') {
-                    json raw_args = json::parse(body, nullptr, false);
-                    if (raw_args.is_discarded() || !raw_args.is_object()) continue;
-                    json props = find_tool_properties(tools, fn_name);
-                    for (auto & [k, v] : raw_args.items()) {
-                        if (v.is_string()) {
-                            args[k] = convert_param_value(v.get<std::string>(), k, props);
-                        } else {
-                            args[k] = v;
+                    json raw_json = json::parse(body, nullptr, false);
+                    if (!raw_json.is_discarded() && raw_json.is_object()) {
+                        json props = find_tool_properties(tools, fn_name);
+                        for (auto & [k, v] : raw_json.items()) {
+                            if (v.is_string()) {
+                                args[k] = convert_param_value(v.get<std::string>(), k, props);
+                            } else {
+                                args[k] = v;
+                            }
                         }
+                        raw_args = args.dump();
+                    } else if (body.back() == '}') {
+                        raw_args = body;
+                    } else {
+                        continue;
                     }
                 } else {
                     size_t cursor = 0;
                     bool valid_body = true;
+                    bool found_param = false;
                     auto pbegin = std::sregex_iterator(body.begin(), body.end(), re_param);
                     auto pend = std::sregex_iterator();
                     for (auto pit = pbegin; pit != pend; ++pit) {
@@ -1246,21 +1252,62 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
                         if (args.contains(k)) { valid_body = false; break; }
                         std::string v = trim_ws((*pit)[3].str());
                         args[k] = convert_param_value(v, k, find_tool_properties(tools, fn_name));
+                        found_param = true;
                         cursor = ppos + pit->length();
                     }
-                    if (!valid_body || (!args.empty() && !trim_ws(body.substr(cursor)).empty())) continue;
+                    if (!valid_body || !found_param || !trim_ws(body.substr(cursor)).empty()) continue;
                 }
-                block_calls.push_back({fn_name, std::move(args)});
+                size_t istart = inner_start + it->position();
+                size_t iend = istart + it->length();
+                block_calls.push_back({fn_name, std::move(args), raw_args, istart, iend});
+            }
+
+            // 2. If no <invoke> tags matched, try JSON lines
+            if (block_calls.empty()) {
+                size_t cursor = 0;
+                while (cursor < block_content.size()) {
+                    size_t s = block_content.find('{', cursor);
+                    if (s == std::string::npos) break;
+                    size_t e = balanced_braces_end(block_content, s);
+                    if (e == std::string::npos) { cursor = s + 1; continue; }
+                    std::string jstr = block_content.substr(s, e - s);
+                    json obj = json::parse(jstr, nullptr, false);
+                    std::string name;
+                    json args;
+                    std::string raw;
+                    if (!obj.is_discarded() && parse_json_tool_call(obj, name, args, raw) && tool_allowed(tools, name)) {
+                        block_calls.push_back({name, std::move(args), raw, inner_start + s, inner_start + e});
+                    }
+                    cursor = e;
+                }
             }
 
             if (!block_calls.empty()) {
-                for (auto & bc : block_calls) {
-                    add_call(bc.first, bc.second, bstart, bend);
+                // If the block contains only whitespace around the calls, remove the whole block
+                bool clean_block = true;
+                size_t last_end = 0;
+                for (const auto & bc : block_calls) {
+                    size_t rel_start = bc.start - inner_start;
+                    if (!trim_ws(block_content.substr(last_end, rel_start - last_end)).empty()) {
+                        clean_block = false;
+                        break;
+                    }
+                    last_end = bc.end - inner_start;
+                }
+                if (!trim_ws(block_content.substr(last_end)).empty()) clean_block = false;
+
+                if (clean_block) {
+                    for (auto & bc : block_calls) {
+                        add_call(bc.name, bc.args, bstart, bend, bc.raw_args);
+                    }
+                } else {
+                    for (auto & bc : block_calls) {
+                        add_call(bc.name, bc.args, bc.start, bc.end, bc.raw_args);
+                    }
                 }
             }
         }
     }
-
 
     // Pattern 5: call:<ns>?<verb>{relaxed-JSON args}
     //
@@ -1337,14 +1384,22 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
             std::string json_str = text.substr(start, end_pos - start);
             json obj2 = json::parse(json_str, nullptr, false);
             if (obj2.is_discarded()) {
+                std::string name;
+                std::string raw_args;
+                if (extract_raw_json_tool_fallback(json_str, name, raw_args) && tool_allowed(tools, name)) {
+                    add_call(name, json::object(), start, end_pos, raw_args);
+                    cursor = end_pos;
+                    continue;
+                }
                 cursor = start + 1;
                 continue;
             }
 
             std::string name;
             json args;
-            if (parse_json_tool_call(obj2, name, args)) {
-                add_call(name, args, start, end_pos);
+            std::string raw_args;
+            if (parse_json_tool_call(obj2, name, args, raw_args)) {
+                add_call(name, args, start, end_pos, raw_args);
             } else if (span_covers_non_ws(text, start, end_pos) &&
                        parse_single_tool_arg_object(obj2, tools, name, args)) {
                 add_call(name, args, start, end_pos);

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -6010,3 +6010,74 @@ TEST_CASE(ServerUnitFixture, test_emitter_function_calls_param_with_literal_thin
     TEST_ASSERT(em.emit_token_count() == 3);
     TEST_ASSERT(em.emit_token_count() - em.first_content_token_index() == 1);
 }
+
+TEST_CASE(ServerUnitFixture, test_emitter_streaming_length_finish_reason_at_cap) {
+    auto em = make_emitter(ApiFormat::OPENAI_CHAT, json::array(), false);
+    em.emit_start();
+    em.emit_token("hello world");
+    auto chunks = em.emit_finish(10, nullptr, 10);
+    TEST_ASSERT(em.finish_reason() == "length");
+    bool found_length = false;
+    for (const auto & chunk : chunks) {
+        if (chunk.find("\"finish_reason\":\"length\"") != std::string::npos) {
+            found_length = true;
+            break;
+        }
+    }
+    TEST_ASSERT(found_length);
+}
+
+TEST_CASE(ServerUnitFixture, test_emitter_streaming_length_finish_reason_at_zero_cap) {
+    auto em = make_emitter(ApiFormat::OPENAI_CHAT, json::array(), false);
+    em.emit_start();
+    auto chunks = em.emit_finish(0, nullptr, 0);
+    TEST_ASSERT(em.finish_reason() == "length");
+    bool found_length = false;
+    for (const auto & chunk : chunks) {
+        if (chunk.find("\"finish_reason\":\"length\"") != std::string::npos) {
+            found_length = true;
+            break;
+        }
+    }
+    TEST_ASSERT(found_length);
+}
+
+TEST_CASE(ServerUnitFixture, test_emitter_streaming_stop_sequence_beats_length_at_cap) {
+    std::vector<std::string> stops = {"END"};
+    auto em = make_emitter_with_stops(ApiFormat::OPENAI_CHAT, stops);
+    em.emit_start();
+    em.emit_token("finished END");
+    auto chunks = em.emit_finish(10, nullptr, 10);
+    TEST_ASSERT(em.stop_hit());
+    TEST_ASSERT(em.finish_reason() == "stop");
+    bool found_stop = false;
+    for (const auto & chunk : chunks) {
+        if (chunk.find("\"finish_reason\":\"stop\"") != std::string::npos) {
+            found_stop = true;
+            break;
+        }
+    }
+    TEST_ASSERT(found_stop);
+}
+
+TEST_CASE(ServerUnitFixture, test_emitter_streaming_anthropic_length_finish_reason_at_cap) {
+    auto em = make_emitter(ApiFormat::ANTHROPIC, json::array(), false);
+    em.emit_start();
+    em.emit_token("hello world");
+    auto chunks = em.emit_finish(10, nullptr, 10);
+    TEST_ASSERT(em.finish_reason() == "length");
+    std::string text = concat(chunks);
+    TEST_ASSERT(text.find("\"stop_reason\":\"max_tokens\"") != std::string::npos);
+}
+
+TEST_CASE(ServerUnitFixture, test_emitter_streaming_anthropic_stop_sequence_beats_length_at_cap) {
+    std::vector<std::string> stops = {"END"};
+    auto em = make_emitter_with_stops(ApiFormat::ANTHROPIC, stops);
+    em.emit_start();
+    em.emit_token("finished END");
+    auto chunks = em.emit_finish(10, nullptr, 10);
+    TEST_ASSERT(em.stop_hit());
+    TEST_ASSERT(em.finish_reason() == "stop");
+    std::string text = concat(chunks);
+    TEST_ASSERT(text.find("\"stop_reason\":\"end_turn\"") != std::string::npos);
+}

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -6081,3 +6081,160 @@ TEST_CASE(ServerUnitFixture, test_emitter_streaming_anthropic_stop_sequence_beat
     std::string text = concat(chunks);
     TEST_ASSERT(text.find("\"stop_reason\":\"end_turn\"") != std::string::npos);
 }
+
+TEST_CASE(ServerUnitFixture, test_parse_function_calls_json_lines) {
+    std::string text =
+        "Let me read the files:\n"
+        "<function_calls>\n"
+        "{\"name\": \"read\", \"arguments\": {\"path\": \"file1.txt\"}}\n"
+        "{\"name\": \"read\", \"arguments\": {\"path\": \"file2.txt\"}}\n"
+        "</function_calls>";
+
+    auto result = parse_tool_calls(text, read_tools());
+    TEST_ASSERT(result.tool_calls.size() == 2);
+    if (result.tool_calls.size() == 2) {
+        TEST_ASSERT(result.tool_calls[0].name == "read");
+        TEST_ASSERT(result.tool_calls[1].name == "read");
+        auto a1 = json::parse(result.tool_calls[0].arguments);
+        auto a2 = json::parse(result.tool_calls[1].arguments);
+        TEST_ASSERT(a1["path"] == "file1.txt");
+        TEST_ASSERT(a2["path"] == "file2.txt");
+    }
+    TEST_ASSERT(result.cleaned_text == "Let me read the files:");
+}
+
+TEST_CASE(ServerUnitFixture, test_parse_function_calls_sibling_invokes_partial_failure) {
+    std::string text =
+        "<function_calls>\n"
+        "<invoke name=\"read\">\n"
+        "  <param name=\"path\">valid.txt</param>\n"
+        "</invoke>\n"
+        "<invoke name=\"read\">\n"
+        "  malformed parameter text\n"
+        "</invoke>\n"
+        "</function_calls>";
+
+    auto result = parse_tool_calls(text, read_tools());
+    TEST_ASSERT(result.tool_calls.size() == 1);
+    if (!result.tool_calls.empty()) {
+        TEST_ASSERT(result.tool_calls[0].name == "read");
+        auto args = json::parse(result.tool_calls[0].arguments);
+        TEST_ASSERT(args["path"] == "valid.txt");
+    }
+    TEST_ASSERT(result.cleaned_text.find("malformed parameter text") != std::string::npos);
+}
+
+TEST_CASE(ServerUnitFixture, test_parse_json_syntax_error_forwarding) {
+    std::string text = "<function_call>{\"name\": \"read\", \"arguments\": {\"offset\": 5o1}}</function_call>";
+    auto result = parse_tool_calls(text, read_tools());
+    TEST_ASSERT(result.tool_calls.size() == 1);
+    if (!result.tool_calls.empty()) {
+        TEST_ASSERT(result.tool_calls[0].name == "read");
+        TEST_ASSERT(result.tool_calls[0].arguments == "{\"offset\": 5o1}");
+    }
+}
+
+TEST_CASE(ServerUnitFixture, test_emitter_streaming_json_syntax_error_openai_delta) {
+    auto em = make_emitter(ApiFormat::OPENAI_CHAT, read_tools(), false);
+    em.emit_start();
+    em.emit_token("<function_call>{\"name\": \"read\", \"arguments\": {\"offset\": 5o1}}</function_call>");
+    auto chunks = em.emit_finish(10, nullptr, -1);
+    TEST_ASSERT(em.tool_calls().size() == 1);
+    if (!em.tool_calls().empty()) {
+        TEST_ASSERT(em.tool_calls()[0].name == "read");
+        TEST_ASSERT(em.tool_calls()[0].arguments == "{\"offset\": 5o1}");
+    }
+    TEST_ASSERT(em.finish_reason() == "tool_calls");
+    std::string text = concat(chunks);
+    TEST_ASSERT(text.find("5o1") != std::string::npos);
+    TEST_ASSERT(text.find("\"finish_reason\":\"tool_calls\"") != std::string::npos);
+}
+
+TEST_CASE(ServerUnitFixture, test_emitter_streaming_json_syntax_error_anthropic) {
+    auto em = make_emitter(ApiFormat::ANTHROPIC, read_tools(), false);
+    em.emit_start();
+    em.emit_token("<function_call>{\"name\": \"read\", \"arguments\": {\"offset\": 5o1}}</function_call>");
+    auto chunks = em.emit_finish(10, nullptr, -1);
+    TEST_ASSERT(em.tool_calls().size() == 1);
+    if (!em.tool_calls().empty()) {
+        TEST_ASSERT(em.tool_calls()[0].name == "read");
+        TEST_ASSERT(em.tool_calls()[0].arguments == "{\"offset\": 5o1}");
+    }
+    std::string text = concat(chunks);
+    TEST_ASSERT(text.find("\"type\":\"tool_use\"") != std::string::npos);
+    TEST_ASSERT(text.find("5o1") != std::string::npos);
+}
+
+TEST_CASE(ServerUnitFixture, test_emitter_streaming_malformed_tool_in_think_recovers_answer) {
+    auto em = make_emitter(ApiFormat::ANTHROPIC, read_tools(), true);
+    em.emit_start();
+    auto c1 = em.emit_token("<think>Let me see <tool_call><bad_tool></tool_call></think>Here is the final answer.");
+    auto c2 = em.emit_finish(10, nullptr, -1);
+    std::string text = concat(c1) + concat(c2);
+    TEST_ASSERT(em.tool_calls().empty());
+    TEST_ASSERT(em.reasoning_text().find("<bad_tool>") == std::string::npos);
+    TEST_ASSERT(em.reasoning_text().find("Let me see ") != std::string::npos);
+    TEST_ASSERT(em.accumulated_text() == "Here is the final answer.");
+    TEST_ASSERT(text.find("\"type\":\"thinking_delta\"") != std::string::npos);
+    TEST_ASSERT(text.find("\"type\":\"text_delta\"") != std::string::npos);
+    TEST_ASSERT(text.find("Here is the final answer.") != std::string::npos);
+}
+
+TEST_CASE(ServerUnitFixture, test_emitter_streaming_malformed_tool_in_think_without_think_close_suppressed) {
+    auto em = make_emitter(ApiFormat::OPENAI_CHAT, read_tools(), true);
+    em.emit_start();
+    em.emit_token("<think>Let me see <tool_call><bad_tool>");
+    auto chunks = em.emit_finish(10, nullptr, -1);
+    TEST_ASSERT(em.tool_calls().empty());
+    TEST_ASSERT(em.accumulated_text().empty());
+    TEST_ASSERT(em.reasoning_text().find("<bad_tool>") == std::string::npos);
+}
+
+TEST_CASE(ServerUnitFixture, test_emitter_streaming_malformed_tool_in_think_literal_think_close_in_args_does_not_leak) {
+    auto em = make_emitter(ApiFormat::OPENAI_CHAT, read_tools(), true);
+    em.emit_start();
+    em.emit_token("<think>Let me see <tool_call><function=bash><parameter=cmd>grep '</think>' file.txt");
+    auto chunks = em.emit_finish(10, nullptr, -1);
+    TEST_ASSERT(em.tool_calls().empty());
+    TEST_ASSERT(em.accumulated_text().empty());
+    TEST_ASSERT(em.reasoning_text().find("grep") == std::string::npos);
+}
+
+TEST_CASE(ServerUnitFixture, test_emitter_streaming_malformed_tool_in_think_envelope_with_internal_think_close_recovers_answer) {
+    auto em = make_emitter(ApiFormat::OPENAI_CHAT, read_tools(), true);
+    em.emit_start();
+    em.emit_token("<think>Let me see <tool_call><function=bash><parameter=cmd>grep '</think>' file.txt</parameter></function></tool_call></think>Real answer here.");
+    auto chunks = em.emit_finish(10, nullptr, -1);
+    TEST_ASSERT(em.tool_calls().empty());
+    TEST_ASSERT(em.accumulated_text() == "Real answer here.");
+    TEST_ASSERT(em.reasoning_text().find("grep") == std::string::npos);
+}
+
+TEST_CASE(ServerUnitFixture, test_emitter_streaming_long_tool_name_split_in_reasoning_holds_back) {
+    json tools = json::array({
+        {
+            {"type", "function"},
+            {"function", {
+                {"name", "fetch_authenticated_user_profile_data"},
+                {"description", "fetch user profile"},
+                {"parameters", {{"type", "object"}, {"properties", {{"id", {{"type", "string"}}}}}}}
+            }}
+        }
+    });
+
+    auto em = make_emitter(ApiFormat::OPENAI_CHAT, tools, true);
+    em.emit_start();
+    em.emit_token("<think>I should fetch the user data. ");
+    em.emit_token("<fetch_authenticated_");
+    em.emit_token("user_profile_data>\n<parameter=id>\n123\n</parameter>\n</fetch_authenticated_user_profile_data></think>");
+    auto chunks = em.emit_finish(10, nullptr, -1);
+
+    TEST_ASSERT(em.tool_calls().size() == 1);
+    if (!em.tool_calls().empty()) {
+        TEST_ASSERT(em.tool_calls()[0].name == "fetch_authenticated_user_profile_data");
+        auto args = json::parse(em.tool_calls()[0].arguments);
+        TEST_ASSERT(args["id"] == "123");
+    }
+    TEST_ASSERT(em.reasoning_text().find("fetch_authenticated") == std::string::npos);
+    TEST_ASSERT(em.finish_reason() == "tool_calls");
+}


### PR DESCRIPTION
Refs #644 (Stage 2 of 3, builds upon #638)

## Description

This PR provides a streamlined, minimal implementation of DeepSeek V4 tool call parsing and streaming emitter state handling based on empirical session logs:
1. **Multi-Format XML Envelopes**:
   - Supports `<function_calls>` enclosing JSON lines or `<invoke name="...">` tags with `<param name="...">` parameters.
   - Supports `<function>` and `<function_call>` JSON wrappers.
   - Retains unparseable sibling content in `cleaned_text` and preserves valid tool calls in the same response.
2. **JSON Syntax Error Fallback**:
   - When the model produces minor token errors in tool arguments (such as `'o'` instead of `'0'` in numeric offsets or filenames like `{"offset": 5o1}`), the parser extracts the declared tool name and forwards the raw arguments string as a standard tool call event with `finish_reason: "tool_calls"` / `stop_reason: "tool_use"`.
   - Allows client agents (such as Pi Agent) to receive the tool invocation, parse the error, and return structured error feedback so the model can self-correct instead of terminating the turn with an empty assistant message.
3. **Streaming State Machine & Reason Split**:
   - Uses dynamic holdback in `StreamMode::REASONING` to detect long tool names across token boundaries.
   - Unified `emit_reasoning_delta` helper eliminating delta-emission duplication.
   - Splits `cleaned_text` across `</think>` boundaries, emitting leading text as reasoning and trailing text as content.
   - Recovers post-think content on parse failures while suppressing buffered malformed tool XML.

## Verification
- Added comprehensive unit tests in `test_server_unit`:
  - `test_parse_function_calls_invoke_json`
  - `test_parse_function_calls_sibling_invokes_partial_failure`
  - `test_parse_json_syntax_error_forwarding`
  - `test_emitter_streaming_json_syntax_error_openai_delta`
  - `test_emitter_streaming_json_syntax_error_anthropic`
  - `test_emitter_streaming_malformed_tool_in_think_recovers_answer`
  - `test_emitter_streaming_safe_prefix_long_tool_name_holdback`
- Tested live in multi-turn sessions with Pi Agent on AMD Strix Halo (`aimax:8087`).
- All 402 unit tests passing (100%).
