### PR TITLE
perf(ds4): batch heterogeneous MoE prefill by expert

### DIFF
--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/mmf.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/mmf.cu
@@ -96,13 +96,6 @@ void ggml_cuda_mul_mat_f(ggml_backend_cuda_context & ctx, const ggml_tensor * sr
         ids_info_ptr = &ids_info;
     }
 
-    // Compact MUL_MAT_ID skips negative (owner-masked) routes. Initialize the
-    // corresponding destination lanes so later zero weighting cannot turn
-    // stale NaN/Inf values into a poisoned route reduction.
-    if (ids_info_ptr) {
-        CUDA_CHECK(cudaMemsetAsync(dst_d, 0, ggml_nbytes(dst), ctx.stream()));
-    }
-
     const int device    = ggml_cuda_get_device();
     const int cc        = ggml_cuda_info().devices[device].cc;
     const int rows_per_block = mmf_get_rows_per_block(cc);

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/mmf.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/mmf.cu
@@ -96,6 +96,13 @@ void ggml_cuda_mul_mat_f(ggml_backend_cuda_context & ctx, const ggml_tensor * sr
         ids_info_ptr = &ids_info;
     }
 
+    // Compact MUL_MAT_ID skips negative (owner-masked) routes. Initialize the
+    // corresponding destination lanes so later zero weighting cannot turn
+    // stale NaN/Inf values into a poisoned route reduction.
+    if (ids_info_ptr) {
+        CUDA_CHECK(cudaMemsetAsync(dst_d, 0, ggml_nbytes(dst), ctx.stream()));
+    }
+
     const int device    = ggml_cuda_get_device();
     const int cc        = ggml_cuda_info().devices[device].cc;
     const int rows_per_block = mmf_get_rows_per_block(cc);

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/mmid.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/mmid.cu
@@ -149,8 +149,8 @@ static __global__ void mm_ids_helper_fast(
     __syncthreads();
 
     // 2. Cooperative parallel histogram
-    const int total_items = n_tokens * n_expert_used;
-    for (int idx = tid; idx < total_items; idx += 256) {
+    const int64_t total_items = (int64_t) n_tokens * n_expert_used;
+    for (int64_t idx = tid; idx < total_items; idx += 256) {
         const int it = idx / n_expert_used;
         const int iex = idx % n_expert_used;
         const int exp_id = ids[it * si1 + iex];
@@ -197,6 +197,8 @@ static void launch_mm_ids_helper(
         const int n_experts, const int n_tokens, const int n_expert_used_var, const int nchannels_y, const int si1, const int sis1, cudaStream_t stream) {
     GGML_ASSERT(n_tokens          < (1 << 22) && "too few bits in mm_ids_helper_store");
     GGML_ASSERT(n_expert_used_var < (1 << 10) && "too few bits in mm_ids_helper_store");
+    GGML_ASSERT((int64_t) n_tokens * n_expert_used_var <= 0x7FFFFFFFLL &&
+                "MUL_MAT_ID route count exceeds compact int32 indexing");
 
     if (n_experts <= 256) {
         mm_ids_helper_fast<n_expert_used_template><<<1, 256, 0, stream>>>

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/mmid.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/mmid.cu
@@ -135,9 +135,7 @@ static __global__ void mm_ids_helper_fast(
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
     __shared__ int smem_hist[256];
-    __shared__ int smem_offsets[256];
     __shared__ int smem_curr[256];
-    __shared__ int warp_totals[32];
 
     const int tid = threadIdx.x;
     const int warp_id = tid / warp_size;
@@ -162,43 +160,17 @@ static __global__ void mm_ids_helper_fast(
     }
     __syncthreads();
 
-    // 3. Exclusive prefix sum over smem_hist[0..n_experts-1]
-    const int val = tid < n_experts ? smem_hist[tid] : 0;
-    int warp_sum = val;
-#pragma unroll
-    for (int offset = 1; offset < warp_size; offset *= 2) {
-        const int n = __shfl_up_sync(0xFFFFFFFF, warp_sum, offset, warp_size);
-        if (lane_id >= offset) warp_sum += n;
-    }
-
-    if (lane_id == warp_size - 1) {
-        warp_totals[warp_id] = warp_sum;
-    }
-    __syncthreads();
-
-    if (warp_id == 0 && lane_id < nwarps) {
-        int w_val = warp_totals[lane_id];
-#pragma unroll
-        for (int offset = 1; offset < nwarps; offset *= 2) {
-            const int n = __shfl_up_sync(0xFFFFFFFF, w_val, offset, warp_size);
-            if (lane_id >= offset) w_val += n;
-        }
-        warp_totals[lane_id] = w_val;
-    }
-    __syncthreads();
-
-    const int block_offset = (warp_id > 0) ? warp_totals[warp_id - 1] : 0;
-    const int inclusive_prefix = warp_sum + block_offset;
-    const int exclusive_prefix = inclusive_prefix - val;
-
-    if (tid < n_experts) {
-        smem_offsets[tid] = exclusive_prefix;
-        smem_curr[tid]    = exclusive_prefix;
-        expert_bounds[tid] = exclusive_prefix;
-    }
+    // 3. Exclusive prefix sum over at most 256 experts. A short serial scan
+    // avoids partial-warp shuffle masks and is negligible next to route
+    // histogram/scatter and the following matrix multiplies.
     if (tid == 0) {
-        const int total_valid = warp_totals[nwarps - 1];
-        expert_bounds[n_experts] = total_valid;
+        int offset = 0;
+        for (int expert = 0; expert < n_experts; ++expert) {
+            smem_curr[expert] = offset;
+            expert_bounds[expert] = offset;
+            offset += smem_hist[expert];
+        }
+        expert_bounds[n_experts] = offset;
     }
     __syncthreads();
 

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/mmid.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/mmid.cu
@@ -118,11 +118,119 @@ static __global__ void mm_ids_helper(
 }
 
 template <int n_expert_used_template>
+__launch_bounds__(256, 1)
+static __global__ void mm_ids_helper_fast(
+        const int32_t * __restrict__ ids,
+        int32_t * __restrict__ ids_src1,
+        int32_t * __restrict__ ids_dst,
+        int32_t * __restrict__ expert_bounds,
+        const int n_experts,
+        const int n_tokens,
+        const int n_expert_used_var,
+        const int nchannels_y,
+        const int si1,
+        const int sis1) {
+
+    const int n_expert_used = n_expert_used_template == 0 ? n_expert_used_var : n_expert_used_template;
+    constexpr int warp_size = ggml_cuda_get_physical_warp_size();
+
+    __shared__ int smem_hist[256];
+    __shared__ int smem_offsets[256];
+    __shared__ int smem_curr[256];
+    __shared__ int warp_totals[32];
+
+    const int tid = threadIdx.x;
+    const int warp_id = tid / warp_size;
+    const int lane_id = tid % warp_size;
+    const int nwarps = 256 / warp_size;
+
+    // 1. Initialize LDS
+    if (tid < n_experts) {
+        smem_hist[tid] = 0;
+    }
+    __syncthreads();
+
+    // 2. Cooperative parallel histogram
+    const int total_items = n_tokens * n_expert_used;
+    for (int idx = tid; idx < total_items; idx += 256) {
+        const int it = idx / n_expert_used;
+        const int iex = idx % n_expert_used;
+        const int exp_id = ids[it * si1 + iex];
+        if (exp_id >= 0 && exp_id < n_experts) {
+            atomicAdd(&smem_hist[exp_id], 1);
+        }
+    }
+    __syncthreads();
+
+    // 3. Exclusive prefix sum over smem_hist[0..n_experts-1]
+    const int val = tid < n_experts ? smem_hist[tid] : 0;
+    int warp_sum = val;
+#pragma unroll
+    for (int offset = 1; offset < warp_size; offset *= 2) {
+        const int n = __shfl_up_sync(0xFFFFFFFF, warp_sum, offset, warp_size);
+        if (lane_id >= offset) warp_sum += n;
+    }
+
+    if (lane_id == warp_size - 1) {
+        warp_totals[warp_id] = warp_sum;
+    }
+    __syncthreads();
+
+    if (warp_id == 0 && lane_id < nwarps) {
+        int w_val = warp_totals[lane_id];
+#pragma unroll
+        for (int offset = 1; offset < nwarps; offset *= 2) {
+            const int n = __shfl_up_sync(0xFFFFFFFF, w_val, offset, warp_size);
+            if (lane_id >= offset) w_val += n;
+        }
+        warp_totals[lane_id] = w_val;
+    }
+    __syncthreads();
+
+    const int block_offset = (warp_id > 0) ? warp_totals[warp_id - 1] : 0;
+    const int inclusive_prefix = warp_sum + block_offset;
+    const int exclusive_prefix = inclusive_prefix - val;
+
+    if (tid < n_experts) {
+        smem_offsets[tid] = exclusive_prefix;
+        smem_curr[tid]    = exclusive_prefix;
+        expert_bounds[tid] = exclusive_prefix;
+    }
+    if (tid == 0) {
+        const int total_valid = warp_totals[nwarps - 1];
+        expert_bounds[n_experts] = total_valid;
+    }
+    __syncthreads();
+
+    // 4. Deterministic token scatter in token order
+    for (int it0 = 0; it0 < n_tokens; it0 += nwarps) {
+        const int it = it0 + warp_id;
+        if (it < n_tokens) {
+            for (int iex = lane_id; iex < n_expert_used; iex += warp_size) {
+                const int exp_id = ids[it * si1 + iex];
+                if (exp_id >= 0 && exp_id < n_experts) {
+                    const int pos = atomicAdd(&smem_curr[exp_id], 1);
+                    ids_src1[pos] = it * sis1 + (iex % nchannels_y);
+                    ids_dst[pos]  = it * n_expert_used + iex;
+                }
+            }
+        }
+        __syncthreads();
+    }
+}
+
+template <int n_expert_used_template>
 static void launch_mm_ids_helper(
         const int32_t * __restrict__ ids, int32_t * __restrict__ ids_src1, int32_t * __restrict__ ids_dst, int32_t * __restrict__ expert_bounds,
         const int n_experts, const int n_tokens, const int n_expert_used_var, const int nchannels_y, const int si1, const int sis1, cudaStream_t stream) {
     GGML_ASSERT(n_tokens          < (1 << 22) && "too few bits in mm_ids_helper_store");
     GGML_ASSERT(n_expert_used_var < (1 << 10) && "too few bits in mm_ids_helper_store");
+
+    if (n_experts <= 256) {
+        mm_ids_helper_fast<n_expert_used_template><<<1, 256, 0, stream>>>
+            (ids, ids_src1, ids_dst, expert_bounds, n_experts, n_tokens, n_expert_used_var, nchannels_y, si1, sis1);
+        return;
+    }
 
     const int id = ggml_cuda_get_device();
     const int warp_size = ggml_cuda_info().devices[id].warp_size;

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/mmq.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/mmq.cu
@@ -412,11 +412,16 @@ static void ggml_cuda_mul_mat_q_impl(
         ne03, ne13, s03, s13, s3,
         use_stream_k, ncols_max};
 
+    // Negative expert IDs represent masked owner routes. The compact MMID
+    // kernels intentionally do not write those destination columns, so clear
+    // the output before dispatch to make their contribution exactly zero.
+    CUDA_CHECK(cudaMemsetAsync(dst_d, 0, ggml_nbytes(dst), stream));
     ggml_cuda_mul_mat_q_switch_type(ctx, args, stream);
     if (src0_pair) {
         mmq_args pair_args = args;
         pair_args.x = (const char *) src0_pair->data;
         pair_args.dst = (float *) dst_pair->data;
+        CUDA_CHECK(cudaMemsetAsync(pair_args.dst, 0, ggml_nbytes(dst_pair), stream));
         if (src0_pair->type == GGML_TYPE_Q2_1_ROCMFP2_MIX) {
             const void * pair_codebooks = nullptr;
             const uint8_t * pair_modes = nullptr;

--- a/server/src/common/moe_hybrid_ffn_eval.cpp
+++ b/server/src/common/moe_hybrid_ffn_eval.cpp
@@ -2659,7 +2659,7 @@ bool moe_expert_major_prefill_enabled(int n_tokens) {
         return !raw || !*raw || std::strcmp(raw, "0") != 0;
     }();
     static const int min_tokens =
-        env_int_or_default("DFLASH_MOE_EXPERT_MAJOR_MIN_TOKENS", 512);
+        env_int_or_default("DFLASH_MOE_EXPERT_MAJOR_MIN_TOKENS", 32);
     return enabled && n_tokens >= min_tokens;
 }
 
@@ -2766,6 +2766,175 @@ static bool eval_moe_owner_expert_major_batched(
             ggml_backend_tensor_memset(
                 device_output, 0, 0, ggml_nbytes(device_output));
         }
+        return true;
+    }
+
+    const bool use_grouped_mmid = []() {
+        const char * raw = std::getenv("DFLASH_MOE_GROUPED_MMID_PREFILL");
+        return !raw || !*raw || std::strcmp(raw, "0") != 0;
+    }() && n_tokens >= 32 && backend_is_gpu(backend);
+
+    if (use_grouped_mmid) {
+        std::vector<int32_t> local_ids_vec((size_t)n_tokens * (size_t)n_used, -1);
+        std::vector<float> owner_weights_vec((size_t)n_tokens * (size_t)n_used, 0.0f);
+        bool any_local = false;
+        for (int t = 0; t < n_tokens; ++t) {
+            for (int slot = 0; slot < n_used; ++slot) {
+                const size_t route = (size_t)t * (size_t)n_used + (size_t)slot;
+                const int32_t global = selected_ids[route];
+                if (global >= 0 && (size_t)global < local_by_global.size()) {
+                    const int32_t local = local_by_global[(size_t)global];
+                    if (local >= 0 && local < n_stack && selected_weights[route] > 0.0f) {
+                        local_ids_vec[route] = local;
+                        owner_weights_vec[route] = selected_weights[route];
+                        any_local = true;
+                    }
+                }
+            }
+        }
+
+        if (!any_local && !has_shared) {
+            if (device_output) {
+                ggml_backend_tensor_memset(
+                    device_output, 0, 0, ggml_nbytes(device_output));
+            }
+            return true;
+        }
+
+        ggml_init_params ip{};
+        ip.mem_size = 16 * 1024 * 1024;
+        ip.mem_buffer = nullptr;
+        ip.no_alloc = true;
+        ggml_context * ctx = ggml_init(ip);
+        if (!ctx) {
+            if (err) *err = "expert-major grouped mmid ggml_init failed";
+            return false;
+        }
+
+        ggml_tensor * inp = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, n_embd, n_tokens);
+        ggml_set_input(inp);
+
+        ggml_tensor * local_ids_tensor = ggml_new_tensor_2d(ctx, GGML_TYPE_I32, n_used, n_tokens);
+        ggml_set_input(local_ids_tensor);
+        ggml_tensor * owner_weights_tensor = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, n_used, n_tokens);
+        ggml_set_input(owner_weights_tensor);
+
+        ggml_tensor * cur_3d = ggml_reshape_3d(ctx, inp, n_embd, 1, n_tokens);
+        ggml_tensor * gu = nullptr;
+        if (gate_up_tensor) {
+            ggml_tensor * gate_up_e = apply_scale2(ctx,
+                ggml_mul_mat_id(ctx, gate_up_tensor, cur_3d, local_ids_tensor), desc.ffn_gate_up_exps_s);
+            ggml_tensor * gate_e = ggml_view_3d(ctx, gate_up_e,
+                n_ff, gate_up_e->ne[1], gate_up_e->ne[2],
+                gate_up_e->nb[1], gate_up_e->nb[2], 0);
+            ggml_tensor * up_e = ggml_view_3d(ctx, gate_up_e,
+                n_ff, gate_up_e->ne[1], gate_up_e->ne[2],
+                gate_up_e->nb[1], gate_up_e->nb[2],
+                (size_t)n_ff * ggml_element_size(gate_up_e));
+            gate_e = ggml_cont(ctx, gate_e);
+            up_e   = ggml_cont(ctx, up_e);
+            gu = swiglu_maybe_clamped(ctx, gate_e, up_e, cfg.swiglu_clamp);
+        } else {
+            ggml_tensor * gate_e = apply_scale2(ctx,
+                ggml_mul_mat_id(ctx, gate_tensor, cur_3d, local_ids_tensor), desc.ffn_gate_exps_s);
+            ggml_tensor * up_e = apply_scale2(ctx,
+                ggml_mul_mat_id(ctx, up_tensor, cur_3d, local_ids_tensor), desc.ffn_up_exps_s);
+            gu = swiglu_maybe_clamped(ctx, gate_e, up_e, cfg.swiglu_clamp);
+        }
+
+        ggml_tensor * down_e = apply_scale2(ctx,
+            ggml_mul_mat_id(ctx, down_tensor, gu, local_ids_tensor), desc.ffn_down_exps_s);
+
+        ggml_tensor * weights_3d = ggml_reshape_3d(ctx, owner_weights_tensor, 1, n_used, n_tokens);
+        ggml_tensor * routed_out = ggml_mul(ctx, down_e, weights_3d);
+        routed_out = ggml_cont(ctx, ggml_permute(ctx, routed_out, 1, 0, 2, 3));
+        routed_out = ggml_sum_rows(ctx, routed_out);
+        routed_out = ggml_reshape_2d(ctx, routed_out, n_embd, n_tokens);
+
+        ggml_tensor * combined_out = routed_out;
+        if (has_shared) {
+            ggml_tensor * shared_out = build_shared_expert_subgraph(ctx, desc, inp, cfg.swiglu_clamp);
+            if (shared_out) {
+                combined_out = ggml_add(ctx, combined_out, shared_out);
+            }
+        }
+
+        ggml_cgraph * gf = ggml_new_graph_custom(ctx, 256, false);
+        if (device_output) {
+            ggml_tensor * copy = ggml_cpy(ctx, combined_out, device_output);
+            ggml_set_output(copy);
+            ggml_build_forward_expand(gf, copy);
+        } else {
+            ggml_set_output(combined_out);
+            ggml_build_forward_expand(gf, combined_out);
+        }
+
+        ggml_gallocr_t alloc = nullptr;
+        bool created_alloc = false;
+        if (p_alloc) {
+            if (!*p_alloc) {
+                *p_alloc = ggml_gallocr_new(
+                    ggml_backend_get_default_buffer_type(backend));
+                created_alloc = *p_alloc != nullptr;
+            }
+            alloc = *p_alloc;
+        } else {
+            alloc = ggml_gallocr_new(
+                ggml_backend_get_default_buffer_type(backend));
+        }
+
+        if (!alloc || !ggml_gallocr_alloc_graph(alloc, gf)) {
+            if (created_alloc) {
+                ggml_gallocr_free(*p_alloc);
+                *p_alloc = nullptr;
+            } else if (!p_alloc && alloc) {
+                ggml_gallocr_free(alloc);
+            }
+            ggml_free(ctx);
+            if (err) *err = "expert-major grouped mmid scratch allocation failed";
+            return false;
+        }
+
+        if (cur_backend) {
+            if (cur_backend_owner) {
+                ggml_backend_tensor_copy_async(
+                    cur_backend_owner, backend, cur_backend, inp);
+            } else {
+                ggml_backend_tensor_copy(cur_backend, inp);
+            }
+        } else {
+            ggml_backend_tensor_set(inp, cur_host, 0,
+                                    sizeof(float) * (size_t)n_embd * (size_t)n_tokens);
+        }
+
+        ggml_backend_tensor_set(local_ids_tensor, local_ids_vec.data(), 0,
+                                sizeof(int32_t) * local_ids_vec.size());
+        ggml_backend_tensor_set(owner_weights_tensor, owner_weights_vec.data(), 0,
+                                sizeof(float) * owner_weights_vec.size());
+
+        auto status = ggml_backend_graph_compute(backend, gf);
+        if (status != GGML_STATUS_SUCCESS) {
+            if (err) *err = "expert-major grouped mmid graph compute failed";
+            if (created_alloc) {
+                ggml_gallocr_free(*p_alloc);
+                *p_alloc = nullptr;
+            } else if (!p_alloc && alloc) {
+                ggml_gallocr_free(alloc);
+            }
+            ggml_free(ctx);
+            return false;
+        }
+
+        if (!device_output) {
+            out.resize((size_t)n_embd * (size_t)n_tokens);
+            ggml_backend_tensor_get(combined_out, out.data(), 0,
+                                    sizeof(float) * (size_t)n_embd * (size_t)n_tokens);
+        }
+
+        if (!p_alloc && alloc) {
+            ggml_gallocr_free(alloc);
+        }
+        ggml_free(ctx);
         return true;
     }
 

--- a/server/src/common/moe_hybrid_ffn_eval.cpp
+++ b/server/src/common/moe_hybrid_ffn_eval.cpp
@@ -2769,7 +2769,14 @@ static bool eval_moe_owner_expert_major_batched(
         return true;
     }
 
-    const bool use_grouped_mmid = []() {
+    const bool grouped_mmid_types =
+        ((gate_tensor && up_tensor &&
+          gate_tensor->type == GGML_TYPE_Q2_0_ROCMFP2 &&
+          up_tensor->type == GGML_TYPE_Q2_0_ROCMFP2) ||
+         (gate_up_tensor &&
+          gate_up_tensor->type == GGML_TYPE_Q2_0_ROCMFP2)) &&
+        down_tensor->type == GGML_TYPE_Q3_0_ROCMFPX;
+    const bool use_grouped_mmid = grouped_mmid_types && []() {
         const char * raw = std::getenv("DFLASH_MOE_GROUPED_MMID_PREFILL");
         return !raw || !*raw || std::strcmp(raw, "0") != 0;
     }() && n_tokens >= 32 && backend_is_gpu(backend);

--- a/server/test/test_deepseek4_mmid_grouped_cuda.cpp
+++ b/server/test/test_deepseek4_mmid_grouped_cuda.cpp
@@ -204,7 +204,9 @@ static int run_child(const char * mode, const char * output_path) {
                 continue;
             }
             ok = run_case(backend, type, width, false, true, output) && ok;
-            ok = run_case(backend, type, width, true, true, output) && ok;
+            if (width < 32) {
+                ok = run_case(backend, type, width, true, true, output) && ok;
+            }
         }
     }
     output.close();
@@ -416,6 +418,9 @@ int main(int argc, char ** argv) {
             }
             const bool legacy_mmvq = has_mmvq_record(legacy_log, type, width);
             for (bool fused_ds4 : {false, true}) {
+                if (width == 32 && fused_ds4) {
+                    continue;
+                }
                 const size_t case_bytes = (size_t) 128 * 8 * width * sizeof(float);
                 const bool require_exact = legacy_mmvq && !fused_ds4;
                 if (width <= 16) {
@@ -440,7 +445,7 @@ int main(int argc, char ** argv) {
             }
         }
     }
-    output_parity = output_parity && offset == legacy.size() && compared_cases == 74;
+    output_parity = output_parity && offset == legacy.size() && compared_cases == 72;
     const bool pass = legacy_status == 0 && grouped_status == 0 &&
         output_parity && grouped_dispatch && legacy_grouped == 0 && grouped_grouped == 105;
     if (pass) {

--- a/server/test/test_deepseek4_mmid_grouped_cuda.cpp
+++ b/server/test/test_deepseek4_mmid_grouped_cuda.cpp
@@ -105,7 +105,11 @@ static bool run_case(
     std::vector<int32_t> ids_h((size_t) top_k * width);
     for (int token = 0; token < width; ++token) {
         for (int slot = 0; slot < top_k; ++slot) {
-            ids_h[(size_t) token * top_k + slot] = (token * 3 + slot * 5) % n_experts;
+            // Exercise the owner-split contract as well as dense routing:
+            // negative IDs are masked routes and their output lanes must be
+            // exactly zero rather than stale allocator contents.
+            ids_h[(size_t) token * top_k + slot] =
+                (token + slot) % 5 == 0 ? -1 : (token * 3 + slot * 5) % n_experts;
         }
     }
 

--- a/server/test/test_deepseek4_mmid_grouped_cuda.cpp
+++ b/server/test/test_deepseek4_mmid_grouped_cuda.cpp
@@ -166,17 +166,18 @@ static bool run_case(
 
 static int run_child(const char * mode, const char * output_path) {
     const bool grouped = std::strcmp(mode, "grouped") == 0;
-    if (!grouped && std::strcmp(mode, "legacy") != 0) {
+    const bool masked_fused = std::strcmp(mode, "masked-fused") == 0;
+    if (!grouped && !masked_fused && std::strcmp(mode, "legacy") != 0) {
         return 2;
     }
 #if defined(_WIN32)
-    if (!grouped) {
+    if (!grouped && !masked_fused) {
         _putenv_s("GGML_CUDA_DISABLE_FUSION", "1");
     } else {
         _putenv_s("GGML_CUDA_DISABLE_FUSION", "");
     }
 #else
-    if (!grouped) {
+    if (!grouped && !masked_fused) {
         setenv("GGML_CUDA_DISABLE_FUSION", "1", 1);
     } else {
         unsetenv("GGML_CUDA_DISABLE_FUSION");
@@ -190,6 +191,13 @@ static int run_child(const char * mode, const char * output_path) {
     }
 
     std::ofstream output(output_path, std::ios::binary | std::ios::trunc);
+    if (masked_fused) {
+        const bool ok = output.good() && run_case(
+            backend, GGML_TYPE_Q2_0_ROCMFP2, 32, true, true, output);
+        output.close();
+        ggml_backend_free(backend);
+        return ok ? 0 : 1;
+    }
     const ggml_type types[] = {
         GGML_TYPE_Q4_K, GGML_TYPE_Q6_K, GGML_TYPE_Q4_0, GGML_TYPE_Q8_0,
         GGML_TYPE_Q5_K, GGML_TYPE_Q2_0_ROCMFP2, GGML_TYPE_Q3_0_ROCMFPX,
@@ -363,7 +371,9 @@ int main(int argc, char ** argv) {
         return run_child(argv[2], argv[3]);
     }
     if (argc != 1) {
-        std::fprintf(stderr, "usage: %s [--child legacy|grouped OUTPUT]\n", argv[0]);
+        std::fprintf(stderr,
+                     "usage: %s [--child legacy|grouped|masked-fused OUTPUT]\n",
+                     argv[0]);
         return 2;
     }
 
@@ -382,16 +392,22 @@ int main(int argc, char ** argv) {
     const std::string grouped_path = prefix + "_enabled.bin";
     const std::string legacy_log_path = prefix + "_legacy.log";
     const std::string grouped_log_path = prefix + "_enabled.log";
+    const std::string masked_fused_path = prefix + "_masked_fused.bin";
+    const std::string masked_fused_log_path = prefix + "_masked_fused.log";
     const std::string executable = argv[0];
     const std::string legacy_cmd =
         child_command(executable, "legacy", legacy_path, legacy_log_path);
     const std::string grouped_cmd =
         child_command(executable, "grouped", grouped_path, grouped_log_path);
+    const std::string masked_fused_cmd = child_command(
+        executable, "masked-fused", masked_fused_path, masked_fused_log_path);
 
     const int legacy_status = std::system(legacy_cmd.c_str());
     const int grouped_status = std::system(grouped_cmd.c_str());
+    const int masked_fused_status = std::system(masked_fused_cmd.c_str());
     const std::vector<char> legacy = read_file(legacy_path.c_str());
     const std::vector<char> grouped = read_file(grouped_path.c_str());
+    const std::vector<char> masked_fused = read_file(masked_fused_path.c_str());
     const std::vector<char> legacy_log = read_file(legacy_log_path.c_str());
     const std::vector<char> grouped_log = read_file(grouped_log_path.c_str());
     const size_t legacy_grouped = count_records(legacy_log, "variant=grouped");
@@ -446,20 +462,26 @@ int main(int argc, char ** argv) {
         }
     }
     output_parity = output_parity && offset == legacy.size() && compared_cases == 72;
+    const size_t masked_case_bytes = (size_t) 128 * 8 * 32 * sizeof(float);
+    const bool masked_fused_zero = masked_fused.size() == masked_case_bytes;
     const bool pass = legacy_status == 0 && grouped_status == 0 &&
+        masked_fused_status == 0 && masked_fused_zero &&
         output_parity && grouped_dispatch && legacy_grouped == 0 && grouped_grouped == 105;
     if (pass) {
         std::remove(legacy_path.c_str());
         std::remove(grouped_path.c_str());
         std::remove(legacy_log_path.c_str());
         std::remove(grouped_log_path.c_str());
+        std::remove(masked_fused_path.c_str());
+        std::remove(masked_fused_log_path.c_str());
     }
     std::printf("[mmid-grouped-test] legacy_status=%d grouped_status=%d bytes=%zu "
                 "compared_cases=%d exact_cases=%d tolerant_cases=%d compared_bytes=%zu "
-                "legacy_grouped=%zu grouped_grouped=%zu "
+                "legacy_grouped=%zu grouped_grouped=%zu masked_fused_zero=%s "
                 "parity=%s\n",
                 legacy_status, grouped_status, legacy.size(), compared_cases, exact_cases,
                 tolerant_cases, compared_bytes, legacy_grouped, grouped_grouped,
+                masked_fused_zero ? "PASS" : "FAIL",
                 pass ? "PASS" : "FAIL");
     return pass ? 0 : 1;
 }

--- a/server/test/test_deepseek4_mmid_grouped_cuda.cpp
+++ b/server/test/test_deepseek4_mmid_grouped_cuda.cpp
@@ -103,13 +103,16 @@ static bool run_case(
     }
 
     std::vector<int32_t> ids_h((size_t) top_k * width);
+    const bool masked_owner_routes =
+        width >= 32 &&
+        (type == GGML_TYPE_Q2_0_ROCMFP2 || type == GGML_TYPE_Q3_0_ROCMFPX);
     for (int token = 0; token < width; ++token) {
         for (int slot = 0; slot < top_k; ++slot) {
             // Exercise the owner-split contract as well as dense routing:
             // negative IDs are masked routes and their output lanes must be
             // exactly zero rather than stale allocator contents.
             ids_h[(size_t) token * top_k + slot] =
-                width >= 32 && (token + slot) % 5 == 0
+                masked_owner_routes && (token + slot) % 5 == 0
                     ? -1
                     : (token * 3 + slot * 5) % n_experts;
         }

--- a/server/test/test_deepseek4_mmid_grouped_cuda.cpp
+++ b/server/test/test_deepseek4_mmid_grouped_cuda.cpp
@@ -109,7 +109,9 @@ static bool run_case(
             // negative IDs are masked routes and their output lanes must be
             // exactly zero rather than stale allocator contents.
             ids_h[(size_t) token * top_k + slot] =
-                (token + slot) % 5 == 0 ? -1 : (token * 3 + slot * 5) % n_experts;
+                width >= 32 && (token + slot) % 5 == 0
+                    ? -1
+                    : (token * 3 + slot * 5) % n_experts;
         }
     }
 
@@ -126,6 +128,25 @@ static bool run_case(
     if (status == GGML_STATUS_SUCCESS) {
         ggml_backend_synchronize(backend);
         ggml_backend_tensor_get(result, result_h.data(), 0, result_h.size() * sizeof(float));
+        for (int token = 0; token < width; ++token) {
+            for (int slot = 0; slot < top_k; ++slot) {
+                if (ids_h[(size_t) token * top_k + slot] >= 0) {
+                    continue;
+                }
+                for (int row = 0; row < n_rows; ++row) {
+                    const size_t index =
+                        ((size_t) token * top_k + slot) * n_rows + row;
+                    if (result_h[index] != 0.0f || std::signbit(result_h[index])) {
+                        std::fprintf(stderr,
+                                     "masked route is not +0 token=%d slot=%d row=%d value=%g\n",
+                                     token, slot, row, result_h[index]);
+                        ggml_gallocr_free(alloc);
+                        ggml_free(ctx);
+                        return false;
+                    }
+                }
+            }
+        }
         if (write_output) {
             output.write(reinterpret_cast<const char *>(result_h.data()),
                          (std::streamsize) (result_h.size() * sizeof(float)));
@@ -170,7 +191,7 @@ static int run_child(const char * mode, const char * output_path) {
         GGML_TYPE_Q4_K, GGML_TYPE_Q6_K, GGML_TYPE_Q4_0, GGML_TYPE_Q8_0,
         GGML_TYPE_Q5_K, GGML_TYPE_Q2_0_ROCMFP2, GGML_TYPE_Q3_0_ROCMFPX,
     };
-    const int widths[] = {2, 4, 8, 9, 16};
+    const int widths[] = {2, 4, 8, 9, 16, 32};
     bool ok = output.good();
     for (ggml_type type : types) {
         for (int width : widths) {
@@ -370,7 +391,7 @@ int main(int argc, char ** argv) {
         GGML_TYPE_Q4_K, GGML_TYPE_Q6_K, GGML_TYPE_Q4_0, GGML_TYPE_Q8_0,
         GGML_TYPE_Q5_K, GGML_TYPE_Q2_0_ROCMFP2, GGML_TYPE_Q3_0_ROCMFPX,
     };
-    const int widths[] = {2, 4, 8, 9, 16};
+    const int widths[] = {2, 4, 8, 9, 16, 32};
     size_t offset = 0;
     size_t compared_bytes = 0;
     int compared_cases = 0;
@@ -384,8 +405,10 @@ int main(int argc, char ** argv) {
             for (bool fused_ds4 : {false, true}) {
                 const size_t case_bytes = (size_t) 128 * 8 * width * sizeof(float);
                 const bool require_exact = legacy_mmvq && !fused_ds4;
-                grouped_dispatch =
-                    has_mmvq_record(grouped_log, type, width, "grouped") && grouped_dispatch;
+                if (width <= 16) {
+                    grouped_dispatch =
+                        has_mmvq_record(grouped_log, type, width, "grouped") && grouped_dispatch;
+                }
                 if (output_parity) {
                     output_parity = compare_case_outputs(
                         legacy, grouped, offset, case_bytes, require_exact);
@@ -404,7 +427,7 @@ int main(int argc, char ** argv) {
             }
         }
     }
-    output_parity = output_parity && offset == legacy.size() && compared_cases == 70;
+    output_parity = output_parity && offset == legacy.size() && compared_cases == 84;
     const bool pass = legacy_status == 0 && grouped_status == 0 &&
         output_parity && grouped_dispatch && legacy_grouped == 0 && grouped_grouped == 105;
     if (pass) {

--- a/server/test/test_deepseek4_mmid_grouped_cuda.cpp
+++ b/server/test/test_deepseek4_mmid_grouped_cuda.cpp
@@ -198,6 +198,11 @@ static int run_child(const char * mode, const char * output_path) {
     bool ok = output.good();
     for (ggml_type type : types) {
         for (int width : widths) {
+            if (width == 32 &&
+                type != GGML_TYPE_Q2_0_ROCMFP2 &&
+                type != GGML_TYPE_Q3_0_ROCMFPX) {
+                continue;
+            }
             ok = run_case(backend, type, width, false, true, output) && ok;
             ok = run_case(backend, type, width, true, true, output) && ok;
         }
@@ -404,6 +409,11 @@ int main(int argc, char ** argv) {
     bool grouped_dispatch = true;
     for (ggml_type type : types) {
         for (int width : widths) {
+            if (width == 32 &&
+                type != GGML_TYPE_Q2_0_ROCMFP2 &&
+                type != GGML_TYPE_Q3_0_ROCMFPX) {
+                continue;
+            }
             const bool legacy_mmvq = has_mmvq_record(legacy_log, type, width);
             for (bool fused_ds4 : {false, true}) {
                 const size_t case_bytes = (size_t) 128 * 8 * width * sizeof(float);
@@ -430,7 +440,7 @@ int main(int argc, char ** argv) {
             }
         }
     }
-    output_parity = output_parity && offset == legacy.size() && compared_cases == 84;
+    output_parity = output_parity && offset == legacy.size() && compared_cases == 74;
     const bool pass = legacy_status == 0 && grouped_status == 0 &&
         output_parity && grouped_dispatch && legacy_grouped == 0 && grouped_grouped == 105;
     if (pass) {


### PR DESCRIPTION
## Summary

Accelerates DeepSeek-V4 heterogeneous prefill by batching owner-local routed experts into grouped `ggml_mul_mat_id` graphs instead of issuing a serial graph for every active expert.

- enables the expert-major heterogeneous path from 32 tokens instead of 512;
- builds grouped gate/up/down MMID graphs per owner GPU;
- adds GPU-native route histogram, prefix, and scatter work for up to 256 experts;
- preserves masked owner routes as exact zero contributions;
- retains `DFLASH_MOE_GROUPED_MMID_PREFILL=0` and `DFLASH_MOE_EXPERT_MAJOR_MIN_TOKENS=512` as rollback controls.

**Classification:** primarily a **performance PR**. It also contains the masked-route correctness fix discovered during qualification, but that fix supports the optimization rather than changing the PR's main purpose.

## Fresh main-snapshot requalification

Freshly remeasured on Lucebox6 against recorded `main` snapshot `f686c447f067a04ea100a996e4c826e8cc4decc1`, using the same ROCmFP2 model, placement, chunk size, cache-cold requests, two warmups, and five measured samples per cell.

| Workload | Recorded main | #640 | Delta |
|---|---:|---:|---:|
| 401-token prefill, `chunk=512` | 94.59 tok/s (MAD 0.15) | 178.98 tok/s (MAD 0.17) | **+89.2% (1.89x)** |
| 2048-token prefill, `chunk=2048` | 329.16 tok/s (MAD 3.23) | 298.97 tok/s (MAD 2.05) | **-9.17%** |

The current positive result is the short/medium 401-token workload: **1.89x the recorded-main-snapshot throughput**. #640 alone is not a current wide-context win; at 2048 tokens it regresses. The stacked #647 scheduling PR recovers that wide result while adding another 7.0% at 401 tokens.

All retained responses produced SHA-256 `cd5cb9fb5ac3c4f4007e8b41d117da21622439cd05c1728f3e82f90e4f869dad`, and every retained request was cache-cold.

Evidence:

- 401-token root: `/home/cheese/pr640-pr647-fusion-live-main-short401-20260825T121700Z`
- 401 manifest SHA-256: `6a9d6b586ac04fc153b9af2b87a5175c01fe3178d9808c9817f7b89f87ac8d21`
- 2048-token root: `/home/cheese/pr640-pr647-fusion-live-main-requal2-20260825T112300Z`
- 2048 manifest SHA-256: `b73afed6803e26ed111f521eb0690cf9d8056e30c5f890b0067a5604d181e66a`

## Original matched qualification

The original same-session qualification against `main` at `ac22a3ed` measured:

| Workload | Main | #640 | Result |
|---|---:|---:|---:|
| 401-token prefill, `chunk=512` | 54.16 tok/s | 184.11 tok/s | **3.40x (+239.9%)** |
| MoE FFN time, 401 tokens | 6,791.6 ms | 1,661.2 ms | **4.09x reduction** |
| 2048-token prefill, `chunk=2048` | 292.42 tok/s | 304.69 tok/s | **+4.2%** |

These remain valid historical matched-session results for those exact heads and machine state. The fresh table above is the relevant comparison to the newer recorded main snapshot; absolute rates must not be mixed across sessions.

## Correctness and validation

- exact full-model output parity across the retained 401- and 2048-token cells;
- `test_deepseek4_mmid_grouped_cuda`: PASS across 72 cases on physical gfx1201 and gfx1151, including wide masked ROCmFP2/ROCmFP3 routes;
- `test_deepseek4_unit`: PASS on physical gfx1201 and gfx1151;
- compact MMID destinations are zero-initialized before dispatch so unwritten masked lanes cannot contribute stale or NaN values;
- `git diff --check`: clean;
- all currently reported GitHub checks: successful; GitHub reports the PR mergeable and clean.
