### PR TITLE
feat(server): simplify tool parser and SSE emitter for DeepSeek V4 and streaming (Stage 2)

### DIFF
--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -3806,7 +3806,10 @@ void HttpServer::send_nonstream_response(
         ClientSendBuffer * send_buffer) {
     CompletionTokenCounts counts;
     counts.total = (int) gen_tokens.size();
-    emitter.emit_finish(counts.total, nullptr, n_gen_cap);
+    const bool is_eos = !gen_tokens.empty() &&
+        (gen_tokens.back() == tokenizer_.eos_id() ||
+         gen_tokens.back() == tokenizer_.eos_chat_id());
+    emitter.emit_finish(counts.total, nullptr, n_gen_cap, is_eos);
     const int first_content = emitter.first_content_token_index();
     const int emitted = emitter.emit_token_count();
     counts.reasoning = first_content < 0 ? emitted : first_content;
@@ -4093,7 +4096,7 @@ void HttpServer::process_job(ServerJob * job) {
          result.tokens.back() == tokenizer_.eos_chat_id());
     if (req.stream && !client_disconnected) {
         auto final_chunks = emitter.emit_finish(
-            completion_tokens, &gen_timings, is_eos ? -1 : n_gen_cap);
+            completion_tokens, &gen_timings, n_gen_cap, is_eos);
         remember_agent_turn(
             req, prepared, cache, result, emitter, completion_tokens,
             visible_output_seen, client_disconnected,

--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -2228,7 +2228,8 @@ CompletionTokenCounts feed_non_streaming_tokens(
 json build_openai_completion_response(
         const ParsedRequest & req, const GenerateResult & result,
         int generation_cap, const GenTimings & timings,
-        const CompletionTokenCounts & counts, const SseEmitter & emitter) {
+        const CompletionTokenCounts & counts, const SseEmitter & emitter,
+        const Tokenizer * tokenizer = nullptr) {
     json message = {
         {"role", "assistant"},
         {"content", emitter.accumulated_text()},
@@ -2261,13 +2262,15 @@ json build_openai_completion_response(
         }
         message["tool_calls"] = tool_calls;
     }
-
     // The emitter only knows "stop" / "tool_calls"; it cannot see that the
     // daemon hit the n_gen cap. Derive "length" from the committed-token
     // count — OpenAI-compatible clients (open-webui, Cline) gate retry
     // logic on finish_reason == "length".
+    const bool is_eos = tokenizer && !result.tokens.empty() &&
+        (result.tokens.back() == tokenizer->eos_id() ||
+         result.tokens.back() == tokenizer->eos_chat_id());
     std::string finish_reason = emitter.finish_reason();
-    if (finish_reason == "stop" && counts.total >= generation_cap) {
+    if (finish_reason == "stop" && !is_eos && counts.total >= generation_cap) {
         finish_reason = "length";
     }
     // Degenerate decode (post-close repetition-loop watchdog) also reports
@@ -2330,7 +2333,8 @@ json build_openai_completion_response(
 json build_anthropic_response(
         const ParsedRequest & req, const GenerateResult & result,
         int generation_cap, const GenTimings & timings,
-        const CompletionTokenCounts & counts, const SseEmitter & emitter) {
+        const CompletionTokenCounts & counts, const SseEmitter & emitter,
+        const Tokenizer * tokenizer = nullptr) {
     json content = json::array();
     if (!emitter.reasoning_text().empty()) {
         content.push_back({
@@ -2367,10 +2371,13 @@ json build_anthropic_response(
     // stop_reason is Anthropic's analog of finish_reason, with the same
     // length-vs-EOS distinction — Cline / Anthropic SDK clients gate
     // retry logic on stop_reason == "max_tokens".
+    const bool is_eos = tokenizer && !result.tokens.empty() &&
+        (result.tokens.back() == tokenizer->eos_id() ||
+         result.tokens.back() == tokenizer->eos_chat_id());
     std::string stop_reason;
     if (emitter.finish_reason() == "tool_calls") {
         stop_reason = "tool_use";
-    } else if (counts.total >= generation_cap) {
+    } else if (!is_eos && counts.total >= generation_cap) {
         stop_reason = "max_tokens";
     } else {
         stop_reason = "end_turn";
@@ -2446,14 +2453,15 @@ json build_responses_api_response(
 json build_non_streaming_response(
         const ParsedRequest & req, const GenerateResult & result,
         int generation_cap, const GenTimings & timings,
-        const CompletionTokenCounts & counts, SseEmitter & emitter) {
+        const CompletionTokenCounts & counts, SseEmitter & emitter,
+        const Tokenizer * tokenizer = nullptr) {
     switch (req.format) {
     case ApiFormat::OPENAI_CHAT:
         return build_openai_completion_response(
-            req, result, generation_cap, timings, counts, emitter);
+            req, result, generation_cap, timings, counts, emitter, tokenizer);
     case ApiFormat::ANTHROPIC:
         return build_anthropic_response(
-            req, result, generation_cap, timings, counts, emitter);
+            req, result, generation_cap, timings, counts, emitter, tokenizer);
     case ApiFormat::RESPONSES:
         return build_responses_api_response(
             req, result, timings, counts, emitter);
@@ -2469,7 +2477,7 @@ json build_non_streaming_response(
     const CompletionTokenCounts counts = feed_non_streaming_tokens(
         result.tokens, tokenizer, emitter);
     return build_non_streaming_response(
-        req, result, generation_cap, timings, counts, emitter);
+        req, result, generation_cap, timings, counts, emitter, &tokenizer);
 }
 
 // Prompt preparation applies exactly one compression policy: FlowKV for
@@ -4080,8 +4088,12 @@ void HttpServer::process_job(ServerJob * job) {
     if (job->client_disconnected.load(std::memory_order_acquire)) {
         client_disconnected = true;
     }
+    const bool is_eos = !result.tokens.empty() &&
+        (result.tokens.back() == tokenizer_.eos_id() ||
+         result.tokens.back() == tokenizer_.eos_chat_id());
     if (req.stream && !client_disconnected) {
-        auto final_chunks = emitter.emit_finish(completion_tokens, &gen_timings, n_gen_cap);
+        auto final_chunks = emitter.emit_finish(
+            completion_tokens, &gen_timings, is_eos ? -1 : n_gen_cap);
         remember_agent_turn(
             req, prepared, cache, result, emitter, completion_tokens,
             visible_output_seen, client_disconnected,

--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -3818,7 +3818,7 @@ void HttpServer::send_nonstream_response(
     result.degenerate_decode_close = degenerate_decode_close;
 
     const json response = build_non_streaming_response(
-        req, result, n_gen_cap, gen_timings, counts, emitter);
+        req, result, n_gen_cap, gen_timings, counts, emitter, &tokenizer_);
 
     const std::string body = response.dump() + "\n";
     if (send_buffer) {

--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -2347,21 +2347,20 @@ json build_anthropic_response(
         });
     }
     for (const auto & tool_call : emitter.tool_calls()) {
-        // Anthropic expects `input` as an object; arguments arrive as a
-        // JSON-encoded string. Fall back to an empty object on bad JSON.
-        json input;
-        try {
-            input = tool_call.arguments.empty()
-                ? json::object()
-                : json::parse(tool_call.arguments);
-        } catch (const std::exception &) {
-            input = json::object();
+        json input = json::object();
+        if (!tool_call.arguments.empty()) {
+            json parsed = json::parse(tool_call.arguments, nullptr, false);
+            if (!parsed.is_discarded() && parsed.is_object()) {
+                input = std::move(parsed);
+            } else {
+                input = {{"_raw", tool_call.arguments}};
+            }
         }
         content.push_back({
             {"type", "tool_use"},
             {"id", tool_call.id},
             {"name", tool_call.name},
-            {"input", input},
+            {"input", std::move(input)},
         });
     }
 

--- a/server/src/server/scheduler.cpp
+++ b/server/src/server/scheduler.cpp
@@ -282,8 +282,12 @@ void HttpServer::scheduler_loop(SeqEngine & engine) {
                 }
             }
         } else if (req.stream && !s.client_disconnected) {
+            const bool is_eos = !s.gen_tokens.empty() &&
+                engine.token_is_eos(s.gen_tokens.back());
             auto final_chunks =
-                s.emitter->emit_finish(s.completion_tokens, &gen_timings, s.n_gen_cap);
+                s.emitter->emit_finish(
+                    s.completion_tokens, &gen_timings,
+                    s.n_gen_cap, is_eos);
             for (const auto & chunk : final_chunks) {
                 s.send_buffer.append(chunk);
             }

--- a/server/src/server/sse_emitter.cpp
+++ b/server/src/server/sse_emitter.cpp
@@ -13,7 +13,6 @@ namespace dflash::common {
 
 static const char THINK_OPEN[]  = "<think>";
 static const char THINK_CLOSE[] = "</think>";
-static const char FUNCTION_CALLS_OPEN[] = "<function_calls>";
 static constexpr size_t THINK_OPEN_LEN  = 7;
 static constexpr size_t THINK_CLOSE_LEN = 8;
 
@@ -349,38 +348,13 @@ std::vector<std::string> SseEmitter::emit_token(const std::string & raw_piece) {
             size_t idx = window_.find(THINK_CLOSE);
             size_t tool_idx = std::string::npos;
             bool tool_hit = has_request_tools(tools_) &&
-                            (tool_idx = window_.find(FUNCTION_CALLS_OPEN)) != std::string::npos;
+                            find_tool_syntax_start(window_, tools_, tool_idx);
 
             if (idx != std::string::npos && (tool_idx == std::string::npos || idx < tool_idx)) {
                 std::string pre = window_.substr(0, idx);
                 if (!pre.empty()) {
                     reasoning_text_ += pre;
-                    // Emit reasoning delta
-                    switch (format_) {
-                    case ApiFormat::OPENAI_CHAT:
-                        out.push_back(format_openai_delta({{"reasoning_content", pre}}));
-                        break;
-                    case ApiFormat::ANTHROPIC: {
-                        if (active_kind_ != "thinking") {
-                            out.push_back(sse_event("content_block_stop",
-                                json({{"type", "content_block_stop"}, {"index", block_index_}}).dump()));
-                            block_index_++;
-                            active_kind_ = "thinking";
-                            json new_block = {{"type", "thinking"}, {"thinking", ""}};
-                            out.push_back(sse_event("content_block_start",
-                                json({{"type", "content_block_start"}, {"index", block_index_},
-                                      {"content_block", new_block}}).dump()));
-                        }
-                        out.push_back(sse_event("content_block_delta",
-                            json({{"type", "content_block_delta"}, {"index", block_index_},
-                                  {"delta", {{"type", "thinking_delta"}, {"thinking", pre}}}}).dump()));
-                        break;
-                    }
-                    case ApiFormat::RESPONSES:
-                        // Responses API doesn't stream reasoning — it's stripped
-                        break;
-                    default: break;
-                    }
+                    emit_reasoning_delta(out, pre);
                 }
                 window_ = window_.substr(idx + THINK_CLOSE_LEN);
                 mode_ = StreamMode::CONTENT;
@@ -390,28 +364,7 @@ std::vector<std::string> SseEmitter::emit_token(const std::string & raw_piece) {
                 std::string pre = window_.substr(0, tool_idx);
                 if (!pre.empty()) {
                     reasoning_text_ += pre;
-                    switch (format_) {
-                    case ApiFormat::OPENAI_CHAT:
-                        out.push_back(format_openai_delta({{"reasoning_content", pre}}));
-                        break;
-                    case ApiFormat::ANTHROPIC: {
-                        if (active_kind_ != "thinking") {
-                            out.push_back(sse_event("content_block_stop",
-                                json({{"type", "content_block_stop"}, {"index", block_index_}}).dump()));
-                            block_index_++;
-                            active_kind_ = "thinking";
-                            json new_block = {{"type", "thinking"}, {"thinking", ""}};
-                            out.push_back(sse_event("content_block_start",
-                                json({{"type", "content_block_start"}, {"index", block_index_},
-                                      {"content_block", new_block}}).dump()));
-                        }
-                        out.push_back(sse_event("content_block_delta",
-                            json({{"type", "content_block_delta"}, {"index", block_index_},
-                                  {"delta", {{"type", "thinking_delta"}, {"thinking", pre}}}}).dump()));
-                        break;
-                    }
-                    default: break;
-                    }
+                    emit_reasoning_delta(out, pre);
                 }
                 tool_buffer_ = window_.substr(tool_idx);
                 tool_from_reasoning_ = true;
@@ -420,34 +373,13 @@ std::vector<std::string> SseEmitter::emit_token(const std::string & raw_piece) {
                 continue;
             }
             // No close tag yet — emit safe prefix if window is large enough
-            if (window_.size() > std::max(BASE_HOLDBACK, stop_holdback_)) {
-                size_t cut = utf8_safe_len(window_, window_.size() - std::max(BASE_HOLDBACK, stop_holdback_));
+            const size_t holdback = std::max(tool_syntax_holdback(tools_), stop_holdback_);
+            if (window_.size() > holdback) {
+                size_t cut = utf8_safe_len(window_, window_.size() - holdback);
                 if (cut == 0) break;  // not enough complete chars yet
                 std::string safe = window_.substr(0, cut);
                 reasoning_text_ += safe;
-                switch (format_) {
-                case ApiFormat::OPENAI_CHAT:
-                    out.push_back(format_openai_delta({{"reasoning_content", safe}}));
-                    break;
-                case ApiFormat::ANTHROPIC:
-                    if (active_kind_ != "thinking") {
-                        out.push_back(sse_event("content_block_stop",
-                            json({{"type", "content_block_stop"}, {"index", block_index_}}).dump()));
-                        block_index_++;
-                        active_kind_ = "thinking";
-                        json new_block = {{"type", "thinking"}, {"thinking", ""}};
-                        out.push_back(sse_event("content_block_start",
-                            json({{"type", "content_block_start"}, {"index", block_index_},
-                                  {"content_block", new_block}}).dump()));
-                    }
-                    out.push_back(sse_event("content_block_delta",
-                        json({{"type", "content_block_delta"}, {"index", block_index_},
-                              {"delta", {{"type", "thinking_delta"}, {"thinking", safe}}}}).dump()));
-                    break;
-                case ApiFormat::RESPONSES:
-                    break;
-                default: break;
-                }
+                emit_reasoning_delta(out, safe);
                 window_ = window_.substr(cut);
             }
             break;
@@ -577,6 +509,120 @@ void SseEmitter::emit_content_delta(std::vector<std::string> & out,
     }
 }
 
+// ─── Reasoning delta emission (format-specific) ─────────────────────────
+
+void SseEmitter::emit_reasoning_delta(std::vector<std::string> & out,
+                                      const std::string & text) {
+    if (text.empty()) return;
+
+    switch (format_) {
+    case ApiFormat::OPENAI_CHAT:
+        out.push_back(format_openai_delta({{"reasoning_content", text}}));
+        break;
+
+    case ApiFormat::ANTHROPIC:
+        if (active_kind_ != "thinking") {
+            out.push_back(sse_event("content_block_stop",
+                json({{"type", "content_block_stop"}, {"index", block_index_}}).dump()));
+            block_index_++;
+            active_kind_ = "thinking";
+            json new_block = {{"type", "thinking"}, {"thinking", ""}};
+            out.push_back(sse_event("content_block_start",
+                json({{"type", "content_block_start"}, {"index", block_index_},
+                      {"content_block", new_block}}).dump()));
+        }
+        out.push_back(sse_event("content_block_delta",
+            json({{"type", "content_block_delta"}, {"index", block_index_},
+                  {"delta", {{"type", "thinking_delta"}, {"thinking", text}}}}).dump()));
+        break;
+
+    case ApiFormat::RESPONSES:
+        break;
+
+    default:
+        break;
+    }
+}
+
+// ─── find_top_level_think_close ─────────────────────────────────────────
+
+static size_t find_top_level_think_close(const std::string & buf, const json & tools) {
+    static const char * const STANDARD_TOOL_CLOSES[] = {
+        "</tool_call>", "</function_call>", "</function_calls>", "</function calls>",
+        "</function>", "</funcname>", "</parameter>", "</parameters>", "</tool_code>",
+        "</invoke>", "</arguments>", "</params>"
+    };
+
+    std::vector<std::string> close_tags;
+    for (const char * tag : STANDARD_TOOL_CLOSES) {
+        close_tags.push_back(tag);
+    }
+    if (tools.is_array()) {
+        for (const auto & t : tools) {
+            const auto & fn = t.contains("function") ? t["function"] : t;
+            if (fn.is_object()) {
+                std::string name = fn.value("name", "");
+                if (!name.empty()) {
+                    close_tags.push_back("</" + name + ">");
+                }
+            }
+        }
+    }
+
+    // Find the end of the last verified tool envelope closing tag
+    size_t last_tool_close_end = 0;
+    for (const auto & tag : close_tags) {
+        size_t pos = buf.find(tag);
+        while (pos != std::string::npos) {
+            last_tool_close_end = std::max(last_tool_close_end, pos + tag.size());
+            pos = buf.find(tag, pos + tag.size());
+        }
+    }
+
+    if (last_tool_close_end > 0) {
+        return buf.find(THINK_CLOSE, last_tool_close_end);
+    }
+
+    // No tool closing tag was found. Check each </think> candidate to ensure
+    // it is not inside an unclosed quote, XML attribute, or parameter body.
+    size_t cursor = 0;
+    while ((cursor = buf.find(THINK_CLOSE, cursor)) != std::string::npos) {
+        // Check quotes before cursor
+        bool in_single_quote = false;
+        bool in_double_quote = false;
+        for (size_t i = 0; i < cursor; i++) {
+            if (buf[i] == '\\' && i + 1 < cursor) {
+                i++;
+                continue;
+            }
+            if (buf[i] == '\'' && !in_double_quote) in_single_quote = !in_single_quote;
+            else if (buf[i] == '"' && !in_single_quote) in_double_quote = !in_double_quote;
+        }
+        if (in_single_quote || in_double_quote) {
+            cursor += THINK_CLOSE_LEN;
+            continue;
+        }
+
+        // Check if remaining suffix contains leftover XML closing tags
+        std::string suffix = buf.substr(cursor + THINK_CLOSE_LEN);
+        bool has_leftover_close = false;
+        for (const auto & tag : close_tags) {
+            if (suffix.find(tag) != std::string::npos) {
+                has_leftover_close = true;
+                break;
+            }
+        }
+        if (has_leftover_close) {
+            cursor += THINK_CLOSE_LEN;
+            continue;
+        }
+
+        return cursor;
+    }
+
+    return std::string::npos;
+}
+
 // ─── emit_finish ────────────────────────────────────────────────────────
 
 std::vector<std::string> SseEmitter::emit_finish(int completion_tokens,
@@ -596,17 +642,7 @@ std::vector<std::string> SseEmitter::emit_finish(int completion_tokens,
     // Flush remaining window
     if (mode_ == StreamMode::REASONING && !window_.empty()) {
         reasoning_text_ += window_;
-        switch (format_) {
-        case ApiFormat::OPENAI_CHAT:
-            out.push_back(format_openai_delta({{"reasoning_content", window_}}));
-            break;
-        case ApiFormat::ANTHROPIC:
-            out.push_back(sse_event("content_block_delta",
-                json({{"type", "content_block_delta"}, {"index", block_index_},
-                      {"delta", {{"type", "thinking_delta"}, {"thinking", window_}}}}).dump()));
-            break;
-        default: break;
-        }
+        emit_reasoning_delta(out, window_);
     } else if (mode_ == StreamMode::CONTENT && !window_.empty()) {
         // Zero-argument Laguna calls in the stripped form are just the bare
         // declared tool name at end of output (the <tool_call> wrapper is
@@ -675,23 +711,7 @@ std::vector<std::string> SseEmitter::emit_finish(int completion_tokens,
                     }
                     if (!reasoning.empty()) {
                         reasoning_text_ += reasoning;
-                        if (format_ == ApiFormat::OPENAI_CHAT) {
-                            out.push_back(format_openai_delta({{"reasoning_content", reasoning}}));
-                        } else if (format_ == ApiFormat::ANTHROPIC) {
-                            if (active_kind_ != "thinking") {
-                                out.push_back(sse_event("content_block_stop",
-                                    json({{"type", "content_block_stop"}, {"index", block_index_}}).dump()));
-                                block_index_++;
-                                active_kind_ = "thinking";
-                                json new_block = {{"type", "thinking"}, {"thinking", ""}};
-                                out.push_back(sse_event("content_block_start",
-                                    json({{"type", "content_block_start"}, {"index", block_index_},
-                                          {"content_block", new_block}}).dump()));
-                            }
-                            out.push_back(sse_event("content_block_delta",
-                                json({{"type", "content_block_delta"}, {"index", block_index_},
-                                      {"delta", {{"type", "thinking_delta"}, {"thinking", reasoning}}}}).dump()));
-                        }
+                        emit_reasoning_delta(out, reasoning);
                     }
                     if (!content.empty()) {
                         accumulated_content_ += content;
@@ -699,23 +719,7 @@ std::vector<std::string> SseEmitter::emit_finish(int completion_tokens,
                     }
                 } else if (tool_from_reasoning_) {
                     reasoning_text_ += parsed.cleaned_text;
-                    if (format_ == ApiFormat::OPENAI_CHAT) {
-                        out.push_back(format_openai_delta({{"reasoning_content", parsed.cleaned_text}}));
-                    } else if (format_ == ApiFormat::ANTHROPIC) {
-                        if (active_kind_ != "thinking") {
-                            out.push_back(sse_event("content_block_stop",
-                                json({{"type", "content_block_stop"}, {"index", block_index_}}).dump()));
-                            block_index_++;
-                            active_kind_ = "thinking";
-                            json new_block = {{"type", "thinking"}, {"thinking", ""}};
-                            out.push_back(sse_event("content_block_start",
-                                json({{"type", "content_block_start"}, {"index", block_index_},
-                                      {"content_block", new_block}}).dump()));
-                        }
-                        out.push_back(sse_event("content_block_delta",
-                            json({{"type", "content_block_delta"}, {"index", block_index_},
-                                  {"delta", {{"type", "thinking_delta"}, {"thinking", parsed.cleaned_text}}}}).dump()));
-                    }
+                    emit_reasoning_delta(out, parsed.cleaned_text);
                 } else {
                     accumulated_content_ += parsed.cleaned_text;
                     emit_content_delta(out, parsed.cleaned_text);
@@ -807,11 +811,25 @@ std::vector<std::string> SseEmitter::emit_finish(int completion_tokens,
             emit_content_delta(out, tool_buffer_);
         } else {
             // Tool syntax was detected but no valid call parsed. Do not leak
-            // malformed/incomplete XML back to the user as assistant text.
+            // malformed/incomplete XML back to the user or reasoning channel.
             std::fprintf(stderr,
                 "[server] tool_call parse failed; suppressing buffered tool text "
                 "request_id=%s format=%d bytes=%zu\n",
                 request_id_.c_str(), (int)format_, tool_buffer_.size());
+
+            if (tool_from_reasoning_) {
+                size_t think_close = find_top_level_think_close(tool_buffer_, tools_);
+                if (think_close != std::string::npos) {
+                    std::string content = tool_buffer_.substr(think_close + THINK_CLOSE_LEN);
+                    if (!content.empty()) {
+                        if (first_content_token_index_ == -1) {
+                            first_content_token_index_ = std::max(0, emit_token_count_ - 1);
+                        }
+                        accumulated_content_ += content;
+                        emit_content_delta(out, content);
+                    }
+                }
+            }
         }
     }
 

--- a/server/src/server/sse_emitter.cpp
+++ b/server/src/server/sse_emitter.cpp
@@ -547,77 +547,89 @@ void SseEmitter::emit_reasoning_delta(std::vector<std::string> & out,
 // ─── find_top_level_think_close ─────────────────────────────────────────
 
 static size_t find_top_level_think_close(const std::string & buf, const json & tools) {
-    static const char * const STANDARD_TOOL_CLOSES[] = {
-        "</tool_call>", "</function_call>", "</function_calls>", "</function calls>",
-        "</function>", "</funcname>", "</parameter>", "</parameters>", "</tool_code>",
-        "</invoke>", "</arguments>", "</params>"
-    };
+    bool in_single_quote = false;
+    bool in_double_quote = false;
+    std::vector<std::string> open_tags;
 
-    std::vector<std::string> close_tags;
-    for (const char * tag : STANDARD_TOOL_CLOSES) {
-        close_tags.push_back(tag);
-    }
-    if (tools.is_array()) {
-        for (const auto & t : tools) {
-            const auto & fn = t.contains("function") ? t["function"] : t;
-            if (fn.is_object()) {
-                std::string name = fn.value("name", "");
-                if (!name.empty()) {
-                    close_tags.push_back("</" + name + ">");
+    auto is_tool_tag = [&](const std::string & name) {
+        if (name == "tool_call" || name == "function_call" ||
+            name == "function_calls" || name == "function" ||
+            name == "invoke" || name == "parameter" || name == "param" ||
+            name == "arguments" || name == "params" || name == "tool_code" ||
+            name == "funcname") {
+            return true;
+        }
+        if (tools.is_array()) {
+            for (const auto & t : tools) {
+                const auto & fn = t.contains("function") ? t["function"] : t;
+                if (fn.is_object() && fn.value("name", "") == name) {
+                    return true;
                 }
             }
         }
-    }
+        return false;
+    };
 
-    // Find the end of the last verified tool envelope closing tag
-    size_t last_tool_close_end = 0;
-    for (const auto & tag : close_tags) {
-        size_t pos = buf.find(tag);
-        while (pos != std::string::npos) {
-            last_tool_close_end = std::max(last_tool_close_end, pos + tag.size());
-            pos = buf.find(tag, pos + tag.size());
+    for (size_t i = 0; i < buf.size(); ) {
+        if (buf[i] == '\\' && i + 1 < buf.size()) {
+            i += 2;
+            continue;
         }
-    }
+        if (buf[i] == '\'' && !in_double_quote) {
+            in_single_quote = !in_single_quote;
+            i++;
+            continue;
+        }
+        if (buf[i] == '"' && !in_single_quote) {
+            in_double_quote = !in_double_quote;
+            i++;
+            continue;
+        }
 
-    if (last_tool_close_end > 0) {
-        return buf.find(THINK_CLOSE, last_tool_close_end);
-    }
+        if (!in_single_quote && !in_double_quote && buf[i] == '<') {
+            // Check for </think>
+            if (buf.compare(i, THINK_CLOSE_LEN, THINK_CLOSE) == 0) {
+                // If not inside any active unclosed tool tags, this is top-level
+                if (open_tags.empty()) {
+                    return i;
+                }
+            }
 
-    // No tool closing tag was found. Check each </think> candidate to ensure
-    // it is not inside an unclosed quote, XML attribute, or parameter body.
-    size_t cursor = 0;
-    while ((cursor = buf.find(THINK_CLOSE, cursor)) != std::string::npos) {
-        // Check quotes before cursor
-        bool in_single_quote = false;
-        bool in_double_quote = false;
-        for (size_t i = 0; i < cursor; i++) {
-            if (buf[i] == '\\' && i + 1 < cursor) {
-                i++;
+            // Check for closing tag </tag_name>
+            if (i + 1 < buf.size() && buf[i + 1] == '/') {
+                size_t close_bracket = buf.find('>', i + 2);
+                if (close_bracket != std::string::npos) {
+                    std::string raw_name = buf.substr(i + 2, close_bracket - (i + 2));
+                    size_t first = raw_name.find_first_not_of(" \t\r\n");
+                    size_t last = raw_name.find_last_not_of(" \t\r\n");
+                    std::string tag_name = (first == std::string::npos) ? "" : raw_name.substr(first, last - first + 1);
+                    for (int idx = (int)open_tags.size() - 1; idx >= 0; --idx) {
+                        if (open_tags[idx] == tag_name) {
+                            open_tags.resize(idx);
+                            break;
+                        }
+                    }
+                    i = close_bracket + 1;
+                    continue;
+                }
+            }
+
+            // Check for opening tag <tag_name ...>
+            size_t close_bracket = buf.find('>', i + 1);
+            if (close_bracket != std::string::npos) {
+                std::string tag_content = buf.substr(i + 1, close_bracket - (i + 1));
+                size_t ws_pos = tag_content.find_first_of(" \t\r\n=");
+                std::string tag_name = (ws_pos == std::string::npos) ? tag_content : tag_content.substr(0, ws_pos);
+                if (is_tool_tag(tag_name)) {
+                    if (!tag_content.empty() && tag_content.back() != '/') {
+                        open_tags.push_back(tag_name);
+                    }
+                }
+                i = close_bracket + 1;
                 continue;
             }
-            if (buf[i] == '\'' && !in_double_quote) in_single_quote = !in_single_quote;
-            else if (buf[i] == '"' && !in_single_quote) in_double_quote = !in_double_quote;
         }
-        if (in_single_quote || in_double_quote) {
-            cursor += THINK_CLOSE_LEN;
-            continue;
-        }
-
-        // Check if remaining suffix contains leftover XML closing tags
-        std::string suffix = buf.substr(cursor + THINK_CLOSE_LEN);
-        bool has_leftover_close = false;
-        for (const auto & tag : close_tags) {
-            if (suffix.find(tag) != std::string::npos) {
-                has_leftover_close = true;
-                break;
-            }
-        }
-        if (has_leftover_close) {
-            cursor += THINK_CLOSE_LEN;
-            continue;
-        }
-
-        return cursor;
+        i++;
     }
 
     return std::string::npos;

--- a/server/src/server/sse_emitter.cpp
+++ b/server/src/server/sse_emitter.cpp
@@ -551,6 +551,11 @@ static size_t find_top_level_think_close(const std::string & buf, const json & t
     bool in_double_quote = false;
     std::vector<std::string> open_tags;
 
+    auto is_word_char = [](char c) {
+        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+               (c >= '0' && c <= '9') || c == '_';
+    };
+
     auto is_tool_tag = [&](const std::string & name) {
         if (name == "tool_call" || name == "function_call" ||
             name == "function_calls" || name == "function" ||
@@ -576,7 +581,12 @@ static size_t find_top_level_think_close(const std::string & buf, const json & t
             continue;
         }
         if (buf[i] == '\'' && !in_double_quote) {
-            in_single_quote = !in_single_quote;
+            const bool apostrophe_in_word =
+                i > 0 && i + 1 < buf.size() &&
+                is_word_char(buf[i - 1]) && is_word_char(buf[i + 1]);
+            if (!apostrophe_in_word) {
+                in_single_quote = !in_single_quote;
+            }
             i++;
             continue;
         }

--- a/server/src/server/sse_emitter.cpp
+++ b/server/src/server/sse_emitter.cpp
@@ -639,7 +639,8 @@ static size_t find_top_level_think_close(const std::string & buf, const json & t
 
 std::vector<std::string> SseEmitter::emit_finish(int completion_tokens,
                                                  const GenTimings * timings,
-                                                 int generation_cap) {
+                                                 int generation_cap,
+                                                 bool ended_on_eos) {
     std::vector<std::string> out;
 
     // A tail still pending at end-of-stream is a genuinely truncated
@@ -657,31 +658,31 @@ std::vector<std::string> SseEmitter::emit_finish(int completion_tokens,
         emit_reasoning_delta(out, window_);
     } else if (mode_ == StreamMode::CONTENT && !window_.empty()) {
         // Zero-argument Laguna calls in the stripped form are just the bare
-        // declared tool name at end of output (the <tool_call> wrapper is
-        // special tokens the detokenizer removed, and with no <arg_key> there
-        // is no trigger). If the output ENDS on exactly a declared tool name,
-        // treat it as a zero-arg call instead of trailing prose.
+        // declared tool name (the <tool_call> wrapper is special tokens the
+        // detokenizer removed, and with no <arg_key> there is no trigger).
+        // Only accept a tool-only content section: matching the final word of
+        // ordinary prose would turn text such as "I cannot read" into a call.
         bool zero_arg_call = false;
-        if (has_request_tools(tools_)) {
-            auto is_ident = [](char c) {
-                return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
-                       (c >= '0' && c <= '9') || c == '_' || c == '-';
-            };
-            size_t name_start = window_.size();
-            while (name_start > 0 && is_ident(window_[name_start - 1])) name_start--;
-            const std::string tail = window_.substr(name_start);
-            if (!tail.empty()) {
+        const char * ws = " \t\r\n";
+        const bool prior_content_is_whitespace =
+            accumulated_content_.find_first_not_of(ws) == std::string::npos;
+        const size_t name_start = window_.find_first_not_of(ws);
+        if (has_request_tools(tools_) && prior_content_is_whitespace &&
+            name_start != std::string::npos) {
+            const size_t name_end = window_.find_last_not_of(ws);
+            const std::string candidate =
+                window_.substr(name_start, name_end - name_start + 1);
+            if (!candidate.empty()) {
                 for (const auto & t : tools_) {
-                    if (t.contains("function") && t["function"].value("name", "") == tail) {
-                        std::string pre = window_.substr(0, name_start);
-                        if (!pre.empty()) {
-                            accumulated_content_ += pre;
-                            emit_content_delta(out, pre);
-                        }
+                    const auto & fn = t.contains("function")
+                        ? t["function"] : t;
+                    if (fn.is_object() &&
+                        fn.value("name", "") == candidate) {
                         // Re-wrap in the canonical form the parser's wrapped
                         // path accepts (it emits name-only bodies as
                         // zero-argument calls).
-                        tool_buffer_ = "<tool_call>" + tail + "</tool_call>";
+                        tool_buffer_ =
+                            "<tool_call>" + candidate + "</tool_call>";
                         mode_ = StreamMode::TOOL_BUFFER;
                         zero_arg_call = true;
                         break;
@@ -845,7 +846,8 @@ std::vector<std::string> SseEmitter::emit_finish(int completion_tokens,
         }
     }
 
-    if (fr == "stop" && !stop_hit_ && generation_cap >= 0 && completion_tokens >= generation_cap) {
+    if (fr == "stop" && !stop_hit_ && !ended_on_eos &&
+        generation_cap >= 0 && completion_tokens >= generation_cap) {
         fr = "length";
     }
     finish_reason_ = fr;

--- a/server/src/server/sse_emitter.h
+++ b/server/src/server/sse_emitter.h
@@ -86,10 +86,12 @@ public:
     // usage chunk; Anthropic: message_delta usage; Responses:
     // response.completed usage). Pass nullptr to suppress, matching
     // the pre-timings API for unit tests that don't exercise that
-    // shape.
+    // shape. ended_on_eos keeps EOS-at-cap completions classified as "stop"
+    // instead of "length".
     std::vector<std::string> emit_finish(int completion_tokens,
                                          const GenTimings * timings = nullptr,
-                                         int generation_cap = -1);
+                                         int generation_cap = -1,
+                                         bool ended_on_eos = false);
 
     // Get the finish_reason for non-streaming responses.
     std::string finish_reason() const;

--- a/server/src/server/sse_emitter.h
+++ b/server/src/server/sse_emitter.h
@@ -146,6 +146,9 @@ private:
     // Emit a content delta (format-specific).
     void emit_content_delta(std::vector<std::string> & out, const std::string & text);
 
+    // Emit a reasoning/thinking delta (format-specific).
+    void emit_reasoning_delta(std::vector<std::string> & out, const std::string & text);
+
     // SSE data line
     static std::string sse_data(const std::string & json_str);
     static std::string sse_event(const std::string & type, const std::string & json_str);

--- a/server/src/server/tool_parser.cpp
+++ b/server/src/server/tool_parser.cpp
@@ -420,6 +420,56 @@ static size_t balanced_braces_end(const std::string & text, size_t open) {
     return std::string::npos;
 }
 
+// Preserve syntax-error forwarding only for bodies that still have the
+// structure of a JSON object. A pair of braces around prose is not enough to
+// identify tool arguments.
+static bool looks_like_malformed_json_object(const std::string & text) {
+    if (text.size() < 2 || text.front() != '{' || text.back() != '}' ||
+        balanced_braces_end(text, 0) != text.size()) {
+        return false;
+    }
+
+    auto is_object_ws = [](char c) {
+        return c == ' ' || c == '\t' || c == '\n' || c == '\r';
+    };
+
+    size_t i = 1;
+    while (i < text.size() && is_object_ws(text[i])) i++;
+    if (i >= text.size() - 1) return false;
+
+    const char first = text[i];
+    if (first == '"' || first == '\'' || first == '`') {
+        const char quote = first;
+        bool closed = false;
+        for (i++; i < text.size() - 1; i++) {
+            if (text[i] == '\\' && i + 1 < text.size() - 1) {
+                i++;
+                continue;
+            }
+            if (text[i] == quote) {
+                i++;
+                closed = true;
+                break;
+            }
+        }
+        if (!closed) return false;
+    } else {
+        auto is_ident_start = [](char c) {
+            return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+                   c == '_';
+        };
+        auto is_ident_continue = [&](char c) {
+            return is_ident_start(c) || (c >= '0' && c <= '9') ||
+                   c == '.' || c == '-';
+        };
+        if (!is_ident_start(first)) return false;
+        while (i < text.size() - 1 && is_ident_continue(text[i])) i++;
+    }
+
+    while (i < text.size() - 1 && is_object_ws(text[i])) i++;
+    return i < text.size() - 1 && text[i] == ':';
+}
+
 // Try strict json::parse first; on failure rewrite single- and
 // backtick-quoted strings to double-quoted, wrap bare identifier keys
 // in double quotes, and retry. Returns true and populates `out` on
@@ -876,6 +926,21 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
     std::vector<Span> removals;
     std::vector<std::pair<size_t, ToolCall>> positioned_calls;
 
+    // JSON lines may be siblings of invoke envelopes, but JSON nested inside
+    // an invoke always belongs to that envelope. Track all invoke spans,
+    // including malformed or disallowed ones, so no later JSON sweep can
+    // reinterpret their bodies as independent calls.
+    static const std::regex re_invoke_span(
+        R"(<invoke(?:\s[^>]*)?>[\s\S]*?</invoke\s*>)");
+    std::vector<Span> invoke_spans;
+    auto invoke_begin = std::sregex_iterator(
+        text.begin(), text.end(), re_invoke_span);
+    auto invoke_end = std::sregex_iterator();
+    for (auto it = invoke_begin; it != invoke_end; ++it) {
+        const size_t start = it->position();
+        invoke_spans.push_back({start, start + it->length()});
+    }
+
     auto add_call = [&](const std::string & fn_name, const json & args,
                         size_t start, size_t end,
                         const std::string & raw_args = "") {
@@ -1273,7 +1338,7 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
                             }
                         }
                         raw_args = args.dump();
-                    } else if (body.back() == '}') {
+                    } else if (looks_like_malformed_json_object(body)) {
                         raw_args = body;
                     } else {
                         continue;
@@ -1308,12 +1373,12 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
             while (cursor < block_content.size()) {
                 size_t s = block_content.find('{', cursor);
                 if (s == std::string::npos) break;
-                size_t abs_s = inner_start + s;
+                const size_t abs_s = inner_start + s;
                 bool inside_invoke = false;
-                for (const auto & bc : block_calls) {
-                    if (abs_s >= bc.start && abs_s < bc.end) {
+                for (const auto & span : invoke_spans) {
+                    if (abs_s >= span.start && abs_s < span.end) {
                         inside_invoke = true;
-                        cursor = bc.end - inner_start;
+                        cursor = span.end - inner_start;
                         break;
                     }
                 }
@@ -1408,7 +1473,7 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
         while (cursor < text.size()) {
             size_t start = text.find('{', cursor);
             if (start == std::string::npos) break;
-            if (overlaps(removals, start)) {
+            if (overlaps(removals, start) || overlaps(invoke_spans, start)) {
                 cursor = start + 1;
                 continue;
             }

--- a/server/src/server/tool_parser.cpp
+++ b/server/src/server/tool_parser.cpp
@@ -569,82 +569,59 @@ static bool parse_complete_parameter_body(const std::string & body,
 
 // ─── JSON tool call parser ──────────────────────────────────────────────
 
+static bool parse_arg_string_or_obj(const json & val, json & out_args,
+                                    std::string & out_raw_args) {
+    if (val.is_object()) {
+        out_args = val;
+        out_raw_args = val.dump();
+        return true;
+    }
+    if (val.is_string()) {
+        out_raw_args = val.get<std::string>();
+        json parsed = json::parse(out_raw_args, nullptr, false);
+        if (!parsed.is_discarded() && parsed.is_object()) {
+            out_args = std::move(parsed);
+        } else {
+            out_args = json::object();
+        }
+        return true;
+    }
+    return false;
+}
+
 // Parse the named JSON tool-call envelopes emitted by supported chat models.
-static bool parse_json_tool_call(const json & obj, std::string & out_name, json & out_args) {
+static bool parse_json_tool_call(const json & obj, std::string & out_name,
+                                 json & out_args, std::string & out_raw_args) {
     if (!obj.is_object()) return false;
 
-    std::string name;
-    json args;
-
     if (obj.contains("name") && obj["name"].is_string()) {
-        name = obj["name"].get<std::string>();
-        if (obj.contains("arguments")) {
-            if (obj["arguments"].is_object()) {
-                args = obj["arguments"];
-            } else if (obj["arguments"].is_string()) {
-                try { args = json::parse(obj["arguments"].get<std::string>()); }
-                catch (...) { return false; }
-            } else {
-                return false;
-            }
-        } else if (obj.contains("parameters")) {
-            if (obj["parameters"].is_object()) {
-                args = obj["parameters"];
-            } else if (obj["parameters"].is_string()) {
-                try { args = json::parse(obj["parameters"].get<std::string>()); }
-                catch (...) { return false; }
-            } else {
-                return false;
-            }
+        out_name = obj["name"].get<std::string>();
+        for (const char * k : {"arguments", "parameters", "args", "params", "input"}) {
+            if (obj.contains(k)) return parse_arg_string_or_obj(obj[k], out_args, out_raw_args);
         }
-    } else if (obj.contains("function") && obj["function"].is_string()) {
-        name = obj["function"].get<std::string>();
-        if (!obj.contains("parameters")) {
-            return false;
-        }
-        if (obj["parameters"].is_object()) {
-            args = obj["parameters"];
-        } else if (obj["parameters"].is_string()) {
-            try { args = json::parse(obj["parameters"].get<std::string>()); }
-            catch (...) { return false; }
-        } else {
-            return false;
-        }
-    } else if ((obj.contains("function") && obj["function"].is_object()) ||
-               (obj.contains("function_call") &&
-                obj["function_call"].is_object())) {
-        const auto & fn = obj.contains("function")
-            ? obj["function"]
-            : obj["function_call"];
-        if (!fn.contains("name") || !fn["name"].is_string()) return false;
-        name = fn["name"].get<std::string>();
-        if (fn.contains("arguments")) {
-            if (fn["arguments"].is_object()) {
-                args = fn["arguments"];
-            } else if (fn["arguments"].is_string()) {
-                try { args = json::parse(fn["arguments"].get<std::string>()); }
-                catch (...) { return false; }
-            } else {
-                return false;
-            }
-        } else if (fn.contains("parameters")) {
-            if (fn["parameters"].is_object()) {
-                args = fn["parameters"];
-            } else if (fn["parameters"].is_string()) {
-                try { args = json::parse(fn["parameters"].get<std::string>()); }
-                catch (...) { return false; }
-            } else {
-                return false;
-            }
-        }
-    } else {
         return false;
     }
 
-    if (name.empty() || !args.is_object()) return false;
-    out_name = name;
-    out_args = args;
-    return true;
+    if (obj.contains("function") && obj["function"].is_string()) {
+        out_name = obj["function"].get<std::string>();
+        for (const char * k : {"parameters", "arguments", "args", "params", "input"}) {
+            if (obj.contains(k)) return parse_arg_string_or_obj(obj[k], out_args, out_raw_args);
+        }
+        return false;
+    }
+
+    for (const char * sub : {"function", "function_call", "tool_call"}) {
+        if (obj.contains(sub) && obj[sub].is_object()) {
+            return parse_json_tool_call(obj[sub], out_name, out_args, out_raw_args);
+        }
+    }
+
+    return false;
+}
+
+static bool parse_json_tool_call(const json & obj, std::string & out_name, json & out_args) {
+    std::string raw;
+    return parse_json_tool_call(obj, out_name, out_args, raw);
 }
 
 static bool is_ws(char c) {
@@ -834,6 +811,25 @@ static bool parse_function_sig_args(const std::string & arg_text, json & out_arg
     return true;
 }
 
+static bool extract_raw_json_tool_fallback(const std::string & text,
+                                           std::string & out_name,
+                                           std::string & out_raw_args) {
+    static const std::regex re_name(R"re("(?:name|function|tool)"\s*:\s*"([A-Za-z_][\w.\-]*)")re");
+    static const std::regex re_args_open(R"re("(?:arguments|parameters|args|params|input)"\s*:\s*\{)re");
+
+    std::smatch mn, ma;
+    if (std::regex_search(text, mn, re_name) && std::regex_search(text, ma, re_args_open)) {
+        out_name = mn[1].str();
+        size_t brace_open = ma.position() + ma.length() - 1;
+        size_t brace_close = balanced_braces_end(text, brace_open);
+        if (brace_close != std::string::npos) {
+            out_raw_args = text.substr(brace_open, brace_close - brace_open);
+            return true;
+        }
+    }
+    return false;
+}
+
 // ─── Main parser ────────────────────────────────────────────────────────
 
 ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
@@ -842,12 +838,13 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
     std::vector<std::pair<size_t, ToolCall>> positioned_calls;
 
     auto add_call = [&](const std::string & fn_name, const json & args,
-                        size_t start, size_t end) {
+                        size_t start, size_t end,
+                        const std::string & raw_args = "") {
         if (!tool_allowed(tools, fn_name)) return;
         ToolCall tc;
         tc.id = generate_call_id();
         tc.name = fn_name;
-        tc.arguments = args.dump();
+        tc.arguments = raw_args.empty() ? args.dump() : raw_args;
         positioned_calls.emplace_back(start, std::move(tc));
         removals.push_back({start, end});
     };
@@ -1158,20 +1155,19 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
             size_t pos = it->position();
             if (overlaps(removals, pos)) continue;
             std::string inner = (*it)[1].str();
-            // trim
             size_t s = inner.find_first_not_of(" \t\n\r");
             if (s != std::string::npos) inner = inner.substr(s);
             size_t e = inner.find_last_not_of(" \t\n\r");
             if (e != std::string::npos) inner = inner.substr(0, e + 1);
-            try {
-                json obj = json::parse(inner);
-                std::string name;
-                json args;
-                if (parse_json_tool_call(obj, name, args)) {
-                    size_t pos = it->position();
-                    add_call(name, args, pos, pos + it->length());
-                }
-            } catch (...) {}
+            json obj = json::parse(inner, nullptr, false);
+            std::string name;
+            json args;
+            std::string raw_args;
+            if (!obj.is_discarded() && parse_json_tool_call(obj, name, args, raw_args)) {
+                add_call(name, args, pos, pos + it->length(), raw_args);
+            } else if (extract_raw_json_tool_fallback(inner, name, raw_args)) {
+                add_call(name, json::object(), pos, pos + it->length(), raw_args);
+            }
         }
     }
 
@@ -1183,24 +1179,23 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
             size_t pos = it->position();
             if (overlaps(removals, pos)) continue;
             std::string inner = (*it)[1].str();
-            // trim
             size_t s = inner.find_first_not_of(" \t\n\r");
             if (s != std::string::npos) inner = inner.substr(s);
             size_t e = inner.find_last_not_of(" \t\n\r");
             if (e != std::string::npos) inner = inner.substr(0, e + 1);
-            try {
-                json obj = json::parse(inner);
-                std::string name;
-                json args;
-                if (parse_json_tool_call(obj, name, args)) {
-                    size_t pos = it->position();
-                    add_call(name, args, pos, pos + it->length());
-                }
-            } catch (...) {}
+            json obj = json::parse(inner, nullptr, false);
+            std::string name;
+            json args;
+            std::string raw_args;
+            if (!obj.is_discarded() && parse_json_tool_call(obj, name, args, raw_args)) {
+                add_call(name, args, pos, pos + it->length(), raw_args);
+            } else if (extract_raw_json_tool_fallback(inner, name, raw_args)) {
+                add_call(name, json::object(), pos, pos + it->length(), raw_args);
+            }
         }
     }
 
-    // Pattern 4d: <function_calls><invoke name="NAME">...<param name="K">V</param>...</invoke></function_calls>
+    // Pattern 4d: <function_calls> containing <invoke> blocks or JSON lines
     {
         static const std::regex re_block(R"(<function_calls>([\s\S]*?)</function_calls>)");
         static const std::regex re_invoke(R"(<invoke\s+(?:name|tool)\s*=\s*["']?([A-Za-z_][\w.\-]*)["']?\s*>([\s\S]*?)</invoke>)");
@@ -1214,29 +1209,40 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
             if (overlaps(removals, bstart)) continue;
 
             std::string block_content = (*fit)[1].str();
+            size_t inner_start = fit->position(1);
+            struct CallMatch { std::string name; json args; std::string raw_args; size_t start, end; };
+            std::vector<CallMatch> block_calls;
+
+            // 1. Try <invoke> tags
             auto begin = std::sregex_iterator(block_content.begin(), block_content.end(), re_invoke);
             auto end = std::sregex_iterator();
-            std::vector<std::pair<std::string, json>> block_calls;
-
             for (auto it = begin; it != end; ++it) {
                 std::string fn_name = (*it)[1].str();
                 if (!tool_allowed(tools, fn_name)) continue;
                 std::string body = trim_ws((*it)[2].str());
                 json args = json::object();
+                std::string raw_args;
                 if (!body.empty() && body.front() == '{') {
-                    json raw_args = json::parse(body, nullptr, false);
-                    if (raw_args.is_discarded() || !raw_args.is_object()) continue;
-                    json props = find_tool_properties(tools, fn_name);
-                    for (auto & [k, v] : raw_args.items()) {
-                        if (v.is_string()) {
-                            args[k] = convert_param_value(v.get<std::string>(), k, props);
-                        } else {
-                            args[k] = v;
+                    json raw_json = json::parse(body, nullptr, false);
+                    if (!raw_json.is_discarded() && raw_json.is_object()) {
+                        json props = find_tool_properties(tools, fn_name);
+                        for (auto & [k, v] : raw_json.items()) {
+                            if (v.is_string()) {
+                                args[k] = convert_param_value(v.get<std::string>(), k, props);
+                            } else {
+                                args[k] = v;
+                            }
                         }
+                        raw_args = args.dump();
+                    } else if (body.back() == '}') {
+                        raw_args = body;
+                    } else {
+                        continue;
                     }
                 } else {
                     size_t cursor = 0;
                     bool valid_body = true;
+                    bool found_param = false;
                     auto pbegin = std::sregex_iterator(body.begin(), body.end(), re_param);
                     auto pend = std::sregex_iterator();
                     for (auto pit = pbegin; pit != pend; ++pit) {
@@ -1246,21 +1252,62 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
                         if (args.contains(k)) { valid_body = false; break; }
                         std::string v = trim_ws((*pit)[3].str());
                         args[k] = convert_param_value(v, k, find_tool_properties(tools, fn_name));
+                        found_param = true;
                         cursor = ppos + pit->length();
                     }
-                    if (!valid_body || (!args.empty() && !trim_ws(body.substr(cursor)).empty())) continue;
+                    if (!valid_body || !found_param || !trim_ws(body.substr(cursor)).empty()) continue;
                 }
-                block_calls.push_back({fn_name, std::move(args)});
+                size_t istart = inner_start + it->position();
+                size_t iend = istart + it->length();
+                block_calls.push_back({fn_name, std::move(args), raw_args, istart, iend});
+            }
+
+            // 2. If no <invoke> tags matched, try JSON lines
+            if (block_calls.empty()) {
+                size_t cursor = 0;
+                while (cursor < block_content.size()) {
+                    size_t s = block_content.find('{', cursor);
+                    if (s == std::string::npos) break;
+                    size_t e = balanced_braces_end(block_content, s);
+                    if (e == std::string::npos) { cursor = s + 1; continue; }
+                    std::string jstr = block_content.substr(s, e - s);
+                    json obj = json::parse(jstr, nullptr, false);
+                    std::string name;
+                    json args;
+                    std::string raw;
+                    if (!obj.is_discarded() && parse_json_tool_call(obj, name, args, raw) && tool_allowed(tools, name)) {
+                        block_calls.push_back({name, std::move(args), raw, inner_start + s, inner_start + e});
+                    }
+                    cursor = e;
+                }
             }
 
             if (!block_calls.empty()) {
-                for (auto & bc : block_calls) {
-                    add_call(bc.first, bc.second, bstart, bend);
+                // If the block contains only whitespace around the calls, remove the whole block
+                bool clean_block = true;
+                size_t last_end = 0;
+                for (const auto & bc : block_calls) {
+                    size_t rel_start = bc.start - inner_start;
+                    if (!trim_ws(block_content.substr(last_end, rel_start - last_end)).empty()) {
+                        clean_block = false;
+                        break;
+                    }
+                    last_end = bc.end - inner_start;
+                }
+                if (!trim_ws(block_content.substr(last_end)).empty()) clean_block = false;
+
+                if (clean_block) {
+                    for (auto & bc : block_calls) {
+                        add_call(bc.name, bc.args, bstart, bend, bc.raw_args);
+                    }
+                } else {
+                    for (auto & bc : block_calls) {
+                        add_call(bc.name, bc.args, bc.start, bc.end, bc.raw_args);
+                    }
                 }
             }
         }
     }
-
 
     // Pattern 5: call:<ns>?<verb>{relaxed-JSON args}
     //
@@ -1337,14 +1384,22 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
             std::string json_str = text.substr(start, end_pos - start);
             json obj2 = json::parse(json_str, nullptr, false);
             if (obj2.is_discarded()) {
+                std::string name;
+                std::string raw_args;
+                if (extract_raw_json_tool_fallback(json_str, name, raw_args) && tool_allowed(tools, name)) {
+                    add_call(name, json::object(), start, end_pos, raw_args);
+                    cursor = end_pos;
+                    continue;
+                }
                 cursor = start + 1;
                 continue;
             }
 
             std::string name;
             json args;
-            if (parse_json_tool_call(obj2, name, args)) {
-                add_call(name, args, start, end_pos);
+            std::string raw_args;
+            if (parse_json_tool_call(obj2, name, args, raw_args)) {
+                add_call(name, args, start, end_pos, raw_args);
             } else if (span_covers_non_ws(text, start, end_pos) &&
                        parse_single_tool_arg_object(obj2, tools, name, args)) {
                 add_call(name, args, start, end_pos);

--- a/server/src/server/tool_parser.cpp
+++ b/server/src/server/tool_parser.cpp
@@ -637,8 +637,9 @@ static bool parse_arg_string_or_obj(const json & val, json & out_args,
             }
             return false;  // reject valid scalar, array, or boolean arguments string
         }
-        // Discarded JSON: check if it has { ... } shape for syntax error tolerance (e.g. {"offset": 5o1})
-        if (!trimmed.empty() && trimmed.front() == '{' && trimmed.back() == '}') {
+        // Preserve object-shaped syntax errors (for example 5o1), but do not
+        // promote an arbitrary scalar string merely because it has braces.
+        if (looks_like_malformed_json_object(trimmed)) {
             out_args = json::object();
             return true;
         }

--- a/server/src/server/tool_parser.cpp
+++ b/server/src/server/tool_parser.cpp
@@ -622,7 +622,10 @@ static bool parse_json_tool_call(const json & obj, std::string & out_name,
 
     for (const char * sub : {"function", "function_call", "tool_call"}) {
         if (obj.contains(sub) && obj[sub].is_object()) {
-            return parse_json_tool_call(obj[sub], out_name, out_args, out_raw_args);
+            if (parse_json_tool_call(
+                    obj[sub], out_name, out_args, out_raw_args)) {
+                return true;
+            }
         }
     }
 
@@ -824,37 +827,43 @@ static bool parse_function_sig_args(const std::string & arg_text, json & out_arg
 static bool extract_raw_json_tool_fallback(const std::string & text,
                                            std::string & out_name,
                                            std::string & out_raw_args) {
-    static const std::regex re_name(R"re("(?:name|function|tool)"\s*:\s*"([A-Za-z_][\w.\-]*)")re");
-    static const std::regex re_args_open(R"re("(?:arguments|parameters|args|params|input)"\s*:\s*\{)re");
+    static const std::regex re_args_open(
+        R"re("(?:arguments|parameters|args|params|input)"\s*:\s*\{)re");
+    static const char marker_key[] = "__lucebox_raw_args_marker__";
+    static const std::string marker_object =
+        std::string("{\"") + marker_key + "\":true}";
 
-    std::smatch ma;
-    if (!std::regex_search(text, ma, re_args_open)) return false;
+    // The compatibility case is malformed JSON *inside* an otherwise valid
+    // arguments object (for example 5o1 instead of 501). Replace each
+    // candidate with a marker object and let the normal structural parser
+    // select the envelope and tool name. Requiring that same marker in the
+    // selected call prevents pairing arguments from one object with the name
+    // from another, while preserving the exact malformed arguments for the
+    // client to report back to the model.
+    auto begin = std::sregex_iterator(text.begin(), text.end(), re_args_open);
+    auto end = std::sregex_iterator();
+    for (auto it = begin; it != end; ++it) {
+        const size_t brace_open = it->position() + it->length() - 1;
+        const size_t brace_close = balanced_braces_end(text, brace_open);
+        if (brace_close == std::string::npos) continue;
 
-    size_t brace_open = ma.position() + ma.length() - 1;
-    size_t brace_close = balanced_braces_end(text, brace_open);
-    if (brace_close == std::string::npos) return false;
+        std::string repaired = text;
+        repaired.replace(
+            brace_open, brace_close - brace_open, marker_object);
+        json obj = json::parse(repaired, nullptr, false);
+        if (obj.is_discarded()) continue;
 
-    // Isolate text outside the arguments object span so nested property "name" inside arguments is ignored
-    std::string prefix = text.substr(0, ma.position());
-    std::string suffix = text.substr(brace_close);
-
-    bool found_name = false;
-    auto pbegin = std::sregex_iterator(prefix.begin(), prefix.end(), re_name);
-    auto pend = std::sregex_iterator();
-    for (auto it = pbegin; it != pend; ++it) {
-        out_name = (*it)[1].str();
-        found_name = true;
-    }
-    if (!found_name) {
-        std::smatch mn;
-        if (std::regex_search(suffix, mn, re_name)) {
-            out_name = mn[1].str();
-            found_name = true;
+        std::string name;
+        json args;
+        if (!parse_json_tool_call(obj, name, args)) continue;
+        if (!args.is_object() || args.size() != 1 ||
+            !args.value(marker_key, false)) {
+            continue;
         }
-    }
 
-    if (found_name && !out_name.empty()) {
-        out_raw_args = text.substr(brace_open, brace_close - brace_open);
+        out_name = std::move(name);
+        out_raw_args = text.substr(
+            brace_open, brace_close - brace_open);
         return true;
     }
     return false;

--- a/server/src/server/tool_parser.cpp
+++ b/server/src/server/tool_parser.cpp
@@ -1285,7 +1285,9 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
                         found_param = true;
                         cursor = ppos + pit->length();
                     }
-                    if (!valid_body || !found_param || !trim_ws(body.substr(cursor)).empty()) continue;
+                    if (!valid_body) continue;
+                    if (!found_param && !trim_ws(body).empty()) continue;
+                    if (!trim_ws(body.substr(cursor)).empty()) continue;
                 }
                 size_t istart = inner_start + it->position();
                 size_t iend = istart + it->length();

--- a/server/src/server/tool_parser.cpp
+++ b/server/src/server/tool_parser.cpp
@@ -578,13 +578,21 @@ static bool parse_arg_string_or_obj(const json & val, json & out_args,
     }
     if (val.is_string()) {
         out_raw_args = val.get<std::string>();
+        std::string trimmed = trim_ws(out_raw_args);
         json parsed = json::parse(out_raw_args, nullptr, false);
-        if (!parsed.is_discarded() && parsed.is_object()) {
-            out_args = std::move(parsed);
-        } else {
-            out_args = json::object();
+        if (!parsed.is_discarded()) {
+            if (parsed.is_object()) {
+                out_args = std::move(parsed);
+                return true;
+            }
+            return false;  // reject valid scalar, array, or boolean arguments string
         }
-        return true;
+        // Discarded JSON: check if it has { ... } shape for syntax error tolerance (e.g. {"offset": 5o1})
+        if (!trimmed.empty() && trimmed.front() == '{' && trimmed.back() == '}') {
+            out_args = json::object();
+            return true;
+        }
+        return false;
     }
     return false;
 }
@@ -596,6 +604,7 @@ static bool parse_json_tool_call(const json & obj, std::string & out_name,
 
     if (obj.contains("name") && obj["name"].is_string()) {
         out_name = obj["name"].get<std::string>();
+        if (out_name.empty()) return false;
         for (const char * k : {"arguments", "parameters", "args", "params", "input"}) {
             if (obj.contains(k)) return parse_arg_string_or_obj(obj[k], out_args, out_raw_args);
         }
@@ -604,6 +613,7 @@ static bool parse_json_tool_call(const json & obj, std::string & out_name,
 
     if (obj.contains("function") && obj["function"].is_string()) {
         out_name = obj["function"].get<std::string>();
+        if (out_name.empty()) return false;
         for (const char * k : {"parameters", "arguments", "args", "params", "input"}) {
             if (obj.contains(k)) return parse_arg_string_or_obj(obj[k], out_args, out_raw_args);
         }
@@ -817,15 +827,35 @@ static bool extract_raw_json_tool_fallback(const std::string & text,
     static const std::regex re_name(R"re("(?:name|function|tool)"\s*:\s*"([A-Za-z_][\w.\-]*)")re");
     static const std::regex re_args_open(R"re("(?:arguments|parameters|args|params|input)"\s*:\s*\{)re");
 
-    std::smatch mn, ma;
-    if (std::regex_search(text, mn, re_name) && std::regex_search(text, ma, re_args_open)) {
-        out_name = mn[1].str();
-        size_t brace_open = ma.position() + ma.length() - 1;
-        size_t brace_close = balanced_braces_end(text, brace_open);
-        if (brace_close != std::string::npos) {
-            out_raw_args = text.substr(brace_open, brace_close - brace_open);
-            return true;
+    std::smatch ma;
+    if (!std::regex_search(text, ma, re_args_open)) return false;
+
+    size_t brace_open = ma.position() + ma.length() - 1;
+    size_t brace_close = balanced_braces_end(text, brace_open);
+    if (brace_close == std::string::npos) return false;
+
+    // Isolate text outside the arguments object span so nested property "name" inside arguments is ignored
+    std::string prefix = text.substr(0, ma.position());
+    std::string suffix = text.substr(brace_close);
+
+    bool found_name = false;
+    auto pbegin = std::sregex_iterator(prefix.begin(), prefix.end(), re_name);
+    auto pend = std::sregex_iterator();
+    for (auto it = pbegin; it != pend; ++it) {
+        out_name = (*it)[1].str();
+        found_name = true;
+    }
+    if (!found_name) {
+        std::smatch mn;
+        if (std::regex_search(suffix, mn, re_name)) {
+            out_name = mn[1].str();
+            found_name = true;
         }
+    }
+
+    if (found_name && !out_name.empty()) {
+        out_raw_args = text.substr(brace_open, brace_close - brace_open);
+        return true;
     }
     return false;
 }
@@ -1262,27 +1292,41 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
                 block_calls.push_back({fn_name, std::move(args), raw_args, istart, iend});
             }
 
-            // 2. If no <invoke> tags matched, try JSON lines
-            if (block_calls.empty()) {
-                size_t cursor = 0;
-                while (cursor < block_content.size()) {
-                    size_t s = block_content.find('{', cursor);
-                    if (s == std::string::npos) break;
-                    size_t e = balanced_braces_end(block_content, s);
-                    if (e == std::string::npos) { cursor = s + 1; continue; }
-                    std::string jstr = block_content.substr(s, e - s);
-                    json obj = json::parse(jstr, nullptr, false);
-                    std::string name;
-                    json args;
-                    std::string raw;
-                    if (!obj.is_discarded() && parse_json_tool_call(obj, name, args, raw) && tool_allowed(tools, name)) {
-                        block_calls.push_back({name, std::move(args), raw, inner_start + s, inner_start + e});
+            // 2. Also scan for JSON objects in spans not covered by <invoke> calls
+            size_t cursor = 0;
+            while (cursor < block_content.size()) {
+                size_t s = block_content.find('{', cursor);
+                if (s == std::string::npos) break;
+                size_t abs_s = inner_start + s;
+                bool inside_invoke = false;
+                for (const auto & bc : block_calls) {
+                    if (abs_s >= bc.start && abs_s < bc.end) {
+                        inside_invoke = true;
+                        cursor = bc.end - inner_start;
+                        break;
                     }
-                    cursor = e;
                 }
+                if (inside_invoke) continue;
+
+                size_t e = balanced_braces_end(block_content, s);
+                if (e == std::string::npos) { cursor = s + 1; continue; }
+                std::string jstr = block_content.substr(s, e - s);
+                json obj = json::parse(jstr, nullptr, false);
+                std::string name;
+                json args;
+                std::string raw;
+                if (!obj.is_discarded() && parse_json_tool_call(obj, name, args, raw) && tool_allowed(tools, name)) {
+                    block_calls.push_back({name, std::move(args), raw, inner_start + s, inner_start + e});
+                } else if (extract_raw_json_tool_fallback(jstr, name, raw) && tool_allowed(tools, name)) {
+                    block_calls.push_back({name, json::object(), raw, inner_start + s, inner_start + e});
+                }
+                cursor = e;
             }
 
             if (!block_calls.empty()) {
+                std::sort(block_calls.begin(), block_calls.end(),
+                          [](const CallMatch & a, const CallMatch & b) { return a.start < b.start; });
+
                 // If the block contains only whitespace around the calls, remove the whole block
                 bool clean_block = true;
                 size_t last_end = 0;

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -6124,6 +6124,53 @@ TEST_CASE(ServerUnitFixture, test_parse_function_calls_sibling_invokes_partial_f
     TEST_ASSERT(result.cleaned_text.find("malformed parameter text") != std::string::npos);
 }
 
+TEST_CASE(ServerUnitFixture, test_parse_function_calls_rejected_invokes_do_not_expose_nested_json) {
+    const std::string disallowed =
+        "<function_calls>"
+        "<invoke name=\"forbidden\">"
+        "{\"name\":\"read\",\"arguments\":{\"path\":\"secret\"}}"
+        "</invoke>"
+        "</function_calls>";
+    auto disallowed_result = parse_tool_calls(disallowed, read_tools());
+    TEST_ASSERT(disallowed_result.tool_calls.empty());
+    TEST_ASSERT(disallowed_result.cleaned_text == disallowed);
+
+    const std::string malformed =
+        "<function_calls>"
+        "<invoke>"
+        "{\"name\":\"read\",\"arguments\":{\"path\":\"secret\"}}"
+        "</invoke>"
+        "</function_calls>";
+    auto malformed_result = parse_tool_calls(malformed, read_tools());
+    TEST_ASSERT(malformed_result.tool_calls.empty());
+    TEST_ASSERT(malformed_result.cleaned_text == malformed);
+}
+
+TEST_CASE(ServerUnitFixture, test_parse_function_calls_invoke_rejects_braced_prose) {
+    const std::string text =
+        "<function_calls>"
+        "<invoke name=\"read\">{this is prose}</invoke>"
+        "</function_calls>";
+
+    auto result = parse_tool_calls(text, read_tools());
+    TEST_ASSERT(result.tool_calls.empty());
+    TEST_ASSERT(result.cleaned_text == text);
+}
+
+TEST_CASE(ServerUnitFixture, test_parse_function_calls_invoke_keeps_structured_json_syntax_errors) {
+    const std::string text =
+        "<function_calls>"
+        "<invoke name=\"read\">{\"offset\":5o1}</invoke>"
+        "</function_calls>";
+
+    auto result = parse_tool_calls(text, read_tools());
+    TEST_ASSERT(result.tool_calls.size() == 1);
+    if (!result.tool_calls.empty()) {
+        TEST_ASSERT(result.tool_calls[0].name == "read");
+        TEST_ASSERT(result.tool_calls[0].arguments == "{\"offset\":5o1}");
+    }
+}
+
 TEST_CASE(ServerUnitFixture, test_parse_json_syntax_error_forwarding) {
     std::string text = "<function_call>{\"name\": \"read\", \"arguments\": {\"offset\": 5o1}}</function_call>";
     auto result = parse_tool_calls(text, read_tools());
@@ -6178,6 +6225,18 @@ TEST_CASE(ServerUnitFixture, test_emitter_streaming_malformed_tool_in_think_reco
     TEST_ASSERT(text.find("\"type\":\"thinking_delta\"") != std::string::npos);
     TEST_ASSERT(text.find("\"type\":\"text_delta\"") != std::string::npos);
     TEST_ASSERT(text.find("Here is the final answer.") != std::string::npos);
+}
+
+TEST_CASE(ServerUnitFixture, test_emitter_streaming_malformed_tool_apostrophe_recovers_answer) {
+    auto em = make_emitter(ApiFormat::OPENAI_CHAT, read_tools(), true);
+    em.emit_start();
+    em.emit_token(
+        "<think>Inspect <tool_call>it's malformed</tool_call></think>Recovered answer.");
+    em.emit_finish(10, nullptr, -1);
+
+    TEST_ASSERT(em.tool_calls().empty());
+    TEST_ASSERT(em.reasoning_text().find("it's malformed") == std::string::npos);
+    TEST_ASSERT(em.accumulated_text() == "Recovered answer.");
 }
 
 TEST_CASE(ServerUnitFixture, test_emitter_streaming_malformed_tool_in_think_without_think_close_suppressed) {

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -6295,6 +6295,82 @@ TEST_CASE(ServerUnitFixture, test_extract_raw_json_tool_fallback_with_nested_nam
     }
 }
 
+TEST_CASE(ServerUnitFixture, test_extract_raw_json_tool_fallback_ignores_nested_metadata_name) {
+    const std::string text =
+        "<function_call>"
+        "{\"function\":{\"name\":\"bash\",\"metadata\":{\"name\":\"read\"},"
+        "\"arguments\":{\"command\":\"pwd\",\"offset\":5o1}}}"
+        "</function_call>";
+
+    auto res = parse_tool_calls(text, read_and_bash_tools());
+    TEST_ASSERT(res.tool_calls.size() == 1);
+    if (!res.tool_calls.empty()) {
+        TEST_ASSERT(res.tool_calls[0].name == "bash");
+        TEST_ASSERT(res.tool_calls[0].arguments.find("5o1") != std::string::npos);
+    }
+}
+
+TEST_CASE(ServerUnitFixture, test_raw_json_fallback_does_not_cross_tool_envelopes) {
+    const std::string text =
+        "{\"metadata\":{\"arguments\":{\"offset\":5o1}},"
+        "\"tool_call\":{\"name\":\"read\",\"arguments\":{\"path\":\"x\"}}}";
+
+    auto res = parse_tool_calls(text, read_and_bash_tools());
+    TEST_ASSERT(res.tool_calls.size() == 1);
+    if (!res.tool_calls.empty()) {
+        TEST_ASSERT(res.tool_calls[0].name == "read");
+        const json args = json::parse(res.tool_calls[0].arguments);
+        TEST_ASSERT(args["path"] == "x");
+        TEST_ASSERT(!args.contains("offset"));
+    }
+}
+
+TEST_CASE(ServerUnitFixture, test_parse_json_tool_call_checks_later_envelope_siblings) {
+    const std::string text =
+        "{\"function\":{\"metadata\":true},"
+        "\"tool_call\":{\"name\":\"read\",\"arguments\":{\"path\":\"x\"}}}";
+
+    auto res = parse_tool_calls(text, read_and_bash_tools());
+    TEST_ASSERT(res.tool_calls.size() == 1);
+    if (!res.tool_calls.empty()) {
+        TEST_ASSERT(res.tool_calls[0].name == "read");
+        TEST_ASSERT(json::parse(res.tool_calls[0].arguments)["path"] == "x");
+    }
+}
+
+TEST_CASE(ServerUnitFixture, test_emitter_prose_ending_in_tool_name_stays_content) {
+    auto em = make_emitter(ApiFormat::OPENAI_CHAT, read_tools());
+    em.emit_start();
+    em.emit_token("I cannot read");
+    em.emit_finish(3);
+
+    TEST_ASSERT(em.tool_calls().empty());
+    TEST_ASSERT(em.accumulated_text() == "I cannot read");
+}
+
+TEST_CASE(ServerUnitFixture, test_emitter_tool_only_bare_name_remains_zero_arg_call) {
+    json tools = json::array({
+        {
+            {"type", "function"},
+            {"function", {
+                {"name", "ping"},
+                {"parameters", {{"type", "object"}, {"properties", json::object()}}}
+            }}
+        }
+    });
+    auto em = make_emitter(ApiFormat::OPENAI_CHAT, tools);
+    em.emit_start();
+    em.emit_token("ping");
+    em.emit_finish(1);
+
+    TEST_ASSERT(em.tool_calls().size() == 1);
+    if (!em.tool_calls().empty()) {
+        TEST_ASSERT(em.tool_calls()[0].name == "ping");
+        TEST_ASSERT(em.tool_calls()[0].arguments == "{}");
+    }
+    TEST_ASSERT(em.accumulated_text().empty());
+}
+
 TEST_CASE(ServerUnitFixture, test_parse_function_calls_mixed_invoke_and_json_line_siblings) {
     const std::string text =
         "Processing files:\n"
@@ -6320,17 +6396,17 @@ TEST_CASE(ServerUnitFixture, test_parse_function_calls_mixed_invoke_and_json_lin
 }
 
 TEST_CASE(ServerUnitFixture, test_build_response_suppresses_length_finish_reason_on_eos) {
-    // When generation finishes on EOS, emitter finish_reason is called with generation_cap=-1 (suppressed cap)
+    // EOS wins even when it lands exactly on the configured token cap.
     auto em_openai = make_emitter(ApiFormat::OPENAI_CHAT);
     em_openai.emit_start();
     em_openai.emit_token("Hello world");
-    auto chunks_openai = em_openai.emit_finish(3, nullptr, -1);
+    auto chunks_openai = em_openai.emit_finish(3, nullptr, 3, true);
     TEST_ASSERT(em_openai.finish_reason() == "stop");
 
     auto em_anthropic = make_emitter(ApiFormat::ANTHROPIC);
     em_anthropic.emit_start();
     em_anthropic.emit_token("Hello world");
-    auto chunks_anthropic = em_anthropic.emit_finish(3, nullptr, -1);
+    auto chunks_anthropic = em_anthropic.emit_finish(3, nullptr, 3, true);
     TEST_ASSERT(em_anthropic.finish_reason() == "stop");
 }
 
@@ -6367,5 +6443,3 @@ TEST_CASE(ServerUnitFixture, test_emitter_streaming_malformed_tool_in_think_answ
     TEST_ASSERT(em.tool_calls().empty());
     TEST_ASSERT(em.accumulated_text() == "The output is </parameter> end.");
 }
-
-

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -6334,3 +6334,38 @@ TEST_CASE(ServerUnitFixture, test_build_response_suppresses_length_finish_reason
     TEST_ASSERT(em_anthropic.finish_reason() == "stop");
 }
 
+TEST_CASE(ServerUnitFixture, test_parse_function_calls_empty_invoke_zero_args) {
+    json tools = json::array({
+        {
+            {"type", "function"},
+            {"function", {
+                {"name", "get_version"},
+                {"description", "get version"},
+                {"parameters", {{"type", "object"}, {"properties", json::object()}}}
+            }}
+        }
+    });
+
+    const std::string text =
+        "<function_calls>\n"
+        "  <invoke name=\"get_version\"></invoke>\n"
+        "</function_calls>";
+
+    auto res = parse_tool_calls(text, tools);
+    TEST_ASSERT(res.tool_calls.size() == 1);
+    if (!res.tool_calls.empty()) {
+        TEST_ASSERT(res.tool_calls[0].name == "get_version");
+        TEST_ASSERT(res.tool_calls[0].arguments == "{}");
+    }
+}
+
+TEST_CASE(ServerUnitFixture, test_emitter_streaming_malformed_tool_in_think_answer_containing_close_tag_recovers_answer) {
+    auto em = make_emitter(ApiFormat::OPENAI_CHAT, read_tools(), true);
+    em.emit_start();
+    em.emit_token("<think><tool_call><bad_param></tool_call></think>The output is </parameter> end.");
+    auto chunks = em.emit_finish(10, nullptr, -1);
+    TEST_ASSERT(em.tool_calls().empty());
+    TEST_ASSERT(em.accumulated_text() == "The output is </parameter> end.");
+}
+
+

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -6081,3 +6081,160 @@ TEST_CASE(ServerUnitFixture, test_emitter_streaming_anthropic_stop_sequence_beat
     std::string text = concat(chunks);
     TEST_ASSERT(text.find("\"stop_reason\":\"end_turn\"") != std::string::npos);
 }
+
+TEST_CASE(ServerUnitFixture, test_parse_function_calls_json_lines) {
+    std::string text =
+        "Let me read the files:\n"
+        "<function_calls>\n"
+        "{\"name\": \"read\", \"arguments\": {\"path\": \"file1.txt\"}}\n"
+        "{\"name\": \"read\", \"arguments\": {\"path\": \"file2.txt\"}}\n"
+        "</function_calls>";
+
+    auto result = parse_tool_calls(text, read_tools());
+    TEST_ASSERT(result.tool_calls.size() == 2);
+    if (result.tool_calls.size() == 2) {
+        TEST_ASSERT(result.tool_calls[0].name == "read");
+        TEST_ASSERT(result.tool_calls[1].name == "read");
+        auto a1 = json::parse(result.tool_calls[0].arguments);
+        auto a2 = json::parse(result.tool_calls[1].arguments);
+        TEST_ASSERT(a1["path"] == "file1.txt");
+        TEST_ASSERT(a2["path"] == "file2.txt");
+    }
+    TEST_ASSERT(result.cleaned_text == "Let me read the files:");
+}
+
+TEST_CASE(ServerUnitFixture, test_parse_function_calls_sibling_invokes_partial_failure) {
+    std::string text =
+        "<function_calls>\n"
+        "<invoke name=\"read\">\n"
+        "  <param name=\"path\">valid.txt</param>\n"
+        "</invoke>\n"
+        "<invoke name=\"read\">\n"
+        "  malformed parameter text\n"
+        "</invoke>\n"
+        "</function_calls>";
+
+    auto result = parse_tool_calls(text, read_tools());
+    TEST_ASSERT(result.tool_calls.size() == 1);
+    if (!result.tool_calls.empty()) {
+        TEST_ASSERT(result.tool_calls[0].name == "read");
+        auto args = json::parse(result.tool_calls[0].arguments);
+        TEST_ASSERT(args["path"] == "valid.txt");
+    }
+    TEST_ASSERT(result.cleaned_text.find("malformed parameter text") != std::string::npos);
+}
+
+TEST_CASE(ServerUnitFixture, test_parse_json_syntax_error_forwarding) {
+    std::string text = "<function_call>{\"name\": \"read\", \"arguments\": {\"offset\": 5o1}}</function_call>";
+    auto result = parse_tool_calls(text, read_tools());
+    TEST_ASSERT(result.tool_calls.size() == 1);
+    if (!result.tool_calls.empty()) {
+        TEST_ASSERT(result.tool_calls[0].name == "read");
+        TEST_ASSERT(result.tool_calls[0].arguments == "{\"offset\": 5o1}");
+    }
+}
+
+TEST_CASE(ServerUnitFixture, test_emitter_streaming_json_syntax_error_openai_delta) {
+    auto em = make_emitter(ApiFormat::OPENAI_CHAT, read_tools(), false);
+    em.emit_start();
+    em.emit_token("<function_call>{\"name\": \"read\", \"arguments\": {\"offset\": 5o1}}</function_call>");
+    auto chunks = em.emit_finish(10, nullptr, -1);
+    TEST_ASSERT(em.tool_calls().size() == 1);
+    if (!em.tool_calls().empty()) {
+        TEST_ASSERT(em.tool_calls()[0].name == "read");
+        TEST_ASSERT(em.tool_calls()[0].arguments == "{\"offset\": 5o1}");
+    }
+    TEST_ASSERT(em.finish_reason() == "tool_calls");
+    std::string text = concat(chunks);
+    TEST_ASSERT(text.find("5o1") != std::string::npos);
+    TEST_ASSERT(text.find("\"finish_reason\":\"tool_calls\"") != std::string::npos);
+}
+
+TEST_CASE(ServerUnitFixture, test_emitter_streaming_json_syntax_error_anthropic) {
+    auto em = make_emitter(ApiFormat::ANTHROPIC, read_tools(), false);
+    em.emit_start();
+    em.emit_token("<function_call>{\"name\": \"read\", \"arguments\": {\"offset\": 5o1}}</function_call>");
+    auto chunks = em.emit_finish(10, nullptr, -1);
+    TEST_ASSERT(em.tool_calls().size() == 1);
+    if (!em.tool_calls().empty()) {
+        TEST_ASSERT(em.tool_calls()[0].name == "read");
+        TEST_ASSERT(em.tool_calls()[0].arguments == "{\"offset\": 5o1}");
+    }
+    std::string text = concat(chunks);
+    TEST_ASSERT(text.find("\"type\":\"tool_use\"") != std::string::npos);
+    TEST_ASSERT(text.find("5o1") != std::string::npos);
+}
+
+TEST_CASE(ServerUnitFixture, test_emitter_streaming_malformed_tool_in_think_recovers_answer) {
+    auto em = make_emitter(ApiFormat::ANTHROPIC, read_tools(), true);
+    em.emit_start();
+    auto c1 = em.emit_token("<think>Let me see <tool_call><bad_tool></tool_call></think>Here is the final answer.");
+    auto c2 = em.emit_finish(10, nullptr, -1);
+    std::string text = concat(c1) + concat(c2);
+    TEST_ASSERT(em.tool_calls().empty());
+    TEST_ASSERT(em.reasoning_text().find("<bad_tool>") == std::string::npos);
+    TEST_ASSERT(em.reasoning_text().find("Let me see ") != std::string::npos);
+    TEST_ASSERT(em.accumulated_text() == "Here is the final answer.");
+    TEST_ASSERT(text.find("\"type\":\"thinking_delta\"") != std::string::npos);
+    TEST_ASSERT(text.find("\"type\":\"text_delta\"") != std::string::npos);
+    TEST_ASSERT(text.find("Here is the final answer.") != std::string::npos);
+}
+
+TEST_CASE(ServerUnitFixture, test_emitter_streaming_malformed_tool_in_think_without_think_close_suppressed) {
+    auto em = make_emitter(ApiFormat::OPENAI_CHAT, read_tools(), true);
+    em.emit_start();
+    em.emit_token("<think>Let me see <tool_call><bad_tool>");
+    auto chunks = em.emit_finish(10, nullptr, -1);
+    TEST_ASSERT(em.tool_calls().empty());
+    TEST_ASSERT(em.accumulated_text().empty());
+    TEST_ASSERT(em.reasoning_text().find("<bad_tool>") == std::string::npos);
+}
+
+TEST_CASE(ServerUnitFixture, test_emitter_streaming_malformed_tool_in_think_literal_think_close_in_args_does_not_leak) {
+    auto em = make_emitter(ApiFormat::OPENAI_CHAT, read_tools(), true);
+    em.emit_start();
+    em.emit_token("<think>Let me see <tool_call><function=bash><parameter=cmd>grep '</think>' file.txt");
+    auto chunks = em.emit_finish(10, nullptr, -1);
+    TEST_ASSERT(em.tool_calls().empty());
+    TEST_ASSERT(em.accumulated_text().empty());
+    TEST_ASSERT(em.reasoning_text().find("grep") == std::string::npos);
+}
+
+TEST_CASE(ServerUnitFixture, test_emitter_streaming_malformed_tool_in_think_envelope_with_internal_think_close_recovers_answer) {
+    auto em = make_emitter(ApiFormat::OPENAI_CHAT, read_tools(), true);
+    em.emit_start();
+    em.emit_token("<think>Let me see <tool_call><function=bash><parameter=cmd>grep '</think>' file.txt</parameter></function></tool_call></think>Real answer here.");
+    auto chunks = em.emit_finish(10, nullptr, -1);
+    TEST_ASSERT(em.tool_calls().empty());
+    TEST_ASSERT(em.accumulated_text() == "Real answer here.");
+    TEST_ASSERT(em.reasoning_text().find("grep") == std::string::npos);
+}
+
+TEST_CASE(ServerUnitFixture, test_emitter_streaming_long_tool_name_split_in_reasoning_holds_back) {
+    json tools = json::array({
+        {
+            {"type", "function"},
+            {"function", {
+                {"name", "fetch_authenticated_user_profile_data"},
+                {"description", "fetch user profile"},
+                {"parameters", {{"type", "object"}, {"properties", {{"id", {{"type", "string"}}}}}}}
+            }}
+        }
+    });
+
+    auto em = make_emitter(ApiFormat::OPENAI_CHAT, tools, true);
+    em.emit_start();
+    em.emit_token("<think>I should fetch the user data. ");
+    em.emit_token("<fetch_authenticated_");
+    em.emit_token("user_profile_data>\n<parameter=id>\n123\n</parameter>\n</fetch_authenticated_user_profile_data></think>");
+    auto chunks = em.emit_finish(10, nullptr, -1);
+
+    TEST_ASSERT(em.tool_calls().size() == 1);
+    if (!em.tool_calls().empty()) {
+        TEST_ASSERT(em.tool_calls()[0].name == "fetch_authenticated_user_profile_data");
+        auto args = json::parse(em.tool_calls()[0].arguments);
+        TEST_ASSERT(args["id"] == "123");
+    }
+    TEST_ASSERT(em.reasoning_text().find("fetch_authenticated") == std::string::npos);
+    TEST_ASSERT(em.finish_reason() == "tool_calls");
+}

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -6238,3 +6238,99 @@ TEST_CASE(ServerUnitFixture, test_emitter_streaming_long_tool_name_split_in_reas
     TEST_ASSERT(em.reasoning_text().find("fetch_authenticated") == std::string::npos);
     TEST_ASSERT(em.finish_reason() == "tool_calls");
 }
+
+TEST_CASE(ServerUnitFixture, test_parse_tool_call_rejects_empty_name_and_scalar_arguments) {
+    // Empty tool name must be rejected
+    const std::string empty_name =
+        "<function_call>\n{\"name\": \"\", \"arguments\": {\"path\": \"/tmp/test\"}}\n</function_call>";
+    auto res_empty = parse_tool_calls(empty_name, read_tools());
+    TEST_ASSERT(res_empty.tool_calls.empty());
+
+    // Valid scalar string argument must be rejected (not an object)
+    const std::string scalar_arg =
+        "<function_call>\n{\"name\": \"read\", \"arguments\": \"just a string\"}\n</function_call>";
+    auto res_scalar = parse_tool_calls(scalar_arg, read_tools());
+    TEST_ASSERT(res_scalar.tool_calls.empty());
+
+    // Valid array argument must be rejected (not an object)
+    const std::string array_arg =
+        "<function_call>\n{\"name\": \"read\", \"arguments\": [1, 2, 3]}\n</function_call>";
+    auto res_array = parse_tool_calls(array_arg, read_tools());
+    TEST_ASSERT(res_array.tool_calls.empty());
+
+    // Malformed JSON object syntax (e.g. 5o1) is forwarded as raw args
+    const std::string bad_obj =
+        "<function_call>\n{\"name\": \"read\", \"arguments\": {\"path\": \"/tmp/test\", \"offset\": 5o1}}\n</function_call>";
+    auto res_bad = parse_tool_calls(bad_obj, read_tools());
+    TEST_ASSERT(res_bad.tool_calls.size() == 1);
+    if (!res_bad.tool_calls.empty()) {
+        TEST_ASSERT(res_bad.tool_calls[0].name == "read");
+        TEST_ASSERT(res_bad.tool_calls[0].arguments.find("5o1") != std::string::npos);
+    }
+}
+
+TEST_CASE(ServerUnitFixture, test_extract_raw_json_tool_fallback_with_nested_name_argument) {
+    // Malformed arguments containing a "name" key before top-level "name"
+    const std::string text_reversed =
+        "<function_call>\n"
+        "{\"arguments\": {\"name\": \"evil_command\", \"offset\": 5o1}, \"name\": \"read\"}\n"
+        "</function_call>";
+    auto res_rev = parse_tool_calls(text_reversed, read_tools());
+    TEST_ASSERT(res_rev.tool_calls.size() == 1);
+    if (!res_rev.tool_calls.empty()) {
+        TEST_ASSERT(res_rev.tool_calls[0].name == "read");
+        TEST_ASSERT(res_rev.tool_calls[0].arguments.find("evil_command") != std::string::npos);
+    }
+
+    // Nested function object with "name" inside arguments
+    const std::string text_nested =
+        "<function_call>\n"
+        "{\"function\": {\"name\": \"read\", \"arguments\": {\"name\": \"evil_nested\", \"offset\": 5o1}}}\n"
+        "</function_call>";
+    auto res_nest = parse_tool_calls(text_nested, read_tools());
+    TEST_ASSERT(res_nest.tool_calls.size() == 1);
+    if (!res_nest.tool_calls.empty()) {
+        TEST_ASSERT(res_nest.tool_calls[0].name == "read");
+        TEST_ASSERT(res_nest.tool_calls[0].arguments.find("evil_nested") != std::string::npos);
+    }
+}
+
+TEST_CASE(ServerUnitFixture, test_parse_function_calls_mixed_invoke_and_json_line_siblings) {
+    const std::string text =
+        "Processing files:\n"
+        "<function_calls>\n"
+        "  <invoke name=\"read\">\n"
+        "    <param name=\"path\">first.go</param>\n"
+        "  </invoke>\n"
+        "  {\"name\": \"read\", \"arguments\": {\"path\": \"second.go\"}}\n"
+        "</function_calls>";
+
+    auto res = parse_tool_calls(text, read_tools());
+    TEST_ASSERT(res.tool_calls.size() == 2);
+    if (res.tool_calls.size() == 2) {
+        TEST_ASSERT(res.tool_calls[0].name == "read");
+        auto args0 = json::parse(res.tool_calls[0].arguments);
+        TEST_ASSERT(args0["path"] == "first.go");
+
+        TEST_ASSERT(res.tool_calls[1].name == "read");
+        auto args1 = json::parse(res.tool_calls[1].arguments);
+        TEST_ASSERT(args1["path"] == "second.go");
+    }
+    TEST_ASSERT(res.cleaned_text == "Processing files:");
+}
+
+TEST_CASE(ServerUnitFixture, test_build_response_suppresses_length_finish_reason_on_eos) {
+    // When generation finishes on EOS, emitter finish_reason is called with generation_cap=-1 (suppressed cap)
+    auto em_openai = make_emitter(ApiFormat::OPENAI_CHAT);
+    em_openai.emit_start();
+    em_openai.emit_token("Hello world");
+    auto chunks_openai = em_openai.emit_finish(3, nullptr, -1);
+    TEST_ASSERT(em_openai.finish_reason() == "stop");
+
+    auto em_anthropic = make_emitter(ApiFormat::ANTHROPIC);
+    em_anthropic.emit_start();
+    em_anthropic.emit_token("Hello world");
+    auto chunks_anthropic = em_anthropic.emit_finish(3, nullptr, -1);
+    TEST_ASSERT(em_anthropic.finish_reason() == "stop");
+}
+

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -6317,6 +6317,26 @@ TEST_CASE(ServerUnitFixture, test_parse_tool_call_rejects_empty_name_and_scalar_
     auto res_array = parse_tool_calls(array_arg, read_tools());
     TEST_ASSERT(res_array.tool_calls.empty());
 
+    // A scalar string wrapped in braces is still prose, not object arguments.
+    const std::string braced_prose =
+        "<function_call>\n"
+        "{\"name\": \"read\", \"arguments\": \"{this is prose}\"}\n"
+        "</function_call>";
+    auto res_braced_prose = parse_tool_calls(braced_prose, read_tools());
+    TEST_ASSERT(res_braced_prose.tool_calls.empty());
+
+    // Keep forwarding a structurally object-like string with a JSON syntax
+    // error so the client can report the exact bad arguments to the model.
+    const std::string bad_obj_string =
+        "<function_call>\n"
+        "{\"name\": \"read\", \"arguments\": \"{\\\"offset\\\": 5o1}\"}\n"
+        "</function_call>";
+    auto res_bad_obj_string = parse_tool_calls(bad_obj_string, read_tools());
+    TEST_ASSERT(res_bad_obj_string.tool_calls.size() == 1);
+    if (!res_bad_obj_string.tool_calls.empty()) {
+        TEST_ASSERT(res_bad_obj_string.tool_calls[0].arguments == "{\"offset\": 5o1}");
+    }
+
     // Malformed JSON object syntax (e.g. 5o1) is forwarded as raw args
     const std::string bad_obj =
         "<function_call>\n{\"name\": \"read\", \"arguments\": {\"path\": \"/tmp/test\", \"offset\": 5o1}}\n</function_call>";


### PR DESCRIPTION
Refs #644 (Stage 2 of 3, builds upon Stage 1)

## Description

This PR provides a streamlined, minimal implementation of DeepSeek V4 tool call parsing and streaming emitter state handling based on empirical session logs:
1. **Multi-Format XML Envelopes**:
   - Supports `<function_calls>` enclosing JSON lines or `<invoke name="...">` tags with `<param name="...">` parameters.
   - Supports `<function>` and `<function_call>` JSON wrappers.
   - Retains unparseable sibling content in `cleaned_text` and preserves valid tool calls in the same response.
2. **JSON Syntax Error Fallback**:
   - When the model produces minor token errors in tool arguments (such as `'o'` instead of `'0'` in numeric offsets or filenames like `{"offset": 5o1}`), the parser extracts the declared tool name and forwards the raw arguments string as a standard tool call event with `finish_reason: "tool_calls"` / `stop_reason: "tool_use"`.
   - Allows client agents (such as Pi Agent) to receive the tool invocation, parse the error, and return structured error feedback so the model can self-correct instead of terminating the turn with an empty assistant message.
3. **Streaming State Machine & Reason Split**:
   - Uses dynamic holdback in `StreamMode::REASONING` to detect long tool names across token boundaries.
   - Unified `emit_reasoning_delta` helper eliminating delta-emission duplication.
   - Splits `cleaned_text` across `</think>` boundaries, emitting leading text as reasoning and trailing text as content.
   - Recovers post-think content on parse failures while suppressing buffered malformed tool XML.

## Verification
- Added comprehensive unit tests in `test_server_unit`:
  - `test_parse_function_calls_invoke_json`
  - `test_parse_function_calls_sibling_invokes_partial_failure`
  - `test_parse_json_syntax_error_forwarding`
  - `test_emitter_streaming_json_syntax_error_openai_delta`
  - `test_emitter_streaming_json_syntax_error_anthropic`
  - `test_emitter_streaming_malformed_tool_in_think_recovers_answer`
  - `test_emitter_streaming_safe_prefix_long_tool_name_holdback`
- Tested live in multi-turn sessions with Pi Agent on AMD Strix Halo (`aimax:8087`).
- All 402 unit tests passing (100%).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

