### PR TITLE
fix(server): keep multi-byte codepoints intact across streamed tokens

### DIFF
--- a/server/src/server/sse_emitter.cpp
+++ b/server/src/server/sse_emitter.cpp
@@ -236,7 +236,31 @@ std::vector<std::string> SseEmitter::emit_token(const std::string & raw_piece) {
     emit_token_count_++;
 
     // Sanitize input to prevent json::dump() from throwing on invalid UTF-8.
-    std::string piece = utf8_sanitize(raw_piece);
+    // First re-join any incomplete multi-byte tail held back from the previous
+    // piece, then hold back a new incomplete tail (if any) so codepoints split
+    // across tokens are emitted intact instead of as U+FFFD pairs.
+    std::string joined = utf8_tail_ + raw_piece;
+    utf8_tail_.clear();
+    {
+        size_t i = joined.size();
+        int cont = 0;
+        while (i > 0 && cont < 3 &&
+               (static_cast<unsigned char>(joined[i - 1]) & 0xC0) == 0x80) {
+            --i; ++cont;
+        }
+        if (i > 0) {
+            const unsigned char lead = static_cast<unsigned char>(joined[i - 1]);
+            int need = 0;
+            if ((lead & 0xE0) == 0xC0) need = 2;
+            else if ((lead & 0xF0) == 0xE0) need = 3;
+            else if ((lead & 0xF8) == 0xF0) need = 4;
+            if (need > 0 && joined.size() - (i - 1) < static_cast<size_t>(need)) {
+                utf8_tail_ = joined.substr(i - 1);
+                joined.resize(i - 1);
+            }
+        }
+    }
+    std::string piece = utf8_sanitize(joined);
     std::vector<std::string> out;
     accumulated_raw_ += piece;
     window_ += piece;
@@ -557,6 +581,15 @@ void SseEmitter::emit_content_delta(std::vector<std::string> & out,
 std::vector<std::string> SseEmitter::emit_finish(int completion_tokens,
                                                  const GenTimings * timings) {
     std::vector<std::string> out;
+
+    // A tail still pending at end-of-stream is a genuinely truncated
+    // codepoint; sanitize it into the window so nothing is silently lost.
+    if (!utf8_tail_.empty()) {
+        const std::string flushed = utf8_sanitize(utf8_tail_);
+        utf8_tail_.clear();
+        accumulated_raw_ += flushed;
+        window_ += flushed;
+    }
 
     // Flush remaining window
     if (mode_ == StreamMode::REASONING && !window_.empty()) {

--- a/server/src/server/sse_emitter.h
+++ b/server/src/server/sse_emitter.h
@@ -155,6 +155,11 @@ private:
     StreamMode   mode_;
     bool         tool_from_reasoning_ = false;
     std::string  window_;           // holdback buffer
+    // Incomplete trailing UTF-8 bytes from the previous token piece.
+    // BPE tokens can split a multi-byte codepoint (emoji arrive as two
+    // 2-byte halves); sanitizing halves independently turned every such
+    // codepoint into two U+FFFD. The tail is carried into the next piece.
+    std::string  utf8_tail_;
     std::string  tool_buffer_;      // accumulated tool text
     bool         tool_buffer_fallback_to_content_ = false;
     std::string  accumulated_content_;


### PR DESCRIPTION
## Problem

Streamed replies containing emoji or other multi-byte codepoints render as pairs of replacement characters (`??`). BPE tokenizers routinely split a multi-byte UTF-8 codepoint across two generated tokens (a 4-byte emoji arrives as two 2-byte pieces), and `SseEmitter::emit_token` sanitized each token piece independently, so each half became U+FFFD before it ever reached the client.

Reproduce: stream any prompt whose answer contains an emoji and watch the `content` deltas:

```
"content":"ob "|"content":"??"|"content":"?? ke"...
```

## Fix

Hold back an incomplete UTF-8 tail at the end of a token piece and prepend it to the next piece before sanitizing; flush any genuinely truncated tail at end-of-stream so no bytes are silently dropped. Two files, no behavior change for valid single-piece text.

## Verification

Streamed emoji replies end to end on an AMD dual-GPU server: previously two U+FFFD per emoji, now intact codepoints in the deltas. ASCII/latin streaming byte-identical before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

