### PR TITLE
fix(qwen35): warn when a prompt outgrows --fa-window

### DIFF
--- a/server/src/qwen35/qwen35_backend.cpp
+++ b/server/src/qwen35/qwen35_backend.cpp
@@ -1624,6 +1624,24 @@ int Qwen35Backend::do_prefill(const std::vector<int32_t> & tokens,
                                const DaemonIO & io,
                                int snap_pos, int snap_slot,
                                int kv_offset) {
+    // A finite --fa-window caps the full-attention layers to a sliding
+    // window, so anything earlier than the window is invisible to them. That
+    // is silent: the model still answers, it just cannot see the head of a
+    // long prompt, which reads as a model quality problem rather than a
+    // configuration one. Say so once, the first time a prompt actually
+    // outgrows the window.
+    if (cfg_.fa_window > 0 &&
+        (int)tokens.size() + kv_offset > cfg_.fa_window) {
+        static std::atomic<bool> s_fa_window_warned{false};
+        if (!s_fa_window_warned.exchange(true)) {
+            std::fprintf(stderr,
+                "[qwen35] WARNING: prompt is %d tokens but --fa-window is %d: "
+                "full-attention layers see only the last %d tokens, so content "
+                "before that cannot be retrieved. Drop --fa-window for "
+                "long-context work.\n",
+                (int)tokens.size() + kv_offset, cfg_.fa_window, cfg_.fa_window);
+        }
+    }
     const int hidden = w_.n_embd;
     const int vocab  = w_.n_vocab;
     int prefill_ubatch = qwen35_prefill_ubatch(512);


### PR DESCRIPTION
## The bug

A finite `--fa-window` caps the full-attention layers to a sliding window, so content earlier than the window is invisible to them. Nothing reports this. The model still answers, it just cannot see the head of a long prompt, so it reads as a model quality problem rather than a configuration one.

Found while benchmarking long context on a Radeon AI PRO R9700 with Qwen3.8-27B. A label was planted at the very top of the prompt and the model asked to repeat it:

| prompt tokens | `--fa-window 2048` | full attention |
|---:|---|---|
| 1,556 | recalled | recalled |
| 6,208 | **missed** | recalled |
| 13,148 | **missed** | recalled |
| 26,728 | **missed** | recalled |

No warning was emitted in any of the failing cases.

Worth noting: on this hardware the flag was not even buying speed. At a 27K prompt it measured 44.4 tok/s with the window against 45.7 without, and full attention recalled the label at every length tested up to 81K.

## The fix

Warn once, the first time a prompt actually outgrows the window, naming both numbers so the cause is unambiguous. No behaviour change otherwise.

## Validation

On the same box with `--fa-window 2048`: the warning fires exactly once, on the 6,208-token request that does lose the label, and does not fire for the 1,556-token request that retrieves it.

```
[qwen35] WARNING: prompt is 6208 tokens but --fa-window is 2048: full-attention
layers see only the last 2048 tokens, so content before that cannot be
retrieved. Drop --fa-window for long-context work.
```

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

