### PR TITLE
feat(qwen35): support sampled concurrent speculation

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -501,6 +501,7 @@ add_library(dflash_common STATIC
     src/qwen35/layer_split_daemon_loop.cpp
     src/qwen35/qwen35_daemon.cpp
     src/common/sampler.cpp
+    src/common/speculative_sampling.cpp
     src/common/backend_precision.cpp
     src/common/daemon_loop.cpp
     src/common/gguf_inspect.cpp
@@ -1455,6 +1456,17 @@ if(DFLASH27B_TESTS)
             ${CMAKE_CURRENT_SOURCE_DIR}/src
             ${CMAKE_CURRENT_SOURCE_DIR}/test)
         list(APPEND _raw_unit_test_targets test_chain_spec_shapes)
+    endif()
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_speculative_sampling.cpp")
+        # Pure host-side sampler/distribution-preserving verification tests.
+        add_executable(test_speculative_sampling
+            test/test_speculative_sampling.cpp
+            src/common/sampler.cpp
+            src/common/speculative_sampling.cpp)
+        target_include_directories(test_speculative_sampling PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src
+            ${CMAKE_CURRENT_SOURCE_DIR}/test)
+        list(APPEND _raw_unit_test_targets test_speculative_sampling)
     endif()
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_dflash2_selector_validation.cpp")
         # Pure host-side selector metadata/layout validation: no GPU.

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -465,6 +465,7 @@ add_library(dflash_common STATIC
     src/common/pflash_drafter_ipc.cpp
     src/common/dflash_draft_graph.cpp
     src/common/dflash_draft_kv.cpp
+    src/common/draft_swa.cpp
     src/common/dflash_spec_decode.cpp
     src/common/concurrency/paged_kv_pool.cpp
     src/qwen35/concurrency/qwen35_slot_manager.cpp
@@ -1464,6 +1465,24 @@ if(DFLASH27B_TESTS)
             ${CMAKE_CURRENT_SOURCE_DIR}/test)
         list(APPEND _raw_unit_test_targets test_dflash2_selector_validation)
     endif()
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_draft_swa.cpp")
+        # Pure host-side draft SWA metadata/override policy tests.
+        add_executable(test_draft_swa test/test_draft_swa.cpp)
+        target_include_directories(test_draft_swa PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src)
+        target_link_libraries(test_draft_swa PRIVATE dflash_common)
+    endif()
+    if((DFLASH27B_GPU_BACKEND STREQUAL "cuda" OR
+        DFLASH27B_GPU_BACKEND STREQUAL "hip") AND
+       EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_draft_swa_multilane.cpp")
+        # Opt-in real-model proof for post-window lane masks and packed draft parity.
+        add_executable(test_draft_swa_multilane test/test_draft_swa_multilane.cpp)
+        target_include_directories(test_draft_swa_multilane PRIVATE
+            ${DFLASH27B_SRC_INCLUDE_DIRS})
+        target_link_libraries(test_draft_swa_multilane PRIVATE
+            dflash_common ggml ${DFLASH27B_GGML_BACKEND_TARGET})
+        list(APPEND _raw_unit_test_targets test_draft_swa_multilane)
+    endif()
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_seq_batch_plan.cpp")
         # Pure-host tests for model-neutral token-budget/FIFO planning.
         add_executable(test_seq_batch_plan test/test_seq_batch_plan.cpp)
@@ -1803,6 +1822,7 @@ if(DFLASH27B_TESTS)
         test_model_smoke)
     set(_new_cppunit_test_targets
         test_platform_compat
+        test_draft_swa
         test_feature_gate
         test_qwen35_split_tree_guard
         test_recurrent_snapshot

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -455,6 +455,7 @@ add_library(dflash_common STATIC
     src/common/domino_head.cpp
     src/common/dspark_head.cpp
     src/common/dflash2_head.cpp
+    src/common/dflash2_batch.cpp
     src/common/target_shard_ipc.cpp
     src/common/target_shard_ipc_daemon.cpp
     src/common/dflash_feature_ring.cpp
@@ -1435,6 +1436,34 @@ if(DFLASH27B_TESTS)
             ${CMAKE_CURRENT_SOURCE_DIR}/test)
         list(APPEND _raw_unit_test_targets test_seq_engine_contract)
     endif()
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_ddtree_path.cpp")
+        # Pure host-side accepted-path/pending-token contract tests.
+        add_executable(test_ddtree_path
+            test/test_ddtree_path.cpp
+            src/common/ddtree.cpp)
+        target_include_directories(test_ddtree_path PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src)
+        list(APPEND _raw_unit_test_targets test_ddtree_path)
+    endif()
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_chain_spec_shapes.cpp")
+        # Pure host-side DFlash2 chain topology and mixed-launch arithmetic.
+        add_executable(test_chain_spec_shapes
+            test/test_chain_spec_shapes.cpp
+            src/common/ddtree.cpp)
+        target_include_directories(test_chain_spec_shapes PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src
+            ${CMAKE_CURRENT_SOURCE_DIR}/test)
+        list(APPEND _raw_unit_test_targets test_chain_spec_shapes)
+    endif()
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_dflash2_selector_validation.cpp")
+        # Pure host-side selector metadata/layout validation: no GPU.
+        add_executable(test_dflash2_selector_validation
+            test/test_dflash2_selector_validation.cpp)
+        target_include_directories(test_dflash2_selector_validation PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src
+            ${CMAKE_CURRENT_SOURCE_DIR}/test)
+        list(APPEND _raw_unit_test_targets test_dflash2_selector_validation)
+    endif()
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_seq_batch_plan.cpp")
         # Pure-host tests for model-neutral token-budget/FIFO planning.
         add_executable(test_seq_batch_plan test/test_seq_batch_plan.cpp)
@@ -1933,6 +1962,17 @@ if(DFLASH27B_TESTS)
         add_test(NAME batched_gdn_cpu COMMAND test_batched_gdn --cpu)
         if(TARGET check)
             add_dependencies(check test_batched_gdn)
+        endif()
+    endif()
+    if((DFLASH27B_GPU_BACKEND STREQUAL "cuda" OR
+        DFLASH27B_GPU_BACKEND STREQUAL "hip")
+       AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_gdn_transition_journal.cpp")
+        dflash_add_ggml_gpu_executable(
+            test_gdn_transition_journal
+            test/test_gdn_transition_journal.cpp)
+        add_test(NAME gdn_transition_journal COMMAND test_gdn_transition_journal)
+        if(TARGET check)
+            add_dependencies(check test_gdn_transition_journal)
         endif()
     endif()
     if((DFLASH27B_GPU_BACKEND STREQUAL "cuda" OR

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -1971,6 +1971,12 @@ if(DFLASH27B_TESTS)
             test_gdn_transition_journal
             test/test_gdn_transition_journal.cpp)
         add_test(NAME gdn_transition_journal COMMAND test_gdn_transition_journal)
+        add_test(
+            NAME gdn_transition_journal_gallocr
+            COMMAND test_gdn_transition_journal --gallocr-only)
+        add_test(
+            NAME gdn_transition_journal_preflight
+            COMMAND test_gdn_transition_journal --preflight-only)
         if(TARGET check)
             add_dependencies(check test_gdn_transition_journal)
         endif()

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -1986,19 +1986,19 @@ if(DFLASH27B_TESTS)
     endif()
     if((DFLASH27B_GPU_BACKEND STREQUAL "cuda" OR
         DFLASH27B_GPU_BACKEND STREQUAL "hip")
-       AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_gdn_transition_journal.cpp")
+       AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_gdn_replay_log.cpp")
         dflash_add_ggml_gpu_executable(
-            test_gdn_transition_journal
-            test/test_gdn_transition_journal.cpp)
-        add_test(NAME gdn_transition_journal COMMAND test_gdn_transition_journal)
+            test_gdn_replay_log
+            test/test_gdn_replay_log.cpp)
+        add_test(NAME gdn_replay_log COMMAND test_gdn_replay_log)
         add_test(
-            NAME gdn_transition_journal_gallocr
-            COMMAND test_gdn_transition_journal --gallocr-only)
+            NAME gdn_replay_log_gallocr
+            COMMAND test_gdn_replay_log --gallocr-only)
         add_test(
-            NAME gdn_transition_journal_preflight
-            COMMAND test_gdn_transition_journal --preflight-only)
+            NAME gdn_replay_log_preflight
+            COMMAND test_gdn_replay_log --preflight-only)
         if(TARGET check)
-            add_dependencies(check test_gdn_transition_journal)
+            add_dependencies(check test_gdn_replay_log)
         endif()
     endif()
     if((DFLASH27B_GPU_BACKEND STREQUAL "cuda" OR

--- a/server/deps/llama.cpp/ggml/include/ggml-cuda.h
+++ b/server/deps/llama.cpp/ggml/include/ggml-cuda.h
@@ -123,6 +123,26 @@ GGML_BACKEND_API bool ggml_backend_cuda_tree_feature_commit(
         const struct ggml_tensor * source, struct ggml_tensor * destination,
         const struct ggml_tensor * destination_rows);
 
+// Validate every packed-tree destination before changing any cache. Once the
+// first kernel launches, a device failure is fatal because fallback cannot
+// recover from a partially committed state.
+GGML_BACKEND_API bool ggml_backend_cuda_tree_commit_transaction(
+        struct ggml_tensor * const * caches,
+        int n_caches,
+        const struct ggml_tensor * feature_source,
+        struct ggml_tensor * feature_destination,
+        const struct ggml_tensor * feature_destination_rows,
+        const struct ggml_tensor * const * journals,
+        struct ggml_tensor * const * states,
+        const struct ggml_tensor * const * conv_inputs,
+        struct ggml_tensor * const * conv_states,
+        int n_layers,
+        const struct ggml_tensor * commit_rows,
+        const struct ggml_tensor * accepted_prefixes,
+        const struct ggml_tensor * active_slot_ids,
+        int tree_scratch_base,
+        int tree_scratch_stride);
+
 // Attach learned per-expert decode tables to a mixed-precision tensor. The
 // host variants copy the tables to the device that owns `base`. Call the
 // matching unregister function before releasing the tensor's backing buffer.

--- a/server/deps/llama.cpp/ggml/include/ggml-cuda.h
+++ b/server/deps/llama.cpp/ggml/include/ggml-cuda.h
@@ -100,10 +100,10 @@ GGML_BACKEND_API bool ggml_backend_cuda_topk_rows(const struct ggml_tensor * log
                                                   float * probs_out, int32_t * ids_out);
 
 // Batched concurrent-tree commit. Validation is fail-closed before any kernel
-// launches; all layer journals and convolution windows commit on one device
+// launches; all layer replay logs and convolution windows commit on one device
 // synchronization.
-GGML_BACKEND_API bool ggml_backend_cuda_gdn_transition_journal_commit_many(
-        const struct ggml_tensor * const * journals,
+GGML_BACKEND_API bool ggml_backend_cuda_gdn_replay_log_commit_many(
+        const struct ggml_tensor * const * replay_logs,
         struct ggml_tensor * const * states,
         const struct ggml_tensor * const * conv_inputs,
         struct ggml_tensor * const * conv_states,
@@ -132,7 +132,7 @@ GGML_BACKEND_API bool ggml_backend_cuda_tree_commit_transaction(
         const struct ggml_tensor * feature_source,
         struct ggml_tensor * feature_destination,
         const struct ggml_tensor * feature_destination_rows,
-        const struct ggml_tensor * const * journals,
+        const struct ggml_tensor * const * replay_logs,
         struct ggml_tensor * const * states,
         const struct ggml_tensor * const * conv_inputs,
         struct ggml_tensor * const * conv_states,

--- a/server/deps/llama.cpp/ggml/include/ggml-cuda.h
+++ b/server/deps/llama.cpp/ggml/include/ggml-cuda.h
@@ -99,6 +99,30 @@ GGML_BACKEND_API ggml_backend_reg_t ggml_backend_cuda_reg(void);
 GGML_BACKEND_API bool ggml_backend_cuda_topk_rows(const struct ggml_tensor * logits, int k,
                                                   float * probs_out, int32_t * ids_out);
 
+// Batched concurrent-tree commit. Validation is fail-closed before any kernel
+// launches; all layer journals and convolution windows commit on one device
+// synchronization.
+GGML_BACKEND_API bool ggml_backend_cuda_gdn_transition_journal_commit_many(
+        const struct ggml_tensor * const * journals,
+        struct ggml_tensor * const * states,
+        const struct ggml_tensor * const * conv_inputs,
+        struct ggml_tensor * const * conv_states,
+        int n_layers,
+        const struct ggml_tensor * accepted_prefixes,
+        const struct ggml_tensor * active_slot_ids);
+
+// Promote accepted packed-tree K/V scratch rows into pager-owned rows.
+GGML_BACKEND_API bool ggml_backend_cuda_tree_cache_commit_many(
+        struct ggml_tensor * const * caches, int n_caches,
+        const struct ggml_tensor * commit_rows,
+        const struct ggml_tensor * active_slot_ids,
+        int tree_scratch_base, int tree_scratch_stride);
+
+// Promote accepted BF16 tree feature rows into slot-local feature rings.
+GGML_BACKEND_API bool ggml_backend_cuda_tree_feature_commit(
+        const struct ggml_tensor * source, struct ggml_tensor * destination,
+        const struct ggml_tensor * destination_rows);
+
 // Attach learned per-expert decode tables to a mixed-precision tensor. The
 // host variants copy the tables to the device that owns `base`. Call the
 // matching unregister function before releasing the tensor's backing buffer.

--- a/server/deps/llama.cpp/ggml/include/ggml.h
+++ b/server/deps/llama.cpp/ggml/include/ggml.h
@@ -2969,12 +2969,12 @@ extern "C" {
             struct ggml_tensor * tensor,
             bool                 skip_intermediate);
 
-    // CUDA/HIP fixed-chain journal in compact F32 [J,H,T,B] layout:
+    // CUDA/HIP fixed-chain replay log in compact F32 [J,H,T,B] layout:
     // scalar gate J=2*S_v+1 stores [g | k | delta], while KDA J=3*S_v
     // stores [g[S_v] | k | delta]. Delta is captured after the
     // state-dependent reduction. The returned tensor owns a compact copy so
     // graph allocation can release the much larger GDN result after capture.
-    GGML_API struct ggml_tensor * ggml_gated_delta_net_capture_transition_journal(
+    GGML_API struct ggml_tensor * ggml_gated_delta_net_capture_replay_log(
             struct ggml_context * ctx,
             struct ggml_tensor  * tensor);
 

--- a/server/deps/llama.cpp/ggml/include/ggml.h
+++ b/server/deps/llama.cpp/ggml/include/ggml.h
@@ -221,7 +221,7 @@
 
 #define GGML_MAX_DIMS           4
 #define GGML_MAX_PARAMS         2048
-#define GGML_MAX_SRC            12
+#define GGML_MAX_SRC            10
 #define GGML_MAX_N_THREADS      512
 #define GGML_MAX_OP_PARAMS      64
 
@@ -2972,11 +2972,11 @@ extern "C" {
     // CUDA/HIP fixed-chain journal in compact F32 [J,H,T,B] layout:
     // scalar gate J=2*S_v+1 stores [g | k | delta], while KDA J=3*S_v
     // stores [g[S_v] | k | delta]. Delta is captured after the
-    // state-dependent reduction. A tree-form op may attach the journal when
-    // its parent table describes one root-inclusive chain.
-    GGML_API void ggml_gated_delta_net_set_transition_journal(
-            struct ggml_tensor * tensor,
-            struct ggml_tensor * journal);
+    // state-dependent reduction. The returned tensor is a view into the
+    // GDN result buffer, so no extra source slot is required.
+    GGML_API struct ggml_tensor * ggml_gated_delta_net_capture_transition_journal(
+            struct ggml_context * ctx,
+            struct ggml_tensor  * tensor);
 
     // dflash extension: let the kernel derive the gates from the raw
     // projections instead of graph-side sigmoid/softplus ops:

--- a/server/deps/llama.cpp/ggml/include/ggml.h
+++ b/server/deps/llama.cpp/ggml/include/ggml.h
@@ -2972,8 +2972,8 @@ extern "C" {
     // CUDA/HIP fixed-chain journal in compact F32 [J,H,T,B] layout:
     // scalar gate J=2*S_v+1 stores [g | k | delta], while KDA J=3*S_v
     // stores [g[S_v] | k | delta]. Delta is captured after the
-    // state-dependent reduction. The returned tensor is a view into the
-    // GDN result buffer, so no extra source slot is required.
+    // state-dependent reduction. The returned tensor owns a compact copy so
+    // graph allocation can release the much larger GDN result after capture.
     GGML_API struct ggml_tensor * ggml_gated_delta_net_capture_transition_journal(
             struct ggml_context * ctx,
             struct ggml_tensor  * tensor);

--- a/server/deps/llama.cpp/ggml/include/ggml.h
+++ b/server/deps/llama.cpp/ggml/include/ggml.h
@@ -2503,17 +2503,6 @@ extern "C" {
     // marks a padding row. NULL keeps the decode semantics (full cached
     // length per row).
     //
-    // parent_ids/tree_sizes optionally enable packed tree verification.
-    // Queries are flattened sequence-major: tree sequence s occupies rows
-    // [s*tree_width, (s+1)*tree_width). parent_ids is contiguous I32
-    // [tree_width, n_tree_seq] (root parent -1), and tree_sizes is contiguous
-    // I32 [n_tree_seq]. active_slot_ids is required and remains per query row;
-    // it selects the physical block-table column and scratch slab. Each live
-    // query attends its complete committed prefix from the block table plus
-    // its own candidate node and ancestors from physical K/V rows
-    // tree_scratch_base + slot*tree_scratch_stride + node. Siblings and rows
-    // at or beyond tree_sizes[s] are excluded. query_positions must be NULL
-    // in tree mode. Pass NULL/NULL/0/0/0 to retain standard paged attention.
     GGML_API struct ggml_tensor * ggml_paged_attn_ext(
             struct ggml_context * ctx,
             struct ggml_tensor  * q,
@@ -2525,32 +2514,37 @@ extern "C" {
             struct ggml_tensor  * query_positions,
             float                 scale,
             int                   block_size,
+            int                   max_kv_seq_len);
+
+    // Packed tree verification over the same paged K/V pool.
+    // Queries are flattened sequence-major: tree sequence s occupies rows
+    // [s*tree_width, (s+1)*tree_width). parent_ids is contiguous I32
+    // [tree_width, n_tree_seq] (root parent -1), and tree_sizes is contiguous
+    // I32 [n_tree_seq]. active_slot_ids is required and remains per query row;
+    // it selects the physical block-table column and scratch slab. Each live
+    // query attends its complete committed prefix from the block table plus
+    // its own candidate node and ancestors from physical K/V rows
+    // tree_scratch_base + slot*tree_scratch_stride + node. Siblings and rows
+    // at or beyond tree_sizes[s] are excluded. query_positions may describe
+    // compact autoregressive rows in a mixed AR/tree batch; tree rows ignore
+    // it and read the full committed prefix. Pure tree batches pass NULL.
+    // tree_width is derived from parent_ids.
+    GGML_API struct ggml_tensor * ggml_paged_attn_ext_tree(
+            struct ggml_context * ctx,
+            struct ggml_tensor  * q,
+            struct ggml_tensor  * k,
+            struct ggml_tensor  * v,
+            struct ggml_tensor  * block_table,
+            struct ggml_tensor  * kv_seq_lens,
+            struct ggml_tensor  * active_slot_ids,
+            struct ggml_tensor  * query_positions,
+            float                 scale,
+            int                   block_size,
             int                   max_kv_seq_len,
-            struct ggml_tensor  * parent_ids
-#ifdef __cplusplus
-                = nullptr
-#endif
-            ,
-            struct ggml_tensor  * tree_sizes
-#ifdef __cplusplus
-                = nullptr
-#endif
-            ,
-            int                   tree_width
-#ifdef __cplusplus
-                = 0
-#endif
-            ,
-            int                   tree_scratch_base
-#ifdef __cplusplus
-                = 0
-#endif
-            ,
-            int                   tree_scratch_stride
-#ifdef __cplusplus
-                = 0
-#endif
-            );
+            struct ggml_tensor  * parent_ids,
+            struct ggml_tensor  * tree_sizes,
+            int                   tree_scratch_base,
+            int                   tree_scratch_stride);
 
     // TurboQuant FWHT rotation. direction: 0 = forward, 1 = inverse.
     // Applies signs1 -> FWHT -> signs2 (forward) or signs2 -> FWHT -> signs1 (inverse).

--- a/server/deps/llama.cpp/ggml/include/ggml.h
+++ b/server/deps/llama.cpp/ggml/include/ggml.h
@@ -221,7 +221,7 @@
 
 #define GGML_MAX_DIMS           4
 #define GGML_MAX_PARAMS         2048
-#define GGML_MAX_SRC            10
+#define GGML_MAX_SRC            12
 #define GGML_MAX_N_THREADS      512
 #define GGML_MAX_OP_PARAMS      64
 
@@ -2502,6 +2502,18 @@ extern "C" {
     // prefill chunks can attend the paged pool causally. A negative position
     // marks a padding row. NULL keeps the decode semantics (full cached
     // length per row).
+    //
+    // parent_ids/tree_sizes optionally enable packed tree verification.
+    // Queries are flattened sequence-major: tree sequence s occupies rows
+    // [s*tree_width, (s+1)*tree_width). parent_ids is contiguous I32
+    // [tree_width, n_tree_seq] (root parent -1), and tree_sizes is contiguous
+    // I32 [n_tree_seq]. active_slot_ids is required and remains per query row;
+    // it selects the physical block-table column and scratch slab. Each live
+    // query attends its complete committed prefix from the block table plus
+    // its own candidate node and ancestors from physical K/V rows
+    // tree_scratch_base + slot*tree_scratch_stride + node. Siblings and rows
+    // at or beyond tree_sizes[s] are excluded. query_positions must be NULL
+    // in tree mode. Pass NULL/NULL/0/0/0 to retain standard paged attention.
     GGML_API struct ggml_tensor * ggml_paged_attn_ext(
             struct ggml_context * ctx,
             struct ggml_tensor  * q,
@@ -2513,7 +2525,32 @@ extern "C" {
             struct ggml_tensor  * query_positions,
             float                 scale,
             int                   block_size,
-            int                   max_kv_seq_len);
+            int                   max_kv_seq_len,
+            struct ggml_tensor  * parent_ids
+#ifdef __cplusplus
+                = nullptr
+#endif
+            ,
+            struct ggml_tensor  * tree_sizes
+#ifdef __cplusplus
+                = nullptr
+#endif
+            ,
+            int                   tree_width
+#ifdef __cplusplus
+                = 0
+#endif
+            ,
+            int                   tree_scratch_base
+#ifdef __cplusplus
+                = 0
+#endif
+            ,
+            int                   tree_scratch_stride
+#ifdef __cplusplus
+                = 0
+#endif
+            );
 
     // TurboQuant FWHT rotation. direction: 0 = forward, 1 = inverse.
     // Applies signs1 -> FWHT -> signs2 (forward) or signs2 -> FWHT -> signs1 (inverse).
@@ -2937,6 +2974,15 @@ extern "C" {
     GGML_API void ggml_gated_delta_net_set_skip_intermediate(
             struct ggml_tensor * tensor,
             bool                 skip_intermediate);
+
+    // CUDA/HIP fixed-chain journal in compact F32 [J,H,T,B] layout:
+    // scalar gate J=2*S_v+1 stores [g | k | delta], while KDA J=3*S_v
+    // stores [g[S_v] | k | delta]. Delta is captured after the
+    // state-dependent reduction. A tree-form op may attach the journal when
+    // its parent table describes one root-inclusive chain.
+    GGML_API void ggml_gated_delta_net_set_transition_journal(
+            struct ggml_tensor * tensor,
+            struct ggml_tensor * journal);
 
     // dflash extension: let the kernel derive the gates from the raw
     // projections instead of graph-side sigmoid/softplus ops:

--- a/server/deps/llama.cpp/ggml/src/ggml-cpu/ggml-cpu.cpp
+++ b/server/deps/llama.cpp/ggml/src/ggml-cpu/ggml-cpu.cpp
@@ -478,10 +478,12 @@ static bool ggml_backend_cpu_device_supports_op(ggml_backend_dev_t dev, const st
             // implements the original mode and asserts if one reaches it.
             return ggml_get_op_params_i32(op, 0) == 0;
         case GGML_OP_GATED_DELTA_NET:
-            // Stateful SpecLA, raw gates and transition journals are
-            // CUDA/HIP-only extensions.
+            // The CPU kernel supports in-place and active-slot recurrence,
+            // but not tree parents, persistent intermediate storage, raw
+            // gates, transition journals, or SpecLA state.
             return ggml_get_op_params_i32(op, 2) != 1 &&
                    ggml_get_op_params_i32(op, 10) == 0 &&
+                   op->src[6] == nullptr && op->src[7] == nullptr &&
                    op->src[9] == nullptr &&
                    op->src[11] == nullptr;
         case GGML_OP_OUT_PROD:

--- a/server/deps/llama.cpp/ggml/src/ggml-cpu/ggml-cpu.cpp
+++ b/server/deps/llama.cpp/ggml/src/ggml-cpu/ggml-cpu.cpp
@@ -478,11 +478,12 @@ static bool ggml_backend_cpu_device_supports_op(ggml_backend_dev_t dev, const st
             // implements the original mode and asserts if one reaches it.
             return ggml_get_op_params_i32(op, 0) == 0;
         case GGML_OP_GATED_DELTA_NET:
-            // The Specla GDN variant (op param 2 == 1) is stateful via HLD and is
-            // only supported by CUDA/HIP. Raw-gate mode is also CUDA/HIP-only:
-            // the CPU kernel expects beta/g to have already been transformed.
+            // Stateful SpecLA, raw gates and transition journals are
+            // CUDA/HIP-only extensions.
             return ggml_get_op_params_i32(op, 2) != 1 &&
-                   ggml_get_op_params_i32(op, 10) == 0 && op->src[9] == nullptr;
+                   ggml_get_op_params_i32(op, 10) == 0 &&
+                   op->src[9] == nullptr &&
+                   op->src[11] == nullptr;
         case GGML_OP_OUT_PROD:
             return (src0->type == GGML_TYPE_F32 || (ggml_is_quantized(src0->type) && src0->ne[2] == src1->ne[2] && src0->ne[3] == src1->ne[3])) &&
                 src1->type == GGML_TYPE_F32 && op->type == GGML_TYPE_F32;

--- a/server/deps/llama.cpp/ggml/src/ggml-cpu/ggml-cpu.cpp
+++ b/server/deps/llama.cpp/ggml/src/ggml-cpu/ggml-cpu.cpp
@@ -480,12 +480,11 @@ static bool ggml_backend_cpu_device_supports_op(ggml_backend_dev_t dev, const st
         case GGML_OP_GATED_DELTA_NET:
             // The CPU kernel supports in-place and active-slot recurrence,
             // but not tree parents, persistent intermediate storage, raw
-            // gates, transition journals, or SpecLA state.
+            // gates or SpecLA state.
             return ggml_get_op_params_i32(op, 2) != 1 &&
                    ggml_get_op_params_i32(op, 10) == 0 &&
                    op->src[6] == nullptr && op->src[7] == nullptr &&
-                   op->src[9] == nullptr &&
-                   op->src[11] == nullptr;
+                   op->src[9] == nullptr;
         case GGML_OP_OUT_PROD:
             return (src0->type == GGML_TYPE_F32 || (ggml_is_quantized(src0->type) && src0->ne[2] == src1->ne[2] && src0->ne[3] == src1->ne[3])) &&
                 src1->type == GGML_TYPE_F32 && op->type == GGML_TYPE_F32;

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/gated_delta_net.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/gated_delta_net.cu
@@ -82,7 +82,7 @@ gated_delta_net_cuda(const float * q,
                                      float *       state_out,
                                      const int *   parent_ids,    // TREE_MODE only; else ignored
                                      InterT *      persist_inter, // optional external buffer for per-token intermediates
-                                     float *       transition_journal,
+                                     float *       replay_log,
                                      int64_t       H,
                                      int64_t       n_tokens,
                                      int64_t       n_seqs,
@@ -199,11 +199,11 @@ gated_delta_net_cuda(const float * q,
         const float * beta_t = beta + gb_offset;
         const float * g_t    = g    + gb_offset * (KDA ? S_v : 1);
 
-        constexpr int journal_gate_values = KDA ? S_v : 1;
-        constexpr int journal_width = journal_gate_values + 2*S_v;
-        float * journal_t = transition_journal
-            ? transition_journal +
-                ((sequence * n_tokens + t) * H + h_idx) * journal_width
+        constexpr int replay_log_gate_values = KDA ? S_v : 1;
+        constexpr int replay_log_width = replay_log_gate_values + 2*S_v;
+        float * replay_log_t = replay_log
+            ? replay_log +
+                ((sequence * n_tokens + t) * H + h_idx) * replay_log_width
             : nullptr;
 
         // raw-gate mode: beta = sigmoid(beta_raw); g = softplus(alpha_raw + bias) * A
@@ -220,13 +220,13 @@ gated_delta_net_cuda(const float * q,
             q_reg[r] = q_t[i];
         }
 
-        if (journal_t && blockIdx.z == 0 && threadIdx.y == 0) {
+        if (replay_log_t && blockIdx.z == 0 && threadIdx.y == 0) {
 #pragma unroll
             for (int r = 0; r < rows_per_lane; ++r) {
                 const int i = r * warp_size + lane;
-                journal_t[journal_gate_values + i] = k_reg[r];
+                replay_log_t[replay_log_gate_values + i] = k_reg[r];
                 if constexpr (KDA) {
-                    journal_t[i] = expf(g_t[i]);
+                    replay_log_t[i] = expf(g_t[i]);
                 }
             }
         }
@@ -238,8 +238,8 @@ gated_delta_net_cuda(const float * q,
                 g_log = ((a > 20.0f) ? a : logf(1.0f + expf(a))) * gate_A[h_idx];
             }
             const float g_val = expf(g_log);
-            if (journal_t && lane == 0 && col == 0) {
-                journal_t[0] = g_val;
+            if (replay_log_t && lane == 0 && col == 0) {
+                replay_log_t[0] = g_val;
             }
 
             // kv[col] = (S^T @ k)[col] = sum_i S[i][col] * k[i]
@@ -252,8 +252,8 @@ gated_delta_net_cuda(const float * q,
 
             // delta[col] = (v[col] - g * kv[col]) * beta
             float delta_col = (v_t[col] - g_val * kv_col) * beta_val;
-            if (journal_t && lane == 0) {
-                journal_t[journal_gate_values + S_v + col] = delta_col;
+            if (replay_log_t && lane == 0) {
+                replay_log_t[replay_log_gate_values + S_v + col] = delta_col;
             }
 
             // fused: S[i][col] = g * S[i][col] + k[i] * delta[col]
@@ -283,8 +283,8 @@ gated_delta_net_cuda(const float * q,
 
             // delta[col] = (v[col] - kv[col]) * beta
             float delta_col = (v_t[col] - kv_col) * beta_val;
-            if (journal_t && lane == 0) {
-                journal_t[journal_gate_values + S_v + col] = delta_col;
+            if (replay_log_t && lane == 0) {
+                replay_log_t[replay_log_gate_values + S_v + col] = delta_col;
             }
 
             // fused: S[i][col] = g[i] * S[i][col] + k[i] * delta[col]
@@ -341,7 +341,7 @@ gated_delta_net_cuda_grouped_cols(const float * q,
                                   float *       state_out,
                                   const int *   parent_ids,    // TREE_MODE only; else ignored
                                   InterT *      persist_inter,
-                                  float *       transition_journal,
+                                  float *       replay_log,
                                   int64_t       H,
                                   int64_t       n_tokens,
                                   int64_t       n_seqs,
@@ -481,10 +481,10 @@ gated_delta_net_cuda_grouped_cols(const float * q,
         g_val = __shfl_sync(0xffffffffU, g_val, 0);
         beta_val = __shfl_sync(0xffffffffU, beta_val, 0);
 
-        constexpr int journal_width = 2*S_v + 1;
-        float * journal_t = transition_journal
-            ? transition_journal +
-                ((sequence * n_tokens + t) * H + h_idx) * journal_width
+        constexpr int replay_log_width = 2*S_v + 1;
+        float * replay_log_t = replay_log
+            ? replay_log +
+                ((sequence * n_tokens + t) * H + h_idx) * replay_log_width
             : nullptr;
 
         float k_reg[rows_per_lane];
@@ -503,9 +503,9 @@ gated_delta_net_cuda_grouped_cols(const float * q,
             const float k_val = k_t[row];
             q_reg[r] = q_val;
             k_reg[r] = k_val;
-            if (journal_t && blockIdx.z == 0 && threadIdx.y == 0 &&
+            if (replay_log_t && blockIdx.z == 0 && threadIdx.y == 0 &&
                 subgroup == 0) {
-                journal_t[1 + row] = k_val;
+                replay_log_t[1 + row] = k_val;
             }
 
 #pragma unroll
@@ -513,9 +513,9 @@ gated_delta_net_cuda_grouped_cols(const float * q,
                 kv_partial[c] += state_shard[c][r] * k_val;
             }
         }
-        if (journal_t && blockIdx.z == 0 && threadIdx.y == 0 &&
+        if (replay_log_t && blockIdx.z == 0 && threadIdx.y == 0 &&
             subgroup == 0 && lane == 0) {
-            journal_t[0] = g_val;
+            replay_log_t[0] = g_val;
         }
 
         float delta[COLS];
@@ -525,8 +525,8 @@ gated_delta_net_cuda_grouped_cols(const float * q,
             float delta_val = 0.0f;
             if (lane == 0) {
                 delta_val = (v_t[col_base + c] - g_val * kv_col) * beta_val;
-                if (journal_t) {
-                    journal_t[1 + S_v + col_base + c] = delta_val;
+                if (replay_log_t) {
+                    replay_log_t[1 + S_v + col_base + c] = delta_val;
                 }
             }
             delta[c] = gdn_subgroup_broadcast_lane0(delta_val, WIDTH);
@@ -604,7 +604,7 @@ static void launch_gated_delta_net(
         int64_t neqk1, int64_t rq3,
         float scale, cudaStream_t stream,
         const float * gate_bias = nullptr, const float * gate_A = nullptr,
-        float * transition_journal_d = nullptr) {
+        float * replay_log_d = nullptr) {
     //TODO: Add chunked kernel for even faster pre-fill
     const int warp_size = ggml_cuda_info().devices[ggml_cuda_get_device()].warp_size;
     const int num_warps = 4;
@@ -626,19 +626,19 @@ static void launch_gated_delta_net(
     switch (S_v) {
         case 16:
             gated_delta_net_cuda<16, KDA, TREE_MODE, WRITE_INTER, InterT><<<grid_dims, block_dims, 0, stream>>>(
-                q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, transition_journal_d, H,
+                q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, replay_log_d, H,
                 n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,
                 sb1, sb2, sb3, neqk1_magic, rq3_magic, scale, gate_bias, gate_A);
             break;
         case 32:
             gated_delta_net_cuda<32, KDA, TREE_MODE, WRITE_INTER, InterT><<<grid_dims, block_dims, 0, stream>>>(
-                q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, transition_journal_d, H,
+                q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, replay_log_d, H,
                 n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,
                 sb1, sb2, sb3, neqk1_magic, rq3_magic, scale, gate_bias, gate_A);
             break;
         case 64: {
             gated_delta_net_cuda<64, KDA, TREE_MODE, WRITE_INTER, InterT><<<grid_dims, block_dims, 0, stream>>>(
-                q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, transition_journal_d, H,
+                q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, replay_log_d, H,
                 n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,
                 sb1, sb2, sb3, neqk1_magic, rq3_magic, scale, gate_bias, gate_A);
             break;
@@ -657,7 +657,7 @@ static void launch_gated_delta_net(
                         dim3 grouped_grid_dims(H, n_seqs, (groups + column_groups_per_block * groups_per_warp - 1) / (column_groups_per_block * groups_per_warp));
                         dim3 grouped_block_dims(32, column_groups_per_block, 1);
                         gated_delta_net_cuda_grouped_cols<128, cols, width, 32, TREE_MODE, WRITE_INTER, InterT><<<grouped_grid_dims, grouped_block_dims, 0, stream>>>(
-                            q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, transition_journal_d, H,
+                            q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, replay_log_d, H,
                             n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,
                             sb1, sb2, sb3, neqk1_magic, rq3_magic, scale, gate_bias, gate_A);
                     } else if (warp_size == 64) {
@@ -665,24 +665,24 @@ static void launch_gated_delta_net(
                         dim3 grouped_grid_dims(H, n_seqs, (groups + column_groups_per_block * groups_per_warp - 1) / (column_groups_per_block * groups_per_warp));
                         dim3 grouped_block_dims(64, column_groups_per_block, 1);
                         gated_delta_net_cuda_grouped_cols<128, cols, width, 64, TREE_MODE, WRITE_INTER, InterT><<<grouped_grid_dims, grouped_block_dims, 0, stream>>>(
-                            q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, transition_journal_d, H,
+                            q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, replay_log_d, H,
                             n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,
                             sb1, sb2, sb3, neqk1_magic, rq3_magic, scale, gate_bias, gate_A);
                     } else {
                         gated_delta_net_cuda<128, KDA, TREE_MODE, WRITE_INTER, InterT><<<grid_dims, block_dims, 0, stream>>>(
-                            q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, transition_journal_d, H,
+                            q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, replay_log_d, H,
                             n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,
                             sb1, sb2, sb3, neqk1_magic, rq3_magic, scale, gate_bias, gate_A);
                     }
                 } else {
                     gated_delta_net_cuda<128, KDA, TREE_MODE, WRITE_INTER, InterT><<<grid_dims, block_dims, 0, stream>>>(
-                        q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, transition_journal_d, H,
+                        q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, replay_log_d, H,
                         n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,
                         sb1, sb2, sb3, neqk1_magic, rq3_magic, scale, gate_bias, gate_A);
                 }
             } else {
                 gated_delta_net_cuda<128, KDA, TREE_MODE, WRITE_INTER, InterT><<<grid_dims, block_dims, 0, stream>>>(
-                    q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, transition_journal_d, H,
+                    q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, replay_log_d, H,
                     n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,
                     sb1, sb2, sb3, neqk1_magic, rq3_magic, scale, gate_bias, gate_A);
             }
@@ -972,9 +972,9 @@ void ggml_cuda_op_gated_delta_net(ggml_backend_cuda_context & ctx, ggml_tensor *
     void *        persist_inter_d = src_persist_inter
         ? src_persist_inter->data
         : nullptr;
-    const int journal_row_offset = ggml_get_op_params_i32(dst, 3);
-    float * transition_journal_d = journal_row_offset > 0
-        ? dst_d + (int64_t) journal_row_offset*dst->ne[0]
+    const int replay_log_row_offset = ggml_get_op_params_i32(dst, 3);
+    float * replay_log_d = replay_log_row_offset > 0
+        ? dst_d + (int64_t) replay_log_row_offset*dst->ne[0]
         : nullptr;
     const bool    persist_is_f16 =
         src_persist_inter && src_persist_inter->type == GGML_TYPE_F16;
@@ -1004,13 +1004,13 @@ void ggml_cuda_op_gated_delta_net(ggml_backend_cuda_context & ctx, ggml_tensor *
         GGML_ASSERT(ggml_is_contiguous(src_active_slots));
         GGML_ASSERT(ggml_nelements(src_active_slots) == n_seqs);
     }
-    if (transition_journal_d) {
-        const int64_t journal_width = kda ? 3*S_v : 2*S_v + 1;
-        const int64_t journal_elements =
-            journal_width*H*n_tokens*n_seqs;
+    if (replay_log_d) {
+        const int64_t replay_log_width = kda ? 3*S_v : 2*S_v + 1;
+        const int64_t replay_log_elements =
+            replay_log_width*H*n_tokens*n_seqs;
         GGML_ASSERT(
-            (int64_t) journal_row_offset*dst->ne[0] +
-                journal_elements <= ggml_nelements(dst));
+            (int64_t) replay_log_row_offset*dst->ne[0] +
+                replay_log_elements <= ggml_nelements(dst));
     }
 
     // strides in floats (beta strides used for both g and beta offset computation)
@@ -1054,34 +1054,34 @@ void ggml_cuda_op_gated_delta_net(ggml_backend_cuda_context & ctx, ggml_tensor *
                     launch_gated_delta_net<true, true, true, INTER_T>(                          \
                         q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_typed, \
                         S_v, H, n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,  \
-                        sb1, sb2, sb3, neqk1, rq3, scale, stream, gate_bias_d, gate_A_d, transition_journal_d); \
+                        sb1, sb2, sb3, neqk1, rq3, scale, stream, gate_bias_d, gate_A_d, replay_log_d); \
                 } else if (write_intermediate) {                                                \
                     launch_gated_delta_net<true, false, true, INTER_T>(                         \
                         q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, nullptr, persist_typed, \
                         S_v, H, n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,  \
-                        sb1, sb2, sb3, neqk1, rq3, scale, stream, gate_bias_d, gate_A_d, transition_journal_d); \
+                        sb1, sb2, sb3, neqk1, rq3, scale, stream, gate_bias_d, gate_A_d, replay_log_d); \
                 } else {                                                                        \
                     launch_gated_delta_net<true, false, false, INTER_T>(                        \
                         q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, nullptr, persist_typed, \
                         S_v, H, n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,  \
-                        sb1, sb2, sb3, neqk1, rq3, scale, stream, gate_bias_d, gate_A_d, transition_journal_d); \
+                        sb1, sb2, sb3, neqk1, rq3, scale, stream, gate_bias_d, gate_A_d, replay_log_d); \
                 }                                                                               \
             } else {                                                                            \
                 if (tree_mode) {                                                                \
                     launch_gated_delta_net<false, true, true, INTER_T>(                         \
                         q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_typed, \
                         S_v, H, n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,  \
-                        sb1, sb2, sb3, neqk1, rq3, scale, stream, gate_bias_d, gate_A_d, transition_journal_d); \
+                        sb1, sb2, sb3, neqk1, rq3, scale, stream, gate_bias_d, gate_A_d, replay_log_d); \
                 } else if (write_intermediate) {                                                \
                     launch_gated_delta_net<false, false, true, INTER_T>(                        \
                         q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, nullptr, persist_typed, \
                         S_v, H, n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,  \
-                        sb1, sb2, sb3, neqk1, rq3, scale, stream, gate_bias_d, gate_A_d, transition_journal_d); \
+                        sb1, sb2, sb3, neqk1, rq3, scale, stream, gate_bias_d, gate_A_d, replay_log_d); \
                 } else {                                                                        \
                     launch_gated_delta_net<false, false, false, INTER_T>(                       \
                         q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, nullptr, persist_typed, \
                         S_v, H, n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,  \
-                        sb1, sb2, sb3, neqk1, rq3, scale, stream, gate_bias_d, gate_A_d, transition_journal_d); \
+                        sb1, sb2, sb3, neqk1, rq3, scale, stream, gate_bias_d, gate_A_d, replay_log_d); \
                 }                                                                               \
             }                                                                                   \
         } while (0)

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/gated_delta_net.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/gated_delta_net.cu
@@ -82,6 +82,7 @@ gated_delta_net_cuda(const float * q,
                                      float *       state_out,
                                      const int *   parent_ids,    // TREE_MODE only; else ignored
                                      InterT *      persist_inter, // optional external buffer for per-token intermediates
+                                     float *       transition_journal,
                                      int64_t       H,
                                      int64_t       n_tokens,
                                      int64_t       n_seqs,
@@ -198,6 +199,13 @@ gated_delta_net_cuda(const float * q,
         const float * beta_t = beta + gb_offset;
         const float * g_t    = g    + gb_offset * (KDA ? S_v : 1);
 
+        constexpr int journal_gate_values = KDA ? S_v : 1;
+        constexpr int journal_width = journal_gate_values + 2*S_v;
+        float * journal_t = transition_journal
+            ? transition_journal +
+                ((sequence * n_tokens + t) * H + h_idx) * journal_width
+            : nullptr;
+
         // raw-gate mode: beta = sigmoid(beta_raw); g = softplus(alpha_raw + bias) * A
         const bool  raw_gates = gate_bias != nullptr;
         const float beta_val  = raw_gates ? 1.0f / (1.0f + expf(-(*beta_t))) : *beta_t;
@@ -212,6 +220,17 @@ gated_delta_net_cuda(const float * q,
             q_reg[r] = q_t[i];
         }
 
+        if (journal_t && blockIdx.z == 0 && threadIdx.y == 0) {
+#pragma unroll
+            for (int r = 0; r < rows_per_lane; ++r) {
+                const int i = r * warp_size + lane;
+                journal_t[journal_gate_values + i] = k_reg[r];
+                if constexpr (KDA) {
+                    journal_t[i] = expf(g_t[i]);
+                }
+            }
+        }
+
         if constexpr (!KDA) {
             float g_log = *g_t;
             if (raw_gates) {
@@ -219,6 +238,9 @@ gated_delta_net_cuda(const float * q,
                 g_log = ((a > 20.0f) ? a : logf(1.0f + expf(a))) * gate_A[h_idx];
             }
             const float g_val = expf(g_log);
+            if (journal_t && lane == 0 && col == 0) {
+                journal_t[0] = g_val;
+            }
 
             // kv[col] = (S^T @ k)[col] = sum_i S[i][col] * k[i]
             float kv_shard = 0.0f;
@@ -230,6 +252,9 @@ gated_delta_net_cuda(const float * q,
 
             // delta[col] = (v[col] - g * kv[col]) * beta
             float delta_col = (v_t[col] - g_val * kv_col) * beta_val;
+            if (journal_t && lane == 0) {
+                journal_t[journal_gate_values + S_v + col] = delta_col;
+            }
 
             // fused: S[i][col] = g * S[i][col] + k[i] * delta[col]
             // attn[col] = (S^T @ q)[col] = sum_i S[i][col] * q[i]
@@ -258,6 +283,9 @@ gated_delta_net_cuda(const float * q,
 
             // delta[col] = (v[col] - kv[col]) * beta
             float delta_col = (v_t[col] - kv_col) * beta_val;
+            if (journal_t && lane == 0) {
+                journal_t[journal_gate_values + S_v + col] = delta_col;
+            }
 
             // fused: S[i][col] = g[i] * S[i][col] + k[i] * delta[col]
             // attn[col] = (S^T @ q)[col] = sum_i S[i][col] * q[i]
@@ -313,6 +341,7 @@ gated_delta_net_cuda_grouped_cols(const float * q,
                                   float *       state_out,
                                   const int *   parent_ids,    // TREE_MODE only; else ignored
                                   InterT *      persist_inter,
+                                  float *       transition_journal,
                                   int64_t       H,
                                   int64_t       n_tokens,
                                   int64_t       n_seqs,
@@ -452,6 +481,12 @@ gated_delta_net_cuda_grouped_cols(const float * q,
         g_val = __shfl_sync(0xffffffffU, g_val, 0);
         beta_val = __shfl_sync(0xffffffffU, beta_val, 0);
 
+        constexpr int journal_width = 2*S_v + 1;
+        float * journal_t = transition_journal
+            ? transition_journal +
+                ((sequence * n_tokens + t) * H + h_idx) * journal_width
+            : nullptr;
+
         float k_reg[rows_per_lane];
         float q_reg[rows_per_lane];
         float kv_partial[COLS];
@@ -468,11 +503,19 @@ gated_delta_net_cuda_grouped_cols(const float * q,
             const float k_val = k_t[row];
             q_reg[r] = q_val;
             k_reg[r] = k_val;
+            if (journal_t && blockIdx.z == 0 && threadIdx.y == 0 &&
+                subgroup == 0) {
+                journal_t[1 + row] = k_val;
+            }
 
 #pragma unroll
             for (int c = 0; c < COLS; ++c) {
                 kv_partial[c] += state_shard[c][r] * k_val;
             }
+        }
+        if (journal_t && blockIdx.z == 0 && threadIdx.y == 0 &&
+            subgroup == 0 && lane == 0) {
+            journal_t[0] = g_val;
         }
 
         float delta[COLS];
@@ -482,6 +525,9 @@ gated_delta_net_cuda_grouped_cols(const float * q,
             float delta_val = 0.0f;
             if (lane == 0) {
                 delta_val = (v_t[col_base + c] - g_val * kv_col) * beta_val;
+                if (journal_t) {
+                    journal_t[1 + S_v + col_base + c] = delta_val;
+                }
             }
             delta[c] = gdn_subgroup_broadcast_lane0(delta_val, WIDTH);
         }
@@ -557,7 +603,8 @@ static void launch_gated_delta_net(
         int64_t sb1,   int64_t sb2, int64_t sb3,
         int64_t neqk1, int64_t rq3,
         float scale, cudaStream_t stream,
-        const float * gate_bias = nullptr, const float * gate_A = nullptr) {
+        const float * gate_bias = nullptr, const float * gate_A = nullptr,
+        float * transition_journal_d = nullptr) {
     //TODO: Add chunked kernel for even faster pre-fill
     const int warp_size = ggml_cuda_info().devices[ggml_cuda_get_device()].warp_size;
     const int num_warps = 4;
@@ -579,19 +626,19 @@ static void launch_gated_delta_net(
     switch (S_v) {
         case 16:
             gated_delta_net_cuda<16, KDA, TREE_MODE, WRITE_INTER, InterT><<<grid_dims, block_dims, 0, stream>>>(
-                q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, H,
+                q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, transition_journal_d, H,
                 n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,
                 sb1, sb2, sb3, neqk1_magic, rq3_magic, scale, gate_bias, gate_A);
             break;
         case 32:
             gated_delta_net_cuda<32, KDA, TREE_MODE, WRITE_INTER, InterT><<<grid_dims, block_dims, 0, stream>>>(
-                q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, H,
+                q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, transition_journal_d, H,
                 n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,
                 sb1, sb2, sb3, neqk1_magic, rq3_magic, scale, gate_bias, gate_A);
             break;
         case 64: {
             gated_delta_net_cuda<64, KDA, TREE_MODE, WRITE_INTER, InterT><<<grid_dims, block_dims, 0, stream>>>(
-                q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, H,
+                q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, transition_journal_d, H,
                 n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,
                 sb1, sb2, sb3, neqk1_magic, rq3_magic, scale, gate_bias, gate_A);
             break;
@@ -610,7 +657,7 @@ static void launch_gated_delta_net(
                         dim3 grouped_grid_dims(H, n_seqs, (groups + column_groups_per_block * groups_per_warp - 1) / (column_groups_per_block * groups_per_warp));
                         dim3 grouped_block_dims(32, column_groups_per_block, 1);
                         gated_delta_net_cuda_grouped_cols<128, cols, width, 32, TREE_MODE, WRITE_INTER, InterT><<<grouped_grid_dims, grouped_block_dims, 0, stream>>>(
-                            q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, H,
+                            q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, transition_journal_d, H,
                             n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,
                             sb1, sb2, sb3, neqk1_magic, rq3_magic, scale, gate_bias, gate_A);
                     } else if (warp_size == 64) {
@@ -618,24 +665,24 @@ static void launch_gated_delta_net(
                         dim3 grouped_grid_dims(H, n_seqs, (groups + column_groups_per_block * groups_per_warp - 1) / (column_groups_per_block * groups_per_warp));
                         dim3 grouped_block_dims(64, column_groups_per_block, 1);
                         gated_delta_net_cuda_grouped_cols<128, cols, width, 64, TREE_MODE, WRITE_INTER, InterT><<<grouped_grid_dims, grouped_block_dims, 0, stream>>>(
-                            q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, H,
+                            q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, transition_journal_d, H,
                             n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,
                             sb1, sb2, sb3, neqk1_magic, rq3_magic, scale, gate_bias, gate_A);
                     } else {
                         gated_delta_net_cuda<128, KDA, TREE_MODE, WRITE_INTER, InterT><<<grid_dims, block_dims, 0, stream>>>(
-                            q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, H,
+                            q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, transition_journal_d, H,
                             n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,
                             sb1, sb2, sb3, neqk1_magic, rq3_magic, scale, gate_bias, gate_A);
                     }
                 } else {
                     gated_delta_net_cuda<128, KDA, TREE_MODE, WRITE_INTER, InterT><<<grid_dims, block_dims, 0, stream>>>(
-                        q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, H,
+                        q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, transition_journal_d, H,
                         n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,
                         sb1, sb2, sb3, neqk1_magic, rq3_magic, scale, gate_bias, gate_A);
                 }
             } else {
                 gated_delta_net_cuda<128, KDA, TREE_MODE, WRITE_INTER, InterT><<<grid_dims, block_dims, 0, stream>>>(
-                    q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, H,
+                    q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, transition_journal_d, H,
                     n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,
                     sb1, sb2, sb3, neqk1_magic, rq3_magic, scale, gate_bias, gate_A);
             }
@@ -884,6 +931,9 @@ void ggml_cuda_op_gated_delta_net(ggml_backend_cuda_context & ctx, ggml_tensor *
     // Optional 9th source maps compact sequence rows to physical recurrent
     // state slabs. Negative ids are graph-bucket padding rows.
     ggml_tensor * src_active_slots = dst->src[8];
+    // Optional compact transition journal [J,H,T,B]. The packed tree caller
+    // uses it only with a root-inclusive linear parent chain.
+    ggml_tensor * src_transition_journal = dst->src[11];
 
     GGML_TENSOR_LOCALS(int64_t, neq, src_q, ne);
     GGML_TENSOR_LOCALS(size_t , nbq, src_q, nb);
@@ -926,6 +976,9 @@ void ggml_cuda_op_gated_delta_net(ggml_backend_cuda_context & ctx, ggml_tensor *
     void *        persist_inter_d = src_persist_inter
         ? src_persist_inter->data
         : nullptr;
+    float * transition_journal_d = src_transition_journal
+        ? (float *) src_transition_journal->data
+        : nullptr;
     const bool    persist_is_f16 =
         src_persist_inter && src_persist_inter->type == GGML_TYPE_F16;
     if (src_persist_inter) {
@@ -953,6 +1006,15 @@ void ggml_cuda_op_gated_delta_net(ggml_backend_cuda_context & ctx, ggml_tensor *
         GGML_ASSERT(src_active_slots->type == GGML_TYPE_I32);
         GGML_ASSERT(ggml_is_contiguous(src_active_slots));
         GGML_ASSERT(ggml_nelements(src_active_slots) == n_seqs);
+    }
+    if (src_transition_journal) {
+        const int64_t journal_width = kda ? 3*S_v : 2*S_v + 1;
+        GGML_ASSERT(src_transition_journal->type == GGML_TYPE_F32);
+        GGML_ASSERT(ggml_is_contiguous(src_transition_journal));
+        GGML_ASSERT(src_transition_journal->ne[0] == journal_width);
+        GGML_ASSERT(src_transition_journal->ne[1] == H);
+        GGML_ASSERT(src_transition_journal->ne[2] == n_tokens);
+        GGML_ASSERT(src_transition_journal->ne[3] == n_seqs);
     }
 
     // strides in floats (beta strides used for both g and beta offset computation)
@@ -995,35 +1057,35 @@ void ggml_cuda_op_gated_delta_net(ggml_backend_cuda_context & ctx, ggml_tensor *
                 if (tree_mode) {                                                                \
                     launch_gated_delta_net<true, true, true, INTER_T>(                          \
                         q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_typed, \
-                        S_v, H, n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,                 \
-                        sb1, sb2, sb3, neqk1, rq3, scale, stream, gate_bias_d, gate_A_d);                              \
+                        S_v, H, n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,  \
+                        sb1, sb2, sb3, neqk1, rq3, scale, stream, gate_bias_d, gate_A_d, transition_journal_d); \
                 } else if (write_intermediate) {                                                \
                     launch_gated_delta_net<true, false, true, INTER_T>(                         \
                         q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, nullptr, persist_typed, \
-                        S_v, H, n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,                 \
-                        sb1, sb2, sb3, neqk1, rq3, scale, stream, gate_bias_d, gate_A_d);                              \
+                        S_v, H, n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,  \
+                        sb1, sb2, sb3, neqk1, rq3, scale, stream, gate_bias_d, gate_A_d, transition_journal_d); \
                 } else {                                                                        \
                     launch_gated_delta_net<true, false, false, INTER_T>(                        \
                         q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, nullptr, persist_typed, \
-                        S_v, H, n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,                 \
-                        sb1, sb2, sb3, neqk1, rq3, scale, stream, gate_bias_d, gate_A_d);                              \
+                        S_v, H, n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,  \
+                        sb1, sb2, sb3, neqk1, rq3, scale, stream, gate_bias_d, gate_A_d, transition_journal_d); \
                 }                                                                               \
             } else {                                                                            \
                 if (tree_mode) {                                                                \
                     launch_gated_delta_net<false, true, true, INTER_T>(                         \
                         q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_typed, \
-                        S_v, H, n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,                 \
-                        sb1, sb2, sb3, neqk1, rq3, scale, stream, gate_bias_d, gate_A_d);                              \
+                        S_v, H, n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,  \
+                        sb1, sb2, sb3, neqk1, rq3, scale, stream, gate_bias_d, gate_A_d, transition_journal_d); \
                 } else if (write_intermediate) {                                                \
                     launch_gated_delta_net<false, false, true, INTER_T>(                        \
                         q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, nullptr, persist_typed, \
-                        S_v, H, n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,                 \
-                        sb1, sb2, sb3, neqk1, rq3, scale, stream, gate_bias_d, gate_A_d);                              \
+                        S_v, H, n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,  \
+                        sb1, sb2, sb3, neqk1, rq3, scale, stream, gate_bias_d, gate_A_d, transition_journal_d); \
                 } else {                                                                        \
                     launch_gated_delta_net<false, false, false, INTER_T>(                       \
                         q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, nullptr, persist_typed, \
-                        S_v, H, n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,                 \
-                        sb1, sb2, sb3, neqk1, rq3, scale, stream, gate_bias_d, gate_A_d);                              \
+                        S_v, H, n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,  \
+                        sb1, sb2, sb3, neqk1, rq3, scale, stream, gate_bias_d, gate_A_d, transition_journal_d); \
                 }                                                                               \
             }                                                                                   \
         } while (0)

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/gated_delta_net.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/gated_delta_net.cu
@@ -931,10 +931,6 @@ void ggml_cuda_op_gated_delta_net(ggml_backend_cuda_context & ctx, ggml_tensor *
     // Optional 9th source maps compact sequence rows to physical recurrent
     // state slabs. Negative ids are graph-bucket padding rows.
     ggml_tensor * src_active_slots = dst->src[8];
-    // Optional compact transition journal [J,H,T,B]. The packed tree caller
-    // uses it only with a root-inclusive linear parent chain.
-    ggml_tensor * src_transition_journal = dst->src[11];
-
     GGML_TENSOR_LOCALS(int64_t, neq, src_q, ne);
     GGML_TENSOR_LOCALS(size_t , nbq, src_q, nb);
     GGML_TENSOR_LOCALS(int64_t, nek, src_k, ne);
@@ -976,8 +972,9 @@ void ggml_cuda_op_gated_delta_net(ggml_backend_cuda_context & ctx, ggml_tensor *
     void *        persist_inter_d = src_persist_inter
         ? src_persist_inter->data
         : nullptr;
-    float * transition_journal_d = src_transition_journal
-        ? (float *) src_transition_journal->data
+    const int journal_row_offset = ggml_get_op_params_i32(dst, 3);
+    float * transition_journal_d = journal_row_offset > 0
+        ? dst_d + (int64_t) journal_row_offset*dst->ne[0]
         : nullptr;
     const bool    persist_is_f16 =
         src_persist_inter && src_persist_inter->type == GGML_TYPE_F16;
@@ -1007,14 +1004,13 @@ void ggml_cuda_op_gated_delta_net(ggml_backend_cuda_context & ctx, ggml_tensor *
         GGML_ASSERT(ggml_is_contiguous(src_active_slots));
         GGML_ASSERT(ggml_nelements(src_active_slots) == n_seqs);
     }
-    if (src_transition_journal) {
+    if (transition_journal_d) {
         const int64_t journal_width = kda ? 3*S_v : 2*S_v + 1;
-        GGML_ASSERT(src_transition_journal->type == GGML_TYPE_F32);
-        GGML_ASSERT(ggml_is_contiguous(src_transition_journal));
-        GGML_ASSERT(src_transition_journal->ne[0] == journal_width);
-        GGML_ASSERT(src_transition_journal->ne[1] == H);
-        GGML_ASSERT(src_transition_journal->ne[2] == n_tokens);
-        GGML_ASSERT(src_transition_journal->ne[3] == n_seqs);
+        const int64_t journal_elements =
+            journal_width*H*n_tokens*n_seqs;
+        GGML_ASSERT(
+            (int64_t) journal_row_offset*dst->ne[0] +
+                journal_elements <= ggml_nelements(dst));
     }
 
     // strides in floats (beta strides used for both g and beta offset computation)

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/gdn-replay-log.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/gdn-replay-log.cu
@@ -16,8 +16,8 @@
 
 namespace {
 
-__global__ void gdn_transition_journal_commit_kernel(
-        const float * journal,
+__global__ void gdn_replay_log_commit_kernel(
+        const float * replay_log,
         float * state,
         const int32_t * accepted_prefixes,
         const int32_t * active_slot_ids,
@@ -26,7 +26,7 @@ __global__ void gdn_transition_journal_commit_kernel(
         int n_tokens,
         int n_seqs,
         int n_state_slots,
-        int journal_width,
+        int replay_log_width,
         int gate_values) {
     const int sequence = blockIdx.z;
     const int head = blockIdx.y;
@@ -51,9 +51,9 @@ __global__ void gdn_transition_journal_commit_kernel(
     float current = state[state_offset];
 
     for (int token = 0; token < accepted; ++token) {
-        const float * transition = journal +
+        const float * transition = replay_log +
             (((size_t) sequence*n_tokens + token)*n_heads + head) *
-                journal_width;
+                replay_log_width;
         const float gate = gate_values == 1
             ? transition[0]
             : transition[row];
@@ -85,7 +85,7 @@ bool device_pointer(const void * pointer, int & device) {
 
 namespace {
 
-__global__ void gdn_conv_journal_commit_kernel(
+__global__ void gdn_conv_replay_log_commit_kernel(
         const float * conv_input,
         float * conv_state,
         const int32_t * accepted_prefixes,
@@ -176,8 +176,8 @@ enum class commit_mode {
     COMMIT_PREVALIDATED,
 };
 
-static bool gdn_transition_journal_commit_many_impl(
-        const ggml_tensor * const * journals,
+static bool gdn_replay_log_commit_many_impl(
+        const ggml_tensor * const * replay_logs,
         ggml_tensor * const * states,
         const ggml_tensor * const * conv_inputs,
         ggml_tensor * const * conv_states,
@@ -189,7 +189,7 @@ static bool gdn_transition_journal_commit_many_impl(
     const bool commit = mode != commit_mode::VALIDATE;
     const bool synchronize = mode == commit_mode::COMMIT;
     if (!prevalidated &&
-        (!journals || !states || !conv_inputs || !conv_states ||
+        (!replay_logs || !states || !conv_inputs || !conv_states ||
          n_layers <= 0 || !accepted_prefixes || !active_slot_ids ||
          accepted_prefixes->type != GGML_TYPE_I32 ||
          active_slot_ids->type != GGML_TYPE_I32 ||
@@ -216,25 +216,25 @@ static bool gdn_transition_journal_commit_many_impl(
         int common_state_slots = -1;
         std::vector<uint8_t> seen;
         for (int layer = 0; layer < n_layers; ++layer) {
-            const ggml_tensor * journal = journals[layer];
+            const ggml_tensor * replay_log = replay_logs[layer];
             ggml_tensor * state = states[layer];
             const ggml_tensor * conv_input = conv_inputs[layer];
             ggml_tensor * conv_state = conv_states[layer];
-            if (!journal || !state || !conv_input || !conv_state ||
-                journal->type != GGML_TYPE_F32 || state->type != GGML_TYPE_F32 ||
+            if (!replay_log || !state || !conv_input || !conv_state ||
+                replay_log->type != GGML_TYPE_F32 || state->type != GGML_TYPE_F32 ||
                 conv_input->type != GGML_TYPE_F32 || conv_state->type != GGML_TYPE_F32 ||
-                !ggml_is_contiguous(journal) || !ggml_is_contiguous(state) ||
+                !ggml_is_contiguous(replay_log) || !ggml_is_contiguous(state) ||
                 !ggml_is_contiguous(conv_input) || !ggml_is_contiguous(conv_state)) return false;
             const int64_t state_size = state->ne[0];
             const int64_t heads = state->ne[2];
-            const int64_t tokens = journal->ne[2];
+            const int64_t tokens = replay_log->ne[2];
             const int64_t state_slots = state->ne[3];
             if ((state_size != 16 && state_size != 32 &&
                  state_size != 64 && state_size != 128) ||
                 state->ne[1] != state_size || heads < 1 ||
-                journal->ne[1] != heads || journal->ne[3] != n_seqs ||
-                (journal->ne[0] != 2*state_size + 1 &&
-                 journal->ne[0] != 3*state_size) || tokens < 1 ||
+                replay_log->ne[1] != heads || replay_log->ne[3] != n_seqs ||
+                (replay_log->ne[0] != 2*state_size + 1 &&
+                 replay_log->ne[0] != 3*state_size) || tokens < 1 ||
                 conv_state->ne[0] < 1 || conv_state->ne[1] < 1 ||
                 conv_state->ne[2] != state_slots || conv_state->ne[3] != 1 ||
                 conv_input->ne[0] != conv_state->ne[0] + tokens ||
@@ -248,7 +248,7 @@ static bool gdn_transition_journal_commit_many_impl(
                 return false;
             }
             const void * pointers[] = {
-                journal->data, state->data, conv_input->data, conv_state->data,
+                replay_log->data, state->data, conv_input->data, conv_state->data,
             };
             for (const void * pointer : pointers) {
                 if (!same_device_pointer(pointer, device)) return false;
@@ -270,23 +270,23 @@ static bool gdn_transition_journal_commit_many_impl(
     constexpr int threads = 256;
     (void) cudaGetLastError();
     for (int layer = 0; layer < n_layers; ++layer) {
-        const ggml_tensor * journal = journals[layer];
+        const ggml_tensor * replay_log = replay_logs[layer];
         ggml_tensor * state = states[layer];
         const int state_size = (int) state->ne[0];
         const int heads = (int) state->ne[2];
-        const int tokens = (int) journal->ne[2];
-        const int journal_width = (int) journal->ne[0];
+        const int tokens = (int) replay_log->ne[2];
+        const int replay_log_width = (int) replay_log->ne[0];
         const int64_t state_elements = (int64_t) state_size*state_size;
         const dim3 state_grid(
             (unsigned int) ((state_elements + threads - 1)/threads),
             (unsigned int) heads, (unsigned int) n_seqs);
-        gdn_transition_journal_commit_kernel<<<state_grid, threads>>>(
-            (const float *) journal->data, (float *) state->data,
+        gdn_replay_log_commit_kernel<<<state_grid, threads>>>(
+            (const float *) replay_log->data, (float *) state->data,
             (const int32_t *) accepted_prefixes->data,
             (const int32_t *) active_slot_ids->data,
             state_size, heads, tokens, (int) n_seqs,
-            (int) state->ne[3], journal_width,
-            journal_width == 2*state_size + 1 ? 1 : state_size);
+            (int) state->ne[3], replay_log_width,
+            replay_log_width == 2*state_size + 1 ? 1 : state_size);
 
         const ggml_tensor * conv_input = conv_inputs[layer];
         ggml_tensor * conv_state = conv_states[layer];
@@ -295,7 +295,7 @@ static bool gdn_transition_journal_commit_many_impl(
         const dim3 conv_grid(
             (unsigned int) ((conv_elements + threads - 1)/threads),
             (unsigned int) n_seqs, 1);
-        gdn_conv_journal_commit_kernel<<<conv_grid, threads>>>(
+        gdn_conv_replay_log_commit_kernel<<<conv_grid, threads>>>(
             (const float *) conv_input->data, (float *) conv_state->data,
             (const int32_t *) accepted_prefixes->data,
             (const int32_t *) active_slot_ids->data,
@@ -306,21 +306,21 @@ static bool gdn_transition_journal_commit_many_impl(
     return !synchronize || cudaDeviceSynchronize() == cudaSuccess;
 }
 
-extern "C" bool ggml_backend_cuda_gdn_transition_journal_commit_many(
-        const ggml_tensor * const * journals,
+extern "C" bool ggml_backend_cuda_gdn_replay_log_commit_many(
+        const ggml_tensor * const * replay_logs,
         ggml_tensor * const * states,
         const ggml_tensor * const * conv_inputs,
         ggml_tensor * const * conv_states,
         int n_layers,
         const ggml_tensor * accepted_prefixes,
         const ggml_tensor * active_slot_ids) {
-    if (!gdn_transition_journal_commit_many_impl(
-            journals, states, conv_inputs, conv_states, n_layers,
+    if (!gdn_replay_log_commit_many_impl(
+            replay_logs, states, conv_inputs, conv_states, n_layers,
             accepted_prefixes, active_slot_ids, commit_mode::VALIDATE)) {
         return false;
     }
-    if (!gdn_transition_journal_commit_many_impl(
-            journals, states, conv_inputs, conv_states, n_layers,
+    if (!gdn_replay_log_commit_many_impl(
+            replay_logs, states, conv_inputs, conv_states, n_layers,
             accepted_prefixes, active_slot_ids, commit_mode::COMMIT)) {
         GGML_ABORT("recurrent commit failed after mutation began");
     }
@@ -501,7 +501,7 @@ extern "C" bool ggml_backend_cuda_tree_commit_transaction(
         const ggml_tensor * feature_source,
         ggml_tensor * feature_destination,
         const ggml_tensor * feature_destination_rows,
-        const ggml_tensor * const * journals,
+        const ggml_tensor * const * replay_logs,
         ggml_tensor * const * states,
         const ggml_tensor * const * conv_inputs,
         ggml_tensor * const * conv_states,
@@ -524,8 +524,8 @@ extern "C" bool ggml_backend_cuda_tree_commit_transaction(
         std::fprintf(stderr, "[gdn-transaction] feature preflight failed\n");
         return false;
     }
-    if (!gdn_transition_journal_commit_many_impl(
-            journals, states, conv_inputs, conv_states, n_layers,
+    if (!gdn_replay_log_commit_many_impl(
+            replay_logs, states, conv_inputs, conv_states, n_layers,
             accepted_prefixes, active_slot_ids, commit_mode::VALIDATE)) {
         std::fprintf(stderr, "[gdn-transaction] recurrent preflight failed\n");
         return false;
@@ -546,8 +546,8 @@ extern "C" bool ggml_backend_cuda_tree_commit_transaction(
             commit_mode::COMMIT_PREVALIDATED)) {
         GGML_ABORT("tree commit failed after feature mutation began");
     }
-    if (!gdn_transition_journal_commit_many_impl(
-            journals, states, conv_inputs, conv_states, n_layers,
+    if (!gdn_replay_log_commit_many_impl(
+            replay_logs, states, conv_inputs, conv_states, n_layers,
             accepted_prefixes, active_slot_ids,
             commit_mode::COMMIT_PREVALIDATED)) {
         GGML_ABORT("tree commit failed after recurrent mutation began");

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/gdn-transition-journal.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/gdn-transition-journal.cu
@@ -169,14 +169,15 @@ bool same_device_pointer(const void * pointer, int expected_device) {
 
 } // namespace
 
-extern "C" bool ggml_backend_cuda_gdn_transition_journal_commit_many(
+static bool gdn_transition_journal_commit_many_impl(
         const ggml_tensor * const * journals,
         ggml_tensor * const * states,
         const ggml_tensor * const * conv_inputs,
         ggml_tensor * const * conv_states,
         int n_layers,
         const ggml_tensor * accepted_prefixes,
-        const ggml_tensor * active_slot_ids) {
+        const ggml_tensor * active_slot_ids,
+        bool commit) {
     if (!journals || !states || !conv_inputs || !conv_states ||
         n_layers <= 0 || !accepted_prefixes || !active_slot_ids ||
         accepted_prefixes->type != GGML_TYPE_I32 ||
@@ -250,6 +251,7 @@ extern "C" bool ggml_backend_cuda_gdn_transition_journal_commit_many(
         seen[(size_t) slot] = 1;
     }
 
+    if (!commit) return true;
     ggml_cuda_set_device(device);
     constexpr int threads = 256;
     (void) cudaGetLastError();
@@ -290,13 +292,35 @@ extern "C" bool ggml_backend_cuda_gdn_transition_journal_commit_many(
     return cudaDeviceSynchronize() == cudaSuccess;
 }
 
-extern "C" bool ggml_backend_cuda_tree_cache_commit_many(
+extern "C" bool ggml_backend_cuda_gdn_transition_journal_commit_many(
+        const ggml_tensor * const * journals,
+        ggml_tensor * const * states,
+        const ggml_tensor * const * conv_inputs,
+        ggml_tensor * const * conv_states,
+        int n_layers,
+        const ggml_tensor * accepted_prefixes,
+        const ggml_tensor * active_slot_ids) {
+    if (!gdn_transition_journal_commit_many_impl(
+            journals, states, conv_inputs, conv_states, n_layers,
+            accepted_prefixes, active_slot_ids, false)) {
+        return false;
+    }
+    if (!gdn_transition_journal_commit_many_impl(
+            journals, states, conv_inputs, conv_states, n_layers,
+            accepted_prefixes, active_slot_ids, true)) {
+        GGML_ABORT("recurrent commit failed after mutation began");
+    }
+    return true;
+}
+
+static bool tree_cache_commit_many_impl(
         ggml_tensor * const * caches,
         int n_caches,
         const ggml_tensor * commit_rows,
         const ggml_tensor * active_slot_ids,
         int tree_scratch_base,
-        int tree_scratch_stride) {
+        int tree_scratch_stride,
+        bool commit) {
     if (!caches || n_caches <= 0 || !commit_rows || !active_slot_ids ||
         commit_rows->type != GGML_TYPE_I64 ||
         active_slot_ids->type != GGML_TYPE_I32 ||
@@ -342,6 +366,7 @@ extern "C" bool ggml_backend_cuda_tree_cache_commit_many(
         }
     }
 
+    if (!commit) return true;
     ggml_cuda_set_device(device);
     constexpr int threads = 256;
     (void) cudaGetLastError();
@@ -362,10 +387,31 @@ extern "C" bool ggml_backend_cuda_tree_cache_commit_many(
     return cudaDeviceSynchronize() == cudaSuccess;
 }
 
-extern "C" bool ggml_backend_cuda_tree_feature_commit(
+extern "C" bool ggml_backend_cuda_tree_cache_commit_many(
+        ggml_tensor * const * caches,
+        int n_caches,
+        const ggml_tensor * commit_rows,
+        const ggml_tensor * active_slot_ids,
+        int tree_scratch_base,
+        int tree_scratch_stride) {
+    if (!tree_cache_commit_many_impl(
+            caches, n_caches, commit_rows, active_slot_ids,
+            tree_scratch_base, tree_scratch_stride, false)) {
+        return false;
+    }
+    if (!tree_cache_commit_many_impl(
+            caches, n_caches, commit_rows, active_slot_ids,
+            tree_scratch_base, tree_scratch_stride, true)) {
+        GGML_ABORT("K/V commit failed after mutation began");
+    }
+    return true;
+}
+
+static bool tree_feature_commit_impl(
         const ggml_tensor * source,
         ggml_tensor * destination,
-        const ggml_tensor * destination_rows) {
+        const ggml_tensor * destination_rows,
+        bool commit) {
     if (!source || !destination || !destination_rows ||
         source->type != destination->type || source->type != GGML_TYPE_BF16 ||
         destination_rows->type != GGML_TYPE_I32 ||
@@ -387,6 +433,7 @@ extern "C" bool ggml_backend_cuda_tree_feature_commit(
     for (int row : rows) {
         if (row < -1 || row >= destination->ne[1]) return false;
     }
+    if (!commit) return true;
     ggml_cuda_set_device(device);
     constexpr int threads = 256;
     const dim3 grid(
@@ -399,4 +446,68 @@ extern "C" bool ggml_backend_cuda_tree_feature_commit(
         source->nb[1], n_rows, (int) destination->ne[1]);
     if (cudaGetLastError() != cudaSuccess) return false;
     return cudaDeviceSynchronize() == cudaSuccess;
+}
+
+extern "C" bool ggml_backend_cuda_tree_feature_commit(
+        const ggml_tensor * source,
+        ggml_tensor * destination,
+        const ggml_tensor * destination_rows) {
+    if (!tree_feature_commit_impl(
+            source, destination, destination_rows, false)) {
+        return false;
+    }
+    if (!tree_feature_commit_impl(
+            source, destination, destination_rows, true)) {
+        GGML_ABORT("feature commit failed after mutation began");
+    }
+    return true;
+}
+
+extern "C" bool ggml_backend_cuda_tree_commit_transaction(
+        ggml_tensor * const * caches,
+        int n_caches,
+        const ggml_tensor * feature_source,
+        ggml_tensor * feature_destination,
+        const ggml_tensor * feature_destination_rows,
+        const ggml_tensor * const * journals,
+        ggml_tensor * const * states,
+        const ggml_tensor * const * conv_inputs,
+        ggml_tensor * const * conv_states,
+        int n_layers,
+        const ggml_tensor * commit_rows,
+        const ggml_tensor * accepted_prefixes,
+        const ggml_tensor * active_slot_ids,
+        int tree_scratch_base,
+        int tree_scratch_stride) {
+    if (!tree_cache_commit_many_impl(
+            caches, n_caches, commit_rows, active_slot_ids,
+            tree_scratch_base, tree_scratch_stride, false) ||
+        !tree_feature_commit_impl(
+            feature_source, feature_destination,
+            feature_destination_rows, false) ||
+        !gdn_transition_journal_commit_many_impl(
+            journals, states, conv_inputs, conv_states, n_layers,
+            accepted_prefixes, active_slot_ids, false)) {
+        return false;
+    }
+
+    // No recoverable error may escape after the first destination changes.
+    // Returning false here would let the caller run fallback from a mixed
+    // pre-commit/post-commit state.
+    if (!tree_cache_commit_many_impl(
+            caches, n_caches, commit_rows, active_slot_ids,
+            tree_scratch_base, tree_scratch_stride, true)) {
+        GGML_ABORT("tree commit failed after K/V mutation began");
+    }
+    if (!tree_feature_commit_impl(
+            feature_source, feature_destination,
+            feature_destination_rows, true)) {
+        GGML_ABORT("tree commit failed after feature mutation began");
+    }
+    if (!gdn_transition_journal_commit_many_impl(
+            journals, states, conv_inputs, conv_states, n_layers,
+            accepted_prefixes, active_slot_ids, true)) {
+        GGML_ABORT("tree commit failed after recurrent mutation began");
+    }
+    return true;
 }

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/gdn-transition-journal.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/gdn-transition-journal.cu
@@ -1,0 +1,402 @@
+#include "common.cuh"
+#include "ggml-cuda.h"
+
+#include <cstddef>
+#include <vector>
+
+#if defined(GGML_USE_HIP)
+#ifndef cudaPointerAttributes
+#define cudaPointerAttributes    hipPointerAttribute_t
+#define cudaPointerGetAttributes hipPointerGetAttributes
+#define cudaMemoryTypeDevice     hipMemoryTypeDevice
+#define cudaMemoryTypeManaged    hipMemoryTypeManaged
+#endif
+#endif
+
+namespace {
+
+__global__ void gdn_transition_journal_commit_kernel(
+        const float * journal,
+        float * state,
+        const int32_t * accepted_prefixes,
+        const int32_t * active_slot_ids,
+        int state_size,
+        int n_heads,
+        int n_tokens,
+        int n_seqs,
+        int n_state_slots,
+        int journal_width,
+        int gate_values) {
+    const int sequence = blockIdx.z;
+    const int head = blockIdx.y;
+    const int element = blockIdx.x * blockDim.x + threadIdx.x;
+    const int state_elements = state_size * state_size;
+    if (sequence >= n_seqs || head >= n_heads ||
+        element >= state_elements) {
+        return;
+    }
+
+    const int slot = active_slot_ids[sequence];
+    const int accepted = accepted_prefixes[sequence];
+    if (slot < 0 || slot >= n_state_slots ||
+        accepted < 0 || accepted > n_tokens) {
+        return;
+    }
+
+    const int row = element % state_size;
+    const int col = element / state_size;
+    const size_t state_offset =
+        (((size_t) slot*n_heads + head)*state_size + col)*state_size + row;
+    float current = state[state_offset];
+
+    for (int token = 0; token < accepted; ++token) {
+        const float * transition = journal +
+            (((size_t) sequence*n_tokens + token)*n_heads + head) *
+                journal_width;
+        const float gate = gate_values == 1
+            ? transition[0]
+            : transition[row];
+        const float key = transition[gate_values + row];
+        const float delta =
+            transition[gate_values + state_size + col];
+        current = fmaf(key, delta, gate * current);
+    }
+
+    state[state_offset] = current;
+}
+
+bool device_pointer(const void * pointer, int & device) {
+    if (pointer == nullptr) return false;
+    cudaPointerAttributes attributes{};
+    if (cudaPointerGetAttributes(&attributes, pointer) != cudaSuccess) {
+        (void) cudaGetLastError();
+        return false;
+    }
+    if (attributes.type != cudaMemoryTypeDevice &&
+        attributes.type != cudaMemoryTypeManaged) {
+        return false;
+    }
+    device = attributes.device;
+    return true;
+}
+
+} // namespace
+
+namespace {
+
+__global__ void gdn_conv_journal_commit_kernel(
+        const float * conv_input,
+        float * conv_state,
+        const int32_t * accepted_prefixes,
+        const int32_t * active_slot_ids,
+        int window,
+        int channels,
+        int n_tokens,
+        int n_seqs,
+        int n_state_slots) {
+    const int sequence = blockIdx.y;
+    const int element = blockIdx.x * blockDim.x + threadIdx.x;
+    const int count = window * channels;
+    if (sequence >= n_seqs || element >= count) return;
+    const int slot = active_slot_ids[sequence];
+    const int accepted = accepted_prefixes[sequence];
+    if (slot < 0 || slot >= n_state_slots ||
+        accepted < 0 || accepted > n_tokens) return;
+    const int k = element % window;
+    const int channel = element / window;
+    const size_t source =
+        ((size_t) sequence * channels + channel) * (window + n_tokens) +
+        accepted + k;
+    const size_t destination =
+        ((size_t) slot * channels + channel) * window + k;
+    conv_state[destination] = conv_input[source];
+}
+
+__global__ void tree_cache_commit_kernel(
+        uint8_t * cache,
+        const int64_t * commit_rows,
+        const int32_t * active_slot_ids,
+        size_t row_bytes,
+        size_t head_stride,
+        int n_heads,
+        int tree_width,
+        int n_seqs,
+        int n_cache_rows,
+        int scratch_base,
+        int scratch_stride) {
+    const int byte = blockIdx.x * blockDim.x + threadIdx.x;
+    const int flat = blockIdx.y;
+    const int head = blockIdx.z;
+    if ((size_t) byte >= row_bytes || flat >= tree_width*n_seqs ||
+        head >= n_heads) return;
+    const int lane = flat / tree_width;
+    const int node = flat % tree_width;
+    const int slot = active_slot_ids[lane];
+    const int64_t destination_row = commit_rows[flat];
+    if (slot < 0 || destination_row < 0 ||
+        destination_row >= n_cache_rows) return;
+    const int64_t source_row =
+        (int64_t) scratch_base + (int64_t) slot*scratch_stride + node;
+    if (source_row < 0 || source_row >= n_cache_rows) return;
+    const size_t source =
+        (size_t) head*head_stride + (size_t) source_row*row_bytes + byte;
+    const size_t destination =
+        (size_t) head*head_stride + (size_t) destination_row*row_bytes + byte;
+    cache[destination] = cache[source];
+}
+
+__global__ void tree_feature_commit_kernel(
+        const uint8_t * source,
+        uint8_t * destination,
+        const int32_t * destination_rows,
+        size_t row_bytes,
+        int n_rows,
+        int destination_capacity) {
+    const int byte = blockIdx.x * blockDim.x + threadIdx.x;
+    const int source_row = blockIdx.y;
+    if ((size_t) byte >= row_bytes || source_row >= n_rows) return;
+    const int destination_row = destination_rows[source_row];
+    if (destination_row < 0 || destination_row >= destination_capacity) return;
+    destination[(size_t) destination_row*row_bytes + byte] =
+        source[(size_t) source_row*row_bytes + byte];
+}
+
+bool same_device_pointer(const void * pointer, int expected_device) {
+    int pointer_device = -1;
+    return device_pointer(pointer, pointer_device) &&
+        pointer_device == expected_device;
+}
+
+} // namespace
+
+extern "C" bool ggml_backend_cuda_gdn_transition_journal_commit_many(
+        const ggml_tensor * const * journals,
+        ggml_tensor * const * states,
+        const ggml_tensor * const * conv_inputs,
+        ggml_tensor * const * conv_states,
+        int n_layers,
+        const ggml_tensor * accepted_prefixes,
+        const ggml_tensor * active_slot_ids) {
+    if (!journals || !states || !conv_inputs || !conv_states ||
+        n_layers <= 0 || !accepted_prefixes || !active_slot_ids ||
+        accepted_prefixes->type != GGML_TYPE_I32 ||
+        active_slot_ids->type != GGML_TYPE_I32 ||
+        !ggml_is_contiguous(accepted_prefixes) ||
+        !ggml_is_contiguous(active_slot_ids)) return false;
+
+    const int64_t n_seqs = ggml_nelements(accepted_prefixes);
+    if (n_seqs < 1 || ggml_nelements(active_slot_ids) != n_seqs) return false;
+    int device = -1;
+    if (!device_pointer(accepted_prefixes->data, device) ||
+        !same_device_pointer(active_slot_ids->data, device)) return false;
+
+    std::vector<int32_t> accepted((size_t) n_seqs);
+    std::vector<int32_t> slots((size_t) n_seqs);
+    const size_t map_bytes = (size_t) n_seqs*sizeof(int32_t);
+    if (cudaMemcpy(accepted.data(), accepted_prefixes->data, map_bytes,
+                   cudaMemcpyDeviceToHost) != cudaSuccess ||
+        cudaMemcpy(slots.data(), active_slot_ids->data, map_bytes,
+                   cudaMemcpyDeviceToHost) != cudaSuccess) return false;
+
+    int common_tokens = -1;
+    int common_state_slots = -1;
+    std::vector<uint8_t> seen;
+    for (int layer = 0; layer < n_layers; ++layer) {
+        const ggml_tensor * journal = journals[layer];
+        ggml_tensor * state = states[layer];
+        const ggml_tensor * conv_input = conv_inputs[layer];
+        ggml_tensor * conv_state = conv_states[layer];
+        if (!journal || !state || !conv_input || !conv_state ||
+            journal->type != GGML_TYPE_F32 || state->type != GGML_TYPE_F32 ||
+            conv_input->type != GGML_TYPE_F32 || conv_state->type != GGML_TYPE_F32 ||
+            !ggml_is_contiguous(journal) || !ggml_is_contiguous(state) ||
+            !ggml_is_contiguous(conv_input) || !ggml_is_contiguous(conv_state)) return false;
+        const int64_t state_size = state->ne[0];
+        const int64_t heads = state->ne[2];
+        const int64_t tokens = journal->ne[2];
+        const int64_t state_slots = state->ne[3];
+        if ((state_size != 16 && state_size != 32 &&
+             state_size != 64 && state_size != 128) ||
+            state->ne[1] != state_size || heads < 1 ||
+            journal->ne[1] != heads || journal->ne[3] != n_seqs ||
+            (journal->ne[0] != 2*state_size + 1 &&
+             journal->ne[0] != 3*state_size) || tokens < 1 ||
+            conv_state->ne[0] < 1 || conv_state->ne[1] < 1 ||
+            conv_state->ne[2] != state_slots || conv_state->ne[3] != 1 ||
+            conv_input->ne[0] != conv_state->ne[0] + tokens ||
+            conv_input->ne[1] != conv_state->ne[1] ||
+            conv_input->ne[2] != n_seqs || conv_input->ne[3] != 1) return false;
+        if (common_tokens < 0) {
+            common_tokens = (int) tokens;
+            common_state_slots = (int) state_slots;
+            seen.assign((size_t) state_slots, 0);
+        } else if (tokens != common_tokens || state_slots != common_state_slots) {
+            return false;
+        }
+        const void * pointers[] = {
+            journal->data, state->data, conv_input->data, conv_state->data,
+        };
+        for (const void * pointer : pointers) {
+            if (!same_device_pointer(pointer, device)) return false;
+        }
+    }
+    for (int64_t lane = 0; lane < n_seqs; ++lane) {
+        if (accepted[(size_t) lane] < 0 ||
+            accepted[(size_t) lane] > common_tokens) return false;
+        const int slot = slots[(size_t) lane];
+        if (slot == -1) continue;
+        if (slot < 0 || slot >= common_state_slots) return false;
+        if (seen[(size_t) slot]) return false;
+        seen[(size_t) slot] = 1;
+    }
+
+    ggml_cuda_set_device(device);
+    constexpr int threads = 256;
+    (void) cudaGetLastError();
+    for (int layer = 0; layer < n_layers; ++layer) {
+        const ggml_tensor * journal = journals[layer];
+        ggml_tensor * state = states[layer];
+        const int state_size = (int) state->ne[0];
+        const int heads = (int) state->ne[2];
+        const int tokens = (int) journal->ne[2];
+        const int journal_width = (int) journal->ne[0];
+        const int64_t state_elements = (int64_t) state_size*state_size;
+        const dim3 state_grid(
+            (unsigned int) ((state_elements + threads - 1)/threads),
+            (unsigned int) heads, (unsigned int) n_seqs);
+        gdn_transition_journal_commit_kernel<<<state_grid, threads>>>(
+            (const float *) journal->data, (float *) state->data,
+            (const int32_t *) accepted_prefixes->data,
+            (const int32_t *) active_slot_ids->data,
+            state_size, heads, tokens, (int) n_seqs,
+            (int) state->ne[3], journal_width,
+            journal_width == 2*state_size + 1 ? 1 : state_size);
+
+        const ggml_tensor * conv_input = conv_inputs[layer];
+        ggml_tensor * conv_state = conv_states[layer];
+        const int conv_elements =
+            (int) (conv_state->ne[0]*conv_state->ne[1]);
+        const dim3 conv_grid(
+            (unsigned int) ((conv_elements + threads - 1)/threads),
+            (unsigned int) n_seqs, 1);
+        gdn_conv_journal_commit_kernel<<<conv_grid, threads>>>(
+            (const float *) conv_input->data, (float *) conv_state->data,
+            (const int32_t *) accepted_prefixes->data,
+            (const int32_t *) active_slot_ids->data,
+            (int) conv_state->ne[0], (int) conv_state->ne[1], tokens,
+            (int) n_seqs, (int) conv_state->ne[2]);
+    }
+    if (cudaGetLastError() != cudaSuccess) return false;
+    return cudaDeviceSynchronize() == cudaSuccess;
+}
+
+extern "C" bool ggml_backend_cuda_tree_cache_commit_many(
+        ggml_tensor * const * caches,
+        int n_caches,
+        const ggml_tensor * commit_rows,
+        const ggml_tensor * active_slot_ids,
+        int tree_scratch_base,
+        int tree_scratch_stride) {
+    if (!caches || n_caches <= 0 || !commit_rows || !active_slot_ids ||
+        commit_rows->type != GGML_TYPE_I64 ||
+        active_slot_ids->type != GGML_TYPE_I32 ||
+        !ggml_is_contiguous(commit_rows) ||
+        !ggml_is_contiguous(active_slot_ids) ||
+        commit_rows->ne[0] < 1 || commit_rows->ne[1] < 1 ||
+        ggml_nelements(active_slot_ids) != commit_rows->ne[1] ||
+        tree_scratch_base < 0 || tree_scratch_stride < commit_rows->ne[0]) return false;
+    const int tree_width = (int) commit_rows->ne[0];
+    const int n_seqs = (int) commit_rows->ne[1];
+    const int n_rows = tree_width*n_seqs;
+    int device = -1;
+    if (!device_pointer(commit_rows->data, device) ||
+        !same_device_pointer(active_slot_ids->data, device)) return false;
+
+    std::vector<int64_t> destinations((size_t) n_rows);
+    std::vector<int32_t> slots((size_t) n_seqs);
+    if (cudaMemcpy(destinations.data(), commit_rows->data,
+                   destinations.size()*sizeof(int64_t), cudaMemcpyDeviceToHost) != cudaSuccess ||
+        cudaMemcpy(slots.data(), active_slot_ids->data,
+                   slots.size()*sizeof(int32_t), cudaMemcpyDeviceToHost) != cudaSuccess) return false;
+    int cache_rows = -1;
+    for (int index = 0; index < n_caches; ++index) {
+        ggml_tensor * cache = caches[index];
+        if (!cache || !ggml_is_contiguous(cache) || cache->ne[0] < 1 ||
+            cache->ne[1] < 1 || cache->ne[2] < 1 || cache->ne[3] != 1 ||
+            cache->nb[1] < ggml_row_size(cache->type, cache->ne[0]) ||
+            !same_device_pointer(cache->data, device)) return false;
+        if (cache_rows < 0) cache_rows = (int) cache->ne[1];
+        else if (cache->ne[1] != cache_rows) return false;
+    }
+    for (int lane = 0; lane < n_seqs; ++lane) {
+        const int slot = slots[(size_t) lane];
+        if (slot == -1) continue;
+        if (slot < 0) return false;
+        const int64_t source_end = (int64_t) tree_scratch_base +
+            (int64_t) slot*tree_scratch_stride + tree_width;
+        if (source_end > cache_rows) return false;
+        for (int node = 0; node < tree_width; ++node) {
+            const int64_t destination =
+                destinations[(size_t) lane*tree_width + node];
+            if (destination < -1 || destination >= cache_rows) return false;
+        }
+    }
+
+    ggml_cuda_set_device(device);
+    constexpr int threads = 256;
+    (void) cudaGetLastError();
+    for (int index = 0; index < n_caches; ++index) {
+        ggml_tensor * cache = caches[index];
+        const dim3 grid(
+            (unsigned int) ((cache->nb[1] + threads - 1)/threads),
+            (unsigned int) n_rows, (unsigned int) cache->ne[2]);
+        tree_cache_commit_kernel<<<grid, threads>>>(
+            (uint8_t *) cache->data,
+            (const int64_t *) commit_rows->data,
+            (const int32_t *) active_slot_ids->data,
+            cache->nb[1], cache->nb[2], (int) cache->ne[2],
+            tree_width, n_seqs, cache_rows,
+            tree_scratch_base, tree_scratch_stride);
+    }
+    if (cudaGetLastError() != cudaSuccess) return false;
+    return cudaDeviceSynchronize() == cudaSuccess;
+}
+
+extern "C" bool ggml_backend_cuda_tree_feature_commit(
+        const ggml_tensor * source,
+        ggml_tensor * destination,
+        const ggml_tensor * destination_rows) {
+    if (!source || !destination || !destination_rows ||
+        source->type != destination->type || source->type != GGML_TYPE_BF16 ||
+        destination_rows->type != GGML_TYPE_I32 ||
+        !ggml_is_contiguous(source) || !ggml_is_contiguous(destination) ||
+        !ggml_is_contiguous(destination_rows) ||
+        source->ne[0] != destination->ne[0] || source->ne[2] != 1 ||
+        source->ne[3] != 1 || destination->ne[2] != 1 ||
+        destination->ne[3] != 1 ||
+        ggml_nelements(destination_rows) != source->ne[1] ||
+        source->nb[1] != destination->nb[1]) return false;
+    int device = -1;
+    if (!device_pointer(source->data, device) ||
+        !same_device_pointer(destination->data, device) ||
+        !same_device_pointer(destination_rows->data, device)) return false;
+    const int n_rows = (int) source->ne[1];
+    std::vector<int32_t> rows((size_t) n_rows);
+    if (cudaMemcpy(rows.data(), destination_rows->data,
+                   rows.size()*sizeof(int32_t), cudaMemcpyDeviceToHost) != cudaSuccess) return false;
+    for (int row : rows) {
+        if (row < -1 || row >= destination->ne[1]) return false;
+    }
+    ggml_cuda_set_device(device);
+    constexpr int threads = 256;
+    const dim3 grid(
+        (unsigned int) ((source->nb[1] + threads - 1)/threads),
+        (unsigned int) n_rows, 1);
+    (void) cudaGetLastError();
+    tree_feature_commit_kernel<<<grid, threads>>>(
+        (const uint8_t *) source->data, (uint8_t *) destination->data,
+        (const int32_t *) destination_rows->data,
+        source->nb[1], n_rows, (int) destination->ne[1]);
+    if (cudaGetLastError() != cudaSuccess) return false;
+    return cudaDeviceSynchronize() == cudaSuccess;
+}

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/gdn-transition-journal.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/gdn-transition-journal.cu
@@ -2,6 +2,7 @@
 #include "ggml-cuda.h"
 
 #include <cstddef>
+#include <cstdio>
 #include <vector>
 
 #if defined(GGML_USE_HIP)
@@ -169,6 +170,12 @@ bool same_device_pointer(const void * pointer, int expected_device) {
 
 } // namespace
 
+enum class commit_mode {
+    VALIDATE,
+    COMMIT,
+    COMMIT_PREVALIDATED,
+};
+
 static bool gdn_transition_journal_commit_many_impl(
         const ggml_tensor * const * journals,
         ggml_tensor * const * states,
@@ -177,78 +184,85 @@ static bool gdn_transition_journal_commit_many_impl(
         int n_layers,
         const ggml_tensor * accepted_prefixes,
         const ggml_tensor * active_slot_ids,
-        bool commit) {
-    if (!journals || !states || !conv_inputs || !conv_states ||
-        n_layers <= 0 || !accepted_prefixes || !active_slot_ids ||
-        accepted_prefixes->type != GGML_TYPE_I32 ||
-        active_slot_ids->type != GGML_TYPE_I32 ||
-        !ggml_is_contiguous(accepted_prefixes) ||
-        !ggml_is_contiguous(active_slot_ids)) return false;
+        commit_mode mode) {
+    const bool prevalidated = mode == commit_mode::COMMIT_PREVALIDATED;
+    const bool commit = mode != commit_mode::VALIDATE;
+    const bool synchronize = mode == commit_mode::COMMIT;
+    if (!prevalidated &&
+        (!journals || !states || !conv_inputs || !conv_states ||
+         n_layers <= 0 || !accepted_prefixes || !active_slot_ids ||
+         accepted_prefixes->type != GGML_TYPE_I32 ||
+         active_slot_ids->type != GGML_TYPE_I32 ||
+         !ggml_is_contiguous(accepted_prefixes) ||
+         !ggml_is_contiguous(active_slot_ids))) return false;
 
     const int64_t n_seqs = ggml_nelements(accepted_prefixes);
-    if (n_seqs < 1 || ggml_nelements(active_slot_ids) != n_seqs) return false;
+    if (!prevalidated &&
+        (n_seqs < 1 || ggml_nelements(active_slot_ids) != n_seqs)) return false;
     int device = -1;
-    if (!device_pointer(accepted_prefixes->data, device) ||
-        !same_device_pointer(active_slot_ids->data, device)) return false;
+    if (!device_pointer(accepted_prefixes->data, device)) return false;
 
-    std::vector<int32_t> accepted((size_t) n_seqs);
-    std::vector<int32_t> slots((size_t) n_seqs);
-    const size_t map_bytes = (size_t) n_seqs*sizeof(int32_t);
-    if (cudaMemcpy(accepted.data(), accepted_prefixes->data, map_bytes,
-                   cudaMemcpyDeviceToHost) != cudaSuccess ||
-        cudaMemcpy(slots.data(), active_slot_ids->data, map_bytes,
-                   cudaMemcpyDeviceToHost) != cudaSuccess) return false;
+    if (!prevalidated) {
+        if (!same_device_pointer(active_slot_ids->data, device)) return false;
+        std::vector<int32_t> accepted((size_t) n_seqs);
+        std::vector<int32_t> slots((size_t) n_seqs);
+        const size_t map_bytes = (size_t) n_seqs*sizeof(int32_t);
+        if (cudaMemcpy(accepted.data(), accepted_prefixes->data, map_bytes,
+                       cudaMemcpyDeviceToHost) != cudaSuccess ||
+            cudaMemcpy(slots.data(), active_slot_ids->data, map_bytes,
+                       cudaMemcpyDeviceToHost) != cudaSuccess) return false;
 
-    int common_tokens = -1;
-    int common_state_slots = -1;
-    std::vector<uint8_t> seen;
-    for (int layer = 0; layer < n_layers; ++layer) {
-        const ggml_tensor * journal = journals[layer];
-        ggml_tensor * state = states[layer];
-        const ggml_tensor * conv_input = conv_inputs[layer];
-        ggml_tensor * conv_state = conv_states[layer];
-        if (!journal || !state || !conv_input || !conv_state ||
-            journal->type != GGML_TYPE_F32 || state->type != GGML_TYPE_F32 ||
-            conv_input->type != GGML_TYPE_F32 || conv_state->type != GGML_TYPE_F32 ||
-            !ggml_is_contiguous(journal) || !ggml_is_contiguous(state) ||
-            !ggml_is_contiguous(conv_input) || !ggml_is_contiguous(conv_state)) return false;
-        const int64_t state_size = state->ne[0];
-        const int64_t heads = state->ne[2];
-        const int64_t tokens = journal->ne[2];
-        const int64_t state_slots = state->ne[3];
-        if ((state_size != 16 && state_size != 32 &&
-             state_size != 64 && state_size != 128) ||
-            state->ne[1] != state_size || heads < 1 ||
-            journal->ne[1] != heads || journal->ne[3] != n_seqs ||
-            (journal->ne[0] != 2*state_size + 1 &&
-             journal->ne[0] != 3*state_size) || tokens < 1 ||
-            conv_state->ne[0] < 1 || conv_state->ne[1] < 1 ||
-            conv_state->ne[2] != state_slots || conv_state->ne[3] != 1 ||
-            conv_input->ne[0] != conv_state->ne[0] + tokens ||
-            conv_input->ne[1] != conv_state->ne[1] ||
-            conv_input->ne[2] != n_seqs || conv_input->ne[3] != 1) return false;
-        if (common_tokens < 0) {
-            common_tokens = (int) tokens;
-            common_state_slots = (int) state_slots;
-            seen.assign((size_t) state_slots, 0);
-        } else if (tokens != common_tokens || state_slots != common_state_slots) {
-            return false;
+        int common_tokens = -1;
+        int common_state_slots = -1;
+        std::vector<uint8_t> seen;
+        for (int layer = 0; layer < n_layers; ++layer) {
+            const ggml_tensor * journal = journals[layer];
+            ggml_tensor * state = states[layer];
+            const ggml_tensor * conv_input = conv_inputs[layer];
+            ggml_tensor * conv_state = conv_states[layer];
+            if (!journal || !state || !conv_input || !conv_state ||
+                journal->type != GGML_TYPE_F32 || state->type != GGML_TYPE_F32 ||
+                conv_input->type != GGML_TYPE_F32 || conv_state->type != GGML_TYPE_F32 ||
+                !ggml_is_contiguous(journal) || !ggml_is_contiguous(state) ||
+                !ggml_is_contiguous(conv_input) || !ggml_is_contiguous(conv_state)) return false;
+            const int64_t state_size = state->ne[0];
+            const int64_t heads = state->ne[2];
+            const int64_t tokens = journal->ne[2];
+            const int64_t state_slots = state->ne[3];
+            if ((state_size != 16 && state_size != 32 &&
+                 state_size != 64 && state_size != 128) ||
+                state->ne[1] != state_size || heads < 1 ||
+                journal->ne[1] != heads || journal->ne[3] != n_seqs ||
+                (journal->ne[0] != 2*state_size + 1 &&
+                 journal->ne[0] != 3*state_size) || tokens < 1 ||
+                conv_state->ne[0] < 1 || conv_state->ne[1] < 1 ||
+                conv_state->ne[2] != state_slots || conv_state->ne[3] != 1 ||
+                conv_input->ne[0] != conv_state->ne[0] + tokens ||
+                conv_input->ne[1] != conv_state->ne[1] ||
+                conv_input->ne[2] != n_seqs || conv_input->ne[3] != 1) return false;
+            if (common_tokens < 0) {
+                common_tokens = (int) tokens;
+                common_state_slots = (int) state_slots;
+                seen.assign((size_t) state_slots, 0);
+            } else if (tokens != common_tokens || state_slots != common_state_slots) {
+                return false;
+            }
+            const void * pointers[] = {
+                journal->data, state->data, conv_input->data, conv_state->data,
+            };
+            for (const void * pointer : pointers) {
+                if (!same_device_pointer(pointer, device)) return false;
+            }
         }
-        const void * pointers[] = {
-            journal->data, state->data, conv_input->data, conv_state->data,
-        };
-        for (const void * pointer : pointers) {
-            if (!same_device_pointer(pointer, device)) return false;
+        for (int64_t lane = 0; lane < n_seqs; ++lane) {
+            if (accepted[(size_t) lane] < 0 ||
+                accepted[(size_t) lane] > common_tokens) return false;
+            const int slot = slots[(size_t) lane];
+            if (slot == -1) continue;
+            if (slot < 0 || slot >= common_state_slots) return false;
+            if (seen[(size_t) slot]) return false;
+            seen[(size_t) slot] = 1;
         }
-    }
-    for (int64_t lane = 0; lane < n_seqs; ++lane) {
-        if (accepted[(size_t) lane] < 0 ||
-            accepted[(size_t) lane] > common_tokens) return false;
-        const int slot = slots[(size_t) lane];
-        if (slot == -1) continue;
-        if (slot < 0 || slot >= common_state_slots) return false;
-        if (seen[(size_t) slot]) return false;
-        seen[(size_t) slot] = 1;
     }
 
     if (!commit) return true;
@@ -289,7 +303,7 @@ static bool gdn_transition_journal_commit_many_impl(
             (int) n_seqs, (int) conv_state->ne[2]);
     }
     if (cudaGetLastError() != cudaSuccess) return false;
-    return cudaDeviceSynchronize() == cudaSuccess;
+    return !synchronize || cudaDeviceSynchronize() == cudaSuccess;
 }
 
 extern "C" bool ggml_backend_cuda_gdn_transition_journal_commit_many(
@@ -302,12 +316,12 @@ extern "C" bool ggml_backend_cuda_gdn_transition_journal_commit_many(
         const ggml_tensor * active_slot_ids) {
     if (!gdn_transition_journal_commit_many_impl(
             journals, states, conv_inputs, conv_states, n_layers,
-            accepted_prefixes, active_slot_ids, false)) {
+            accepted_prefixes, active_slot_ids, commit_mode::VALIDATE)) {
         return false;
     }
     if (!gdn_transition_journal_commit_many_impl(
             journals, states, conv_inputs, conv_states, n_layers,
-            accepted_prefixes, active_slot_ids, true)) {
+            accepted_prefixes, active_slot_ids, commit_mode::COMMIT)) {
         GGML_ABORT("recurrent commit failed after mutation began");
     }
     return true;
@@ -320,49 +334,58 @@ static bool tree_cache_commit_many_impl(
         const ggml_tensor * active_slot_ids,
         int tree_scratch_base,
         int tree_scratch_stride,
-        bool commit) {
-    if (!caches || n_caches <= 0 || !commit_rows || !active_slot_ids ||
-        commit_rows->type != GGML_TYPE_I64 ||
-        active_slot_ids->type != GGML_TYPE_I32 ||
-        !ggml_is_contiguous(commit_rows) ||
-        !ggml_is_contiguous(active_slot_ids) ||
-        commit_rows->ne[0] < 1 || commit_rows->ne[1] < 1 ||
-        ggml_nelements(active_slot_ids) != commit_rows->ne[1] ||
-        tree_scratch_base < 0 || tree_scratch_stride < commit_rows->ne[0]) return false;
+        commit_mode mode) {
+    const bool prevalidated = mode == commit_mode::COMMIT_PREVALIDATED;
+    const bool commit = mode != commit_mode::VALIDATE;
+    const bool synchronize = mode == commit_mode::COMMIT;
+    if (!prevalidated &&
+        (!caches || n_caches <= 0 || !commit_rows || !active_slot_ids ||
+         commit_rows->type != GGML_TYPE_I64 ||
+         active_slot_ids->type != GGML_TYPE_I32 ||
+         !ggml_is_contiguous(commit_rows) ||
+         !ggml_is_contiguous(active_slot_ids) ||
+         commit_rows->ne[0] < 1 || commit_rows->ne[1] < 1 ||
+         ggml_nelements(active_slot_ids) != commit_rows->ne[1] ||
+         tree_scratch_base < 0 ||
+         tree_scratch_stride < commit_rows->ne[0])) return false;
     const int tree_width = (int) commit_rows->ne[0];
     const int n_seqs = (int) commit_rows->ne[1];
     const int n_rows = tree_width*n_seqs;
     int device = -1;
-    if (!device_pointer(commit_rows->data, device) ||
-        !same_device_pointer(active_slot_ids->data, device)) return false;
+    if (!device_pointer(commit_rows->data, device)) return false;
 
-    std::vector<int64_t> destinations((size_t) n_rows);
-    std::vector<int32_t> slots((size_t) n_seqs);
-    if (cudaMemcpy(destinations.data(), commit_rows->data,
-                   destinations.size()*sizeof(int64_t), cudaMemcpyDeviceToHost) != cudaSuccess ||
-        cudaMemcpy(slots.data(), active_slot_ids->data,
-                   slots.size()*sizeof(int32_t), cudaMemcpyDeviceToHost) != cudaSuccess) return false;
-    int cache_rows = -1;
-    for (int index = 0; index < n_caches; ++index) {
-        ggml_tensor * cache = caches[index];
-        if (!cache || !ggml_is_contiguous(cache) || cache->ne[0] < 1 ||
-            cache->ne[1] < 1 || cache->ne[2] < 1 || cache->ne[3] != 1 ||
-            cache->nb[1] < ggml_row_size(cache->type, cache->ne[0]) ||
-            !same_device_pointer(cache->data, device)) return false;
-        if (cache_rows < 0) cache_rows = (int) cache->ne[1];
-        else if (cache->ne[1] != cache_rows) return false;
-    }
-    for (int lane = 0; lane < n_seqs; ++lane) {
-        const int slot = slots[(size_t) lane];
-        if (slot == -1) continue;
-        if (slot < 0) return false;
-        const int64_t source_end = (int64_t) tree_scratch_base +
-            (int64_t) slot*tree_scratch_stride + tree_width;
-        if (source_end > cache_rows) return false;
-        for (int node = 0; node < tree_width; ++node) {
-            const int64_t destination =
-                destinations[(size_t) lane*tree_width + node];
-            if (destination < -1 || destination >= cache_rows) return false;
+    int cache_rows = prevalidated ? (int) caches[0]->ne[1] : -1;
+    if (!prevalidated) {
+        if (!same_device_pointer(active_slot_ids->data, device)) return false;
+        std::vector<int64_t> destinations((size_t) n_rows);
+        std::vector<int32_t> slots((size_t) n_seqs);
+        if (cudaMemcpy(destinations.data(), commit_rows->data,
+                       destinations.size()*sizeof(int64_t),
+                       cudaMemcpyDeviceToHost) != cudaSuccess ||
+            cudaMemcpy(slots.data(), active_slot_ids->data,
+                       slots.size()*sizeof(int32_t),
+                       cudaMemcpyDeviceToHost) != cudaSuccess) return false;
+        for (int index = 0; index < n_caches; ++index) {
+            ggml_tensor * cache = caches[index];
+            if (!cache || !ggml_is_contiguous(cache) || cache->ne[0] < 1 ||
+                cache->ne[1] < 1 || cache->ne[2] < 1 || cache->ne[3] != 1 ||
+                cache->nb[1] < ggml_row_size(cache->type, cache->ne[0]) ||
+                !same_device_pointer(cache->data, device)) return false;
+            if (cache_rows < 0) cache_rows = (int) cache->ne[1];
+            else if (cache->ne[1] != cache_rows) return false;
+        }
+        for (int lane = 0; lane < n_seqs; ++lane) {
+            const int slot = slots[(size_t) lane];
+            if (slot == -1) continue;
+            if (slot < 0) return false;
+            const int64_t source_end = (int64_t) tree_scratch_base +
+                (int64_t) slot*tree_scratch_stride + tree_width;
+            if (source_end > cache_rows) return false;
+            for (int node = 0; node < tree_width; ++node) {
+                const int64_t destination =
+                    destinations[(size_t) lane*tree_width + node];
+                if (destination < -1 || destination >= cache_rows) return false;
+            }
         }
     }
 
@@ -384,7 +407,7 @@ static bool tree_cache_commit_many_impl(
             tree_scratch_base, tree_scratch_stride);
     }
     if (cudaGetLastError() != cudaSuccess) return false;
-    return cudaDeviceSynchronize() == cudaSuccess;
+    return !synchronize || cudaDeviceSynchronize() == cudaSuccess;
 }
 
 extern "C" bool ggml_backend_cuda_tree_cache_commit_many(
@@ -396,12 +419,12 @@ extern "C" bool ggml_backend_cuda_tree_cache_commit_many(
         int tree_scratch_stride) {
     if (!tree_cache_commit_many_impl(
             caches, n_caches, commit_rows, active_slot_ids,
-            tree_scratch_base, tree_scratch_stride, false)) {
+            tree_scratch_base, tree_scratch_stride, commit_mode::VALIDATE)) {
         return false;
     }
     if (!tree_cache_commit_many_impl(
             caches, n_caches, commit_rows, active_slot_ids,
-            tree_scratch_base, tree_scratch_stride, true)) {
+            tree_scratch_base, tree_scratch_stride, commit_mode::COMMIT)) {
         GGML_ABORT("K/V commit failed after mutation began");
     }
     return true;
@@ -411,27 +434,36 @@ static bool tree_feature_commit_impl(
         const ggml_tensor * source,
         ggml_tensor * destination,
         const ggml_tensor * destination_rows,
-        bool commit) {
-    if (!source || !destination || !destination_rows ||
-        source->type != destination->type || source->type != GGML_TYPE_BF16 ||
-        destination_rows->type != GGML_TYPE_I32 ||
-        !ggml_is_contiguous(source) || !ggml_is_contiguous(destination) ||
-        !ggml_is_contiguous(destination_rows) ||
-        source->ne[0] != destination->ne[0] || source->ne[2] != 1 ||
-        source->ne[3] != 1 || destination->ne[2] != 1 ||
-        destination->ne[3] != 1 ||
-        ggml_nelements(destination_rows) != source->ne[1] ||
-        source->nb[1] != destination->nb[1]) return false;
+        commit_mode mode) {
+    const bool prevalidated = mode == commit_mode::COMMIT_PREVALIDATED;
+    const bool commit = mode != commit_mode::VALIDATE;
+    const bool synchronize = mode == commit_mode::COMMIT;
+    if (!prevalidated &&
+        (!source || !destination || !destination_rows ||
+         source->type != destination->type ||
+         source->type != GGML_TYPE_BF16 ||
+         destination_rows->type != GGML_TYPE_I32 ||
+         !ggml_is_contiguous(source) ||
+         !ggml_is_contiguous(destination) ||
+         !ggml_is_contiguous(destination_rows) ||
+         source->ne[0] != destination->ne[0] || source->ne[2] != 1 ||
+         source->ne[3] != 1 || destination->ne[2] != 1 ||
+         destination->ne[3] != 1 ||
+         ggml_nelements(destination_rows) != source->ne[1] ||
+         source->nb[1] != destination->nb[1])) return false;
     int device = -1;
-    if (!device_pointer(source->data, device) ||
-        !same_device_pointer(destination->data, device) ||
-        !same_device_pointer(destination_rows->data, device)) return false;
+    if (!device_pointer(source->data, device)) return false;
     const int n_rows = (int) source->ne[1];
-    std::vector<int32_t> rows((size_t) n_rows);
-    if (cudaMemcpy(rows.data(), destination_rows->data,
-                   rows.size()*sizeof(int32_t), cudaMemcpyDeviceToHost) != cudaSuccess) return false;
-    for (int row : rows) {
-        if (row < -1 || row >= destination->ne[1]) return false;
+    if (!prevalidated) {
+        if (!same_device_pointer(destination->data, device) ||
+            !same_device_pointer(destination_rows->data, device)) return false;
+        std::vector<int32_t> rows((size_t) n_rows);
+        if (cudaMemcpy(rows.data(), destination_rows->data,
+                       rows.size()*sizeof(int32_t),
+                       cudaMemcpyDeviceToHost) != cudaSuccess) return false;
+        for (int row : rows) {
+            if (row < -1 || row >= destination->ne[1]) return false;
+        }
     }
     if (!commit) return true;
     ggml_cuda_set_device(device);
@@ -445,7 +477,7 @@ static bool tree_feature_commit_impl(
         (const int32_t *) destination_rows->data,
         source->nb[1], n_rows, (int) destination->ne[1]);
     if (cudaGetLastError() != cudaSuccess) return false;
-    return cudaDeviceSynchronize() == cudaSuccess;
+    return !synchronize || cudaDeviceSynchronize() == cudaSuccess;
 }
 
 extern "C" bool ggml_backend_cuda_tree_feature_commit(
@@ -453,11 +485,11 @@ extern "C" bool ggml_backend_cuda_tree_feature_commit(
         ggml_tensor * destination,
         const ggml_tensor * destination_rows) {
     if (!tree_feature_commit_impl(
-            source, destination, destination_rows, false)) {
+            source, destination, destination_rows, commit_mode::VALIDATE)) {
         return false;
     }
     if (!tree_feature_commit_impl(
-            source, destination, destination_rows, true)) {
+            source, destination, destination_rows, commit_mode::COMMIT)) {
         GGML_ABORT("feature commit failed after mutation began");
     }
     return true;
@@ -481,13 +513,21 @@ extern "C" bool ggml_backend_cuda_tree_commit_transaction(
         int tree_scratch_stride) {
     if (!tree_cache_commit_many_impl(
             caches, n_caches, commit_rows, active_slot_ids,
-            tree_scratch_base, tree_scratch_stride, false) ||
-        !tree_feature_commit_impl(
+            tree_scratch_base, tree_scratch_stride,
+            commit_mode::VALIDATE)) {
+        std::fprintf(stderr, "[gdn-transaction] K/V preflight failed\n");
+        return false;
+    }
+    if (!tree_feature_commit_impl(
             feature_source, feature_destination,
-            feature_destination_rows, false) ||
-        !gdn_transition_journal_commit_many_impl(
+            feature_destination_rows, commit_mode::VALIDATE)) {
+        std::fprintf(stderr, "[gdn-transaction] feature preflight failed\n");
+        return false;
+    }
+    if (!gdn_transition_journal_commit_many_impl(
             journals, states, conv_inputs, conv_states, n_layers,
-            accepted_prefixes, active_slot_ids, false)) {
+            accepted_prefixes, active_slot_ids, commit_mode::VALIDATE)) {
+        std::fprintf(stderr, "[gdn-transaction] recurrent preflight failed\n");
         return false;
     }
 
@@ -496,18 +536,24 @@ extern "C" bool ggml_backend_cuda_tree_commit_transaction(
     // pre-commit/post-commit state.
     if (!tree_cache_commit_many_impl(
             caches, n_caches, commit_rows, active_slot_ids,
-            tree_scratch_base, tree_scratch_stride, true)) {
+            tree_scratch_base, tree_scratch_stride,
+            commit_mode::COMMIT_PREVALIDATED)) {
         GGML_ABORT("tree commit failed after K/V mutation began");
     }
     if (!tree_feature_commit_impl(
             feature_source, feature_destination,
-            feature_destination_rows, true)) {
+            feature_destination_rows,
+            commit_mode::COMMIT_PREVALIDATED)) {
         GGML_ABORT("tree commit failed after feature mutation began");
     }
     if (!gdn_transition_journal_commit_many_impl(
             journals, states, conv_inputs, conv_states, n_layers,
-            accepted_prefixes, active_slot_ids, true)) {
+            accepted_prefixes, active_slot_ids,
+            commit_mode::COMMIT_PREVALIDATED)) {
         GGML_ABORT("tree commit failed after recurrent mutation began");
+    }
+    if (cudaStreamSynchronize(nullptr) != cudaSuccess) {
+        GGML_ABORT("tree commit failed during final synchronization");
     }
     return true;
 }

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/paged-attn.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/paged-attn.cu
@@ -29,6 +29,42 @@ static __host__ __device__ __forceinline__ int32_t paged_attn_partitions(
     return requested < available ? requested : available;
 }
 
+// parent_ids is a sequence-major [tree_width, n_tree_seq] table. Walk only
+// from the current query node toward the root; a candidate is visible iff it
+// appears on that chain. The bounded walk also turns malformed cycles or
+// out-of-range parents into invisible edges instead of an unsafe read.
+static __device__ __forceinline__ bool paged_attn_tree_visible(
+        const char * __restrict__ parent_ids,
+        int64_t parent_nb0,
+        int64_t parent_nb1,
+        int32_t tree_seq,
+        int32_t query_node,
+        int32_t candidate,
+        int32_t tree_size) {
+    if (candidate < 0 || candidate >= tree_size ||
+        query_node < 0 || query_node >= tree_size) {
+        return false;
+    }
+
+    int32_t current = query_node;
+    for (int32_t depth = 0; depth < tree_size; ++depth) {
+        if (current == candidate) {
+            return true;
+        }
+        if (current < 0 || current >= tree_size) {
+            return false;
+        }
+        const int32_t parent = *(const int32_t *) (
+            parent_ids + (int64_t) current * parent_nb0 +
+            (int64_t) tree_seq * parent_nb1);
+        if (parent == current) {
+            return false;
+        }
+        current = parent;
+    }
+    return false;
+}
+
 // All scores are computed in the log2 domain: log2(e) is folded into the same
 // Q prescale that already carries the 1/sqrt(D) attention scale, so every
 // softmax exponential uses the fast exp2f SFU path.
@@ -180,6 +216,8 @@ static __global__ void paged_attn_decode(
         const char    * __restrict__ kv_seq_lens,
         const char    * __restrict__ active_slot_ids,
         const char    * __restrict__ query_positions,
+        const char    * __restrict__ parent_ids,
+        const char    * __restrict__ tree_sizes,
         char          * __restrict__ dst,
         half          * __restrict__ partial_acc,
         float2        * __restrict__ partial_meta,
@@ -189,6 +227,7 @@ static __global__ void paged_attn_decode(
         int64_t bt_nb0,  int64_t bt_nb1,
         int64_t ksl_nb0,
         int64_t asi_nb0, int64_t qpos_nb0,
+        int64_t parent_nb0, int64_t parent_nb1, int64_t tree_size_nb0,
         int64_t dst_nb1, int64_t dst_nb2,
         int32_t n_table_seq,
         int32_t n_head,
@@ -197,6 +236,10 @@ static __global__ void paged_attn_decode(
         int32_t max_blocks,
         int32_t block_size,
         int32_t min_partitions,
+        int32_t tree_width,
+        int32_t tree_row_offset,
+        int32_t tree_scratch_base,
+        int32_t tree_scratch_stride,
         float scale) {
     constexpr int nthreads = WARP_SIZE;
     constexpr int values_per_load = 4;
@@ -222,29 +265,40 @@ static __global__ void paged_attn_decode(
     const int n_seq        = gridDim.y;
     const int n_partitions = gridDim.z;
 
+    const bool tree_mode = parent_ids != nullptr;
     const int32_t physical_seq_raw = active_slot_ids
         ? *(const int32_t *) (active_slot_ids + (int64_t) seq * asi_nb0)
         : seq;
     const int32_t query_pos = query_positions
         ? *(const int32_t *) (query_positions + (int64_t) seq * qpos_nb0)
         : -1;
+    const bool tree_query = tree_mode && seq >= tree_row_offset;
+    const int32_t tree_seq = tree_query
+        ? (seq - tree_row_offset) / tree_width : 0;
+    const int32_t query_node = tree_query
+        ? seq - tree_row_offset - tree_seq * tree_width : -1;
+    const int32_t tree_size = tree_query
+        ? *(const int32_t *) (
+            tree_sizes + (int64_t) tree_seq * tree_size_nb0)
+        : 0;
     // A row is live when its slot id selects a real block-table column and,
-    // for ragged batches, its causal position is non-negative. Dead rows are
-    // pinned to column 0 with kv_seq_len forced to 0, which routes every
-    // partition through the existing zero-output early path; the block table
-    // is then never read for them.
+    // for ragged batches, its causal position is non-negative. Tree padding
+    // rows are validated by tree_sizes. Dead rows are pinned to column 0 with
+    // an empty virtual context, so the block table and scratch are never read.
     const bool valid_query =
         physical_seq_raw >= 0 && physical_seq_raw < n_table_seq &&
-        (!query_positions || query_pos >= 0);
+        (!query_positions || tree_query || query_pos >= 0) &&
+        (!tree_query ||
+         (tree_size >= 0 && tree_size <= tree_width &&
+          query_node < tree_size));
     const int32_t physical_seq = valid_query ? physical_seq_raw : 0;
     int32_t kv_seq_len_raw = valid_query
         ? *(const int32_t *) (kv_seq_lens +
                               (int64_t) physical_seq * ksl_nb0)
         : 0;
-    // The inclusive clamp IS the causal mask: this row attends tokens
-    // [0, pos] only, and every downstream bound (partition count, token loop
-    // extents) already derives from kv_seq_len.
-    if (query_positions && query_pos < kv_seq_len_raw) {
+    // The inclusive clamp IS the causal mask for non-tree ragged rows. Tree
+    // rows always read the whole committed prefix carried by kv_seq_lens.
+    if (query_positions && !tree_query && query_pos < kv_seq_len_raw) {
         kv_seq_len_raw = query_pos + 1;
     }
     const int64_t table_capacity =
@@ -254,8 +308,14 @@ static __global__ void paged_attn_decode(
         : (kv_seq_len_raw < table_capacity
             ? kv_seq_len_raw
             : (int32_t) table_capacity);
+    // Treat the candidate slab as a virtual tail of tree_width tokens. The
+    // normal partition split then covers prefix and tree candidates in one
+    // stable softmax; invisible siblings/padding resolve to no physical row.
+    const int32_t virtual_tokens = valid_query
+        ? kv_seq_len + (tree_query ? tree_width : 0)
+        : 0;
     const int32_t n_logical_blocks =
-        (kv_seq_len + block_size - 1) / block_size;
+        (virtual_tokens + block_size - 1) / block_size;
     const int32_t active_partitions =
         paged_attn_partitions(n_logical_blocks, min_partitions, n_partitions);
 
@@ -289,7 +349,7 @@ static __global__ void paged_attn_decode(
     const int32_t token_begin = logical_block_begin * block_size;
     const int32_t token_end_blocks = logical_block_end * block_size;
     const int32_t token_end =
-        kv_seq_len < token_end_blocks ? kv_seq_len : token_end_blocks;
+        virtual_tokens < token_end_blocks ? virtual_tokens : token_end_blocks;
 
     constexpr bool quantize_q = type_K != GGML_TYPE_F16;
     constexpr int q_registers   = (D / 2) / nthreads;
@@ -363,7 +423,12 @@ static __global__ void paged_attn_decode(
         qk_sum[h] = 0.0f;
     }
 
-    const int32_t n_physical_blocks = pool_tokens / block_size;
+    // In tree mode the committed block table may address only the prefix
+    // pool before tree_scratch_base. Candidate rows are addressed directly
+    // below, keeping uncommitted nodes out of every sequence block table.
+    const int32_t prefix_pool_tokens =
+        tree_mode ? tree_scratch_base : pool_tokens;
+    const int32_t n_physical_blocks = prefix_pool_tokens / block_size;
 
     for (int32_t tile_begin = token_begin;
          tile_begin < token_end;
@@ -380,7 +445,7 @@ static __global__ void paged_attn_decode(
         // read; their tokens contribute nothing, mirroring the CPU reference.
         int32_t phys_mine = -1;
         const int32_t my_token = tile_begin + lane;
-        if (my_token < token_end) {
+        if (my_token < token_end && my_token < kv_seq_len) {
             const int32_t logical_block = my_token / block_size;
             const int32_t physical_block =
                 *(const int32_t *) (block_table +
@@ -389,6 +454,19 @@ static __global__ void paged_attn_decode(
             if (physical_block >= 0 && physical_block < n_physical_blocks) {
                 phys_mine =
                     physical_block * block_size + my_token % block_size;
+            }
+        } else if (tree_query && my_token < token_end) {
+            const int32_t candidate = my_token - kv_seq_len;
+            if (paged_attn_tree_visible(
+                    parent_ids, parent_nb0, parent_nb1,
+                    tree_seq, query_node, candidate, tree_size)) {
+                const int64_t physical =
+                    (int64_t) tree_scratch_base +
+                    (int64_t) physical_seq * tree_scratch_stride +
+                    candidate;
+                if (physical >= 0 && physical < pool_tokens) {
+                    phys_mine = (int32_t) physical;
+                }
             }
         }
 
@@ -619,6 +697,8 @@ bool ggml_cuda_paged_attn_supported(const ggml_tensor * dst) {
     const ggml_tensor * kv_seq_lens   = dst->src[4];
     const ggml_tensor * active_slot_ids = dst->src[5];
     const ggml_tensor * query_positions = dst->src[6];
+    const ggml_tensor * parent_ids      = dst->src[7];
+    const ggml_tensor * tree_sizes      = dst->src[8];
 
     if (!q || !k || !v || !block_table || !kv_seq_lens) {
         return false;
@@ -626,6 +706,11 @@ bool ggml_cuda_paged_attn_supported(const ggml_tensor * dst) {
 
     // Ragged causal positions require the explicit row -> column mapping.
     if (query_positions && !active_slot_ids) {
+        return false;
+    }
+    const bool tree_mode = parent_ids || tree_sizes;
+    if ((parent_ids == nullptr) != (tree_sizes == nullptr) ||
+        (tree_mode && !active_slot_ids)) {
         return false;
     }
 
@@ -636,7 +721,9 @@ bool ggml_cuda_paged_attn_supported(const ggml_tensor * dst) {
         block_table->type != GGML_TYPE_I32 ||
         kv_seq_lens->type != GGML_TYPE_I32 ||
         (active_slot_ids && active_slot_ids->type != GGML_TYPE_I32) ||
-        (query_positions && query_positions->type != GGML_TYPE_I32)) {
+        (query_positions && query_positions->type != GGML_TYPE_I32) ||
+        (parent_ids && parent_ids->type != GGML_TYPE_I32) ||
+        (tree_sizes && tree_sizes->type != GGML_TYPE_I32)) {
         return false;
     }
 
@@ -647,6 +734,8 @@ bool ggml_cuda_paged_attn_supported(const ggml_tensor * dst) {
         kv_seq_lens->nb[0] != sizeof(int32_t) ||
         (active_slot_ids && active_slot_ids->nb[0] != sizeof(int32_t)) ||
         (query_positions && query_positions->nb[0] != sizeof(int32_t)) ||
+        (parent_ids && parent_ids->nb[0] != sizeof(int32_t)) ||
+        (tree_sizes && tree_sizes->nb[0] != sizeof(int32_t)) ||
         dst->nb[0] != sizeof(float)) {
         return false;
     }
@@ -701,10 +790,49 @@ bool ggml_cuda_paged_attn_supported(const ggml_tensor * dst) {
 
     const int32_t block_size = ggml_get_op_params_i32(dst, 1);
     const int32_t max_kv_seq_len = ggml_get_op_params_i32(dst, 2);
-    return block_size > 0 &&
-           max_kv_seq_len > 0 &&
-           max_kv_seq_len <= k->ne[1] &&
-           k->ne[1] % block_size == 0;
+    const int32_t tree_width = ggml_get_op_params_i32(dst, 3);
+    const int32_t tree_scratch_base = ggml_get_op_params_i32(dst, 4);
+    const int32_t tree_scratch_stride = ggml_get_op_params_i32(dst, 5);
+    if (block_size <= 0 ||
+        max_kv_seq_len <= 0 ||
+        (int64_t) max_kv_seq_len + tree_width > INT32_MAX ||
+        k->ne[1] % block_size != 0) {
+        return false;
+    }
+
+    if (!tree_mode) {
+        return tree_width == 0 &&
+               tree_scratch_base == 0 &&
+               tree_scratch_stride == 0;
+    }
+
+    if (tree_width <= 0 ||
+        tree_scratch_base <= 0 ||
+        tree_scratch_base % block_size != 0 ||
+        tree_scratch_stride < tree_width ||
+        !ggml_is_contiguous(parent_ids) ||
+        !ggml_is_contiguous(tree_sizes) ||
+        parent_ids->ne[0] != tree_width ||
+        parent_ids->ne[1] <= 0 ||
+        parent_ids->ne[1] != tree_sizes->ne[0] ||
+        parent_ids->ne[2] != 1 ||
+        parent_ids->ne[3] != 1 ||
+        tree_sizes->ne[1] != 1 ||
+        tree_sizes->ne[2] != 1 ||
+        tree_sizes->ne[3] != 1 ||
+        parent_ids->ne[1] > INT64_MAX / tree_width ||
+        q->ne[1] < parent_ids->ne[1] * tree_width ||
+        (!query_positions &&
+         q->ne[1] != parent_ids->ne[1] * tree_width) ||
+        (int64_t) max_kv_seq_len + tree_width > INT32_MAX) {
+        return false;
+    }
+
+    const int64_t scratch_end =
+        (int64_t) tree_scratch_base +
+        (block_table->ne[1] - 1) * (int64_t) tree_scratch_stride +
+        tree_width;
+    return scratch_end <= k->ne[1];
 }
 
 // Cached max resident blocks/SM for this instantiation at the given block
@@ -764,6 +892,12 @@ static bool try_launch_paged_attn(
     const ggml_tensor * kv_seq_lens = dst->src[4];
     const ggml_tensor * active_slot_ids = dst->src[5];
     const ggml_tensor * query_positions = dst->src[6];
+    const ggml_tensor * parent_ids      = dst->src[7];
+    const ggml_tensor * tree_sizes      = dst->src[8];
+
+    const int32_t tree_width = ggml_get_op_params_i32(dst, 3);
+    const int32_t tree_scratch_base = ggml_get_op_params_i32(dst, 4);
+    const int32_t tree_scratch_stride = ggml_get_op_params_i32(dst, 5);
 
     const int32_t n_head    = (int32_t) q->ne[2];
     const int32_t n_head_kv = (int32_t) k->ne[2];
@@ -837,15 +971,21 @@ static bool try_launch_paged_attn(
     if (min_partitions > partition_limit) {
         min_partitions = partition_limit;
     }
-    if (min_partitions > block_table->ne[0]) {
-        min_partitions = (int32_t) block_table->ne[0];
+    const int32_t tree_blocks =
+        (tree_width + block_size - 1) / block_size;
+    const int64_t partitionable_blocks =
+        block_table->ne[0] + (parent_ids ? tree_blocks : 0);
+    if (min_partitions > partitionable_blocks) {
+        min_partitions = (int32_t) partitionable_blocks;
     }
 
-    // Size the launch from the live maximum sequence length carried in the
-    // graph op, not the block-table capacity. Ragged sequences still clamp
-    // their own active partition count from kv_seq_lens on device.
+    // Size the launch from the live maximum committed prefix plus the virtual
+    // tree tail. Ragged/tree rows still clamp their own active partition count
+    // from device metadata.
+    const int32_t live_tokens =
+        max_kv_seq_len + (parent_ids ? tree_width : 0);
     const int32_t live_blocks =
-        (max_kv_seq_len + block_size - 1) / block_size;
+        (live_tokens + block_size - 1) / block_size;
     int32_t n_partitions = paged_attn_partitions(
         live_blocks, min_partitions, PAGED_ATTN_MAX_PARTITIONS);
 
@@ -861,7 +1001,7 @@ static bool try_launch_paged_attn(
     }();
     if (forced_partitions >= 1 &&
         forced_partitions <= PAGED_ATTN_MAX_PARTITIONS &&
-        forced_partitions <= block_table->ne[0]) {
+        forced_partitions <= partitionable_blocks) {
         min_partitions = forced_partitions;
         n_partitions = forced_partitions;
     }
@@ -914,6 +1054,8 @@ static bool try_launch_paged_attn(
         (const char *) kv_seq_lens->data,
         active_slot_ids ? (const char *) active_slot_ids->data : nullptr,
         query_positions ? (const char *) query_positions->data : nullptr,
+        parent_ids ? (const char *) parent_ids->data : nullptr,
+        tree_sizes ? (const char *) tree_sizes->data : nullptr,
         (char *) dst->data,
         partial_acc,
         partial_meta,
@@ -924,6 +1066,9 @@ static bool try_launch_paged_attn(
         kv_seq_lens->nb[0],
         active_slot_ids ? active_slot_ids->nb[0] : 0,
         query_positions ? query_positions->nb[0] : 0,
+        parent_ids ? parent_ids->nb[0] : 0,
+        parent_ids ? parent_ids->nb[1] : 0,
+        tree_sizes ? tree_sizes->nb[0] : 0,
         dst->nb[1], dst->nb[2],
         (int32_t) block_table->ne[1],
         n_head,
@@ -932,6 +1077,12 @@ static bool try_launch_paged_attn(
         (int32_t) block_table->ne[0],
         block_size,
         min_partitions,
+        tree_width,
+        parent_ids
+            ? (int32_t)(q->ne[1] - parent_ids->ne[1] * tree_width)
+            : 0,
+        tree_scratch_base,
+        tree_scratch_stride,
         scale);
 
     if (n_partitions > 1) {

--- a/server/deps/llama.cpp/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/server/deps/llama.cpp/ggml/src/ggml-metal/ggml-metal-device.m
@@ -1190,9 +1190,9 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
         case GGML_OP_RWKV_WKV7:
             return true;
         case GGML_OP_GATED_DELTA_NET:
-            // Active-slot, raw-gate, and transition-journal variants are CUDA/HIP only.
+            // Active-slot and raw-gate variants are CUDA/HIP only.
             return has_simdgroup_reduction && op->src[2]->ne[0] % 32 == 0 &&
-                   op->src[8] == NULL && op->src[9] == NULL && op->src[11] == NULL &&
+                   op->src[8] == NULL && op->src[9] == NULL &&
                    ggml_get_op_params_i32(op, 10) != 1;
         case GGML_OP_SOLVE_TRI:
         case GGML_OP_MUL_MAT:

--- a/server/deps/llama.cpp/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/server/deps/llama.cpp/ggml/src/ggml-metal/ggml-metal-device.m
@@ -1190,9 +1190,10 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
         case GGML_OP_RWKV_WKV7:
             return true;
         case GGML_OP_GATED_DELTA_NET:
-            // src[9]/raw-gate mode is CUDA/HIP only.
+            // Active-slot, raw-gate, and transition-journal variants are CUDA/HIP only.
             return has_simdgroup_reduction && op->src[2]->ne[0] % 32 == 0 &&
-                   op->src[8] == NULL && op->src[9] == NULL;
+                   op->src[8] == NULL && op->src[9] == NULL && op->src[11] == NULL &&
+                   ggml_get_op_params_i32(op, 10) != 1;
         case GGML_OP_SOLVE_TRI:
         case GGML_OP_MUL_MAT:
         case GGML_OP_MUL_MAT_ID:

--- a/server/deps/llama.cpp/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/server/deps/llama.cpp/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -4962,7 +4962,6 @@ static bool ggml_backend_sycl_device_supports_op(ggml_backend_dev_t dev, const g
             return op->src[6] == nullptr &&
                    op->src[7] == nullptr &&
                    op->src[8] == nullptr &&
-                   op->src[11] == nullptr &&
                    ggml_get_op_params_i32(op, 1) == 0 &&
                    ggml_get_op_params_i32(op, 2) != 1 &&
                    ggml_get_op_params_i32(op, 10) != 1;

--- a/server/deps/llama.cpp/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/server/deps/llama.cpp/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -4957,7 +4957,14 @@ static bool ggml_backend_sycl_device_supports_op(ggml_backend_dev_t dev, const g
         case GGML_OP_GATED_LINEAR_ATTN:
             return true;
         case GGML_OP_GATED_DELTA_NET:
-            return op->src[8] == nullptr && op->src[11] == nullptr &&
+            // The SYCL kernel consumes only src[0..5] and writes final state
+            // into the result tensor.
+            return op->src[6] == nullptr &&
+                   op->src[7] == nullptr &&
+                   op->src[8] == nullptr &&
+                   op->src[11] == nullptr &&
+                   ggml_get_op_params_i32(op, 1) == 0 &&
+                   ggml_get_op_params_i32(op, 2) != 1 &&
                    ggml_get_op_params_i32(op, 10) != 1;
         case GGML_OP_SSM_CONV:
             return op->type == GGML_TYPE_F32 &&

--- a/server/deps/llama.cpp/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/server/deps/llama.cpp/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -4957,7 +4957,8 @@ static bool ggml_backend_sycl_device_supports_op(ggml_backend_dev_t dev, const g
         case GGML_OP_GATED_LINEAR_ATTN:
             return true;
         case GGML_OP_GATED_DELTA_NET:
-            return op->src[8] == nullptr;
+            return op->src[8] == nullptr && op->src[11] == nullptr &&
+                   ggml_get_op_params_i32(op, 10) != 1;
         case GGML_OP_SSM_CONV:
             return op->type == GGML_TYPE_F32 &&
                    op->src[0]->type == GGML_TYPE_F32 &&

--- a/server/deps/llama.cpp/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/server/deps/llama.cpp/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -15781,9 +15781,10 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
         case GGML_OP_GATED_DELTA_NET:
             {
                 // The Vulkan kernel addresses state by compact sequence row
-                // and does not consume the physical-slot mapping in src[8];
-                // raw-gate mode (src[9]) is CUDA/HIP only.
-                if (op->src[8] != nullptr || op->src[9] != nullptr) {
+                // and does not consume the active-slot, raw-gate, or journal inputs.
+                if (op->src[8] != nullptr || op->src[9] != nullptr ||
+                    op->src[11] != nullptr ||
+                    ggml_get_op_params_i32(op, 10) == 1) {
                     return false;
                 }
                 const uint32_t S_v = op->src[2]->ne[0];

--- a/server/deps/llama.cpp/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/server/deps/llama.cpp/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -15780,10 +15780,14 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
             return true; // all inputs are contiguous, see ggml.c
         case GGML_OP_GATED_DELTA_NET:
             {
-                // The Vulkan kernel addresses state by compact sequence row
-                // and does not consume the active-slot, raw-gate, or journal inputs.
-                if (op->src[8] != nullptr || op->src[9] != nullptr ||
+                // The Vulkan kernel consumes only src[0..5] and writes final
+                // state into the result tensor. Reject tree, persistent,
+                // active-slot, raw-gate, journal, and in-place variants.
+                if (op->src[6] != nullptr || op->src[7] != nullptr ||
+                    op->src[8] != nullptr || op->src[9] != nullptr ||
                     op->src[11] != nullptr ||
+                    ggml_get_op_params_i32(op, 1) != 0 ||
+                    ggml_get_op_params_i32(op, 2) == 1 ||
                     ggml_get_op_params_i32(op, 10) == 1) {
                     return false;
                 }

--- a/server/deps/llama.cpp/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/server/deps/llama.cpp/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -15782,10 +15782,9 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
             {
                 // The Vulkan kernel consumes only src[0..5] and writes final
                 // state into the result tensor. Reject tree, persistent,
-                // active-slot, raw-gate, journal, and in-place variants.
+                // active-slot, raw-gate, and in-place variants.
                 if (op->src[6] != nullptr || op->src[7] != nullptr ||
                     op->src[8] != nullptr || op->src[9] != nullptr ||
-                    op->src[11] != nullptr ||
                     ggml_get_op_params_i32(op, 1) != 0 ||
                     ggml_get_op_params_i32(op, 2) == 1 ||
                     ggml_get_op_params_i32(op, 10) == 1) {

--- a/server/deps/llama.cpp/ggml/src/ggml.c
+++ b/server/deps/llama.cpp/ggml/src/ggml.c
@@ -6951,7 +6951,7 @@ void ggml_gated_delta_net_set_skip_intermediate(
     tensor->nb[3] = tensor->nb[2]*tensor->ne[2];
 }
 
-struct ggml_tensor * ggml_gated_delta_net_capture_transition_journal(
+struct ggml_tensor * ggml_gated_delta_net_capture_replay_log(
         struct ggml_context * ctx,
         struct ggml_tensor  * tensor) {
     GGML_ASSERT(ctx != NULL && tensor != NULL);
@@ -6969,36 +6969,36 @@ struct ggml_tensor * ggml_gated_delta_net_capture_transition_journal(
     const int64_t n_tokens = v->ne[2];
     const int64_t n_seqs = v->ne[3];
     const bool kda = g->ne[0] == S_v;
-    const int64_t journal_width = kda ? 3*S_v : 2*S_v + 1;
-    GGML_ASSERT(journal_width > 0 && H > 0 && n_tokens > 0 && n_seqs > 0);
-    GGML_ASSERT(journal_width <= INT64_MAX/H);
-    const int64_t journal_head = journal_width*H;
-    GGML_ASSERT(journal_head <= INT64_MAX/n_tokens);
-    const int64_t journal_token = journal_head*n_tokens;
-    GGML_ASSERT(journal_token <= INT64_MAX/n_seqs);
-    const int64_t journal_elements = journal_token*n_seqs;
+    const int64_t replay_log_width = kda ? 3*S_v : 2*S_v + 1;
+    GGML_ASSERT(replay_log_width > 0 && H > 0 && n_tokens > 0 && n_seqs > 0);
+    GGML_ASSERT(replay_log_width <= INT64_MAX/H);
+    const int64_t replay_log_head = replay_log_width*H;
+    GGML_ASSERT(replay_log_head <= INT64_MAX/n_tokens);
+    const int64_t replay_log_token = replay_log_head*n_tokens;
+    GGML_ASSERT(replay_log_token <= INT64_MAX/n_seqs);
+    const int64_t replay_log_elements = replay_log_token*n_seqs;
     GGML_ASSERT(tensor->ne[0] > 0);
-    GGML_ASSERT(journal_elements <= INT64_MAX - (tensor->ne[0] - 1));
-    const int64_t journal_rows =
-        (journal_elements + tensor->ne[0] - 1)/tensor->ne[0];
+    GGML_ASSERT(replay_log_elements <= INT64_MAX - (tensor->ne[0] - 1));
+    const int64_t replay_log_rows =
+        (replay_log_elements + tensor->ne[0] - 1)/tensor->ne[0];
     GGML_ASSERT(tensor->ne[1] > 0 && tensor->ne[1] <= INT32_MAX);
-    GGML_ASSERT(journal_rows <= INT64_MAX - tensor->ne[1]);
-    const int32_t journal_row_offset = (int32_t) tensor->ne[1];
-    GGML_ASSERT((size_t) journal_row_offset <= SIZE_MAX/tensor->nb[1]);
-    const size_t journal_byte_offset =
-        (size_t) journal_row_offset*tensor->nb[1];
+    GGML_ASSERT(replay_log_rows <= INT64_MAX - tensor->ne[1]);
+    const int32_t replay_log_row_offset = (int32_t) tensor->ne[1];
+    GGML_ASSERT((size_t) replay_log_row_offset <= SIZE_MAX/tensor->nb[1]);
+    const size_t replay_log_byte_offset =
+        (size_t) replay_log_row_offset*tensor->nb[1];
 
-    tensor->ne[1] += journal_rows;
+    tensor->ne[1] += replay_log_rows;
     tensor->nb[2] = tensor->nb[1]*tensor->ne[1];
     tensor->nb[3] = tensor->nb[2]*tensor->ne[2];
-    ggml_set_op_params_i32(tensor, 3, journal_row_offset);
+    ggml_set_op_params_i32(tensor, 3, replay_log_row_offset);
 
     return ggml_dup(ctx, ggml_view_4d(
-        ctx, tensor, journal_width, H, n_tokens, n_seqs,
-        (size_t) journal_width*sizeof(float),
-        (size_t) journal_head*sizeof(float),
-        (size_t) journal_token*sizeof(float),
-        journal_byte_offset));
+        ctx, tensor, replay_log_width, H, n_tokens, n_seqs,
+        (size_t) replay_log_width*sizeof(float),
+        (size_t) replay_log_head*sizeof(float),
+        (size_t) replay_log_token*sizeof(float),
+        replay_log_byte_offset));
 }
 
 // dflash: raw-gate mode (see ggml.h). [dt_bias | A] -> src[9],

--- a/server/deps/llama.cpp/ggml/src/ggml.c
+++ b/server/deps/llama.cpp/ggml/src/ggml.c
@@ -6923,6 +6923,7 @@ void ggml_gated_delta_net_set_skip_intermediate(
         bool                 skip_intermediate) {
     GGML_ASSERT(tensor != NULL);
     GGML_ASSERT(tensor->op == GGML_OP_GATED_DELTA_NET);
+    GGML_ASSERT(ggml_get_op_params_i32(tensor, 3) == 0);
     ggml_set_op_params_i32(tensor, 0, skip_intermediate ? 1 : 0);
 
     const struct ggml_tensor * v = tensor->src[2];
@@ -6950,13 +6951,15 @@ void ggml_gated_delta_net_set_skip_intermediate(
     tensor->nb[3] = tensor->nb[2]*tensor->ne[2];
 }
 
-void ggml_gated_delta_net_set_transition_journal(
-        struct ggml_tensor * tensor,
-        struct ggml_tensor * journal) {
-    GGML_ASSERT(tensor != NULL && journal != NULL);
+struct ggml_tensor * ggml_gated_delta_net_capture_transition_journal(
+        struct ggml_context * ctx,
+        struct ggml_tensor  * tensor) {
+    GGML_ASSERT(ctx != NULL && tensor != NULL);
     GGML_ASSERT(tensor->op == GGML_OP_GATED_DELTA_NET);
-    GGML_ASSERT(journal->type == GGML_TYPE_F32);
-    GGML_ASSERT(ggml_is_contiguous(journal));
+    GGML_ASSERT(tensor->type == GGML_TYPE_F32);
+    GGML_ASSERT(ggml_is_contiguous(tensor));
+    GGML_ASSERT(ggml_get_op_params_i32(tensor, 3) == 0);
+    GGML_ASSERT(ggml_get_op_params_i32(tensor, 2) == 0);
 
     const struct ggml_tensor * v = tensor->src[2];
     const struct ggml_tensor * g = tensor->src[3];
@@ -6967,12 +6970,35 @@ void ggml_gated_delta_net_set_transition_journal(
     const int64_t n_seqs = v->ne[3];
     const bool kda = g->ne[0] == S_v;
     const int64_t journal_width = kda ? 3*S_v : 2*S_v + 1;
-    GGML_ASSERT(journal->ne[0] == journal_width &&
-                journal->ne[1] == H &&
-                journal->ne[2] == n_tokens &&
-                journal->ne[3] == n_seqs);
+    GGML_ASSERT(journal_width > 0 && H > 0 && n_tokens > 0 && n_seqs > 0);
+    GGML_ASSERT(journal_width <= INT64_MAX/H);
+    const int64_t journal_head = journal_width*H;
+    GGML_ASSERT(journal_head <= INT64_MAX/n_tokens);
+    const int64_t journal_token = journal_head*n_tokens;
+    GGML_ASSERT(journal_token <= INT64_MAX/n_seqs);
+    const int64_t journal_elements = journal_token*n_seqs;
+    GGML_ASSERT(tensor->ne[0] > 0);
+    GGML_ASSERT(journal_elements <= INT64_MAX - (tensor->ne[0] - 1));
+    const int64_t journal_rows =
+        (journal_elements + tensor->ne[0] - 1)/tensor->ne[0];
+    GGML_ASSERT(tensor->ne[1] > 0 && tensor->ne[1] <= INT32_MAX);
+    GGML_ASSERT(journal_rows <= INT64_MAX - tensor->ne[1]);
+    const int32_t journal_row_offset = (int32_t) tensor->ne[1];
+    GGML_ASSERT((size_t) journal_row_offset <= SIZE_MAX/tensor->nb[1]);
+    const size_t journal_byte_offset =
+        (size_t) journal_row_offset*tensor->nb[1];
 
-    tensor->src[11] = journal;
+    tensor->ne[1] += journal_rows;
+    tensor->nb[2] = tensor->nb[1]*tensor->ne[1];
+    tensor->nb[3] = tensor->nb[2]*tensor->ne[2];
+    ggml_set_op_params_i32(tensor, 3, journal_row_offset);
+
+    return ggml_view_4d(
+        ctx, tensor, journal_width, H, n_tokens, n_seqs,
+        (size_t) journal_width*sizeof(float),
+        (size_t) journal_head*sizeof(float),
+        (size_t) journal_token*sizeof(float),
+        journal_byte_offset);
 }
 
 // dflash: raw-gate mode (see ggml.h). [dt_bias | A] -> src[9],

--- a/server/deps/llama.cpp/ggml/src/ggml.c
+++ b/server/deps/llama.cpp/ggml/src/ggml.c
@@ -6993,12 +6993,12 @@ struct ggml_tensor * ggml_gated_delta_net_capture_transition_journal(
     tensor->nb[3] = tensor->nb[2]*tensor->ne[2];
     ggml_set_op_params_i32(tensor, 3, journal_row_offset);
 
-    return ggml_view_4d(
+    return ggml_dup(ctx, ggml_view_4d(
         ctx, tensor, journal_width, H, n_tokens, n_seqs,
         (size_t) journal_width*sizeof(float),
         (size_t) journal_head*sizeof(float),
         (size_t) journal_token*sizeof(float),
-        journal_byte_offset);
+        journal_byte_offset));
 }
 
 // dflash: raw-gate mode (see ggml.h). [dt_bias | A] -> src[9],

--- a/server/deps/llama.cpp/ggml/src/ggml.c
+++ b/server/deps/llama.cpp/ggml/src/ggml.c
@@ -5708,7 +5708,12 @@ struct ggml_tensor * ggml_paged_attn_ext(
         struct ggml_tensor  * query_positions,
         float                 scale,
         int                   block_size,
-        int                   max_kv_seq_len) {
+        int                   max_kv_seq_len,
+        struct ggml_tensor  * parent_ids,
+        struct ggml_tensor  * tree_sizes,
+        int                   tree_width,
+        int                   tree_scratch_base,
+        int                   tree_scratch_stride) {
     GGML_ASSERT(q->type == GGML_TYPE_F32);
     GGML_ASSERT(k->type == GGML_TYPE_F16 || k->type == GGML_TYPE_Q4_0 || k->type == GGML_TYPE_Q8_0);
     GGML_ASSERT(v->type == GGML_TYPE_F16 || v->type == GGML_TYPE_Q4_0 || v->type == GGML_TYPE_Q8_0);
@@ -5719,6 +5724,16 @@ struct ggml_tensor * ggml_paged_attn_ext(
     // an explicit row -> block-table-column mapping.
     GGML_ASSERT(query_positions == NULL || active_slot_ids != NULL);
     GGML_ASSERT(query_positions == NULL || query_positions->type == GGML_TYPE_I32);
+
+    const bool tree_mode = parent_ids != NULL || tree_sizes != NULL;
+    GGML_ASSERT((parent_ids == NULL) == (tree_sizes == NULL));
+    GGML_ASSERT(!tree_mode || active_slot_ids != NULL);
+    // Mixed direct-commit batches use causal positions for a compact AR
+    // prefix and -1 for the fixed-width tree tail. Pure trees keep this null.
+    GGML_ASSERT(!tree_mode || query_positions == NULL ||
+                query_positions->ne[0] == q->ne[1]);
+    GGML_ASSERT(!tree_mode || parent_ids->type == GGML_TYPE_I32);
+    GGML_ASSERT(!tree_mode || tree_sizes->type == GGML_TYPE_I32);
 
     GGML_ASSERT(q->ne[0] == k->ne[0] && q->ne[0] == v->ne[0]);
     GGML_ASSERT(k->ne[1] == v->ne[1]);
@@ -5749,13 +5764,50 @@ struct ggml_tensor * ggml_paged_attn_ext(
     GGML_ASSERT(block_size > 0);
     GGML_ASSERT(k->ne[1] % block_size == 0);
     GGML_ASSERT(max_kv_seq_len > 0);
-    GGML_ASSERT(max_kv_seq_len <= k->ne[1]);
+    // This is a padded logical launch bound, not a physical-cache extent.
+    // Each row clamps its actual sequence length to the block-table capacity
+    // and validates every resolved physical block before dereferencing K/V.
+    GGML_ASSERT((int64_t) max_kv_seq_len + tree_width <= INT32_MAX);
+
+    if (tree_mode) {
+        GGML_ASSERT(tree_width > 0);
+        GGML_ASSERT(tree_scratch_base > 0);
+        GGML_ASSERT(tree_scratch_base % block_size == 0);
+        GGML_ASSERT(tree_scratch_stride >= tree_width);
+        GGML_ASSERT(ggml_is_contiguous(parent_ids));
+        GGML_ASSERT(ggml_is_contiguous(tree_sizes));
+        GGML_ASSERT(parent_ids->ne[0] == tree_width);
+        GGML_ASSERT(parent_ids->ne[1] == tree_sizes->ne[0]);
+        GGML_ASSERT(parent_ids->ne[2] == 1 && parent_ids->ne[3] == 1);
+        GGML_ASSERT(tree_sizes->ne[1] == 1 && tree_sizes->ne[2] == 1 && tree_sizes->ne[3] == 1);
+        GGML_ASSERT(parent_ids->ne[1] > 0);
+        GGML_ASSERT(parent_ids->ne[1] <= INT64_MAX / tree_width);
+        const int64_t tree_rows = parent_ids->ne[1] * tree_width;
+        GGML_ASSERT(q->ne[1] >= tree_rows);
+        GGML_ASSERT(query_positions || q->ne[1] == tree_rows);
+
+        // Every physical sequence slot owns one non-overlapping scratch slab.
+        // Bound the largest address with int64 arithmetic before the GPU sees
+        // the int32 op parameters.
+        const int64_t scratch_end =
+            (int64_t) tree_scratch_base +
+            (block_table->ne[1] - 1) * (int64_t) tree_scratch_stride +
+            tree_width;
+        GGML_ASSERT(scratch_end <= k->ne[1]);
+    } else {
+        GGML_ASSERT(tree_width == 0);
+        GGML_ASSERT(tree_scratch_base == 0);
+        GGML_ASSERT(tree_scratch_stride == 0);
+    }
 
     struct ggml_tensor * result = ggml_new_tensor(ctx, GGML_TYPE_F32, GGML_MAX_DIMS, q->ne);
 
     ggml_set_op_params_f32(result, 0, scale);
     ggml_set_op_params_i32(result, 1, block_size);
     ggml_set_op_params_i32(result, 2, max_kv_seq_len);
+    ggml_set_op_params_i32(result, 3, tree_width);
+    ggml_set_op_params_i32(result, 4, tree_scratch_base);
+    ggml_set_op_params_i32(result, 5, tree_scratch_stride);
 
     result->op     = GGML_OP_PAGED_ATTN;
     result->src[0] = q;
@@ -5765,6 +5817,8 @@ struct ggml_tensor * ggml_paged_attn_ext(
     result->src[4] = kv_seq_lens;
     result->src[5] = active_slot_ids;
     result->src[6] = query_positions;
+    result->src[7] = parent_ids;
+    result->src[8] = tree_sizes;
 
     return result;
 }
@@ -6850,6 +6904,31 @@ void ggml_gated_delta_net_set_skip_intermediate(
     }
     tensor->nb[2] = tensor->nb[1]*tensor->ne[1];
     tensor->nb[3] = tensor->nb[2]*tensor->ne[2];
+}
+
+void ggml_gated_delta_net_set_transition_journal(
+        struct ggml_tensor * tensor,
+        struct ggml_tensor * journal) {
+    GGML_ASSERT(tensor != NULL && journal != NULL);
+    GGML_ASSERT(tensor->op == GGML_OP_GATED_DELTA_NET);
+    GGML_ASSERT(journal->type == GGML_TYPE_F32);
+    GGML_ASSERT(ggml_is_contiguous(journal));
+
+    const struct ggml_tensor * v = tensor->src[2];
+    const struct ggml_tensor * g = tensor->src[3];
+    GGML_ASSERT(v != NULL && g != NULL);
+    const int64_t S_v = v->ne[0];
+    const int64_t H = v->ne[1];
+    const int64_t n_tokens = v->ne[2];
+    const int64_t n_seqs = v->ne[3];
+    const bool kda = g->ne[0] == S_v;
+    const int64_t journal_width = kda ? 3*S_v : 2*S_v + 1;
+    GGML_ASSERT(journal->ne[0] == journal_width &&
+                journal->ne[1] == H &&
+                journal->ne[2] == n_tokens &&
+                journal->ne[3] == n_seqs);
+
+    tensor->src[11] = journal;
 }
 
 // dflash: raw-gate mode (see ggml.h). [dt_bias | A] -> src[9],

--- a/server/deps/llama.cpp/ggml/src/ggml.c
+++ b/server/deps/llama.cpp/ggml/src/ggml.c
@@ -5697,7 +5697,7 @@ struct ggml_tensor * ggml_flash_attn_sparse(
 
 // ggml_paged_attn
 
-struct ggml_tensor * ggml_paged_attn_ext(
+static struct ggml_tensor * ggml_paged_attn_ext_impl(
         struct ggml_context * ctx,
         struct ggml_tensor  * q,
         struct ggml_tensor  * k,
@@ -5821,6 +5821,50 @@ struct ggml_tensor * ggml_paged_attn_ext(
     result->src[8] = tree_sizes;
 
     return result;
+}
+
+struct ggml_tensor * ggml_paged_attn_ext(
+        struct ggml_context * ctx,
+        struct ggml_tensor  * q,
+        struct ggml_tensor  * k,
+        struct ggml_tensor  * v,
+        struct ggml_tensor  * block_table,
+        struct ggml_tensor  * kv_seq_lens,
+        struct ggml_tensor  * active_slot_ids,
+        struct ggml_tensor  * query_positions,
+        float                 scale,
+        int                   block_size,
+        int                   max_kv_seq_len) {
+    return ggml_paged_attn_ext_impl(
+        ctx, q, k, v, block_table, kv_seq_lens,
+        active_slot_ids, query_positions, scale, block_size,
+        max_kv_seq_len, NULL, NULL, 0, 0, 0);
+}
+
+struct ggml_tensor * ggml_paged_attn_ext_tree(
+        struct ggml_context * ctx,
+        struct ggml_tensor  * q,
+        struct ggml_tensor  * k,
+        struct ggml_tensor  * v,
+        struct ggml_tensor  * block_table,
+        struct ggml_tensor  * kv_seq_lens,
+        struct ggml_tensor  * active_slot_ids,
+        struct ggml_tensor  * query_positions,
+        float                 scale,
+        int                   block_size,
+        int                   max_kv_seq_len,
+        struct ggml_tensor  * parent_ids,
+        struct ggml_tensor  * tree_sizes,
+        int                   tree_scratch_base,
+        int                   tree_scratch_stride) {
+    GGML_ASSERT(parent_ids != NULL);
+    GGML_ASSERT(parent_ids->ne[0] > 0 && parent_ids->ne[0] <= INT_MAX);
+    const int tree_width = (int) parent_ids->ne[0];
+    return ggml_paged_attn_ext_impl(
+        ctx, q, k, v, block_table, kv_seq_lens,
+        active_slot_ids, query_positions, scale, block_size,
+        max_kv_seq_len, parent_ids, tree_sizes, tree_width,
+        tree_scratch_base, tree_scratch_stride);
 }
 
 // ggml_flash_attn_back

--- a/server/src/common/backend_args.h
+++ b/server/src/common/backend_args.h
@@ -7,6 +7,7 @@
 
 #include <limits>
 
+#include "placement/draft_residency.h"
 #include "placement/placement_config.h"
 #include "placement/remote_draft_config.h"
 #include "placement/remote_target_shard_config.h"
@@ -21,6 +22,7 @@ namespace dflash::common {
 struct BackendFeatureConfig {
     bool pflash_enabled = false;
     bool pflash_drafter_configured = false;
+    DraftResidencyPolicy draft_residency = DraftResidencyPolicy::Auto;
 
     // MoE-only server features. Recorded here so the gate can report them as
     // inert on a dense architecture; both are applied via env vars at parse

--- a/server/src/common/concurrency/chain_spec_shapes.h
+++ b/server/src/common/concurrency/chain_spec_shapes.h
@@ -24,7 +24,7 @@ inline int chain_decode_bucket_width(int lanes) {
 inline DDTree make_chain_verify_tree(
         const std::vector<int32_t> & draft_tokens) {
     DDTree tree;
-    if (draft_tokens.size() <= 1) return tree;
+    if (draft_tokens.empty()) return tree;
 
     tree.n_nodes = static_cast<int>(draft_tokens.size()) - 1;
     tree.token_ids.assign(draft_tokens.begin() + 1, draft_tokens.end());

--- a/server/src/common/concurrency/chain_spec_shapes.h
+++ b/server/src/common/concurrency/chain_spec_shapes.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include "common/ddtree.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+namespace dflash::common {
+
+inline int chain_decode_bucket_width(int lanes) {
+    static constexpr int buckets[] = {
+        1, 2, 3, 4, 6, 8, 12, 16, 24, 32, 48, 64,
+    };
+    if (lanes <= 0) return 0;
+    for (int bucket : buckets) {
+        if (bucket >= lanes) return bucket;
+    }
+    return 64;
+}
+
+// draft_tokens[0] is the already-pending root; positions 1.. form the
+// proposal. DDTree's flat indices then coincide with chain depth.
+inline DDTree make_chain_verify_tree(
+        const std::vector<int32_t> & draft_tokens) {
+    DDTree tree;
+    if (draft_tokens.size() <= 1) return tree;
+
+    tree.n_nodes = static_cast<int>(draft_tokens.size()) - 1;
+    tree.token_ids.assign(draft_tokens.begin() + 1, draft_tokens.end());
+    tree.depths.resize(static_cast<size_t>(tree.n_nodes));
+    tree.parents.resize(static_cast<size_t>(tree.n_nodes) + 1);
+    tree.child_maps.resize(static_cast<size_t>(tree.n_nodes) + 1);
+    tree.parents[0] = -1;
+    for (int node = 1; node <= tree.n_nodes; ++node) {
+        tree.depths[static_cast<size_t>(node) - 1] = node;
+        tree.parents[static_cast<size_t>(node)] = node - 1;
+        tree.child_maps[static_cast<size_t>(node) - 1]
+                       [tree.token_ids[static_cast<size_t>(node) - 1]] = node;
+    }
+
+    const int width = tree.n_nodes + 1;
+    tree.visibility.assign(static_cast<size_t>(width) * width, 0);
+    for (int row = 0; row < width; ++row) {
+        for (int col = 0; col <= row; ++col) {
+            tree.visibility[static_cast<size_t>(row) * width + col] = 1;
+        }
+    }
+    return tree;
+}
+
+struct ChainLaunchShape {
+    int spec_lanes = 0;
+    int tree_bucket = 0;
+    int tree_rows = 0;
+    int ar_lanes = 0;
+    int accepted_rows = 0;
+    int commit_rows = 0;
+};
+
+inline ChainLaunchShape chain_launch_shape(
+        const std::vector<uint8_t> & admitted,
+        const std::vector<int> & accepted_lengths,
+        int tree_width) {
+    ChainLaunchShape shape;
+    const size_t count = admitted.size();
+    for (size_t i = 0; i < count; ++i) {
+        if (admitted[i]) {
+            ++shape.spec_lanes;
+            if (i < accepted_lengths.size()) {
+                shape.accepted_rows += std::max(0, accepted_lengths[i]);
+            }
+        }
+    }
+    shape.ar_lanes = static_cast<int>(count) - shape.spec_lanes;
+    shape.tree_bucket = chain_decode_bucket_width(shape.spec_lanes);
+    shape.tree_rows = shape.tree_bucket * std::max(0, tree_width);
+    shape.commit_rows = shape.accepted_rows + shape.ar_lanes;
+    return shape;
+}
+
+// The pending root at path[0] was sampled by the preceding target step, so
+// the ordinary sampler has already applied the min-token EOS floor to it.
+// Accepted children would bypass that sampler. Stop before an EOS that is
+// still below the floor so replay samples a replacement from the kept
+// tip's exact logits. Once the floor is met, keep the EOS itself but discard
+// deeper accepted tokens that the scheduler would hide after retirement.
+template <typename IsEos>
+inline size_t chain_min_tokens_safe_prefix(
+        const std::vector<int32_t> & path,
+        int generated_tokens_before_root,
+        int min_tokens,
+        IsEos is_eos) {
+    const int generated = std::max(0, generated_tokens_before_root);
+    for (size_t child = 1; child < path.size(); ++child) {
+        if (!is_eos(path[child])) continue;
+        return generated + static_cast<int>(child) < min_tokens
+            ? child : child + 1;
+    }
+    return path.size();
+}
+
+}  // namespace dflash::common

--- a/server/src/common/concurrency/paged_kv_pool.cpp
+++ b/server/src/common/concurrency/paged_kv_pool.cpp
@@ -169,6 +169,26 @@ PagedKvAppendResult PagedKvPool::append(PagedKvSequenceHandle handle,
     return result;
 }
 
+PagedKvStatus PagedKvPool::rollback_append(
+        PagedKvSequenceHandle handle, uint32_t token_count) {
+    const PagedKvStatus status = validate(handle);
+    if (status != PagedKvStatus::Ok) return status;
+
+    SequenceState & sequence = sequences_[handle.slot];
+    if (token_count > sequence.kv_seq_len) {
+        return PagedKvStatus::InvalidArgument;
+    }
+    const uint32_t restored_length = sequence.kv_seq_len - token_count;
+    const uint32_t restored_blocks = blocks_for_tokens(restored_length);
+    while (sequence.block_table.size() > restored_blocks) {
+        const uint32_t block = sequence.block_table.back();
+        sequence.block_table.pop_back();
+        give_back(sequence.reserved_blocks, block);
+    }
+    sequence.kv_seq_len = restored_length;
+    return PagedKvStatus::Ok;
+}
+
 PagedKvStatus PagedKvPool::release(PagedKvSequenceHandle handle) {
     const PagedKvStatus status = validate(handle);
     if (status != PagedKvStatus::Ok) return status;

--- a/server/src/common/concurrency/paged_kv_pool.h
+++ b/server/src/common/concurrency/paged_kv_pool.h
@@ -139,6 +139,13 @@ public:
                               uint32_t token_count,
                               bool only_first_last_slots = false);
 
+    // Reverse the most recent `token_count` appended rows. Pages made
+    // invisible by the rewind stay owned as private reservations, so the
+    // same append receives the same physical rows on retry. On failure the
+    // sequence is unchanged.
+    PagedKvStatus rollback_append(PagedKvSequenceHandle handle,
+                                  uint32_t token_count);
+
     // Return the sequence's blocks and slot to the pool; the handle (and
     // any copy of it) becomes stale.
     PagedKvStatus release(PagedKvSequenceHandle handle);

--- a/server/src/common/concurrency/seq_engine.h
+++ b/server/src/common/concurrency/seq_engine.h
@@ -181,14 +181,20 @@ public:
     struct StepInput {
         int     slot  = -1;
         int32_t token = -1;   // token to commit at this slot's next position
+        // Scheduler-side hooks may replace the next token before it is fed
+        // back. A speculative burst is unsafe while that authority is live.
+        bool allow_speculation = true;
     };
     struct DecodeOutput {
         int     slot   = -1;
-        int32_t token  = -1;  // newly sampled token (pending until next step)
+        // Final newly sampled token, pending until the scheduler feeds it
+        // into the next step. Durable speculative children precede it.
+        int32_t token  = -1;
         bool    failed = false;
         // Present when failed=true so the scheduler can report an honest
         // per-request error instead of silently truncating generation.
         std::string error;
+        std::vector<int32_t> committed_tokens;
     };
 
     struct PrefillOutput {
@@ -250,6 +256,16 @@ public:
     virtual bool token_is_eos(int32_t token) const = 0;
 };
 
+template <typename Advance>
+inline bool consume_decode_output_tokens(
+        const SeqEngine::DecodeOutput & output, Advance advance) {
+    if (output.failed) return false;
+    for (int32_t token : output.committed_tokens) {
+        if (!advance(token)) return false;
+    }
+    return advance(output.token);
+}
+
 // Validate the model-neutral step protocol before the scheduler consumes any
 // output. Malformed row ownership is fatal because re-feeding a token after an
 // omitted output would silently corrupt that sequence.
@@ -265,6 +281,7 @@ inline std::string validate_step_result(
     }
 
     std::vector<uint8_t> decode_planned((size_t)slot_count, 0);
+    std::vector<uint8_t> speculation_allowed((size_t)slot_count, 0);
     std::vector<uint8_t> prefill_planned((size_t)slot_count, 0);
     for (const SeqEngine::StepInput & input : plan.decode) {
         if (input.slot < 0 || input.slot >= slot_count || input.token < 0)
@@ -272,6 +289,8 @@ inline std::string validate_step_result(
         if (decode_planned[(size_t)input.slot])
             return "decode plan contains a duplicate slot";
         decode_planned[(size_t)input.slot] = 1;
+        speculation_allowed[(size_t)input.slot] =
+            input.allow_speculation ? 1 : 0;
     }
     for (const PrefillSlice & slice : plan.prefills) {
         if (slice.slot < 0 || slice.slot >= slot_count ||
@@ -290,10 +309,22 @@ inline std::string validate_step_result(
             return "decode output names an unplanned slot";
         if (decode_seen[(size_t)output.slot])
             return "step returned duplicate decode outputs";
-        if (output.failed && (output.token >= 0 || output.error.empty()))
-            return "failed decode has invalid payload";
-        if (!output.failed && (output.token < 0 || !output.error.empty()))
-            return "successful decode has invalid payload";
+        if (output.failed) {
+            if (output.token >= 0 || !output.committed_tokens.empty() ||
+                output.error.empty())
+                return "failed decode has invalid payload";
+        } else {
+            if (output.token < 0 || !output.error.empty())
+                return "successful decode has invalid payload";
+            if (!speculation_allowed[(size_t)output.slot] &&
+                !output.committed_tokens.empty())
+                return "decode output burst violates disabled speculation";
+            if (std::any_of(
+                    output.committed_tokens.begin(),
+                    output.committed_tokens.end(),
+                    [](int32_t token) { return token < 0; }))
+                return "decode output burst contains an invalid token";
+        }
         decode_seen[(size_t)output.slot] = 1;
     }
 

--- a/server/src/common/ddtree.cpp
+++ b/server/src/common/ddtree.cpp
@@ -376,4 +376,14 @@ std::vector<int> follow_verified_tree(const DDTree & tree,
     return accepted;
 }
 
+bool truncate_verified_path(std::vector<int> & accepted,
+                            std::size_t max_committed,
+                            const int32_t * posterior,
+                            int & out_next_token) {
+    if (accepted.size() <= max_committed) return false;
+    accepted.resize(max_committed);
+    out_next_token = accepted.empty() ? -1 : posterior[accepted.back()];
+    return true;
+}
+
 }  // namespace dflash::common

--- a/server/src/common/ddtree.h
+++ b/server/src/common/ddtree.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <limits>
@@ -87,5 +88,14 @@ std::vector<int> follow_verified_tree(const DDTree & tree,
                                       const int32_t * posterior,
                                       int & out_next_token,
                                       int * out_node_idx = nullptr);
+
+// Bound a verified path to the number of tokens that can actually be
+// committed. When truncation removes the old tip, the pending token must be
+// recomputed from the posterior at the new tip; otherwise it describes model
+// state that was never committed.
+bool truncate_verified_path(std::vector<int> & accepted,
+                            std::size_t max_committed,
+                            const int32_t * posterior,
+                            int & out_next_token);
 
 }  // namespace dflash::common

--- a/server/src/common/dflash2_batch.cpp
+++ b/server/src/common/dflash2_batch.cpp
@@ -1,0 +1,376 @@
+#include "dflash2_head.h"
+
+#include "dflash2_selector_validation.h"
+#include "ddtree.h"
+#include "geometric_draft_topk_cuda.h"
+#include "ggml-alloc.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <limits>
+#include <vector>
+
+namespace dflash::common {
+namespace {
+
+struct ProjectionGraph {
+    const DraftWeights * dw = nullptr;
+    ggml_backend_t backend = nullptr;
+    ggml_tensor * lm_head = nullptr;
+    int n_positions = 0;
+    std::vector<uint8_t> arena;
+    ggml_context * ctx = nullptr;
+    ggml_cgraph * gf = nullptr;
+    ggml_gallocr_t galloc = nullptr;
+    ggml_tensor * inp_hidden = nullptr;
+    ggml_tensor * logits = nullptr;
+};
+
+struct BatchedSelectorGraph {
+    const DraftWeights * dw = nullptr;
+    ggml_backend_t backend = nullptr;
+    int n_lanes = 0;
+    int n_cand = 0;
+    int K = 0;
+    std::vector<uint8_t> arena;
+    ggml_context * ctx = nullptr;
+    ggml_cgraph * gf = nullptr;
+    ggml_gallocr_t galloc = nullptr;
+    ggml_tensor * inp_hidden = nullptr;
+    ggml_tensor * inp_succ = nullptr;
+    ggml_tensor * inp_pred = nullptr;
+    ggml_tensor * hproj = nullptr;
+    ggml_tensor * succ = nullptr;
+    ggml_tensor * pred = nullptr;
+};
+
+ProjectionGraph & projection_graph() {
+    static thread_local ProjectionGraph graph;
+    return graph;
+}
+
+BatchedSelectorGraph & batched_selector_graph() {
+    static thread_local BatchedSelectorGraph graph;
+    return graph;
+}
+
+void free_projection_graph(ProjectionGraph & graph) {
+    if (graph.galloc) {
+        ggml_gallocr_free(graph.galloc);
+        graph.galloc = nullptr;
+    }
+    if (graph.ctx) {
+        ggml_free(graph.ctx);
+        graph.ctx = nullptr;
+    }
+    graph = {};
+}
+
+void free_selector_graph(BatchedSelectorGraph & graph) {
+    if (graph.galloc) {
+        ggml_gallocr_free(graph.galloc);
+        graph.galloc = nullptr;
+    }
+    if (graph.ctx) {
+        ggml_free(graph.ctx);
+        graph.ctx = nullptr;
+    }
+    graph = {};
+}
+
+bool ensure_projection_graph(
+        ProjectionGraph & graph, const DraftWeights & dw,
+        ggml_backend_t backend, ggml_tensor * lm_head, int n_positions) {
+    if (graph.ctx && graph.dw == &dw && graph.backend == backend &&
+        graph.lm_head == lm_head && graph.n_positions == n_positions) {
+        return true;
+    }
+    free_projection_graph(graph);
+    if (!backend || !lm_head || n_positions <= 0 || dw.n_embd <= 0 ||
+        lm_head->ne[0] != dw.n_embd || lm_head->ne[1] <= 0) {
+        return false;
+    }
+
+    const size_t arena_size =
+        ggml_tensor_overhead() * 32 +
+        ggml_graph_overhead_custom(256, false) + 4096;
+    graph.arena.assign(arena_size, 0);
+    ggml_init_params params{};
+    params.mem_size = graph.arena.size();
+    params.mem_buffer = graph.arena.data();
+    params.no_alloc = true;
+    graph.ctx = ggml_init(params);
+    if (!graph.ctx) return false;
+    graph.gf = ggml_new_graph_custom(graph.ctx, 256, false);
+    graph.inp_hidden = ggml_new_tensor_2d(
+        graph.ctx, GGML_TYPE_F32, dw.n_embd, n_positions);
+    ggml_set_input(graph.inp_hidden);
+    graph.logits = ggml_mul_mat(graph.ctx, lm_head, graph.inp_hidden);
+    ggml_set_output(graph.logits);
+    ggml_build_forward_expand(graph.gf, graph.logits);
+    graph.galloc =
+        ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend));
+    if (!graph.galloc || !ggml_gallocr_alloc_graph(graph.galloc, graph.gf)) {
+        std::fprintf(stderr,
+            "dflash2_select_chains_batched: projection graph alloc failed\n");
+        free_projection_graph(graph);
+        return false;
+    }
+    graph.dw = &dw;
+    graph.backend = backend;
+    graph.lm_head = lm_head;
+    graph.n_positions = n_positions;
+    return true;
+}
+
+bool ensure_selector_graph(
+        BatchedSelectorGraph & graph, const DraftWeights & dw,
+        ggml_backend_t backend, int n_lanes, int n_cand, int K) {
+    if (graph.ctx && graph.dw == &dw && graph.backend == backend &&
+        graph.n_lanes == n_lanes && graph.n_cand == n_cand &&
+        graph.K == K) {
+        return true;
+    }
+    free_selector_graph(graph);
+    const DraftSelectorWeights & selector = dw.selector;
+    if (!backend || n_lanes <= 0 || n_cand <= 0 || K <= 0 ||
+        dw.n_embd <= 0 || selector.rank <= 0 || !selector.hproj ||
+        !selector.pred_cb || !selector.succ_cb) {
+        return false;
+    }
+
+    const int n_positions = n_lanes * n_cand;
+    const int n_pred_rows = n_lanes + n_positions * K;
+    const size_t arena_size =
+        ggml_tensor_overhead() * 48 +
+        ggml_graph_overhead_custom(256, false) + 4096;
+    graph.arena.assign(arena_size, 0);
+    ggml_init_params params{};
+    params.mem_size = graph.arena.size();
+    params.mem_buffer = graph.arena.data();
+    params.no_alloc = true;
+    graph.ctx = ggml_init(params);
+    if (!graph.ctx) return false;
+    graph.gf = ggml_new_graph_custom(graph.ctx, 256, false);
+    graph.inp_hidden = ggml_new_tensor_2d(
+        graph.ctx, GGML_TYPE_F32, dw.n_embd, n_positions);
+    graph.inp_succ = ggml_new_tensor_1d(
+        graph.ctx, GGML_TYPE_I32, n_positions * K);
+    graph.inp_pred = ggml_new_tensor_1d(
+        graph.ctx, GGML_TYPE_I32, n_pred_rows);
+    ggml_set_input(graph.inp_hidden);
+    ggml_set_input(graph.inp_succ);
+    ggml_set_input(graph.inp_pred);
+    graph.hproj =
+        ggml_mul_mat(graph.ctx, selector.hproj, graph.inp_hidden);
+    graph.succ =
+        ggml_get_rows(graph.ctx, selector.succ_cb, graph.inp_succ);
+    graph.pred =
+        ggml_get_rows(graph.ctx, selector.pred_cb, graph.inp_pred);
+    ggml_set_output(graph.hproj);
+    ggml_set_output(graph.succ);
+    ggml_set_output(graph.pred);
+    ggml_build_forward_expand(graph.gf, graph.hproj);
+    ggml_build_forward_expand(graph.gf, graph.succ);
+    ggml_build_forward_expand(graph.gf, graph.pred);
+    graph.galloc =
+        ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend));
+    if (!graph.galloc || !ggml_gallocr_alloc_graph(graph.galloc, graph.gf)) {
+        std::fprintf(stderr,
+            "dflash2_select_chains_batched: selector graph alloc failed\n");
+        free_selector_graph(graph);
+        return false;
+    }
+    graph.dw = &dw;
+    graph.backend = backend;
+    graph.n_lanes = n_lanes;
+    graph.n_cand = n_cand;
+    graph.K = K;
+    return true;
+}
+
+}  // namespace
+
+bool dflash2_select_chains_batched(
+        const DraftWeights & dw,
+        ggml_backend_t backend,
+        ggml_tensor * lm_head,
+        const std::vector<const float *> & hidden_by_lane,
+        int q_len,
+        const std::vector<int32_t> & last_tokens,
+        std::vector<std::vector<int32_t>> & draft_tokens) {
+    draft_tokens.clear();
+    const DraftSelectorWeights & selector = dw.selector;
+    const int n_lanes = static_cast<int>(hidden_by_lane.size());
+    const int n_cand = q_len - 1;
+    const int K = selector.top_k;
+    const int rank = selector.rank;
+    const int hdim = dw.n_embd;
+    if (!selector.enabled || !selector.hproj || !selector.pred_cb ||
+        !selector.succ_cb || !backend || !lm_head || n_lanes <= 0 ||
+        static_cast<int>(last_tokens.size()) != n_lanes ||
+        n_cand <= 0 || K <= 0 || rank <= 0 || hdim <= 0) {
+        return false;
+    }
+    DFlash2SelectorLayout selector_layout;
+    selector_layout.rank = rank;
+    selector_layout.top_k = K;
+    selector_layout.hproj_rank = selector.hproj->ne[1];
+    selector_layout.pred_rank = selector.pred_cb->ne[0];
+    selector_layout.pred_vocab = selector.pred_cb->ne[1];
+    selector_layout.succ_rank = selector.succ_cb->ne[0];
+    selector_layout.succ_vocab = selector.succ_cb->ne[1];
+    selector_layout.target_output_vocab = lm_head->ne[1];
+    std::string selector_error;
+    if (!validate_dflash2_selector_layout(
+            selector_layout, selector_error)) {
+        std::fprintf(stderr, "dflash2_select_chains_batched: %s\n",
+                     selector_error.c_str());
+        return false;
+    }
+    for (const float * hidden : hidden_by_lane) {
+        if (!hidden) return false;
+    }
+
+    const int n_positions = n_lanes * n_cand;
+    std::vector<float> candidate_hidden(
+        (size_t) hdim * (size_t) n_positions);
+    for (int lane = 0; lane < n_lanes; ++lane) {
+        for (int depth = 0; depth < n_cand; ++depth) {
+            const int position = lane * n_cand + depth;
+            const float * source = hidden_by_lane[(size_t) lane] +
+                (size_t) (depth + 1) * (size_t) hdim;
+            std::memcpy(
+                candidate_hidden.data() +
+                    (size_t) position * (size_t) hdim,
+                source, sizeof(float) * (size_t) hdim);
+        }
+    }
+
+    ProjectionGraph & projection = projection_graph();
+    if (!ensure_projection_graph(
+            projection, dw, backend, lm_head, n_positions)) {
+        return false;
+    }
+    ggml_backend_tensor_set(
+        projection.inp_hidden, candidate_hidden.data(), 0,
+        sizeof(float) * candidate_hidden.size());
+    if (ggml_backend_graph_compute(backend, projection.gf) !=
+        GGML_STATUS_SUCCESS) {
+        std::fprintf(stderr,
+            "dflash2_select_chains_batched: projection compute failed\n");
+        return false;
+    }
+
+    const int vocab = static_cast<int>(lm_head->ne[1]);
+    std::vector<float> candidate_log_probs(
+        (size_t) n_positions * (size_t) K);
+    std::vector<int32_t> candidate_ids(
+        (size_t) n_positions * (size_t) K);
+    bool have_top_k = false;
+#ifdef DFLASH27B_HAVE_DRAFT_TOPK
+    if (projection.logits && projection.logits->data) {
+        have_top_k = geometric_extract_draft_topk_cuda(
+            projection.logits->data, n_positions, vocab, K,
+            candidate_log_probs.data(), candidate_ids.data(), 1.0f);
+    }
+#endif
+    if (!have_top_k) {
+        std::vector<float> logits(
+            (size_t) vocab * (size_t) n_positions);
+        ggml_backend_tensor_get(
+            projection.logits, logits.data(), 0,
+            sizeof(float) * logits.size());
+        extract_draft_topk(
+            logits.data(), n_positions, vocab, K,
+            candidate_log_probs.data(), candidate_ids.data(), 1.0f);
+    }
+
+    BatchedSelectorGraph & graph = batched_selector_graph();
+    if (!ensure_selector_graph(
+            graph, dw, backend, n_lanes, n_cand, K)) {
+        return false;
+    }
+    std::vector<int32_t> predecessor_ids(
+        (size_t) n_lanes + candidate_ids.size());
+    std::copy(
+        last_tokens.begin(), last_tokens.end(), predecessor_ids.begin());
+    std::copy(
+        candidate_ids.begin(), candidate_ids.end(),
+        predecessor_ids.begin() + n_lanes);
+    ggml_backend_tensor_set(
+        graph.inp_hidden, candidate_hidden.data(), 0,
+        sizeof(float) * candidate_hidden.size());
+    ggml_backend_tensor_set(
+        graph.inp_succ, candidate_ids.data(), 0,
+        sizeof(int32_t) * candidate_ids.size());
+    ggml_backend_tensor_set(
+        graph.inp_pred, predecessor_ids.data(), 0,
+        sizeof(int32_t) * predecessor_ids.size());
+    if (ggml_backend_graph_compute(backend, graph.gf) !=
+        GGML_STATUS_SUCCESS) {
+        std::fprintf(stderr,
+            "dflash2_select_chains_batched: selector compute failed\n");
+        return false;
+    }
+
+    std::vector<float> projected_hidden(
+        (size_t) rank * (size_t) n_positions);
+    std::vector<float> successor_codes(
+        (size_t) rank * candidate_ids.size());
+    std::vector<float> predecessor_codes(
+        (size_t) rank * predecessor_ids.size());
+    ggml_backend_tensor_get_async(
+        backend, graph.hproj, projected_hidden.data(), 0,
+        sizeof(float) * projected_hidden.size());
+    ggml_backend_tensor_get_async(
+        backend, graph.succ, successor_codes.data(), 0,
+        sizeof(float) * successor_codes.size());
+    ggml_backend_tensor_get_async(
+        backend, graph.pred, predecessor_codes.data(), 0,
+        sizeof(float) * predecessor_codes.size());
+    ggml_backend_synchronize(backend);
+
+    draft_tokens.assign(
+        (size_t) n_lanes,
+        std::vector<int32_t>((size_t) q_len));
+    for (int lane = 0; lane < n_lanes; ++lane) {
+        draft_tokens[(size_t) lane][0] = last_tokens[(size_t) lane];
+        int predecessor_row = lane;
+        for (int depth = 0; depth < n_cand; ++depth) {
+            const int position = lane * n_cand + depth;
+            const float * predecessor = predecessor_codes.data() +
+                (size_t) predecessor_row * (size_t) rank;
+            const float * hidden = projected_hidden.data() +
+                (size_t) position * (size_t) rank;
+            float best_score = -INFINITY;
+            int best_candidate = 0;
+            for (int candidate = 0; candidate < K; ++candidate) {
+                const int candidate_row = position * K + candidate;
+                const float * successor = successor_codes.data() +
+                    (size_t) candidate_row * (size_t) rank;
+                float correction = 0.0f;
+                for (int r = 0; r < rank; ++r) {
+                    correction +=
+                        predecessor[r] * hidden[r] * successor[r];
+                }
+                const float score =
+                    candidate_log_probs[(size_t) candidate_row] +
+                    correction;
+                if (score > best_score) {
+                    best_score = score;
+                    best_candidate = candidate;
+                }
+            }
+            const int selected_row = position * K + best_candidate;
+            draft_tokens[(size_t) lane][(size_t) depth + 1] =
+                candidate_ids[(size_t) selected_row];
+            predecessor_row = n_lanes + selected_row;
+        }
+    }
+    return true;
+}
+
+}  // namespace dflash::common

--- a/server/src/common/dflash2_head.cpp
+++ b/server/src/common/dflash2_head.cpp
@@ -1,5 +1,6 @@
 #include "dflash2_head.h"
 
+#include "dflash2_selector_validation.h"
 #include "ggml-alloc.h"
 
 #include <algorithm>
@@ -80,6 +81,21 @@ bool dflash2_score_candidates(const DraftWeights & dw,
     const int K      = sel.top_k;
     const int n_cand = q_len - 1;
     if (hdim <= 0 || rank <= 0 || K <= 0) return false;
+    DFlash2SelectorLayout selector_layout;
+    selector_layout.rank = rank;
+    selector_layout.top_k = K;
+    selector_layout.hproj_rank = sel.hproj->ne[1];
+    selector_layout.pred_rank = sel.pred_cb->ne[0];
+    selector_layout.pred_vocab = sel.pred_cb->ne[1];
+    selector_layout.succ_rank = sel.succ_cb->ne[0];
+    selector_layout.succ_vocab = sel.succ_cb->ne[1];
+    std::string selector_error;
+    if (!validate_dflash2_selector_layout(
+            selector_layout, selector_error)) {
+        std::fprintf(stderr, "dflash2_score_candidates: %s\n",
+                     selector_error.c_str());
+        return false;
+    }
 
     // 1. Top-k candidates (log-probs) per block position through the target
     //    lm_head. Position 0 of local_hidden is the seed slot; candidates are

--- a/server/src/common/dflash2_head.h
+++ b/server/src/common/dflash2_head.h
@@ -33,6 +33,19 @@ bool dflash2_select_chain(const DraftWeights & dw,
                           int32_t last_tok,
                           std::vector<int32_t> & draft_tok);
 
+// Same selector, batched over host-resident drafter hidden blocks and using a
+// local target lm_head tensor. The expensive lm_head projection covers every
+// (lane, depth) in one graph, GPU top-K is invoked once, and selector
+// projections/readback are shared across the cohort.
+bool dflash2_select_chains_batched(
+    const DraftWeights & dw,
+    ggml_backend_t backend,
+    ggml_tensor * lm_head,
+    const std::vector<const float *> & hidden_by_lane,
+    int q_len,
+    const std::vector<int32_t> & last_tokens,
+    std::vector<std::vector<int32_t>> & draft_tokens);
+
 // Selector-scored candidates for DDTree construction (DARTree-style): the
 // same per-position top-k + selector projections as the chain path, kept on
 // the host so the tree builder can ask for branch-conditioned scores.

--- a/server/src/common/dflash2_selector_validation.h
+++ b/server/src/common/dflash2_selector_validation.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include "geometric_draft_topk_cuda.h"
+
+#include <cstdint>
+#include <string>
+
+namespace dflash::common {
+
+// Host-only description of the selector tensors. Keeping validation in terms
+// of dimensions makes it usable both while GGUF tensor descriptors are being
+// loaded and when a concrete target lm_head is attached to the batched path.
+struct DFlash2SelectorLayout {
+    int rank = 0;
+    int top_k = 0;
+    int64_t hproj_rank = 0;
+    int64_t pred_rank = 0;
+    int64_t pred_vocab = 0;
+    int64_t succ_rank = 0;
+    int64_t succ_vocab = 0;
+    // Zero means that source is unavailable at this validation point. A
+    // partial target shard, for example, can declare n_vocab without owning
+    // the final output tensor; the concrete lm_head is checked again at use.
+    int64_t target_output_vocab = 0;
+    int64_t target_declared_vocab = 0;
+};
+
+inline bool validate_dflash2_selector_layout(
+        const DFlash2SelectorLayout & layout, std::string & error) {
+    error.clear();
+    if (layout.rank <= 0) {
+        error = "DFlash 2 selector rank must be positive (got " +
+            std::to_string(layout.rank) + ")";
+        return false;
+    }
+    if (!geometric_draft_topk_cuda_supports_k(layout.top_k)) {
+        error = "DFlash 2 selector top_k=" + std::to_string(layout.top_k) +
+            " is unsupported; expected one of 1..8, 12, or 16";
+        return false;
+    }
+    if (layout.hproj_rank != layout.rank ||
+        layout.pred_rank != layout.rank ||
+        layout.succ_rank != layout.rank) {
+        error = "DFlash 2 selector rank mismatch: metadata=" +
+            std::to_string(layout.rank) + " hproj=" +
+            std::to_string(layout.hproj_rank) + " pred_cb=" +
+            std::to_string(layout.pred_rank) + " succ_cb=" +
+            std::to_string(layout.succ_rank);
+        return false;
+    }
+    if (layout.pred_vocab <= 0 || layout.succ_vocab <= 0) {
+        error = "DFlash 2 selector codebook vocab must be positive: pred_cb=" +
+            std::to_string(layout.pred_vocab) + " succ_cb=" +
+            std::to_string(layout.succ_vocab);
+        return false;
+    }
+    if (layout.pred_vocab != layout.succ_vocab) {
+        error = "DFlash 2 selector codebook vocab mismatch: pred_cb=" +
+            std::to_string(layout.pred_vocab) + " succ_cb=" +
+            std::to_string(layout.succ_vocab);
+        return false;
+    }
+    if (layout.top_k > layout.pred_vocab) {
+        error = "DFlash 2 selector top_k=" + std::to_string(layout.top_k) +
+            " exceeds codebook vocab=" + std::to_string(layout.pred_vocab);
+        return false;
+    }
+    if (layout.target_output_vocab > 0 &&
+        layout.target_declared_vocab > 0 &&
+        layout.target_output_vocab != layout.target_declared_vocab) {
+        error = "DFlash 2 target vocab mismatch: output/lm_head=" +
+            std::to_string(layout.target_output_vocab) + " target.n_vocab=" +
+            std::to_string(layout.target_declared_vocab);
+        return false;
+    }
+    if (layout.target_output_vocab > 0 &&
+        layout.pred_vocab != layout.target_output_vocab) {
+        error = "DFlash 2 selector vocab mismatch: codebook=" +
+            std::to_string(layout.pred_vocab) + " target output/lm_head=" +
+            std::to_string(layout.target_output_vocab);
+        return false;
+    }
+    if (layout.target_declared_vocab > 0 &&
+        layout.pred_vocab != layout.target_declared_vocab) {
+        error = "DFlash 2 selector vocab mismatch: codebook=" +
+            std::to_string(layout.pred_vocab) + " target.n_vocab=" +
+            std::to_string(layout.target_declared_vocab);
+        return false;
+    }
+    return true;
+}
+
+}  // namespace dflash::common

--- a/server/src/common/dflash2_selector_validation.h
+++ b/server/src/common/dflash2_selector_validation.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "geometric_draft_topk_cuda.h"
-
 #include <cstdint>
 #include <string>
 
@@ -33,9 +31,9 @@ inline bool validate_dflash2_selector_layout(
             std::to_string(layout.rank) + ")";
         return false;
     }
-    if (!geometric_draft_topk_cuda_supports_k(layout.top_k)) {
-        error = "DFlash 2 selector top_k=" + std::to_string(layout.top_k) +
-            " is unsupported; expected one of 1..8, 12, or 16";
+    if (layout.top_k <= 0) {
+        error = "DFlash 2 selector top_k must be positive (got " +
+            std::to_string(layout.top_k) + ")";
         return false;
     }
     if (layout.hproj_rank != layout.rank ||

--- a/server/src/common/dflash_draft_kv.cpp
+++ b/server/src/common/dflash_draft_kv.cpp
@@ -4,6 +4,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
 
 namespace dflash::common {
 
@@ -352,9 +353,36 @@ static bool draft_kv_batch_build(
     }
 
     draft_kv_batch_free(batch);
-    const int n_lanes = static_cast<int>(lane_states.size());
-    const size_t arena_size =
-        (32u + 16u * static_cast<size_t>(n_lanes)) * 1024u * 1024u;
+    constexpr size_t graph_nodes_per_lane = 4096;
+    constexpr size_t shared_graph_nodes = 2048;
+    const size_t n_lanes_size = lane_states.size();
+    if (n_lanes_size >
+        (static_cast<size_t>(std::numeric_limits<int>::max()) -
+            shared_graph_nodes) /
+            graph_nodes_per_lane) {
+        return false;
+    }
+    const int n_lanes = static_cast<int>(n_lanes_size);
+    const size_t graph_capacity =
+        graph_nodes_per_lane * n_lanes_size + shared_graph_nodes;
+    if (graph_capacity > std::numeric_limits<size_t>::max() / 2) {
+        return false;
+    }
+    const size_t tensor_capacity = 2 * graph_capacity;
+    const size_t tensor_overhead = ggml_tensor_overhead();
+    if (tensor_overhead != 0 &&
+        tensor_capacity >
+            std::numeric_limits<size_t>::max() / tensor_overhead) {
+        return false;
+    }
+    const size_t tensor_bytes = tensor_capacity * tensor_overhead;
+    const size_t graph_bytes =
+        ggml_graph_overhead_custom(graph_capacity, false);
+    if (tensor_bytes >
+        std::numeric_limits<size_t>::max() - graph_bytes) {
+        return false;
+    }
+    const size_t arena_size = graph_bytes + tensor_bytes;
     batch.meta_arena.resize(arena_size);
     ggml_init_params params{};
     params.mem_size = batch.meta_arena.size();
@@ -366,7 +394,7 @@ static bool draft_kv_batch_build(
         return false;
     }
     batch.gf = ggml_new_graph_custom(
-        batch.g_ctx, 4096 * n_lanes + 2048, false);
+        batch.g_ctx, graph_capacity, false);
 
     batch.hidden_by_lane.reserve(static_cast<size_t>(n_lanes));
     for (DraftKvState * state : lane_states) {
@@ -413,8 +441,11 @@ static bool draft_kv_batch_build(
     batch.built_for = &dw;
     batch.lane_states = lane_states;
     std::fprintf(stderr,
-        "[draft-kv-batch] packed backbone ready lanes=%d q_len=%d\n",
-        n_lanes, dw.block_size);
+        "[draft-kv-batch] packed backbone ready lanes=%d q_len=%d "
+        "metadata=%.1f MiB\n",
+        n_lanes, dw.block_size,
+        static_cast<double>(batch.meta_arena.size()) /
+            (1024.0 * 1024.0));
     return true;
 }
 

--- a/server/src/common/dflash_draft_kv.cpp
+++ b/server/src/common/dflash_draft_kv.cpp
@@ -96,10 +96,12 @@ bool draft_kv_init(DraftKvState & st,
     si.mask_full   = st.mask_full;
     si.mask_swa    = st.mask_swa;
     si.lm_head     = lm_head;
-    DraftGraphOutputs go = build_draft_kv_step(st.g_ctx, st.gf, dw, st.cache, si);
-    if (!go.hidden_states) return false;
-    st.hidden_states = go.hidden_states;
-    st.logits        = go.logits;
+    const std::vector<DraftKvLaneInputs> lanes{{&st.cache, si}};
+    const std::vector<DraftGraphOutputs> outputs =
+        build_draft_kv_steps(st.g_ctx, st.gf, dw, lanes);
+    if (outputs.size() != 1 || !outputs.front().hidden_states) return false;
+    st.hidden_states = outputs.front().hidden_states;
+    st.logits        = outputs.front().logits;
     ggml_set_output(st.hidden_states);
     ggml_build_forward_expand(st.gf, st.hidden_states);
     if (st.logits) {
@@ -334,6 +336,7 @@ void draft_kv_batch_free(DraftKvBatchGraph & batch) {
     batch.meta_arena.clear();
     batch.n_lanes = 0;
     batch.q_len = 0;
+    batch.backend = nullptr;
     batch.built_for = nullptr;
 }
 
@@ -397,6 +400,8 @@ static bool draft_kv_batch_build(
         batch.g_ctx, graph_capacity, false);
 
     batch.hidden_by_lane.reserve(static_cast<size_t>(n_lanes));
+    std::vector<DraftKvLaneInputs> lanes;
+    lanes.reserve(n_lanes_size);
     for (DraftKvState * state : lane_states) {
         DraftKvAppendInputs append{};
         append.n_rows = state->a_step;
@@ -415,8 +420,16 @@ static bool draft_kv_batch_build(
         step.noise_rows = state->noise_rows;
         step.mask_full = state->mask_full;
         step.mask_swa = state->mask_swa;
-        DraftGraphOutputs output = build_draft_kv_step(
-            batch.g_ctx, batch.gf, dw, state->cache, step);
+        lanes.push_back({&state->cache, step});
+    }
+
+    const std::vector<DraftGraphOutputs> outputs = build_draft_kv_steps(
+        batch.g_ctx, batch.gf, dw, lanes);
+    if (outputs.size() != lane_states.size()) {
+        draft_kv_batch_free(batch);
+        return false;
+    }
+    for (const DraftGraphOutputs & output : outputs) {
         if (!output.hidden_states) {
             draft_kv_batch_free(batch);
             return false;
@@ -439,6 +452,7 @@ static bool draft_kv_batch_build(
     batch.n_lanes = n_lanes;
     batch.q_len = dw.block_size;
     batch.built_for = &dw;
+    batch.backend = backend;
     batch.lane_states = lane_states;
     std::fprintf(stderr,
         "[draft-kv-batch] packed backbone ready lanes=%d q_len=%d "
@@ -460,7 +474,7 @@ bool draft_kv_batch_compute(
 
     const bool reusable =
         batch.gf && batch.built_for == static_cast<const void *>(&dw) &&
-        batch.lane_states == lane_states;
+        batch.backend == backend && batch.lane_states == lane_states;
     if (!reusable &&
         !draft_kv_batch_build(
             batch, dw, backend, lane_states)) {

--- a/server/src/common/dflash_draft_kv.cpp
+++ b/server/src/common/dflash_draft_kv.cpp
@@ -318,4 +318,144 @@ bool draft_kv_begin_step(DraftKvState & st,
     return true;
 }
 
+void draft_kv_batch_free(DraftKvBatchGraph & batch) {
+    if (batch.galloc) {
+        ggml_gallocr_free(batch.galloc);
+        batch.galloc = nullptr;
+    }
+    if (batch.g_ctx) {
+        ggml_free(batch.g_ctx);
+        batch.g_ctx = nullptr;
+    }
+    batch.gf = nullptr;
+    batch.hidden_by_lane.clear();
+    batch.lane_states.clear();
+    batch.meta_arena.clear();
+    batch.n_lanes = 0;
+    batch.q_len = 0;
+    batch.built_for = nullptr;
+}
+
+static bool draft_kv_batch_build(
+        DraftKvBatchGraph & batch,
+        const DraftWeights & dw,
+        ggml_backend_t backend,
+        const std::vector<DraftKvState *> & lane_states) {
+    if (!backend || lane_states.empty() || dw.block_size <= 1) {
+        return false;
+    }
+    for (DraftKvState * state : lane_states) {
+        if (!state || !state->mem_buf || state->q_len != dw.block_size ||
+            state->built_for != static_cast<const void *>(&dw)) {
+            return false;
+        }
+    }
+
+    draft_kv_batch_free(batch);
+    const int n_lanes = static_cast<int>(lane_states.size());
+    const size_t arena_size =
+        (32u + 16u * static_cast<size_t>(n_lanes)) * 1024u * 1024u;
+    batch.meta_arena.resize(arena_size);
+    ggml_init_params params{};
+    params.mem_size = batch.meta_arena.size();
+    params.mem_buffer = batch.meta_arena.data();
+    params.no_alloc = true;
+    batch.g_ctx = ggml_init(params);
+    if (!batch.g_ctx) {
+        draft_kv_batch_free(batch);
+        return false;
+    }
+    batch.gf = ggml_new_graph_custom(
+        batch.g_ctx, 4096 * n_lanes + 2048, false);
+
+    batch.hidden_by_lane.reserve(static_cast<size_t>(n_lanes));
+    for (DraftKvState * state : lane_states) {
+        DraftKvAppendInputs append{};
+        append.n_rows = state->a_step;
+        append.feat = state->ap_feat;
+        append.positions = state->ap_pos;
+        append.rows = state->ap_rows;
+        if (!build_draft_kv_append(
+                batch.g_ctx, batch.gf, dw, state->cache, append)) {
+            draft_kv_batch_free(batch);
+            return false;
+        }
+
+        DraftKvStepInputs step{};
+        step.noise_embed = state->inp_embed;
+        step.positions_q = state->pos_q;
+        step.noise_rows = state->noise_rows;
+        step.mask_full = state->mask_full;
+        step.mask_swa = state->mask_swa;
+        DraftGraphOutputs output = build_draft_kv_step(
+            batch.g_ctx, batch.gf, dw, state->cache, step);
+        if (!output.hidden_states) {
+            draft_kv_batch_free(batch);
+            return false;
+        }
+        ggml_set_output(output.hidden_states);
+        ggml_build_forward_expand(batch.gf, output.hidden_states);
+        batch.hidden_by_lane.push_back(output.hidden_states);
+    }
+
+    batch.galloc =
+        ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend));
+    if (!batch.galloc ||
+        !ggml_gallocr_alloc_graph(batch.galloc, batch.gf)) {
+        std::fprintf(stderr,
+            "[draft-kv-batch] graph alloc failed lanes=%d\n", n_lanes);
+        draft_kv_batch_free(batch);
+        return false;
+    }
+
+    batch.n_lanes = n_lanes;
+    batch.q_len = dw.block_size;
+    batch.built_for = &dw;
+    batch.lane_states = lane_states;
+    std::fprintf(stderr,
+        "[draft-kv-batch] packed backbone ready lanes=%d q_len=%d\n",
+        n_lanes, dw.block_size);
+    return true;
+}
+
+bool draft_kv_batch_compute(
+        DraftKvBatchGraph & batch,
+        const DraftWeights & dw,
+        ggml_backend_t backend,
+        const std::vector<DraftKvState *> & lane_states,
+        std::vector<std::vector<float>> & hidden_by_lane) {
+    hidden_by_lane.clear();
+    if (lane_states.empty()) return false;
+
+    const bool reusable =
+        batch.gf && batch.built_for == static_cast<const void *>(&dw) &&
+        batch.lane_states == lane_states;
+    if (!reusable &&
+        !draft_kv_batch_build(
+            batch, dw, backend, lane_states)) {
+        return false;
+    }
+    if (ggml_backend_graph_compute(backend, batch.gf) !=
+        GGML_STATUS_SUCCESS) {
+        std::fprintf(stderr,
+            "[draft-kv-batch] graph compute failed lanes=%d\n",
+            batch.n_lanes);
+        return false;
+    }
+
+    const size_t elements =
+        static_cast<size_t>(dw.n_embd) * static_cast<size_t>(batch.q_len);
+    hidden_by_lane.assign(
+        static_cast<size_t>(batch.n_lanes),
+        std::vector<float>(elements));
+    for (int lane = 0; lane < batch.n_lanes; ++lane) {
+        ggml_backend_tensor_get_async(
+            backend, batch.hidden_by_lane[static_cast<size_t>(lane)],
+            hidden_by_lane[static_cast<size_t>(lane)].data(), 0,
+            sizeof(float) * elements);
+    }
+    ggml_backend_synchronize(backend);
+    return true;
+}
+
 }  // namespace dflash::common

--- a/server/src/common/dflash_draft_kv.h
+++ b/server/src/common/dflash_draft_kv.h
@@ -99,4 +99,33 @@ bool draft_kv_begin_step(DraftKvState & st,
                          const DraftFeatureMirror & ring,
                          int committed);
 
+struct DraftKvBatchGraph {
+    DraftKvBatchGraph() = default;
+    DraftKvBatchGraph(const DraftKvBatchGraph &) = delete;
+    DraftKvBatchGraph & operator=(const DraftKvBatchGraph &) = delete;
+
+    int n_lanes = 0;
+    int q_len = 0;
+    const void * built_for = nullptr;
+    std::vector<DraftKvState *> lane_states;
+
+    std::vector<uint8_t> meta_arena;
+    ggml_context * g_ctx = nullptr;
+    ggml_cgraph * gf = nullptr;
+    ggml_gallocr_t galloc = nullptr;
+    std::vector<ggml_tensor *> hidden_by_lane;
+};
+
+void draft_kv_batch_free(DraftKvBatchGraph & batch);
+
+// All lane states must already have draft_kv_begin_step() inputs and
+// inp_embed uploaded. The packed graph computes the shared backbone and
+// returns one host-visible hidden-state block per lane.
+bool draft_kv_batch_compute(
+    DraftKvBatchGraph & batch,
+    const DraftWeights & dw,
+    ggml_backend_t backend,
+    const std::vector<DraftKvState *> & lane_states,
+    std::vector<std::vector<float>> & hidden_by_lane);
+
 }  // namespace dflash::common

--- a/server/src/common/dflash_draft_kv.h
+++ b/server/src/common/dflash_draft_kv.h
@@ -107,6 +107,7 @@ struct DraftKvBatchGraph {
     int n_lanes = 0;
     int q_len = 0;
     const void * built_for = nullptr;
+    ggml_backend_t backend = nullptr;
     std::vector<DraftKvState *> lane_states;
 
     std::vector<uint8_t> meta_arena;

--- a/server/src/common/draft_swa.cpp
+++ b/server/src/common/draft_swa.cpp
@@ -1,0 +1,38 @@
+#include "draft_swa.h"
+
+#include "internal.h"
+
+namespace dflash::common {
+
+DraftSwaOverrideResult apply_draft_swa_window_override(
+        DraftWeights & weights, int requested_window) {
+    DraftSwaOverrideResult result;
+    result.effective_window = weights.swa_window;
+    result.total_layers = static_cast<int>(weights.layers.size());
+
+    bool any_swa = false;
+    for (const DraftLayer & layer : weights.layers) {
+        if (layer.is_swa) {
+            any_swa = true;
+            ++result.swa_layers;
+        }
+    }
+
+    if (requested_window <= 0) {
+        return result;
+    }
+
+    if (!weights.swa_pattern_loaded && !any_swa && weights.layers.size() > 1) {
+        for (size_t index = 0; index + 1 < weights.layers.size(); ++index) {
+            weights.layers[index].is_swa = true;
+        }
+        result.swa_layers = result.total_layers - 1;
+        result.inferred_legacy_pattern = true;
+    }
+
+    weights.swa_window = requested_window;
+    result.effective_window = requested_window;
+    return result;
+}
+
+} // namespace dflash::common

--- a/server/src/common/draft_swa.h
+++ b/server/src/common/draft_swa.h
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace dflash::common {
+
+struct DraftWeights;
+
+struct DraftSwaOverrideResult {
+    int  effective_window = 0;
+    int  swa_layers = 0;
+    int  total_layers = 0;
+    bool inferred_legacy_pattern = false;
+};
+
+DraftSwaOverrideResult apply_draft_swa_window_override(
+    DraftWeights & weights, int requested_window);
+
+} // namespace dflash::common

--- a/server/src/common/feature_gate.cpp
+++ b/server/src/common/feature_gate.cpp
@@ -174,6 +174,17 @@ std::string check_feature_compatibility(
         }
     }
 
+    const bool concurrent_local_chain =
+        arch == "qwen35" && args.paged_attention &&
+        args.max_concurrency > 1 && args.draft_path != nullptr &&
+        !args.ddtree_mode && !args.remote_draft.enabled() &&
+        !args.device.is_layer_split() &&
+        !args.device.is_tensor_parallel() &&
+        !args.remote_target_shard.enabled() &&
+        target_backend == draft_backend &&
+        args.device.gpu == args.draft_device.gpu &&
+        args.fa_window == 0;
+
     // ── --paged-attention × architecture, placement, and decode features
     // Paged decode swaps the contiguous K/V cache for a block table owned by
     // the monolithic qwen35 backend, so every rule below is about reaching
@@ -191,10 +202,13 @@ std::string check_feature_compatibility(
             args.remote_target_shard.enabled()) {
             return "--paged-attention requires one local target device";
         }
-        if (args.draft_path != nullptr || args.remote_draft.enabled() ||
-            args.ddtree_mode) {
+        if ((args.draft_path != nullptr || args.remote_draft.enabled()) &&
+            !concurrent_local_chain) {
             return "--paged-attention requires autoregressive decode without a "
-                   "draft or DDTree";
+                   "draft, or concurrent local same-device DFlash2 chains";
+        }
+        if (args.ddtree_mode) {
+            return "--paged-attention does not support DDTree";
         }
         if (args.fa_window != 0) {
             return "--paged-attention requires full attention (--fa-window 0)";
@@ -243,10 +257,12 @@ std::string check_feature_compatibility(
         if (args.max_concurrency <= 1) {
             return "--kv-pool-tokens requires --max-concurrency greater than 1";
         }
-        // The cache appends one scratch block after the physical pool, and
-        // the requested pool itself is rounded up to a whole block. Cap the
-        // request at the largest aligned pool that leaves room for scratch.
-        const int64_t max_pool_tokens = paged_kv_address_cap();
+        const int64_t chain_scratch = concurrent_local_chain
+            ? (int64_t)args.max_concurrency * paged_token_capacity(16)
+            : 0;
+        const int64_t max_pool_tokens =
+            ((int64_t)INT32_MAX - PAGED_BLOCK_SIZE - chain_scratch) /
+            PAGED_BLOCK_SIZE * PAGED_BLOCK_SIZE;
         if (args.kv_pool_tokens < PAGED_BLOCK_SIZE ||
             args.kv_pool_tokens > max_pool_tokens) {
             return "--kv-pool-tokens must be in [" +

--- a/server/src/common/feature_gate.cpp
+++ b/server/src/common/feature_gate.cpp
@@ -185,6 +185,12 @@ std::string check_feature_compatibility(
         args.device.gpu == args.draft_device.gpu &&
         args.fa_window == 0;
 
+    if (concurrent_local_chain &&
+        features.draft_residency == DraftResidencyPolicy::RequestScoped) {
+        return "concurrent DFlash2 does not support "
+               "--draft-residency=request-scoped";
+    }
+
     // ── --paged-attention × architecture, placement, and decode features
     // Paged decode swaps the contiguous K/V cache for a block table owned by
     // the monolithic qwen35 backend, so every rule below is about reaching

--- a/server/src/common/geometric_draft_topk_cuda.cu
+++ b/server/src/common/geometric_draft_topk_cuda.cu
@@ -331,7 +331,10 @@ bool geometric_extract_draft_topk_cuda(const void * d_logits,
                              float * out_log_probs,
                              int32_t * out_token_ids,
                              float temperature) {
-    if (!d_logits || n_positions <= 0 || vocab <= 0 || K <= 0 || K > kMaxK) return false;
+    if (!d_logits || !out_log_probs || !out_token_ids || n_positions <= 0 ||
+        vocab <= 0 || K > vocab || !geometric_draft_topk_cuda_supports_k(K)) {
+        return false;
+    }
 
     cudaPointerAttributes attr{};
     if (cudaPointerGetAttributes(&attr, d_logits) != cudaSuccess) {
@@ -362,9 +365,6 @@ bool geometric_extract_draft_topk_cuda(const void * d_logits,
         // the tensor base aligned and a vocab stride that is a multiple of 4.
         const bool use_vec = (vocab % 4 == 0) &&
                              (reinterpret_cast<uintptr_t>(lp_in) % 16 == 0);
-        // K (and the vectorization flag) are compile-time template parameters
-        // so the per-thread/per-partial top-K stays register-resident; dispatch
-        // the runtime K to its instantiation. K>kMaxK is already rejected above.
 #define DFLASH_TOPK_LAUNCH(KV, VEC)                                                             \
             geometric_draft_topk_partial<KV, VEC><<<grid1, kBlock>>>(                                     \
                 lp_in, vocab, inv_t, split,                                                     \

--- a/server/src/common/geometric_draft_topk_cuda.h
+++ b/server/src/common/geometric_draft_topk_cuda.h
@@ -25,6 +25,10 @@
 
 namespace dflash::common {
 
+inline constexpr bool geometric_draft_topk_cuda_supports_k(int K) noexcept {
+    return (K >= 1 && K <= 8) || K == 12 || K == 16;
+}
+
 // d_logits: device pointer to row-major [n_positions][vocab] f32 logits (the
 //           position stride is `vocab` floats — pass an offset pointer to skip
 //           leading positions). out_* are HOST buffers of size n_positions*K.

--- a/server/src/common/gpu_runtime_compat.h
+++ b/server/src/common/gpu_runtime_compat.h
@@ -60,6 +60,7 @@
 #define cudaPointerAttributes hipPointerAttribute_t
 #define cudaPointerGetAttributes hipPointerGetAttributes
 #define cudaStreamCreate hipStreamCreate
+#define cudaStreamCreateWithFlags hipStreamCreateWithFlags
 #define cudaStreamDefault hipStreamDefault
 #define cudaStreamDestroy hipStreamDestroy
 #define cudaStreamNonBlocking hipStreamNonBlocking

--- a/server/src/common/sampler.cpp
+++ b/server/src/common/sampler.cpp
@@ -104,154 +104,295 @@ int sample_from_gpu_probs(std::vector<float> & probs, double top_p, double r_uni
 
 }  // namespace
 
+bool SamplerDistribution::valid() const {
+    if (probabilities.empty() || support.empty()) return false;
+    double total = 0.0;
+    for (float probability : probabilities) {
+        if (!std::isfinite(probability) || probability < 0.0f) return false;
+        total += probability;
+    }
+    double support_total = 0.0;
+    for (int32_t token : support) {
+        if (token < 0 || static_cast<size_t>(token) >= probabilities.size()) {
+            return false;
+        }
+        support_total += probabilities[static_cast<size_t>(token)];
+    }
+    return std::fabs(total - 1.0) <= 1e-4 &&
+           std::fabs(support_total - total) <= 1e-4;
+}
+
+float SamplerDistribution::probability_of(int32_t token) const {
+    if (token < 0 || static_cast<size_t>(token) >= probabilities.size()) {
+        return 0.0f;
+    }
+    return probabilities[static_cast<size_t>(token)];
+}
+
+bool SamplerDistribution::deterministic() const {
+    int positive = 0;
+    for (int32_t token : support) {
+        if (probability_of(token) > 0.0f && ++positive > 1) return false;
+    }
+    return positive == 1;
+}
+
+int sample_distribution(
+        const SamplerDistribution & distribution,
+        double r_uniform) {
+    if (distribution.probabilities.empty() || distribution.support.empty() ||
+        !std::isfinite(r_uniform) || r_uniform < 0.0 || r_uniform >= 1.0) {
+        return -1;
+    }
+    double total = 0.0;
+    for (int32_t token : distribution.support) {
+        if (token < 0 ||
+            static_cast<size_t>(token) >= distribution.probabilities.size()) {
+            return -1;
+        }
+        total += distribution.probability_of(token);
+    }
+    if (!(total > 0.0)) return -1;
+
+    const double target = r_uniform * total;
+    double cumulative = 0.0;
+    int last_positive = -1;
+    for (int32_t token : distribution.support) {
+        const float probability = distribution.probability_of(token);
+        if (probability <= 0.0f) continue;
+        last_positive = token;
+        cumulative += probability;
+        if (target <= cumulative) return token;
+    }
+    return last_positive;
+}
+
+bool redirect_distribution_mass(
+        SamplerDistribution & distribution,
+        const int32_t * source_ids,
+        int source_count,
+        int32_t replacement) {
+    if (!distribution.valid() || source_count < 0 ||
+        (source_count > 0 && !source_ids) || replacement < 0 ||
+        static_cast<size_t>(replacement) >= distribution.probabilities.size()) {
+        return false;
+    }
+
+    double redirected = 0.0;
+    for (int i = 0; i < source_count; ++i) {
+        const int32_t source = source_ids[i];
+        if (source < 0 ||
+            static_cast<size_t>(source) >= distribution.probabilities.size() ||
+            source == replacement) {
+            return false;
+        }
+        redirected += distribution.probabilities[static_cast<size_t>(source)];
+        distribution.probabilities[static_cast<size_t>(source)] = 0.0f;
+    }
+    distribution.probabilities[static_cast<size_t>(replacement)] +=
+        static_cast<float>(redirected);
+    if (std::find(distribution.support.begin(), distribution.support.end(),
+                  replacement) == distribution.support.end()) {
+        distribution.support.push_back(replacement);
+    }
+    return true;
+}
+
+static bool build_sampler_candidates(
+        const float * logits_in,
+        int vocab,
+        const SamplerCfg & cfg,
+        const std::vector<int32_t> & history,
+        std::vector<std::pair<float, int>> & candidates) {
+    candidates.clear();
+    if (!logits_in || vocab <= 0) return false;
+    candidates.resize(static_cast<size_t>(vocab));
+    for (int token = 0; token < vocab; ++token) {
+        candidates[static_cast<size_t>(token)] = {logits_in[token], token};
+    }
+
+    if (cfg.rep_pen > 1.0f && !history.empty()) {
+        const int window = std::min(
+            static_cast<int>(history.size()), cfg.rep_window);
+        const int from = static_cast<int>(history.size()) - window;
+        std::unordered_set<int> seen;
+        for (int i = from; i < static_cast<int>(history.size()); ++i) {
+            seen.insert(history[static_cast<size_t>(i)]);
+        }
+        for (auto & candidate : candidates) {
+            if (seen.count(candidate.second) != 0) {
+                candidate.first = candidate.first > 0.0f
+                    ? candidate.first / cfg.rep_pen
+                    : candidate.first * cfg.rep_pen;
+            }
+        }
+    }
+
+    if ((cfg.freq_pen != 0.0f || cfg.pres_pen != 0.0f) &&
+        !history.empty()) {
+        const int window = std::min(
+            static_cast<int>(history.size()), cfg.rep_window);
+        const int from = static_cast<int>(history.size()) - window;
+        std::unordered_map<int, int> counts;
+        for (int i = from; i < static_cast<int>(history.size()); ++i) {
+            ++counts[history[static_cast<size_t>(i)]];
+        }
+        for (auto & candidate : candidates) {
+            const auto it = counts.find(candidate.second);
+            if (it != counts.end()) {
+                candidate.first -= cfg.freq_pen * it->second;
+                candidate.first -= cfg.pres_pen;
+            }
+        }
+    }
+
+    if (cfg.temp <= 0.0f) {
+        const int token = std::max_element(
+            candidates.begin(), candidates.end(),
+            [](const auto & a, const auto & b) {
+                return a.first < b.first;
+            })->second;
+        candidates.assign(1, {1.0f, token});
+        return true;
+    }
+
+    const bool need_top_k = cfg.top_k > 0 && cfg.top_k < vocab;
+    const bool need_top_p = cfg.top_p > 0.0f && cfg.top_p < 1.0f;
+    if (need_top_k) {
+        std::partial_sort(
+            candidates.begin(), candidates.begin() + cfg.top_k,
+            candidates.end(),
+            [](const auto & a, const auto & b) {
+                return a.first > b.first;
+            });
+        candidates.resize(static_cast<size_t>(cfg.top_k));
+    }
+
+    const float inverse_temperature =
+        1.0f / std::max(1e-3f, cfg.temp);
+    const float max_logit = need_top_k
+        ? candidates.front().first
+        : std::max_element(
+              candidates.begin(), candidates.end(),
+              [](const auto & a, const auto & b) {
+                  return a.first < b.first;
+              })->first;
+    const float scaled_max = max_logit * inverse_temperature;
+
+    if (need_top_p && !need_top_k) {
+        double denominator = 0.0;
+        for (const auto & candidate : candidates) {
+            denominator += std::exp(
+                static_cast<double>(candidate.first) *
+                    inverse_temperature -
+                scaled_max);
+        }
+        const double target = static_cast<double>(cfg.top_p) * denominator;
+        const size_t cutoff = nucleus_cutoff(
+            candidates, target, [&](const auto & candidate) {
+                return std::exp(
+                    static_cast<double>(candidate.first) *
+                        inverse_temperature -
+                    scaled_max);
+            });
+        candidates.resize(cutoff);
+    }
+
+    double denominator = 0.0;
+    for (auto & candidate : candidates) {
+        candidate.first = std::exp(
+            candidate.first * inverse_temperature - scaled_max);
+        denominator += candidate.first;
+    }
+    if (!(denominator > 0.0) || !std::isfinite(denominator)) return false;
+    for (auto & candidate : candidates) {
+        candidate.first =
+            static_cast<float>(candidate.first / denominator);
+    }
+
+    if (need_top_p && need_top_k) {
+        double cumulative = 0.0;
+        size_t cutoff = candidates.size();
+        for (size_t i = 0; i < candidates.size(); ++i) {
+            cumulative += candidates[i].first;
+            if (cumulative >= cfg.top_p) {
+                cutoff = i + 1;
+                break;
+            }
+        }
+        candidates.resize(cutoff);
+    }
+    return true;
+}
+
+bool build_sampler_distribution(
+        const float * logits_in,
+        int vocab,
+        const SamplerCfg & cfg,
+        const std::vector<int32_t> & history,
+        SamplerDistribution & out) {
+    out.probabilities.clear();
+    out.support.clear();
+
+    static thread_local std::vector<std::pair<float, int>> candidates;
+    if (!build_sampler_candidates(
+            logits_in, vocab, cfg, history, candidates)) {
+        return false;
+    }
+
+    double total = 0.0;
+    for (const auto & candidate : candidates) total += candidate.first;
+    if (!(total > 0.0) || !std::isfinite(total)) return false;
+
+    out.probabilities.assign(static_cast<size_t>(vocab), 0.0f);
+    out.support.reserve(candidates.size());
+    for (const auto & candidate : candidates) {
+        out.probabilities[static_cast<size_t>(candidate.second)] =
+            static_cast<float>(candidate.first / total);
+        out.support.push_back(candidate.second);
+    }
+    return true;
+}
+
 int sample_logits(const float * logits_in,
                   int vocab,
                   const SamplerCfg & cfg,
                   const std::vector<int32_t> & history,
                   std::mt19937_64 & rng) {
-    // Draw the single uniform up front, exactly once, and only when we will
-    // actually sample (temp>0; greedy returns before any draw). It is then
-    // threaded through every path below — the full-GPU draw, the GPU-assisted
-    // top_p draw, and the CPU draw all consume this same value — so the RNG
-    // stream advances identically no matter which path resolves the token
-    // (including a GPU→CPU fallback), keeping decode reproducible whether the
-    // GPU sampler is on or off.
     double r_uniform = 0.0;
     if (cfg.temp > 0.0f) {
-        std::uniform_real_distribution<double> u(0.0, 1.0);
-        r_uniform = u(rng);
+        std::uniform_real_distribution<double> uniform(0.0, 1.0);
+        r_uniform = uniform(rng);
     }
 
 #ifdef DFLASH27B_HAVE_GPU_SAMPLER
-    // GPU path (on by default; set DFLASH_GPU_SAMPLE=0 to disable). top_k>0,
-    // top_p in (0,1) (both unsupported on the GPU, see geometric_sampler_cuda.h),
-    // and any CUDA error return -1 and fall through to the CPU chain below.
     if (gpu_sampler_enabled() && gpu_sampler_supports(cfg)) {
-        const int g = geometric_sample_logits_cuda(logits_in, vocab, cfg, history, r_uniform,
-                                         /*logits_on_device=*/false);
-        if (g >= 0) return g;
+        const int token = geometric_sample_logits_cuda(
+            logits_in, vocab, cfg, history, r_uniform,
+            /*logits_on_device=*/false);
+        if (token >= 0) return token;
     }
-#endif
+
     const bool need_top_k = cfg.top_k > 0 && cfg.top_k < vocab;
     const bool need_top_p = cfg.top_p > 0.0f && cfg.top_p < 1.0f;
-
-#ifdef DFLASH27B_HAVE_GPU_SAMPLER
-    // Reaching here means the GPU either can't fully handle this config
-    // (top_k/top_p above) or is disabled. For pure top_p (no top_k), the GPU
-    // can still compute the shared, vocab-wide penalty+softmax prefix and
-    // hand back normalized probabilities, letting the CPU skip straight to
-    // nucleus_cutoff — worth it because that search's O(vocab) cost dominates
-    // regardless of who computed its input. top_k (with or without top_p) is
-    // deliberately excluded: its CPU cost is already cheap (partial_sort
-    // scales with k, not vocab), so the GPU round trip would make it slower,
-    // not faster (measured regression, not just "no win").
-    if (cfg.temp > 0.0f && need_top_p && !need_top_k && gpu_sampler_enabled()) {
-        std::vector<float> gpu_probs(vocab);
-        if (geometric_compute_probs_cuda(logits_in, vocab, cfg, history,
-                                         gpu_probs.data(), /*logits_on_device=*/false)) {
-            return sample_from_gpu_probs(gpu_probs, cfg.top_p, r_uniform);
+    if (cfg.temp > 0.0f && need_top_p && !need_top_k &&
+        gpu_sampler_enabled()) {
+        std::vector<float> gpu_probabilities(static_cast<size_t>(vocab));
+        if (geometric_compute_probs_cuda(
+                logits_in, vocab, cfg, history, gpu_probabilities.data(),
+                /*logits_on_device=*/false)) {
+            return sample_from_gpu_probs(
+                gpu_probabilities, cfg.top_p, r_uniform);
         }
-        // else: fall through to the full CPU chain below.
     }
 #endif
 
-    std::vector<std::pair<float, int>> cand(vocab);
-    for (int i = 0; i < vocab; i++) cand[i] = {logits_in[i], i};
-
-    // Multiplicative repetition penalty (HuggingFace-style).
-    if (cfg.rep_pen > 1.0f && !history.empty()) {
-        const int win  = std::min((int)history.size(), cfg.rep_window);
-        const int from = (int)history.size() - win;
-        std::unordered_set<int> seen;
-        for (int i = from; i < (int)history.size(); i++) seen.insert(history[i]);
-        for (auto & c : cand) {
-            if (seen.count(c.second)) {
-                c.first = (c.first > 0.0f) ? c.first / cfg.rep_pen
-                                           : c.first * cfg.rep_pen;
-            }
-        }
+    static thread_local std::vector<std::pair<float, int>> candidates;
+    if (!build_sampler_candidates(
+            logits_in, vocab, cfg, history, candidates)) {
+        return -1;
     }
-
-    // OpenAI-style additive frequency and presence penalties.
-    if ((cfg.freq_pen != 0.0f || cfg.pres_pen != 0.0f) && !history.empty()) {
-        const int win  = std::min((int)history.size(), cfg.rep_window);
-        const int from = (int)history.size() - win;
-        std::unordered_map<int, int> counts;
-        for (int i = from; i < (int)history.size(); i++) counts[history[i]]++;
-        for (auto & c : cand) {
-            auto it = counts.find(c.second);
-            if (it != counts.end()) {
-                c.first -= cfg.freq_pen * it->second;
-                c.first -= cfg.pres_pen;
-            }
-        }
-    }
-
-    // temp=0 → deterministic argmax (after penalties have been applied above).
-    // Independent of top_k/top_p (the single highest-logit token is always the
-    // answer), so this skips sorting/truncation entirely: an O(vocab) max scan
-    // beats the O(vocab log vocab) sort below. Ties go to the lowest token id
-    // (max_element returns the first of equal maxima), matching the GPU kernel.
-    if (cfg.temp <= 0.0f) {
-        return std::max_element(cand.begin(), cand.end(),
-                                [](auto & a, auto & b){ return a.first < b.first; })->second;
-    }
-
-    // Only sort/truncate when top_k or top_p actually need it. Softmax and the
-    // inverse-CDF draw below are order-independent, so the common case (plain
-    // temperature sampling, no truncation) skips sorting entirely.
-    if (need_top_k) {
-        std::partial_sort(cand.begin(), cand.begin() + cfg.top_k, cand.end(),
-                          [](auto & a, auto & b){ return a.first > b.first; });
-        cand.resize(cfg.top_k);
-    }
-
-    const float inv_t = 1.0f / std::max(1e-3f, cfg.temp);
-    const float maxv_logit = need_top_k
-        ? cand.front().first
-        : std::max_element(cand.begin(), cand.end(),
-                           [](auto & a, auto & b){ return a.first < b.first; })->first;
-    const float maxv = maxv_logit * inv_t;
-
-    if (need_top_p && !need_top_k) {
-        // Nucleus cutoff over the full (untruncated) vocab. Z is the true
-        // full-vocab softmax denominator (one O(vocab) exp() pass, needed
-        // regardless to know the absolute mass threshold).
-        double Z = 0.0;
-        for (auto & c : cand) Z += std::exp((double)c.first * inv_t - maxv);
-        const double target = (double)cfg.top_p * Z;
-        const size_t cut = nucleus_cutoff(cand, target, [&](auto & c) {
-            return std::exp((double)c.first * inv_t - maxv);
-        });
-        cand.resize(cut);
-    }
-
-    double Z = 0.0;
-    std::vector<float> probs(cand.size());
-    for (size_t i = 0; i < cand.size(); i++) {
-        probs[i] = std::exp(cand[i].first * inv_t - maxv);
-        Z       += probs[i];
-    }
-    for (auto & p : probs) p = (float)(p / Z);
-
-    // top_k+top_p combined: cut the already top_k-truncated (and thus
-    // already-sorted) subset further to the top_p nucleus within it.
-    if (need_top_p && need_top_k) {
-        double cum = 0.0;
-        size_t cut = probs.size();
-        for (size_t i = 0; i < probs.size(); i++) {
-            cum += probs[i];
-            if (cum >= cfg.top_p) { cut = i + 1; break; }
-        }
-        probs.resize(cut); cand.resize(cut);
-    }
-
-    // Draw from the final candidate set. Same CDF walk as draw_from_weights
-    // above (it renormalizes internally, which is a no-op cost here since
-    // probs already sums to ~1) — reuse it instead of re-deriving the same
-    // loop a second time.
-    for (size_t i = 0; i < cand.size(); i++) cand[i].first = probs[i];
-    return draw_from_weights(cand, r_uniform);
+    return draw_from_weights(candidates, r_uniform);
 }
 
 bool parse_sampler_token(std::string & line, SamplerCfg & out) {

--- a/server/src/common/sampler.h
+++ b/server/src/common/sampler.h
@@ -40,6 +40,38 @@ struct SamplerCfg {
     }
 };
 
+// The exact post-penalty, post-temperature, post-top-k/top-p distribution used
+// by sample_logits(). probabilities is dense by token id; support preserves
+// the inverse-CDF traversal order used by the sampler.
+struct SamplerDistribution {
+    std::vector<float> probabilities;
+    std::vector<int32_t> support;
+
+    bool valid() const;
+    float probability_of(int32_t token) const;
+    bool deterministic() const;
+};
+
+bool build_sampler_distribution(
+    const float * logits_in,
+    int vocab,
+    const SamplerCfg & cfg,
+    const std::vector<int32_t> & history,
+    SamplerDistribution & out);
+
+// Sample a prebuilt distribution with a caller-owned uniform in [0, 1).
+int sample_distribution(
+    const SamplerDistribution & distribution,
+    double r_uniform);
+
+// Model the minimum-token EOS floor as a probability-mass redirect so
+// speculative verification uses the same effective target law as AR decode.
+bool redirect_distribution_mass(
+    SamplerDistribution & distribution,
+    const int32_t * source_ids,
+    int source_count,
+    int32_t replacement);
+
 // Returns the chosen token id. cfg.temp == 0 -> caller should use argmax;
 // the chain assumes a positive temperature and falls back to a small floor.
 int sample_logits(const float * logits_in,

--- a/server/src/common/speculative_sampling.cpp
+++ b/server/src/common/speculative_sampling.cpp
@@ -1,0 +1,90 @@
+#include "speculative_sampling.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace dflash::common {
+
+bool SparseProposalDistribution::valid(int vocab) const {
+    if (vocab <= 0 || token_ids.empty() ||
+        token_ids.size() != probabilities.size()) {
+        return false;
+    }
+    double total = 0.0;
+    for (size_t i = 0; i < token_ids.size(); ++i) {
+        if (token_ids[i] < 0 || token_ids[i] >= vocab ||
+            !std::isfinite(probabilities[i]) ||
+            probabilities[i] < 0.0f) {
+            return false;
+        }
+        for (size_t prior = 0; prior < i; ++prior) {
+            if (token_ids[prior] == token_ids[i]) return false;
+        }
+        total += probabilities[i];
+    }
+    return std::fabs(total - 1.0) <= 1e-4;
+}
+
+float SparseProposalDistribution::probability_of(int32_t token) const {
+    for (size_t i = 0; i < token_ids.size(); ++i) {
+        if (token_ids[i] == token) return probabilities[i];
+    }
+    return 0.0f;
+}
+
+float speculative_acceptance_probability(
+        const SamplerDistribution & target,
+        const SparseProposalDistribution & proposal,
+        int32_t proposed_token) {
+    if (target.probabilities.empty() ||
+        !proposal.valid(static_cast<int>(target.probabilities.size()))) {
+        return 0.0f;
+    }
+    const float draft_probability =
+        proposal.probability_of(proposed_token);
+    if (!(draft_probability > 0.0f)) return 0.0f;
+    return std::min(
+        1.0f,
+        target.probability_of(proposed_token) / draft_probability);
+}
+
+bool sample_speculative_residual(
+        const SamplerDistribution & target,
+        const SparseProposalDistribution & proposal,
+        double r_uniform,
+        int & out_token) {
+    out_token = -1;
+    if (target.probabilities.empty() || target.support.empty() ||
+        !proposal.valid(static_cast<int>(target.probabilities.size())) ||
+        !std::isfinite(r_uniform) || r_uniform < 0.0 || r_uniform >= 1.0) {
+        return false;
+    }
+
+    double total = 0.0;
+    for (int32_t token : target.support) {
+        total += std::max(
+            0.0f, target.probability_of(token) -
+                      proposal.probability_of(token));
+    }
+    if (!(total > 0.0)) return false;
+
+    const double target_mass = r_uniform * total;
+    double cumulative = 0.0;
+    int last_positive = -1;
+    for (int32_t token : target.support) {
+        const float residual = std::max(
+            0.0f, target.probability_of(token) -
+                      proposal.probability_of(token));
+        if (residual <= 0.0f) continue;
+        last_positive = token;
+        cumulative += residual;
+        if (target_mass <= cumulative) {
+            out_token = token;
+            return true;
+        }
+    }
+    out_token = last_positive;
+    return out_token >= 0;
+}
+
+}  // namespace dflash::common

--- a/server/src/common/speculative_sampling.h
+++ b/server/src/common/speculative_sampling.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "sampler.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace dflash::common {
+
+// Sparse draft law q over the selector's retained top-k candidates.
+struct SparseProposalDistribution {
+    std::vector<int32_t> token_ids;
+    std::vector<float> probabilities;
+
+    bool valid(int vocab) const;
+    float probability_of(int32_t token) const;
+};
+
+// min(1, p(x) / q(x)) for the draft token x.
+float speculative_acceptance_probability(
+    const SamplerDistribution & target,
+    const SparseProposalDistribution & proposal,
+    int32_t proposed_token);
+
+// Sample the rejection residual proportional to max(p - q, 0).
+// Returns false only when the inputs are invalid or the residual has zero mass.
+bool sample_speculative_residual(
+    const SamplerDistribution & target,
+    const SparseProposalDistribution & proposal,
+    double r_uniform,
+    int & out_token);
+
+}  // namespace dflash::common

--- a/server/src/common/step_graph.h
+++ b/server/src/common/step_graph.h
@@ -20,6 +20,8 @@ struct StepGraph {
     ggml_context *  ctx = nullptr;
     ggml_cgraph *   gf  = nullptr;
     ggml_gallocr_t  alloc = nullptr;
+    ggml_context * commit_ctx = nullptr;
+    ggml_backend_buffer_t commit_buffer = nullptr;
 
     // Persistent metadata arena for the draft graph. Reusing the same arena
     // across rebuilds keeps every ggml_tensor at a stable address, which is
@@ -36,6 +38,7 @@ struct StepGraph {
     ggml_tensor *   positions = nullptr;
     ggml_tensor *   attn_mask = nullptr;     // may be null
     ggml_tensor *   parent_ids = nullptr;    // DDTree tree-mode; null for chain mode
+    ggml_tensor *   tree_sizes = nullptr;    // DDTree [n_tree_seqs], 0 = padding
     // SpecLA topology masks ([n_tokens, n_tokens] f32, host-filled; see
     // delta_net_specla.h). Created only when DFLASH_SPECLA capture is active.
     ggml_tensor *   specla_m_strict = nullptr;
@@ -61,11 +64,21 @@ struct StepGraph {
     // state_slot_ids has the same shape but maps padding to a safe readable
     // slot for graph-level conv-state gathers.
     ggml_tensor *   active_slot_ids = nullptr;
+    // Recurrent gather rows. Unlike active/paged IDs, padding must name a
+    // valid harmless slot (normally 0): ggml_get_rows does not mask -1.
     ggml_tensor *   state_slot_ids = nullptr;
     // Ragged paged read (concurrent prefill): per-row block-table column and
     // inclusive causal position, [n_tokens] i32 each. Padding rows carry -1.
     ggml_tensor *   paged_query_seq_ids = nullptr;
     ggml_tensor *   paged_query_positions = nullptr;
+    // DFlash target-feature destination rows. Multi-slot replay maps each
+    // token to its slot-local ring; padding maps to the cache's dead row.
+    ggml_tensor *   target_feat_rows = nullptr;
+    // Packed-tree direct-commit metadata uploaded after posterior selection.
+    ggml_tensor *   accepted_prefixes = nullptr;   // [n_tree_seqs] i32
+    ggml_tensor *   commit_slot_ids = nullptr;      // [n_tree_seqs] i32
+    ggml_tensor *   commit_rows = nullptr;         // [tree_width,n_tree_seqs] i64
+    ggml_tensor *   feature_commit_rows = nullptr; // same shape, i32
     // Multi-prompt steps: i32 row indices gathered from the final norm
     // before the LM head (committing rows + decode rows).
     ggml_tensor *   logits_row_indices = nullptr;
@@ -83,12 +96,18 @@ struct StepGraph {
 
     // Per-delta-net-layer captures (verify only).
     std::vector<DeltaNetCapture> delta_captures;
+    ggml_tensor * tree_features = nullptr;
     std::vector<ggml_tensor *> moe_selected;
 };
 
 // Reset the per-call graph state (ctx + graph + tensor handles) but KEEP the
 // persistent CUDA buffer in `sg.alloc` alive across steps.
 inline void step_graph_free(StepGraph & sg) {
+    if (sg.commit_buffer) {
+        ggml_backend_buffer_free(sg.commit_buffer);
+        sg.commit_buffer = nullptr;
+    }
+    if (sg.commit_ctx) { ggml_free(sg.commit_ctx); sg.commit_ctx = nullptr; }
     if (sg.ctx)   { ggml_free(sg.ctx); sg.ctx = nullptr; }
     sg.gf = nullptr;
     sg.inp_embed = sg.positions = sg.attn_mask = nullptr;
@@ -98,6 +117,7 @@ inline void step_graph_free(StepGraph & sg) {
     sg.built_view = false;
     sg.hidden_input = nullptr;
     sg.parent_ids = nullptr;
+    sg.tree_sizes = nullptr;
     sg.specla_m_strict = sg.specla_m_incl = sg.specla_m_eye = nullptr;
     sg.specla_hld = nullptr;
     sg.kv_write_rows = nullptr;
@@ -105,6 +125,11 @@ inline void step_graph_free(StepGraph & sg) {
     sg.state_slot_ids = nullptr;
     sg.paged_query_seq_ids = nullptr;
     sg.paged_query_positions = nullptr;
+    sg.target_feat_rows = nullptr;
+    sg.accepted_prefixes = nullptr;
+    sg.commit_slot_ids = nullptr;
+    sg.commit_rows = nullptr;
+    sg.feature_commit_rows = nullptr;
     sg.logits_row_indices = nullptr;
     sg.logits = nullptr;
     sg.hidden_states = nullptr;
@@ -116,6 +141,7 @@ inline void step_graph_free(StepGraph & sg) {
     sg.hot_local_lut = nullptr;
     sg.valid_lut = nullptr;
     sg.delta_captures.clear();
+    sg.tree_features = nullptr;
     sg.moe_selected.clear();
 }
 

--- a/server/src/common/step_graph.h
+++ b/server/src/common/step_graph.h
@@ -78,7 +78,7 @@ struct StepGraph {
     ggml_tensor *   accepted_prefixes = nullptr;   // [n_tree_seqs] i32
     ggml_tensor *   commit_slot_ids = nullptr;      // [n_tree_seqs] i32
     ggml_tensor *   commit_rows = nullptr;         // [tree_width,n_tree_seqs] i64
-    ggml_tensor *   feature_commit_rows = nullptr; // same shape, i32
+    ggml_tensor *   feature_commit_rows = nullptr; // [n_tokens] i32
     // Multi-prompt steps: i32 row indices gathered from the final norm
     // before the LM head (committing rows + decode rows).
     ggml_tensor *   logits_row_indices = nullptr;

--- a/server/src/draft/draft_gguf_loader.cpp
+++ b/server/src/draft/draft_gguf_loader.cpp
@@ -26,6 +26,7 @@
 
 #include "internal.h"
 #include "common/dflash2_selector_validation.h"
+#include "common/draft_swa.h"
 #include "common/derived_scalars.h"
 #include "common/gguf_mmap.h"
 #include "common/gguf_bounds.h"
@@ -56,14 +57,6 @@ uint32_t get_u32_or(const gguf_context * g, const char * key, uint32_t fallback)
     int64_t id = gguf_find_key(g, key);
     if (id < 0) return fallback;
     return gguf_get_val_u32(g, id);
-}
-
-int count_swa_layers(const DraftWeights & w) {
-    int n_swa = 0;
-    for (const DraftLayer & layer : w.layers) {
-        if (layer.is_swa) n_swa++;
-    }
-    return n_swa;
 }
 
 int count_attn_gate_layers(const DraftWeights & w) {
@@ -614,6 +607,7 @@ bool load_draft_gguf(const std::string & path,
     // GGUF Qwen3.6 drafters carry SWA metadata emitted by the converter:
     //   dflash-draft.attention.sliding_window = 2048
     //   dflash-draft.attention.sliding_window_pattern = [true,true,true,true,false]
+    out.swa_pattern_loaded = false;
     out.swa_window = (int)read_u32("attention.sliding_window", 0);
     std::snprintf(key, sizeof(key), "%s.%s", A, "attention.sliding_window_pattern");
     int64_t swp_id = gguf_find_key(gctx, key);
@@ -621,14 +615,16 @@ bool load_draft_gguf(const std::string & path,
         gguf_get_arr_type(gctx, swp_id) == GGUF_TYPE_BOOL) {
         const size_t n = gguf_get_arr_n(gctx, swp_id);
         const bool * pattern = static_cast<const bool *>(gguf_get_arr_data(gctx, swp_id));
+        out.swa_pattern_loaded = true;
         for (size_t il = 0; il < n && il < out.layers.size(); il++) {
             out.layers[il].is_swa = pattern[il];
         }
     }
-    const int n_swa = count_swa_layers(out);
-    if (n_swa > 0) {
+    const DraftSwaOverrideResult swa =
+        apply_draft_swa_window_override(out, 0);
+    if (swa.swa_layers > 0) {
         std::fprintf(stderr, "[draft GGUF] SWA layers: %d/%d (window=%d)\n",
-                     n_swa, out.n_layer, out.swa_window);
+                     swa.swa_layers, swa.total_layers, swa.effective_window);
     }
     const bool meta_context_kv_layer_norm =
         read_u32("dflash.context_kv_layer_norm", 0) != 0;

--- a/server/src/draft/draft_gguf_loader.cpp
+++ b/server/src/draft/draft_gguf_loader.cpp
@@ -25,6 +25,7 @@
 //   blk.<i>.ffn_down.weight                 [hidden, intermediate]  Q8_0 / F16
 
 #include "internal.h"
+#include "common/dflash2_selector_validation.h"
 #include "common/derived_scalars.h"
 #include "common/gguf_mmap.h"
 #include "common/gguf_bounds.h"
@@ -582,6 +583,25 @@ bool load_draft_gguf(const std::string & path,
                 !check_shape_2d(out.selector.pred_cb, R, out.selector.pred_cb->ne[1], "selector.pred_cb", shape_err, sizeof(shape_err)) ||
                 !check_shape_2d(out.selector.succ_cb, R, out.selector.pred_cb->ne[1], "selector.succ_cb", shape_err, sizeof(shape_err))) {
                 set_last_error(shape_err);
+                ggml_free(meta_ctx); out.ctx = nullptr; gguf_free(gctx);
+                return false;
+            }
+            DFlash2SelectorLayout selector_layout;
+            selector_layout.rank = out.selector.rank;
+            selector_layout.top_k = out.selector.top_k;
+            selector_layout.hproj_rank = out.selector.hproj->ne[1];
+            selector_layout.pred_rank = out.selector.pred_cb->ne[0];
+            selector_layout.pred_vocab = out.selector.pred_cb->ne[1];
+            selector_layout.succ_rank = out.selector.succ_cb->ne[0];
+            selector_layout.succ_vocab = out.selector.succ_cb->ne[1];
+            selector_layout.target_output_vocab =
+                target && target->output ? target->output->ne[1] : 0;
+            selector_layout.target_declared_vocab =
+                target ? target->n_vocab : 0;
+            std::string selector_error;
+            if (!validate_dflash2_selector_layout(
+                    selector_layout, selector_error)) {
+                set_last_error("draft GGUF: " + selector_error);
                 ggml_free(meta_ctx); out.ctx = nullptr; gguf_free(gctx);
                 return false;
             }

--- a/server/src/draft/draft_graph.cpp
+++ b/server/src/draft/draft_graph.cpp
@@ -441,135 +441,203 @@ bool build_draft_kv_append(
     return true;
 }
 
-DraftGraphOutputs build_draft_kv_step(
-    ggml_context *            ctx,
-    ggml_cgraph *             gf,
-    const DraftWeights &      w,
-    const DraftKvCacheRefs &  cache,
-    const DraftKvStepInputs & in) {
-    const int q_len    = w.block_size;
-    const int n_head   = w.n_head;
-    const int n_kv     = w.n_head_kv;
-    const int head_dim = w.head_dim;
-    const float eps    = DFLASH27B_RMS_EPS;
-    const int kv_total = cache.kv_total;
+static ggml_tensor * draft_pack_columns(
+        ggml_context * ctx,
+        const std::vector<ggml_tensor *> & lanes) {
+    ggml_tensor * packed = lanes.front();
+    for (size_t lane = 1; lane < lanes.size(); ++lane) {
+        packed = ggml_concat(ctx, packed, lanes[lane], 1);
+    }
+    return packed;
+}
 
+static ggml_tensor * draft_lane_columns(
+        ggml_context * ctx, ggml_tensor * packed,
+        int q_len, size_t lane) {
+    return ggml_view_2d(
+        ctx, packed, packed->ne[0], q_len, packed->nb[1],
+        lane * static_cast<size_t>(q_len) * packed->nb[1]);
+}
+
+std::vector<DraftGraphOutputs> build_draft_kv_steps(
+        ggml_context *                         ctx,
+        ggml_cgraph *                          gf,
+        const DraftWeights &                   w,
+        const std::vector<DraftKvLaneInputs> & lanes) {
+    const size_t n_lanes = lanes.size();
+    if (!ctx || !gf || n_lanes == 0) {
+        return {};
+    }
+
+    const int q_len = w.block_size;
+    const int n_head = w.n_head;
+    const int n_kv = w.n_head_kv;
+    const int head_dim = w.head_dim;
+    const int64_t q_dim = static_cast<int64_t>(head_dim) * n_head;
+    const int64_t kv_dim = static_cast<int64_t>(head_dim) * n_kv;
+    const float eps = DFLASH27B_RMS_EPS;
     static const bool disable_attn_gate =
         std::getenv("DFLASH_DISABLE_DRAFT_ATTN_GATE") != nullptr;
     static const bool disable_swa =
         std::getenv("DFLASH_DISABLE_DRAFT_SWA") != nullptr;
 
-    ggml_tensor * h = in.noise_embed;  // [hidden, q_len]
-    char probe_name[64];
-
-    for (int il = 0; il < w.n_layer; il++) {
-        const DraftLayer & L = w.layers[il];
-        const bool layer_is_swa = L.is_swa && !disable_swa;
-        const bool dyn_conv = w.conv_kernel_size > 0 && L.attn_conv.present() && L.mlp_conv.present();
-
-        // ── attention pre-norm (+ DFlash 2 dynamic conv "prepare")
-        ggml_tensor * hn = ggml_rms_norm(ctx, h, eps);
-        hn = ggml_mul(ctx, hn, L.attn_norm);
-        DraftDynConv attn_dc;
-        if (dyn_conv) {
-            attn_dc = draft_dyn_conv_kernel(ctx, L.attn_conv, hn);
-            hn = draft_dyn_conv_apply(ctx, w, L.attn_conv, attn_dc, 0, hn);
+    for (const DraftKvLaneInputs & lane : lanes) {
+        const DraftKvCacheRefs * cache = lane.cache;
+        const DraftKvStepInputs & in = lane.inputs;
+        if (!cache || !in.noise_embed || !in.positions_q || !in.noise_rows ||
+            cache->kv_total <= 0 ||
+            cache->k.size() != static_cast<size_t>(w.n_layer) ||
+            cache->v.size() != static_cast<size_t>(w.n_layer)) {
+            return {};
         }
+    }
 
-        // ── Q from noise, per-head RMSNorm, RoPE at absolute positions
-        ggml_tensor * Q = ggml_mul_mat(ctx, L.wq, hn);
-        Q = ggml_reshape_3d(ctx, Q, head_dim, n_head, q_len);
-        Q = ggml_rms_norm(ctx, Q, eps);
-        Q = ggml_mul     (ctx, Q, L.q_norm);
-        Q = draft_rope(ctx, Q, in.positions_q, w);
+    std::vector<ggml_tensor *> h(n_lanes);
+    for (size_t lane = 0; lane < n_lanes; ++lane) {
+        h[lane] = lanes[lane].inputs.noise_embed;
+    }
 
-        // ── noise K/V into the scratch cache slots
-        ggml_tensor * Kn = ggml_mul_mat(ctx, L.wk, hn);
-        Kn = ggml_reshape_3d(ctx, Kn, head_dim, n_kv, q_len);
-        Kn = ggml_rms_norm(ctx, Kn, eps);
-        Kn = ggml_mul     (ctx, Kn, L.k_norm);
-        Kn = draft_rope(ctx, Kn, in.positions_q, w);
-        ggml_tensor * Kn_rows = ggml_view_2d(ctx, Kn,
-            (int64_t)head_dim * n_kv, q_len, Kn->nb[2], 0);
-        ggml_tensor * Vn_rows = ggml_mul_mat(ctx, L.wv, hn);  // [kv_dim, q_len]
-        ggml_build_forward_expand(gf,
-            ggml_set_rows(ctx, cache.k[il], Kn_rows, in.noise_rows));
-        ggml_build_forward_expand(gf,
-            ggml_set_rows(ctx, cache.v[il], Vn_rows, in.noise_rows));
+    for (int il = 0; il < w.n_layer; ++il) {
+        const DraftLayer & layer = w.layers[il];
+        const bool layer_is_swa = layer.is_swa && !disable_swa;
+        const bool dyn_conv = w.conv_kernel_size > 0 &&
+            layer.attn_conv.present() && layer.mlp_conv.present();
 
-        // ── flash attention over the full cache span (masks gate validity).
-        // The set_rows nodes were expanded above, so graph order guarantees
-        // the scratch slots hold this step's noise K/V before the FA reads.
-        ggml_tensor * Qfa = ggml_permute(ctx, Q, 0, 2, 1, 3);  // [hd, q_len, n_head]
-        Qfa = ggml_cont(ctx, Qfa);
-        ggml_tensor * Kview = ggml_view_3d(ctx, cache.k[il],
-            head_dim, n_kv, kv_total,
-            ggml_row_size(cache.k[il]->type, head_dim), cache.k[il]->nb[1], 0);
-        ggml_tensor * Vview = ggml_view_3d(ctx, cache.v[il],
-            head_dim, n_kv, kv_total,
-            ggml_row_size(cache.v[il]->type, head_dim), cache.v[il]->nb[1], 0);
-        ggml_tensor * Kfa = ggml_permute(ctx, Kview, 0, 2, 1, 3);  // [hd, kv_total, n_kv]
-        ggml_tensor * Vfa = ggml_permute(ctx, Vview, 0, 2, 1, 3);
-
-        const float scale = 1.0f / std::sqrt((float)head_dim);
-        ggml_tensor * mask = layer_is_swa ? in.mask_swa : in.mask_full;
-        ggml_tensor * attn = ggml_flash_attn_ext(ctx, Qfa, Kfa, Vfa, mask,
-                                                 scale, /*max_bias=*/0.0f,
-                                                 /*logit_softcap=*/0.0f);
-        std::snprintf(probe_name, sizeof(probe_name), "draft_kv_l%d_attn", il);
-        ggml_set_name(attn, probe_name);
-
-        if (!disable_attn_gate && L.attn_gate) {
-            ggml_tensor * gate = ggml_mul_mat(ctx, L.attn_gate, hn);
-            gate = ggml_softplus(ctx, gate);
-            if (L.attn_gate_per_head) {
-                gate = ggml_reshape_3d(ctx, gate, 1, n_head, q_len);
-            } else {
-                gate = ggml_reshape_3d(ctx, gate, head_dim, n_head, q_len);
+        std::vector<ggml_tensor *> hn(n_lanes);
+        std::vector<DraftDynConv> attn_dc(n_lanes);
+        for (size_t lane = 0; lane < n_lanes; ++lane) {
+            hn[lane] = ggml_rms_norm(ctx, h[lane], eps);
+            hn[lane] = ggml_mul(ctx, hn[lane], layer.attn_norm);
+            if (dyn_conv) {
+                attn_dc[lane] = draft_dyn_conv_kernel(
+                    ctx, layer.attn_conv, hn[lane]);
+                hn[lane] = draft_dyn_conv_apply(
+                    ctx, w, layer.attn_conv, attn_dc[lane], 0, hn[lane]);
             }
-            gate = ggml_cast(ctx, gate, attn->type);
-            attn = ggml_mul(ctx, attn, gate);
         }
-        attn = ggml_reshape_2d(ctx, attn, head_dim * n_head, q_len);
 
-        ggml_tensor * attn_out = ggml_mul_mat(ctx, L.wo, attn);
-        if (dyn_conv) {
-            attn_out = draft_dyn_conv_apply(ctx, w, L.attn_conv, attn_dc, 1, attn_out);
+        ggml_tensor * hn_packed = draft_pack_columns(ctx, hn);
+        ggml_tensor * q_packed = ggml_mul_mat(ctx, layer.wq, hn_packed);
+        ggml_tensor * k_packed = ggml_mul_mat(ctx, layer.wk, hn_packed);
+        ggml_tensor * v_packed = ggml_mul_mat(ctx, layer.wv, hn_packed);
+        ggml_tensor * gate_packed = nullptr;
+        if (!disable_attn_gate && layer.attn_gate) {
+            gate_packed = ggml_mul_mat(ctx, layer.attn_gate, hn_packed);
+            gate_packed = ggml_softplus(ctx, gate_packed);
         }
-        h = ggml_add(ctx, h, attn_out);
 
-        // ── FFN (+ DFlash 2 dynamic conv prepare/finish)
-        ggml_tensor * hf = ggml_rms_norm(ctx, h, eps);
-        hf = ggml_mul(ctx, hf, L.ffn_norm);
-        DraftDynConv mlp_dc;
-        if (dyn_conv) {
-            mlp_dc = draft_dyn_conv_kernel(ctx, L.mlp_conv, hf);
-            hf = draft_dyn_conv_apply(ctx, w, L.mlp_conv, mlp_dc, 0, hf);
+        std::vector<ggml_tensor *> attn_by_lane(n_lanes);
+        for (size_t lane = 0; lane < n_lanes; ++lane) {
+            const DraftKvCacheRefs & cache = *lanes[lane].cache;
+            const DraftKvStepInputs & in = lanes[lane].inputs;
+
+            ggml_tensor * q = draft_lane_columns(ctx, q_packed, q_len, lane);
+            q = ggml_reshape_3d(ctx, q, head_dim, n_head, q_len);
+            q = ggml_rms_norm(ctx, q, eps);
+            q = ggml_mul(ctx, q, layer.q_norm);
+            q = draft_rope(ctx, q, in.positions_q, w);
+
+            ggml_tensor * kn = draft_lane_columns(ctx, k_packed, q_len, lane);
+            kn = ggml_reshape_3d(ctx, kn, head_dim, n_kv, q_len);
+            kn = ggml_rms_norm(ctx, kn, eps);
+            kn = ggml_mul(ctx, kn, layer.k_norm);
+            kn = draft_rope(ctx, kn, in.positions_q, w);
+            ggml_tensor * kn_rows = ggml_view_2d(
+                ctx, kn, kv_dim, q_len, kn->nb[2], 0);
+            ggml_tensor * vn_rows = draft_lane_columns(
+                ctx, v_packed, q_len, lane);
+            ggml_build_forward_expand(
+                gf, ggml_set_rows(ctx, cache.k[il], kn_rows, in.noise_rows));
+            ggml_build_forward_expand(
+                gf, ggml_set_rows(ctx, cache.v[il], vn_rows, in.noise_rows));
+
+            ggml_tensor * qfa = ggml_permute(ctx, q, 0, 2, 1, 3);
+            qfa = ggml_cont(ctx, qfa);
+            ggml_tensor * kview = ggml_view_3d(
+                ctx, cache.k[il], head_dim, n_kv, cache.kv_total,
+                ggml_row_size(cache.k[il]->type, head_dim),
+                cache.k[il]->nb[1], 0);
+            ggml_tensor * vview = ggml_view_3d(
+                ctx, cache.v[il], head_dim, n_kv, cache.kv_total,
+                ggml_row_size(cache.v[il]->type, head_dim),
+                cache.v[il]->nb[1], 0);
+            ggml_tensor * kfa = ggml_permute(ctx, kview, 0, 2, 1, 3);
+            ggml_tensor * vfa = ggml_permute(ctx, vview, 0, 2, 1, 3);
+            ggml_tensor * mask = layer_is_swa ? in.mask_swa : in.mask_full;
+            ggml_tensor * attn = ggml_flash_attn_ext(
+                ctx, qfa, kfa, vfa, mask,
+                1.0f / std::sqrt(static_cast<float>(head_dim)), 0.0f, 0.0f);
+
+            if (gate_packed) {
+                ggml_tensor * gate = draft_lane_columns(
+                    ctx, gate_packed, q_len, lane);
+                if (layer.attn_gate_per_head) {
+                    gate = ggml_reshape_3d(ctx, gate, 1, n_head, q_len);
+                } else {
+                    gate = ggml_reshape_3d(ctx, gate, head_dim, n_head, q_len);
+                }
+                gate = ggml_cast(ctx, gate, attn->type);
+                attn = ggml_mul(ctx, attn, gate);
+            }
+            attn_by_lane[lane] = ggml_reshape_2d(
+                ctx, attn, q_dim, q_len);
         }
-        ggml_tensor * g  = ggml_mul_mat(ctx, L.w_gate, hf);
-        g = ggml_silu(ctx, g);
-        ggml_tensor * u  = ggml_mul_mat(ctx, L.w_up,   hf);
-        ggml_tensor * gu = ggml_mul(ctx, g, u);
-        ggml_tensor * ffn_out = ggml_mul_mat(ctx, L.w_down, gu);
-        if (dyn_conv) {
-            ffn_out = draft_dyn_conv_apply(ctx, w, L.mlp_conv, mlp_dc, 1, ffn_out);
+
+        ggml_tensor * attn_packed = draft_pack_columns(ctx, attn_by_lane);
+        ggml_tensor * attn_out_packed =
+            ggml_mul_mat(ctx, layer.wo, attn_packed);
+        for (size_t lane = 0; lane < n_lanes; ++lane) {
+            ggml_tensor * attn_out = draft_lane_columns(
+                ctx, attn_out_packed, q_len, lane);
+            if (dyn_conv) {
+                attn_out = draft_dyn_conv_apply(
+                    ctx, w, layer.attn_conv, attn_dc[lane], 1, attn_out);
+            }
+            h[lane] = ggml_add(ctx, h[lane], attn_out);
         }
-        h = ggml_add(ctx, h, ffn_out);
+
+        std::vector<ggml_tensor *> hf(n_lanes);
+        std::vector<DraftDynConv> mlp_dc(n_lanes);
+        for (size_t lane = 0; lane < n_lanes; ++lane) {
+            hf[lane] = ggml_rms_norm(ctx, h[lane], eps);
+            hf[lane] = ggml_mul(ctx, hf[lane], layer.ffn_norm);
+            if (dyn_conv) {
+                mlp_dc[lane] = draft_dyn_conv_kernel(
+                    ctx, layer.mlp_conv, hf[lane]);
+                hf[lane] = draft_dyn_conv_apply(
+                    ctx, w, layer.mlp_conv, mlp_dc[lane], 0, hf[lane]);
+            }
+        }
+
+        ggml_tensor * hf_packed = draft_pack_columns(ctx, hf);
+        ggml_tensor * gate = ggml_mul_mat(ctx, layer.w_gate, hf_packed);
+        gate = ggml_silu(ctx, gate);
+        ggml_tensor * up = ggml_mul_mat(ctx, layer.w_up, hf_packed);
+        ggml_tensor * ffn = ggml_mul(ctx, gate, up);
+        ggml_tensor * ffn_out_packed = ggml_mul_mat(ctx, layer.w_down, ffn);
+        for (size_t lane = 0; lane < n_lanes; ++lane) {
+            ggml_tensor * ffn_out = draft_lane_columns(
+                ctx, ffn_out_packed, q_len, lane);
+            if (dyn_conv) {
+                ffn_out = draft_dyn_conv_apply(
+                    ctx, w, layer.mlp_conv, mlp_dc[lane], 1, ffn_out);
+            }
+            h[lane] = ggml_add(ctx, h[lane], ffn_out);
+        }
     }
 
-    ggml_tensor * out = ggml_rms_norm(ctx, h, eps);
-    out = ggml_mul(ctx, out, w.out_norm);
-    ggml_set_name(out, "draft_kv_hidden_out");
-
-    DraftGraphOutputs og{};
-    og.hidden_states = out;
-    og.logits = nullptr;
-    if (in.lm_head) {
-        ggml_tensor * logits = ggml_mul_mat(ctx, in.lm_head, out);
-        ggml_set_name(logits, "draft_kv_logits");
-        og.logits = logits;
+    std::vector<DraftGraphOutputs> outputs(n_lanes);
+    for (size_t lane = 0; lane < n_lanes; ++lane) {
+        ggml_tensor * out = ggml_rms_norm(ctx, h[lane], eps);
+        out = ggml_mul(ctx, out, w.out_norm);
+        outputs[lane].hidden_states = out;
+        outputs[lane].logits = nullptr;
+        if (lanes[lane].inputs.lm_head) {
+            outputs[lane].logits = ggml_mul_mat(
+                ctx, lanes[lane].inputs.lm_head, out);
+        }
     }
-    return og;
+    return outputs;
 }
 
 } // namespace dflash::common

--- a/server/src/draft/draft_graph.h
+++ b/server/src/draft/draft_graph.h
@@ -85,11 +85,18 @@ struct DraftKvStepInputs {
     ggml_tensor * mask_swa = nullptr;    // [kv_total, q_len] f16 (SWA layers)
     ggml_tensor * lm_head = nullptr;     // optional fused projection
 };
-DraftGraphOutputs build_draft_kv_step(
-    ggml_context *            ctx,
-    ggml_cgraph *             gf,
-    const DraftWeights &      w,
-    const DraftKvCacheRefs &  cache,
-    const DraftKvStepInputs & in);
+
+struct DraftKvLaneInputs {
+    const DraftKvCacheRefs * cache = nullptr;
+    DraftKvStepInputs inputs;
+};
+
+// Build one cached draft step for all lanes. Dense weight projections share
+// the packed column axis; positions, cache writes and attention stay per lane.
+std::vector<DraftGraphOutputs> build_draft_kv_steps(
+    ggml_context *                         ctx,
+    ggml_cgraph *                          gf,
+    const DraftWeights &                   w,
+    const std::vector<DraftKvLaneInputs> & lanes);
 
 } // namespace dflash::common

--- a/server/src/draft/draft_safetensors_loader.cpp
+++ b/server/src/draft/draft_safetensors_loader.cpp
@@ -514,6 +514,9 @@ bool load_draft_safetensors(const std::string & path,
                             ggml_backend_t       backend,
                             DraftWeights &       out,
                             const TargetWeights * target) {
+    out.swa_window = 0;
+    out.swa_pattern_loaded = false;
+
     // ── 1. Open + mmap ────────────────────────────────────────────
     Mmap mm;
     std::string err;

--- a/server/src/internal.h
+++ b/server/src/internal.h
@@ -338,7 +338,8 @@ struct DraftWeights {
     int head_dim  = DFLASH27B_TARGET_HEAD_DIM;         // 128
     int n_embd    = DFLASH27B_TARGET_HIDDEN;           // 5120
     int n_ff      = DFLASH27B_TARGET_INTERMEDIATE;     // 17408
-    int swa_window = 0;  // sliding window size (0 = disabled)
+    int swa_window = 0;                 // sliding window size (0 = disabled)
+    bool swa_pattern_loaded = false;    // GGUF supplied sliding_window_pattern
     float rope_theta = 0.0f;  // RoPE frequency base (must come from GGUF)
 
     // YaRN rope scaling (populated by loader; 0 = disabled / plain RoPE).

--- a/server/src/internal.h
+++ b/server/src/internal.h
@@ -498,13 +498,12 @@ struct TargetCache {
     ggml_tensor * specla_factor_ptrs = nullptr;
 
     // Rolling target layer features captured during target forward passes.
-    // Shape [5 * hidden, target_feat_cap] bf16. target_feat_cap is typically
-    // << max_ctx (e.g. 4096) so the buffer stays small at 128K context. The
-    // graph writes to slot `(kv_start + i) % target_feat_cap` so positions
-    // beyond the cap wrap and overwrite older entries. Readers (draft) only
-    // need the last DRAFT_CTX_MAX positions, so wrap is invisible in
-    // practice. Fed into the draft graph's fc projection after a bf16→f32
-    // cast (ggml_get_to_fp32_cuda).
+    // Single-sequence shape: [5 * hidden, target_feat_cap] bf16. A concurrent
+    // tree cache owns one ring per physical sequence slot and one final dead row:
+    // [5 * hidden, target_feat_cap * n_seq_slots + 1]. Live row P in slot S
+    // maps to S*target_feat_cap + P%target_feat_cap; bucket padding maps to the
+    // dead final row because ggml_set_rows does not accept a negative index.
+    // target_feat_cap remains the per-sequence ring width.
     ggml_tensor * target_feat = nullptr;
     int target_feat_cap = 0;
 
@@ -639,10 +638,11 @@ bool restore_target_cache_chain(const PrefixSnapshot * thick,
 // `n_seq_slots` (concurrent serving): number of sequence slots the cache
 // serves at once. > 1 requires paged_attention; it adds a trailing slot axis
 // to the recurrent state, widens the paged metadata to one block-table column
-// per slot, and skips the spec-decode rollback tensors entirely (concurrent
-// decode is AR-only). With
+// per slot, and skips the legacy rollback tensors entirely. With
 // n_seq_slots > 1 the attention K/V tensors are sized by ctx_alloc (the shared
 // pool capacity plus one scratch block) rather than one sequence's max_ctx.
+// `concurrent_tree` declares that a paged multi-slot caller owns fixed tree
+// scratch and disjoint target-feature rings for GPU promotion.
 bool create_target_cache(const TargetWeights & w,
                          int max_ctx,
                          int max_verify_tokens,
@@ -651,7 +651,8 @@ bool create_target_cache(const TargetWeights & w,
                          bool prefill_only = false,
                          int ctx_alloc = 0,
                          bool paged_attention = false,
-                         int n_seq_slots = 1);
+                         int n_seq_slots = 1,
+                         bool concurrent_tree = false);
 
 // `f32_ssm_intermediates` enables exact per-token checkpoints for the opt-in
 // layer-split fast rollback path. The default preserves the established Q8_0
@@ -668,7 +669,8 @@ bool create_target_cache_partial(const TargetWeights & w,
                                  int ctx_alloc = 0,
                                  bool f32_ssm_intermediates = false,
                                  bool paged_attention = false,
-                                 int n_seq_slots = 1);
+                                 int n_seq_slots = 1,
+                                 bool concurrent_tree = false);
 
 void free_target_cache(TargetCache & c);
 
@@ -729,6 +731,10 @@ bool specla_commit_accepted(TargetCache & cache,
 struct DeltaNetCapture {
     ggml_tensor * ssm_intermediate_states = nullptr;
     ggml_tensor * conv_input              = nullptr;
+    // Concurrent tree direct-commit data. The compact journal plus the
+    // tree conv input can advance accepted recurrent prefixes without a
+    // second target-model forward. These are graph-owned outputs.
+    ggml_tensor * transition_journal      = nullptr;
 
     // SpecLA factor capture (DFLASH_SPECLA=1, docs/SPECLA.md). Persistent F32
     // aliases into the bank written by this verify. In the HLD path the
@@ -770,10 +776,12 @@ struct QwenGraphInputs {
     int           kv_start;       // position where the new tokens begin
     bool          capture_layers; // if true, write captured layer features into cache.target_feat
     bool          capture_delta_intermediate = false; // if true, populate out_delta_captures
+    bool          capture_tree_commit = false; // compact recurrent journal + tree features
     bool          capture_moe_router = false; // if true, expose selected expert ids for MoE layers
     int           fa_window = 0;  // sliding window for FA layers: 0 = full attention
     int           logits_tail_rows = 0; // compute logits only for last n rows; 0 = all
-    ggml_tensor * parent_ids = nullptr; // [n_tokens] i32; tree mode when non-null
+    ggml_tensor * parent_ids = nullptr; // tree: [tree_width,n_tree_seqs] i32
+    ggml_tensor * tree_sizes = nullptr; // tree: [n_tree_seqs] i32; 0 = padding tree
     // [n_tokens,n_head_kv] i64 physical destination rows for the
     // ggml_set_rows KV write; step-invariant.
     ggml_tensor * kv_write_rows = nullptr;
@@ -799,6 +807,10 @@ struct QwenGraphInputs {
     // last row plus the decode rows), which a tail view cannot express.
     // Non-null overrides logits_tail_rows.
     ggml_tensor * logits_row_indices = nullptr;
+    // Optional replay-stable DFlash capture destinations. When present, all
+    // captured layers are concatenated once and written with ggml_set_rows.
+    // Multi-slot callers provide per-slot ring rows (padding uses dead row).
+    ggml_tensor * target_feat_rows = nullptr; // [n_tokens] i32
     // Prefill segments on the leading token axis (see QwenPrefillSegment).
     // n_prefill_tokens is their total row count. seq_slot is ignored when
     // segments are present.
@@ -830,9 +842,19 @@ struct QwenGraphInputs {
     // Packed steps use logits_row_indices for scattered committing rows and
     // compact decode rows; logits_tail_rows remains the dense-path fallback.
     int  n_seqs = 1;
+    // Mixed direct-commit tree graphs place this many one-token mapped AR
+    // sequences before the fixed-width speculative tree segment. Their slot
+    // IDs share active_slot_ids/state_slot_ids with the tree lanes.
+    int  mapped_ar_seqs = 0;
     int  seq_slot = 0;
     int  paged_max_kv_len = 0;
     int  n_prefill_tokens = 0;
+    // Packed paged-tree metadata. Tokens are flattened sequence-major:
+    // row = sequence*tree_width + node. tree_scratch_* describe the physical
+    // KV scratch slab owned by each physical sequence slot.
+    int  tree_width = 0;
+    int  tree_scratch_base = 0;
+    int  tree_scratch_stride = 0;
     // Capture the LAST token's post-RoPE/post-rotation Q per full-attention
     // layer into cache.q_cap (KVFlash target-QK scorer). Step-invariant:
     // node properties depend only on n_tokens and the layer index.
@@ -859,6 +881,8 @@ struct QwenGraphOutputs {
     // views marked as ggml_set_output() so their data persists after
     // graph_compute; the spec-decode loop reads them host-side for rollback.
     std::vector<DeltaNetCapture> delta_captures;
+    // BF16 [n_capture_layers*n_embd, n_tokens], packed-tree only.
+    ggml_tensor * tree_features = nullptr;
     // One entry per target layer. Populated only when capture_moe_router is
     // true; qwen35 dense layers and non-MoE models leave entries null.
     std::vector<ggml_tensor *> moe_selected;

--- a/server/src/internal.h
+++ b/server/src/internal.h
@@ -732,10 +732,10 @@ bool specla_commit_accepted(TargetCache & cache,
 struct DeltaNetCapture {
     ggml_tensor * ssm_intermediate_states = nullptr;
     ggml_tensor * conv_input              = nullptr;
-    // Concurrent tree direct-commit data. The compact journal plus the
+    // Concurrent tree direct-commit data. The compact replay log plus the
     // tree conv input can advance accepted recurrent prefixes without a
     // second target-model forward. These are graph-owned outputs.
-    ggml_tensor * transition_journal      = nullptr;
+    ggml_tensor * replay_log              = nullptr;
 
     // SpecLA factor capture (DFLASH_SPECLA=1, docs/SPECLA.md). Persistent F32
     // aliases into the bank written by this verify. In the HLD path the
@@ -777,7 +777,7 @@ struct QwenGraphInputs {
     int           kv_start;       // position where the new tokens begin
     bool          capture_layers; // if true, write captured layer features into cache.target_feat
     bool          capture_delta_intermediate = false; // if true, populate out_delta_captures
-    bool          capture_tree_commit = false; // compact recurrent journal + tree features
+    bool          capture_tree_commit = false; // compact recurrent replay log + tree features
     bool          capture_moe_router = false; // if true, expose selected expert ids for MoE layers
     int           fa_window = 0;  // sliding window for FA layers: 0 = full attention
     int           logits_tail_rows = 0; // compute logits only for last n rows; 0 = all

--- a/server/src/qwen35/concurrency/qwen35_seq_engine.cpp
+++ b/server/src/qwen35/concurrency/qwen35_seq_engine.cpp
@@ -58,6 +58,7 @@ Qwen35SeqEngine::Qwen35SeqEngine(
     const int n_slots = slots_.slot_count();
     slot_draft_kv_.resize(static_cast<size_t>(n_slots));
     prepared_chain_drafts_.resize(static_cast<size_t>(n_slots));
+    seq_lens_.assign(static_cast<size_t>(n_slots), 0);
 
     capture_features_ = tree_width_ > 1 && tree_width_ <= 16 &&
         tree_width_ == b_.dw_.block_size && b_.dw_.selector.enabled &&
@@ -97,6 +98,22 @@ Qwen35SeqEngine::Qwen35SeqEngine(
         mirror.n_target_layers = b_.w_.n_capture_layers;
         mirror.hidden_size = b_.w_.n_embd;
         mirror.storage_type = b_.cache_.target_feat->type;
+    }
+
+    if (n_slots == 4 && tree_width_ == 8) {
+        bool draft_states_ready = true;
+        for (int slot = 0; slot < n_slots; ++slot) {
+            draft_states_ready =
+                ensure_slot_draft_kv(slot) && draft_states_ready;
+        }
+        if (draft_states_ready) {
+            std::fprintf(stderr,
+                "[parallel-chain] preallocated C=4/W8 draft states\n");
+        } else {
+            std::fprintf(stderr,
+                "[parallel-chain] C=4/W8 draft-state preallocation incomplete; "
+                "falling back to lazy setup\n");
+        }
     }
 }
 
@@ -482,6 +499,8 @@ SeqEngine::StepResult Qwen35SeqEngine::step_chain_spec(
         std::vector<int> accepted;
         std::vector<int32_t> path;
         int32_t pending = -1;
+        Qwen35SlotManager::StepAppend append;
+        int seq_len = -1;
     };
     struct ArLane {
         size_t input_index = 0;
@@ -548,6 +567,49 @@ SeqEngine::StepResult Qwen35SeqEngine::step_chain_spec(
         return result;
     }
 
+    struct StagedRound {
+        Qwen35SlotManager & slots;
+        std::vector<int32_t> & seq_lens;
+        ggml_tensor * device_seq_lens;
+        std::vector<int> staged_slots;
+        std::vector<int32_t> saved_seq_lens;
+        bool device_lengths_dirty = false;
+        bool committed = false;
+
+        StagedRound(
+                Qwen35SlotManager & slots,
+                std::vector<int32_t> & seq_lens,
+                ggml_tensor * device_seq_lens,
+                size_t lane_count)
+            : slots(slots), seq_lens(seq_lens),
+              device_seq_lens(device_seq_lens),
+              saved_seq_lens(seq_lens) {
+            staged_slots.reserve(lane_count);
+        }
+
+        ~StagedRound() {
+            if (committed) return;
+            for (auto it = staged_slots.rbegin();
+                 it != staged_slots.rend(); ++it) {
+                if (!slots.rollback_step(*it)) {
+                    std::fprintf(stderr,
+                        "[parallel] staged round rollback failed for slot %d\n",
+                        *it);
+                    std::abort();
+                }
+            }
+            seq_lens = saved_seq_lens;
+            if (!device_lengths_dirty) return;
+            ggml_backend_tensor_set(
+                device_seq_lens, seq_lens.data(), 0,
+                sizeof(int32_t) * seq_lens.size());
+        }
+
+        void track(int slot) { staged_slots.push_back(slot); }
+    } staged_round(
+        slots_, seq_lens_, b_.cache_.paged_kv_seq_lens,
+        inputs.size());
+
     // AR peers write their ordinary rows in the same target forward. Host
     // history and positions remain staged until every promotion succeeds.
     for (ArLane & lane : ar_lanes) {
@@ -559,6 +621,7 @@ SeqEngine::StepResult Qwen35SeqEngine::step_chain_spec(
                 : "compact AR K/V staging failed";
             return result;
         }
+        staged_round.track(lane.slot);
         if (append.new_block >= 0 &&
             !upload_block_table_delta(
                 lane.slot, append.new_block_index,
@@ -711,6 +774,7 @@ SeqEngine::StepResult Qwen35SeqEngine::step_chain_spec(
     ggml_backend_tensor_set(
         b_.cache_.paged_kv_seq_lens, seq_lens_.data(), 0,
         sizeof(int32_t) * seq_lens_.size());
+    staged_round.device_lengths_dirty = true;
     if (ggml_backend_graph_compute(b_.target_backend_, graph.gf) !=
         GGML_STATUS_SUCCESS) {
         result.error = "fixed chain target compute failed";
@@ -775,11 +839,22 @@ SeqEngine::StepResult Qwen35SeqEngine::step_chain_spec(
             lane.slot * feature_cap + lane.position % feature_cap;
     }
 
+    const auto block_table_delta_fits = [&](int slot, int first_block,
+                                             size_t count) {
+        if (count == 0) return true;
+        const ggml_tensor * table = b_.cache_.paged_block_table;
+        return table && slot >= 0 && slot < table->ne[1] &&
+            first_block >= 0 &&
+            static_cast<uint64_t>(first_block) + count <=
+                static_cast<uint64_t>(table->ne[0]);
+    };
+
     for (int lane_index = 0; lane_index < spec_count; ++lane_index) {
         Proposal & proposal = proposals[static_cast<size_t>(lane_index)];
-        const Qwen35SlotManager::StepAppend append = slots_.append_tokens(
+        proposal.append = slots_.append_tokens(
             proposal.slot, proposal.path.data(),
             static_cast<int>(proposal.path.size()));
+        const Qwen35SlotManager::StepAppend & append = proposal.append;
         if (!append.ok ||
             append.physical_rows.size() != proposal.path.size()) {
             result.error = append.busy
@@ -787,9 +862,10 @@ SeqEngine::StepResult Qwen35SeqEngine::step_chain_spec(
                 : "accepted chain K/V staging failed";
             return result;
         }
-        if (!upload_block_table_delta(
+        staged_round.track(proposal.slot);
+        if (!block_table_delta_fits(
                 proposal.slot, append.first_new_block,
-                append.new_blocks.data(), append.new_blocks.size())) {
+                append.new_blocks.size())) {
             result.error = "accepted chain block-table update failed";
             return result;
         }
@@ -811,9 +887,8 @@ SeqEngine::StepResult Qwen35SeqEngine::step_chain_spec(
                 proposal.slot * feature_cap +
                 (append.position + static_cast<int>(depth)) % feature_cap;
         }
-        const int seq_len =
+        proposal.seq_len =
             append.position + static_cast<int>(proposal.path.size());
-        seq_lens_[static_cast<size_t>(proposal.slot)] = seq_len;
     }
 
     ggml_backend_tensor_set(
@@ -883,6 +958,18 @@ SeqEngine::StepResult Qwen35SeqEngine::step_chain_spec(
         result.error = "fixed chain commit preflight failed";
         return result;
     }
+
+    for (const Proposal & proposal : proposals) {
+        if (!upload_block_table_delta(
+                proposal.slot, proposal.append.first_new_block,
+                proposal.append.new_blocks.data(),
+                proposal.append.new_blocks.size())) {
+            std::fprintf(stderr,
+                "[parallel] validated chain block-table upload failed\n");
+            std::abort();
+        }
+        seq_lens_[static_cast<size_t>(proposal.slot)] = proposal.seq_len;
+    }
     ggml_backend_tensor_set(
         b_.cache_.paged_kv_seq_lens, seq_lens_.data(), 0,
         sizeof(int32_t) * seq_lens_.size());
@@ -890,6 +977,7 @@ SeqEngine::StepResult Qwen35SeqEngine::step_chain_spec(
     for (const StepInput & input : inputs) {
         slots_.commit_step(input.slot);
     }
+    staged_round.committed = true;
     for (int lane_index = 0; lane_index < spec_count; ++lane_index) {
         Proposal & proposal = proposals[static_cast<size_t>(lane_index)];
         const int graph_row = ar_count + lane_index * tree_width +
@@ -981,6 +1069,17 @@ SeqEngine::StepResult Qwen35SeqEngine::step(const StepPlan & plan) {
         }
     }
     if (inputs.empty() && plan.prefills.empty()) return result;
+
+    const Qwen35RoctxMetadata service_round_metadata{
+        static_cast<int>(inputs.size()),
+        -1,
+        planned_prefill_tokens,
+        static_cast<int>(plan.prefills.size()),
+        -1,
+        -1,
+    };
+    const Qwen35RoctxRange roctx_service_round(
+        "qwen35.service_round", service_round_metadata);
 
     FixedServiceRound service_round = make_fixed_service_round(plan);
     if (auto * decode_round =

--- a/server/src/qwen35/concurrency/qwen35_seq_engine.cpp
+++ b/server/src/qwen35/concurrency/qwen35_seq_engine.cpp
@@ -871,24 +871,16 @@ SeqEngine::StepResult Qwen35SeqEngine::step_chain_spec(
         return result;
     }
 
-    if (!ggml_backend_cuda_tree_cache_commit_many(
+    if (!ggml_backend_cuda_tree_commit_transaction(
             caches.data(), static_cast<int>(caches.size()),
-            graph.commit_rows, graph.commit_slot_ids,
-            tree_scratch_base_, tree_scratch_stride_)) {
-        result.error = "fixed chain K/V promotion failed";
-        return result;
-    }
-    if (!ggml_backend_cuda_tree_feature_commit(
             graph.tree_features, b_.cache_.target_feat,
-            graph.feature_commit_rows)) {
-        result.error = "fixed chain feature promotion failed";
-        return result;
-    }
-    if (!ggml_backend_cuda_gdn_transition_journal_commit_many(
+            graph.feature_commit_rows,
             journals.data(), states.data(), conv_inputs.data(),
             conv_states.data(), static_cast<int>(n_delta),
-            graph.accepted_prefixes, graph.commit_slot_ids)) {
-        result.error = "fixed chain recurrent promotion failed";
+            graph.commit_rows, graph.accepted_prefixes,
+            graph.commit_slot_ids,
+            tree_scratch_base_, tree_scratch_stride_)) {
+        result.error = "fixed chain commit preflight failed";
         return result;
     }
     ggml_backend_tensor_set(

--- a/server/src/qwen35/concurrency/qwen35_seq_engine.cpp
+++ b/server/src/qwen35/concurrency/qwen35_seq_engine.cpp
@@ -15,12 +15,14 @@
 #include "common/ddtree.h"
 #include "common/dflash2_head.h"
 #include "common/sampler.h"
+#include "common/speculative_sampling.h"
 #include "internal.h"
 #include "ggml-cuda.h"
 
 #include <algorithm>
 #include <cstdio>
 #include <cstdlib>
+#include <limits>
 #include <utility>
 #include <vector>
 
@@ -189,8 +191,7 @@ bool Qwen35SeqEngine::chain_spec_input_capable(
         return false;
     }
     const Qwen35Slot & slot = slots_.slot(input.slot);
-    return slot.decoding() && !slot.sampler.needs_logit_processing() &&
-           slot.cur_pos >= 1 &&
+    return slot.decoding() && slot.cur_pos >= 1 &&
            slot.cur_pos + tree_width_ <= slots_.max_context();
 }
 
@@ -357,10 +358,13 @@ bool Qwen35SeqEngine::prepare_chain_drafts(
         }
         PreparedChainDraft & prepared =
             prepared_chain_drafts_[static_cast<size_t>(lane.slot)];
+        const Qwen35Slot & slot = slots_.slot(lane.slot);
         prepared.valid = true;
-        prepared.generated = slots_.slot(lane.slot).generated_tokens();
+        prepared.sampled = slot.sampler.needs_logit_processing();
+        prepared.generated = slot.generated_tokens();
         prepared.root = lane.root;
         prepared.tokens = std::move(tokens);
+        if (prepared.sampled) prepared.rng_snapshot = slot.rng;
     }
     return true;
 }
@@ -508,6 +512,8 @@ SeqEngine::StepResult Qwen35SeqEngine::step_chain_spec(
     struct Proposal {
         size_t input_index = 0;
         int slot = -1;
+        bool sampled = false;
+        std::mt19937_64 rng;
         int32_t root = -1;
         DDTree tree;
         std::vector<int32_t> tokens;
@@ -550,6 +556,9 @@ SeqEngine::StepResult Qwen35SeqEngine::step_chain_spec(
             if (!prepared.valid || prepared.root != input.token ||
                 prepared.generated !=
                     slots_.slot(input.slot).generated_tokens() ||
+                (prepared.sampled &&
+                 prepared.rng_snapshot !=
+                    slots_.slot(input.slot).rng) ||
                 prepared.tokens.size() !=
                     static_cast<size_t>(tree_width)) {
                 result.error = "prepared DFlash2 chain became stale";
@@ -558,8 +567,10 @@ SeqEngine::StepResult Qwen35SeqEngine::step_chain_spec(
             Proposal proposal;
             proposal.input_index = i;
             proposal.slot = input.slot;
+            proposal.sampled = prepared.sampled;
             proposal.root = input.token;
             proposal.tokens = std::move(prepared.tokens);
+            if (proposal.sampled) proposal.rng = prepared.rng_snapshot;
             prepared = {};
             proposal.tree = make_chain_verify_tree(proposal.tokens);
             if (proposal.tree.n_nodes + 1 != tree_width) {
@@ -802,8 +813,16 @@ SeqEngine::StepResult Qwen35SeqEngine::step_chain_spec(
         graph.argmax_tokens, posterior.data(), 0,
         sizeof(int32_t) * posterior.size());
 
+    int sampled_proposals = 0;
     for (int lane_index = 0; lane_index < spec_count; ++lane_index) {
         Proposal & proposal = proposals[static_cast<size_t>(lane_index)];
+        if (proposal.sampled) {
+            proposal.accepted = {0};
+            proposal.path = {proposal.root};
+            ++sampled_proposals;
+            continue;
+        }
+
         const int row_base = ar_count + lane_index * tree_width;
         const int32_t * lane_posterior =
             posterior.data() + static_cast<size_t>(row_base);
@@ -835,6 +854,172 @@ SeqEngine::StepResult Qwen35SeqEngine::step_chain_spec(
         if (proposal.path.empty()) {
             result.error = "fixed chain min-token clamp removed the root";
             return result;
+        }
+    }
+
+    if (sampled_proposals > 0) {
+        const int vocab = b_.w_.n_vocab;
+        std::vector<int> active_lanes;
+        active_lanes.reserve(static_cast<size_t>(sampled_proposals));
+        std::vector<float> sampled_logits(
+            static_cast<size_t>(sampled_proposals) *
+            static_cast<size_t>(vocab));
+        std::vector<int32_t> sampling_history;
+        SamplerDistribution target_distribution;
+        SparseProposalDistribution draft_distribution;
+        // The selector traces one deterministic chain, so its conditional q
+        // at each depth is a point mass on that child. The standard p/q
+        // correction below is exact for this sparse distribution.
+        draft_distribution.token_ids.resize(1);
+        draft_distribution.probabilities = {1.0f};
+        std::uniform_real_distribution<double> uniform(0.0, 1.0);
+
+        const auto build_target_distribution =
+            [&](Proposal & proposal, const float * logits) {
+                const Qwen35Slot & slot = slots_.slot(proposal.slot);
+                sampling_history.clear();
+                sampling_history.reserve(
+                    slot.sample_history.size() + proposal.path.size());
+                sampling_history.insert(
+                    sampling_history.end(),
+                    slot.sample_history.begin(), slot.sample_history.end());
+                sampling_history.insert(
+                    sampling_history.end(),
+                    proposal.path.begin(), proposal.path.end());
+                if (!build_sampler_distribution(
+                        logits, vocab, slot.sampler, sampling_history,
+                        target_distribution)) {
+                    return false;
+                }
+
+                const int generated_before_next =
+                    slot.generated_tokens() +
+                    static_cast<int>(proposal.path.size());
+                if (min_tokens <= 0 ||
+                    generated_before_next >= min_tokens) {
+                    return true;
+                }
+
+                int replacement = -1;
+                float best_logit = std::numeric_limits<float>::lowest();
+                for (int token = 0; token < vocab; ++token) {
+                    if (token_is_eos(token)) continue;
+                    if (logits[static_cast<size_t>(token)] > best_logit) {
+                        best_logit = logits[static_cast<size_t>(token)];
+                        replacement = token;
+                    }
+                }
+                if (replacement < 0) return true;
+
+                int32_t eos_ids[2];
+                int eos_count = 0;
+                if (b_.w_.eos_id >= 0) {
+                    eos_ids[eos_count++] = b_.w_.eos_id;
+                }
+                if (b_.w_.eos_chat_id >= 0 &&
+                    b_.w_.eos_chat_id != b_.w_.eos_id) {
+                    eos_ids[eos_count++] = b_.w_.eos_chat_id;
+                }
+                return eos_count == 0 || redirect_distribution_mass(
+                    target_distribution, eos_ids, eos_count, replacement);
+            };
+
+        for (int depth = 0; depth < tree_width; ++depth) {
+            active_lanes.clear();
+            for (int lane_index = 0;
+                 lane_index < spec_count; ++lane_index) {
+                const Proposal & proposal =
+                    proposals[static_cast<size_t>(lane_index)];
+                if (proposal.sampled && proposal.pending < 0 &&
+                    proposal.accepted.size() ==
+                        static_cast<size_t>(depth + 1)) {
+                    active_lanes.push_back(lane_index);
+                }
+            }
+            if (active_lanes.empty()) break;
+
+            for (size_t active_index = 0;
+                 active_index < active_lanes.size(); ++active_index) {
+                const int lane_index = active_lanes[active_index];
+                const int graph_row =
+                    ar_count + lane_index * tree_width + depth;
+                ggml_backend_tensor_get_async(
+                    b_.target_backend_, graph.logits,
+                    sampled_logits.data() +
+                        active_index * static_cast<size_t>(vocab),
+                    static_cast<size_t>(graph_row) *
+                        static_cast<size_t>(vocab) * sizeof(float),
+                    static_cast<size_t>(vocab) * sizeof(float));
+            }
+            ggml_backend_synchronize(b_.target_backend_);
+
+            for (size_t active_index = 0;
+                 active_index < active_lanes.size(); ++active_index) {
+                Proposal & proposal = proposals[
+                    static_cast<size_t>(active_lanes[active_index])];
+                const float * logits = sampled_logits.data() +
+                    active_index * static_cast<size_t>(vocab);
+                if (!build_target_distribution(proposal, logits)) {
+                    result.error =
+                        "sampled chain target distribution failed";
+                    return result;
+                }
+
+                const bool terminal =
+                    depth + 1 >= tree_width ||
+                    token_is_eos(proposal.path.back());
+                if (terminal) {
+                    const double draw = target_distribution.deterministic()
+                        ? 0.0
+                        : uniform(proposal.rng);
+                    proposal.pending =
+                        sample_distribution(target_distribution, draw);
+                    if (proposal.pending < 0) {
+                        result.error = "sampled chain bonus draw failed";
+                        return result;
+                    }
+                    continue;
+                }
+
+                const int32_t proposed_token =
+                    proposal.tokens[static_cast<size_t>(depth + 1)];
+                draft_distribution.token_ids[0] = proposed_token;
+                const float acceptance =
+                    speculative_acceptance_probability(
+                        target_distribution, draft_distribution,
+                        proposed_token);
+                const bool accepted =
+                    acceptance >= 1.0f ||
+                    (acceptance > 0.0f &&
+                     uniform(proposal.rng) < acceptance);
+                if (accepted) {
+                    proposal.accepted.push_back(depth + 1);
+                    proposal.path.push_back(proposed_token);
+                    continue;
+                }
+
+                if (target_distribution.deterministic()) {
+                    proposal.pending =
+                        sample_distribution(target_distribution, 0.0);
+                } else if (!sample_speculative_residual(
+                               target_distribution, draft_distribution,
+                               uniform(proposal.rng), proposal.pending)) {
+                    result.error =
+                        "sampled chain residual draw failed";
+                    return result;
+                }
+                if (proposal.pending < 0) {
+                    result.error = "sampled chain rejection failed";
+                    return result;
+                }
+            }
+        }
+
+        for (const Proposal & proposal : proposals) {
+            if (proposal.sampled && proposal.pending < 0) {
+                result.error = "sampled chain did not resolve a token";
+                return result;
+            }
         }
     }
 
@@ -992,9 +1177,15 @@ SeqEngine::StepResult Qwen35SeqEngine::step_chain_spec(
     for (const StepInput & input : inputs) {
         slots_.commit_step(input.slot);
     }
+    for (const Proposal & proposal : proposals) {
+        if (proposal.sampled) {
+            slots_.slot(proposal.slot).rng = proposal.rng;
+        }
+    }
     staged_round.committed = true;
     for (int lane_index = 0; lane_index < spec_count; ++lane_index) {
         Proposal & proposal = proposals[static_cast<size_t>(lane_index)];
+        if (proposal.sampled) continue;
         const int graph_row = ar_count + lane_index * tree_width +
             proposal.accepted.back();
         proposal.pending = sample_graph_row(

--- a/server/src/qwen35/concurrency/qwen35_seq_engine.cpp
+++ b/server/src/qwen35/concurrency/qwen35_seq_engine.cpp
@@ -100,19 +100,34 @@ Qwen35SeqEngine::Qwen35SeqEngine(
         mirror.storage_type = b_.cache_.target_feat->type;
     }
 
-    if (n_slots == 4 && tree_width_ == 8) {
+    if (n_slots <= 6 && tree_width_ == 8) {
         bool draft_states_ready = true;
         for (int slot = 0; slot < n_slots; ++slot) {
             draft_states_ready =
                 ensure_slot_draft_kv(slot) && draft_states_ready;
         }
+        if (draft_states_ready && n_slots >= 5) {
+            auto dummy = std::make_unique<DraftKvState>();
+            const int draft_cap = std::min(
+                cap, std::max(1, b_.cfg_.draft_ctx_max));
+            if (draft_kv_init(
+                    *dummy, b_.dw_, b_.draft_backend_, draft_cap, nullptr)) {
+                dummy_draft_kv_.push_back(std::move(dummy));
+            } else {
+                draft_kv_free(*dummy);
+                draft_states_ready = false;
+            }
+        }
+
         if (draft_states_ready) {
             std::fprintf(stderr,
-                "[parallel-chain] preallocated C=4/W8 draft states\n");
+                "[parallel-chain] preallocated C=%d/W8 draft states\n",
+                n_slots);
         } else {
             std::fprintf(stderr,
-                "[parallel-chain] C=4/W8 draft-state preallocation incomplete; "
-                "falling back to lazy setup\n");
+                "[parallel-chain] C=%d/W8 draft-state preallocation incomplete; "
+                "falling back to lazy setup\n",
+                n_slots);
         }
     }
 }

--- a/server/src/qwen35/concurrency/qwen35_seq_engine.cpp
+++ b/server/src/qwen35/concurrency/qwen35_seq_engine.cpp
@@ -926,23 +926,23 @@ SeqEngine::StepResult Qwen35SeqEngine::step_chain_spec(
         result.error = "fixed chain capture set is incomplete";
         return result;
     }
-    std::vector<const ggml_tensor *> journals;
+    std::vector<const ggml_tensor *> replay_logs;
     std::vector<ggml_tensor *> states;
     std::vector<const ggml_tensor *> conv_inputs;
     std::vector<ggml_tensor *> conv_states;
-    journals.reserve(n_delta);
+    replay_logs.reserve(n_delta);
     states.reserve(n_delta);
     conv_inputs.reserve(n_delta);
     conv_states.reserve(n_delta);
     for (size_t layer = 0; layer < n_delta; ++layer) {
         const DeltaNetCapture & capture = graph.delta_captures[layer];
-        if (!capture.transition_journal || !capture.conv_input ||
+        if (!capture.replay_log || !capture.conv_input ||
             !b_.cache_.ssm_state[layer] ||
             !b_.cache_.conv_state[layer]) {
             result.error = "fixed chain layer capture is incomplete";
             return result;
         }
-        journals.push_back(capture.transition_journal);
+        replay_logs.push_back(capture.replay_log);
         states.push_back(b_.cache_.ssm_state[layer]);
         conv_inputs.push_back(capture.conv_input);
         conv_states.push_back(b_.cache_.conv_state[layer]);
@@ -965,7 +965,7 @@ SeqEngine::StepResult Qwen35SeqEngine::step_chain_spec(
             caches.data(), static_cast<int>(caches.size()),
             graph.tree_features, b_.cache_.target_feat,
             graph.feature_commit_rows,
-            journals.data(), states.data(), conv_inputs.data(),
+            replay_logs.data(), states.data(), conv_inputs.data(),
             conv_states.data(), static_cast<int>(n_delta),
             graph.commit_rows, graph.accepted_prefixes,
             graph.commit_slot_ids,

--- a/server/src/qwen35/concurrency/qwen35_seq_engine.cpp
+++ b/server/src/qwen35/concurrency/qwen35_seq_engine.cpp
@@ -11,8 +11,12 @@
 #include "graph_builders.h"
 #include "attn_masks.h"
 #include "prefill_helpers.h"
+#include "common/concurrency/chain_spec_shapes.h"
+#include "common/ddtree.h"
+#include "common/dflash2_head.h"
 #include "common/sampler.h"
 #include "internal.h"
+#include "ggml-cuda.h"
 
 #include <algorithm>
 #include <cstdio>
@@ -35,6 +39,300 @@ int decode_bucket_width(int live_count) {
 
 } // namespace
 
+Qwen35SeqEngine::Qwen35SeqEngine(
+        Qwen35Backend & backend, PagedKvPool & pool, int max_ctx,
+        int64_t scratch_row, int tree_width, int tree_scratch_base,
+        int tree_scratch_stride, int max_prefills,
+        int mixed_prefill_tokens, int long_mixed_prefill_tokens,
+        int long_prefill_threshold, int idle_prefill_tokens,
+        int prefill_quantum)
+    : max_prefills_(std::max(1, max_prefills)),
+      mixed_prefill_tokens_(std::max(1, mixed_prefill_tokens)),
+      long_mixed_prefill_tokens_(std::max(1, long_mixed_prefill_tokens)),
+      long_prefill_threshold_(std::max(1, long_prefill_threshold)),
+      idle_prefill_tokens_(std::max(1, idle_prefill_tokens)),
+      prefill_quantum_(std::max(1, prefill_quantum)), b_(backend),
+      slots_(pool, max_ctx), scratch_row_(scratch_row),
+      tree_width_(tree_width), tree_scratch_base_(tree_scratch_base),
+      tree_scratch_stride_(tree_scratch_stride) {
+    const int n_slots = slots_.slot_count();
+    slot_draft_kv_.resize(static_cast<size_t>(n_slots));
+    prepared_chain_drafts_.resize(static_cast<size_t>(n_slots));
+
+    capture_features_ = tree_width_ > 1 && tree_width_ <= 16 &&
+        tree_width_ == b_.dw_.block_size && b_.dw_.selector.enabled &&
+        b_.cache_.target_feat && b_.cache_.target_feat_cap > 0 &&
+        b_.cfg_.paged_attention && b_.cfg_.fa_window == 0 &&
+        b_.cfg_.draft_path && !b_.cfg_.remote_draft.enabled() &&
+        !b_.split_gpus_ && !b_.cfg_.device.is_tensor_parallel() &&
+        b_.target_backend_ == b_.draft_backend_ &&
+        b_.cfg_.draft_gpu == b_.cfg_.device.gpu && b_.w_.output;
+    if (!capture_features_) return;
+
+    ggml_init_params params{};
+    params.mem_size = ggml_tensor_overhead() *
+        static_cast<size_t>(n_slots + 1);
+    params.no_alloc = true;
+    feature_view_ctx_ = ggml_init(params);
+    if (!feature_view_ctx_) {
+        capture_features_ = false;
+        return;
+    }
+
+    const int cap = b_.cache_.target_feat_cap;
+    const int64_t feature_width =
+        static_cast<int64_t>(b_.w_.n_capture_layers) * b_.w_.n_embd;
+    slot_feature_mirrors_.resize(static_cast<size_t>(n_slots));
+    for (int slot = 0; slot < n_slots; ++slot) {
+        DraftFeatureMirror & mirror =
+            slot_feature_mirrors_[static_cast<size_t>(slot)];
+        mirror.target_feat = ggml_view_2d(
+            feature_view_ctx_, b_.cache_.target_feat, feature_width, cap,
+            b_.cache_.target_feat->nb[1],
+            static_cast<size_t>(slot) * static_cast<size_t>(cap) *
+                b_.cache_.target_feat->nb[1]);
+        mirror.device = b_.cfg_.draft_gpu;
+        mirror.target_device = b_.cfg_.device.gpu;
+        mirror.cap = cap;
+        mirror.n_target_layers = b_.w_.n_capture_layers;
+        mirror.hidden_size = b_.w_.n_embd;
+        mirror.storage_type = b_.cache_.target_feat->type;
+    }
+}
+
+Qwen35SeqEngine::~Qwen35SeqEngine() {
+    draft_kv_batch_free(batch_draft_graph_);
+    for (std::unique_ptr<DraftKvState> & state : dummy_draft_kv_) {
+        if (state) draft_kv_free(*state);
+    }
+    for (std::unique_ptr<DraftKvState> & state : slot_draft_kv_) {
+        if (state) draft_kv_free(*state);
+    }
+    for (DraftFeatureMirror & mirror : slot_feature_mirrors_) {
+        draft_feature_mirror_free(mirror);
+    }
+    if (feature_view_ctx_) {
+        ggml_free(feature_view_ctx_);
+        feature_view_ctx_ = nullptr;
+    }
+}
+
+DraftFeatureMirror * Qwen35SeqEngine::slot_feature_mirror(int slot) {
+    if (!capture_features_ || slot < 0 ||
+        slot >= static_cast<int>(slot_feature_mirrors_.size())) {
+        return nullptr;
+    }
+    return &slot_feature_mirrors_[static_cast<size_t>(slot)];
+}
+
+DraftKvState * Qwen35SeqEngine::ensure_slot_draft_kv(int slot) {
+    DraftFeatureMirror * mirror = slot_feature_mirror(slot);
+    if (!mirror || slot < 0 ||
+        slot >= static_cast<int>(slot_draft_kv_.size())) {
+        return nullptr;
+    }
+    std::unique_ptr<DraftKvState> & state =
+        slot_draft_kv_[static_cast<size_t>(slot)];
+    if (state && state->gf &&
+        state->built_for == static_cast<const void *>(&b_.dw_)) {
+        return state.get();
+    }
+    if (state) draft_kv_free(*state);
+    state = std::make_unique<DraftKvState>();
+    const int cap = std::min(
+        mirror->cap, std::max(1, b_.cfg_.draft_ctx_max));
+    if (!draft_kv_init(
+            *state, b_.dw_, b_.draft_backend_, cap, nullptr)) {
+        draft_kv_free(*state);
+        state.reset();
+        return nullptr;
+    }
+    return state.get();
+}
+
+bool Qwen35SeqEngine::chain_spec_input_capable(
+        const StepInput & input) const {
+    if (!capture_features_ || !input.allow_speculation ||
+        input.slot < 0 || input.slot >= slots_.slot_count()) {
+        return false;
+    }
+    const Qwen35Slot & slot = slots_.slot(input.slot);
+    return slot.decoding() && !slot.sampler.needs_logit_processing() &&
+           slot.cur_pos >= 1 &&
+           slot.cur_pos + tree_width_ <= slots_.max_context();
+}
+
+Qwen35SeqEngine::FixedServiceRound
+Qwen35SeqEngine::make_fixed_service_round(const StepPlan & plan) const {
+    if (!plan.prefills.empty()) return PromptServiceRound{};
+    SpeculativeDecodeRound round;
+    round.chain_lanes.resize(plan.decode.size(), 0);
+    for (size_t i = 0; i < plan.decode.size(); ++i) {
+        round.chain_lanes[i] =
+            chain_spec_input_capable(plan.decode[i]) ? 1 : 0;
+    }
+    return round;
+}
+
+bool Qwen35SeqEngine::prepare_chain_drafts(
+        const std::vector<StepInput> & inputs,
+        const std::vector<uint8_t> & selected) {
+    if (selected.size() != inputs.size() || !capture_features_ ||
+        tree_width_ <= 1 || tree_width_ != b_.dw_.block_size) {
+        return false;
+    }
+
+    struct Lane {
+        int slot = -1;
+        int32_t root = -1;
+        DraftKvState * state = nullptr;
+        DraftFeatureMirror * mirror = nullptr;
+    };
+    std::vector<Lane> lanes;
+    lanes.reserve(inputs.size());
+    const int hidden = b_.w_.n_embd;
+    std::vector<int32_t> noise(
+        static_cast<size_t>(tree_width_), b_.w_.mask_token_id);
+    std::vector<float> noise_embed(
+        static_cast<size_t>(hidden) * tree_width_);
+
+    auto reset_lanes = [&]() {
+        for (const Lane & lane : lanes) {
+            if (lane.state) draft_kv_reset(*lane.state);
+            if (lane.slot >= 0 &&
+                lane.slot < static_cast<int>(prepared_chain_drafts_.size())) {
+                prepared_chain_drafts_[static_cast<size_t>(lane.slot)] = {};
+            }
+        }
+        for (const std::unique_ptr<DraftKvState> & state : dummy_draft_kv_) {
+            if (state) draft_kv_reset(*state);
+        }
+    };
+
+    for (size_t i = 0; i < inputs.size(); ++i) {
+        if (!selected[i]) continue;
+        const StepInput & input = inputs[i];
+        if (!chain_spec_input_capable(input)) {
+            reset_lanes();
+            return false;
+        }
+        prepared_chain_drafts_[static_cast<size_t>(input.slot)] = {};
+        DraftKvState * state = ensure_slot_draft_kv(input.slot);
+        DraftFeatureMirror * mirror = slot_feature_mirror(input.slot);
+        if (!state || !mirror) {
+            if (state) draft_kv_reset(*state);
+            reset_lanes();
+            return false;
+        }
+        lanes.push_back({input.slot, input.token, state, mirror});
+        if (!draft_kv_begin_step(
+                *state, b_.dw_, b_.draft_backend_, *mirror,
+                slots_.slot(input.slot).cur_pos)) {
+            reset_lanes();
+            return false;
+        }
+        noise[0] = input.token;
+        std::fill(
+            noise.begin() + 1, noise.end(), b_.w_.mask_token_id);
+        if (!b_.w_.embedder.embed(
+                noise.data(), tree_width_, noise_embed.data())) {
+            reset_lanes();
+            return false;
+        }
+        ggml_backend_tensor_set(
+            state->inp_embed, noise_embed.data(), 0,
+            sizeof(float) * noise_embed.size());
+    }
+    if (lanes.empty()) return true;
+
+    const int bucket = chain_decode_bucket_width(
+        static_cast<int>(lanes.size()));
+    std::vector<DraftKvState *> batch_states;
+    std::vector<int32_t> roots;
+    batch_states.reserve(static_cast<size_t>(bucket));
+    roots.reserve(static_cast<size_t>(bucket));
+    for (const Lane & lane : lanes) {
+        batch_states.push_back(lane.state);
+        roots.push_back(lane.root);
+    }
+
+    const int dummy_count = bucket - static_cast<int>(lanes.size());
+    const int cap = std::min(
+        lanes.front().mirror->cap,
+        std::max(1, b_.cfg_.draft_ctx_max));
+    while (static_cast<int>(dummy_draft_kv_.size()) < dummy_count) {
+        auto dummy = std::make_unique<DraftKvState>();
+        if (!draft_kv_init(
+                *dummy, b_.dw_, b_.draft_backend_, cap, nullptr)) {
+            draft_kv_free(*dummy);
+            reset_lanes();
+            return false;
+        }
+        dummy_draft_kv_.push_back(std::move(dummy));
+    }
+    noise[0] = lanes.front().root;
+    std::fill(noise.begin() + 1, noise.end(), b_.w_.mask_token_id);
+    if (!b_.w_.embedder.embed(
+            noise.data(), tree_width_, noise_embed.data())) {
+        reset_lanes();
+        return false;
+    }
+    for (int i = 0; i < dummy_count; ++i) {
+        DraftKvState * dummy =
+            dummy_draft_kv_[static_cast<size_t>(i)].get();
+        if (!draft_kv_begin_step(
+                *dummy, b_.dw_, b_.draft_backend_,
+                *lanes.front().mirror, 1)) {
+            reset_lanes();
+            return false;
+        }
+        ggml_backend_tensor_set(
+            dummy->inp_embed, noise_embed.data(), 0,
+            sizeof(float) * noise_embed.size());
+        batch_states.push_back(dummy);
+        roots.push_back(lanes.front().root);
+    }
+
+    std::vector<std::vector<float>> hidden_blocks;
+    std::vector<std::vector<int32_t>> proposals;
+    if (!draft_kv_batch_compute(
+            batch_draft_graph_, b_.dw_, b_.draft_backend_,
+            batch_states, hidden_blocks) ||
+        hidden_blocks.size() != batch_states.size()) {
+        reset_lanes();
+        return false;
+    }
+    std::vector<const float *> hidden_by_lane;
+    hidden_by_lane.reserve(hidden_blocks.size());
+    for (const std::vector<float> & block : hidden_blocks) {
+        hidden_by_lane.push_back(block.data());
+    }
+    if (!dflash2_select_chains_batched(
+            b_.dw_, b_.draft_backend_, b_.w_.output, hidden_by_lane,
+            tree_width_, roots, proposals) ||
+        proposals.size() != batch_states.size()) {
+        reset_lanes();
+        return false;
+    }
+
+    for (size_t lane_index = 0; lane_index < lanes.size(); ++lane_index) {
+        const Lane & lane = lanes[lane_index];
+        std::vector<int32_t> & tokens = proposals[lane_index];
+        if (tokens.size() != static_cast<size_t>(tree_width_) ||
+            tokens.front() != lane.root) {
+            reset_lanes();
+            return false;
+        }
+        PreparedChainDraft & prepared =
+            prepared_chain_drafts_[static_cast<size_t>(lane.slot)];
+        prepared.valid = true;
+        prepared.generated = slots_.slot(lane.slot).generated_tokens();
+        prepared.root = lane.root;
+        prepared.tokens = std::move(tokens);
+    }
+    return true;
+}
+
 bool Qwen35SeqEngine::token_is_eos(int32_t token) const {
     return b_.token_is_eos(token);
 }
@@ -46,6 +344,15 @@ SeqEngine::AdmitResult Qwen35SeqEngine::admit(
     AdmitResult result = slots_.admit(request_id, prompt, sampler);
     if (result.status == AdmitResult::Status::admitted) {
         reset_recurrent_slot(b_.cache_, result.slot);
+        if (result.slot >= 0 &&
+            result.slot < static_cast<int>(slot_draft_kv_.size()) &&
+            slot_draft_kv_[static_cast<size_t>(result.slot)]) {
+            draft_kv_reset(*slot_draft_kv_[static_cast<size_t>(result.slot)]);
+        }
+        if (result.slot >= 0 && result.slot <
+                static_cast<int>(prepared_chain_drafts_.size())) {
+            prepared_chain_drafts_[static_cast<size_t>(result.slot)] = {};
+        }
     }
     return result;
 }
@@ -157,6 +464,482 @@ Qwen35SeqEngine::PrefillStage Qwen35SeqEngine::stage_prefill_chunk(
     return stage;
 }
 
+SeqEngine::StepResult Qwen35SeqEngine::step_chain_spec(
+        const StepPlan & plan, const std::vector<uint8_t> & selected) {
+    StepResult result;
+    const std::vector<StepInput> & inputs = plan.decode;
+    if (!plan.prefills.empty() || selected.size() != inputs.size()) {
+        result.error = "invalid fixed chain round";
+        return result;
+    }
+
+    struct Proposal {
+        size_t input_index = 0;
+        int slot = -1;
+        int32_t root = -1;
+        DDTree tree;
+        std::vector<int32_t> tokens;
+        std::vector<int> accepted;
+        std::vector<int32_t> path;
+        int32_t pending = -1;
+    };
+    struct ArLane {
+        size_t input_index = 0;
+        int slot = -1;
+        int32_t token = -1;
+        int position = -1;
+        int64_t physical_row = -1;
+        int32_t pending = -1;
+    };
+
+    const int tree_width = tree_width_;
+    const int hidden = b_.w_.n_embd;
+    const int n_head_kv = b_.w_.n_head_kv;
+    const int n_slots = slots_.slot_count();
+    const int min_tokens = []() {
+        const char * value = std::getenv("DFLASH_MIN_TOKENS");
+        return value ? std::max(0, std::atoi(value)) : 0;
+    }();
+
+    std::vector<Proposal> proposals;
+    std::vector<ArLane> ar_lanes;
+    std::vector<int> proposal_for_input(inputs.size(), -1);
+    std::vector<int> ar_for_input(inputs.size(), -1);
+    proposals.reserve(inputs.size());
+    ar_lanes.reserve(inputs.size());
+
+    for (size_t i = 0; i < inputs.size(); ++i) {
+        const StepInput & input = inputs[i];
+        if (selected[i]) {
+            PreparedChainDraft & prepared =
+                prepared_chain_drafts_[static_cast<size_t>(input.slot)];
+            if (!prepared.valid || prepared.root != input.token ||
+                prepared.generated !=
+                    slots_.slot(input.slot).generated_tokens() ||
+                prepared.tokens.size() !=
+                    static_cast<size_t>(tree_width)) {
+                result.error = "prepared DFlash2 chain became stale";
+                return result;
+            }
+            Proposal proposal;
+            proposal.input_index = i;
+            proposal.slot = input.slot;
+            proposal.root = input.token;
+            proposal.tokens = std::move(prepared.tokens);
+            prepared = {};
+            proposal.tree = make_chain_verify_tree(proposal.tokens);
+            if (proposal.tree.n_nodes + 1 != tree_width) {
+                result.error = "prepared DFlash2 chain has invalid shape";
+                return result;
+            }
+            proposal_for_input[i] = static_cast<int>(proposals.size());
+            proposals.push_back(std::move(proposal));
+        } else {
+            ArLane lane;
+            lane.input_index = i;
+            lane.slot = input.slot;
+            lane.token = input.token;
+            ar_for_input[i] = static_cast<int>(ar_lanes.size());
+            ar_lanes.push_back(lane);
+        }
+    }
+    if (proposals.empty()) {
+        result.error = "fixed chain round has no speculative lanes";
+        return result;
+    }
+
+    // AR peers write their ordinary rows in the same target forward. Host
+    // history and positions remain staged until every promotion succeeds.
+    for (ArLane & lane : ar_lanes) {
+        const Qwen35SlotManager::StepAppend append =
+            slots_.append_token(lane.slot, lane.token);
+        if (!append.ok) {
+            result.error = append.busy
+                ? "paged KV pool exhausted during compact AR staging"
+                : "compact AR K/V staging failed";
+            return result;
+        }
+        if (append.new_block >= 0 &&
+            !upload_block_table_delta(
+                lane.slot, append.new_block_index,
+                &append.new_block, 1)) {
+            result.error = "compact AR block-table update failed";
+            return result;
+        }
+        lane.position = append.position;
+        lane.physical_row = append.physical_row;
+    }
+
+    const int spec_count = static_cast<int>(proposals.size());
+    const int ar_count = static_cast<int>(ar_lanes.size());
+    const int tree_bucket = chain_decode_bucket_width(spec_count);
+    const int tree_rows_count = tree_width * tree_bucket;
+    const int total_rows = ar_count + tree_rows_count;
+
+    int max_prefix = 1;
+    for (const Proposal & proposal : proposals) {
+        max_prefix = std::max(
+            max_prefix, slots_.slot(proposal.slot).cur_pos);
+    }
+    for (const ArLane & lane : ar_lanes) {
+        max_prefix = std::max(max_prefix, lane.position + 1);
+    }
+
+    StepGraph & graph = b_.sg_;
+    if (!build_target_step_paged_tree(
+            graph, b_.w_, b_.cache_, b_.target_backend_,
+            tree_width, tree_bucket, max_prefix,
+            tree_scratch_base_, tree_scratch_stride_,
+            b_.cfg_.kq_stride_pad, ar_count)) {
+        result.error = "fixed chain target graph build failed";
+        return result;
+    }
+
+    std::vector<int32_t> tokens(static_cast<size_t>(total_rows), 0);
+    std::vector<int32_t> parents(
+        static_cast<size_t>(tree_rows_count), -1);
+    std::vector<int32_t> tree_sizes(
+        static_cast<size_t>(tree_bucket), 0);
+    std::vector<int32_t> mapped_slots(
+        static_cast<size_t>(ar_count + tree_bucket), -1);
+    std::vector<int32_t> state_slots(
+        static_cast<size_t>(ar_count + tree_bucket), 0);
+    std::vector<int32_t> query_slots(
+        static_cast<size_t>(total_rows), -1);
+    std::vector<int32_t> query_positions(
+        static_cast<size_t>(total_rows), -1);
+    std::vector<int64_t> write_rows(
+        static_cast<size_t>(total_rows) * n_head_kv, scratch_row_);
+    std::vector<int32_t> positions(
+        static_cast<size_t>(4) * total_rows, 0);
+    std::vector<float> embeddings(
+        static_cast<size_t>(hidden) * total_rows, 0.0f);
+    seq_lens_.assign(static_cast<size_t>(n_slots), 0);
+
+    for (int lane_index = 0; lane_index < ar_count; ++lane_index) {
+        const ArLane & lane = ar_lanes[static_cast<size_t>(lane_index)];
+        mapped_slots[static_cast<size_t>(lane_index)] = lane.slot;
+        state_slots[static_cast<size_t>(lane_index)] = lane.slot;
+        tokens[static_cast<size_t>(lane_index)] = lane.token;
+        query_slots[static_cast<size_t>(lane_index)] = lane.slot;
+        query_positions[static_cast<size_t>(lane_index)] = lane.position;
+        seq_lens_[static_cast<size_t>(lane.slot)] = lane.position + 1;
+        for (int axis = 0; axis < 3; ++axis) {
+            positions[static_cast<size_t>(axis) * total_rows + lane_index] =
+                lane.position;
+        }
+        for (int head = 0; head < n_head_kv; ++head) {
+            write_rows[static_cast<size_t>(head) * total_rows + lane_index] =
+                lane.physical_row;
+        }
+    }
+
+    for (int lane_index = 0; lane_index < spec_count; ++lane_index) {
+        const Proposal & proposal =
+            proposals[static_cast<size_t>(lane_index)];
+        const int tree_base = lane_index * tree_width;
+        const int row_base = ar_count + tree_base;
+        const int mapped_lane = ar_count + lane_index;
+        tree_sizes[static_cast<size_t>(lane_index)] = tree_width;
+        mapped_slots[static_cast<size_t>(mapped_lane)] = proposal.slot;
+        state_slots[static_cast<size_t>(mapped_lane)] = proposal.slot;
+        seq_lens_[static_cast<size_t>(proposal.slot)] =
+            slots_.slot(proposal.slot).cur_pos;
+        for (int node = 0; node < tree_width; ++node) {
+            const int tree_row = tree_base + node;
+            const int row = row_base + node;
+            tokens[static_cast<size_t>(row)] =
+                proposal.tokens[static_cast<size_t>(node)];
+            parents[static_cast<size_t>(tree_row)] = node == 0
+                ? -1
+                : proposal.tree.parents[static_cast<size_t>(node)];
+            query_slots[static_cast<size_t>(row)] = proposal.slot;
+            const int depth = node == 0
+                ? 0
+                : proposal.tree.depths[static_cast<size_t>(node) - 1];
+            const int position =
+                slots_.slot(proposal.slot).cur_pos + depth;
+            for (int axis = 0; axis < 3; ++axis) {
+                positions[static_cast<size_t>(axis) * total_rows + row] =
+                    position;
+            }
+            for (int head = 0; head < n_head_kv; ++head) {
+                write_rows[static_cast<size_t>(head) * total_rows + row] =
+                    static_cast<int64_t>(tree_scratch_base_) +
+                    static_cast<int64_t>(proposal.slot) *
+                        tree_scratch_stride_ + node;
+            }
+        }
+    }
+
+    if (!b_.w_.embedder.embed(
+            tokens.data(), total_rows, embeddings.data())) {
+        result.error = "fixed chain embedding failed";
+        return result;
+    }
+    ggml_backend_tensor_set(
+        graph.inp_embed, embeddings.data(), 0,
+        sizeof(float) * embeddings.size());
+    ggml_backend_tensor_set(
+        graph.positions, positions.data(), 0,
+        sizeof(int32_t) * positions.size());
+    ggml_backend_tensor_set(
+        graph.parent_ids, parents.data(), 0,
+        sizeof(int32_t) * parents.size());
+    ggml_backend_tensor_set(
+        graph.tree_sizes, tree_sizes.data(), 0,
+        sizeof(int32_t) * tree_sizes.size());
+    if (detail::target_paged_tree_active_slots_need_upload(graph)) {
+        ggml_backend_tensor_set(
+            graph.active_slot_ids, mapped_slots.data(), 0,
+            sizeof(int32_t) * mapped_slots.size());
+    }
+    ggml_backend_tensor_set(
+        graph.state_slot_ids, state_slots.data(), 0,
+        sizeof(int32_t) * state_slots.size());
+    ggml_backend_tensor_set(
+        graph.paged_query_seq_ids, query_slots.data(), 0,
+        sizeof(int32_t) * query_slots.size());
+    if (graph.paged_query_positions) {
+        ggml_backend_tensor_set(
+            graph.paged_query_positions, query_positions.data(), 0,
+            sizeof(int32_t) * query_positions.size());
+    }
+    ggml_backend_tensor_set(
+        graph.kv_write_rows, write_rows.data(), 0,
+        sizeof(int64_t) * write_rows.size());
+    ggml_backend_tensor_set(
+        b_.cache_.paged_kv_seq_lens, seq_lens_.data(), 0,
+        sizeof(int32_t) * seq_lens_.size());
+    if (ggml_backend_graph_compute(b_.target_backend_, graph.gf) !=
+        GGML_STATUS_SUCCESS) {
+        result.error = "fixed chain target compute failed";
+        return result;
+    }
+
+    std::vector<int32_t> posterior(
+        static_cast<size_t>(total_rows), -1);
+    ggml_backend_tensor_get(
+        graph.argmax_tokens, posterior.data(), 0,
+        sizeof(int32_t) * posterior.size());
+
+    for (int lane_index = 0; lane_index < spec_count; ++lane_index) {
+        Proposal & proposal = proposals[static_cast<size_t>(lane_index)];
+        const int row_base = ar_count + lane_index * tree_width;
+        const int32_t * lane_posterior =
+            posterior.data() + static_cast<size_t>(row_base);
+        int32_t ignored_bonus = -1;
+        proposal.accepted = follow_verified_tree(
+            proposal.tree, lane_posterior, ignored_bonus);
+        const int room =
+            slots_.max_context() - slots_.slot(proposal.slot).cur_pos;
+        truncate_verified_path(
+            proposal.accepted, static_cast<size_t>(std::max(0, room)),
+            lane_posterior, ignored_bonus);
+        if (proposal.accepted.empty()) {
+            result.error = "fixed chain accepted path is empty";
+            return result;
+        }
+        proposal.path.reserve(proposal.accepted.size());
+        for (int node : proposal.accepted) {
+            proposal.path.push_back(node == 0
+                ? proposal.root
+                : proposal.tree.token_ids[
+                    static_cast<size_t>(node) - 1]);
+        }
+        const size_t safe_prefix = chain_min_tokens_safe_prefix(
+            proposal.path,
+            slots_.slot(proposal.slot).generated_tokens(), min_tokens,
+            [&](int32_t token) { return token_is_eos(token); });
+        proposal.path.resize(safe_prefix);
+        proposal.accepted.resize(safe_prefix);
+        if (proposal.path.empty()) {
+            result.error = "fixed chain min-token clamp removed the root";
+            return result;
+        }
+    }
+
+    std::vector<int32_t> accepted_prefixes(
+        static_cast<size_t>(tree_bucket), 0);
+    std::vector<int32_t> commit_slots(
+        static_cast<size_t>(tree_bucket), -1);
+    std::vector<int64_t> commit_rows(
+        static_cast<size_t>(tree_rows_count), -1);
+    std::vector<int32_t> feature_commit_rows(
+        static_cast<size_t>(total_rows), -1);
+    const int feature_cap = b_.cache_.target_feat_cap;
+
+    for (int lane_index = 0; lane_index < ar_count; ++lane_index) {
+        const ArLane & lane = ar_lanes[static_cast<size_t>(lane_index)];
+        feature_commit_rows[static_cast<size_t>(lane_index)] =
+            lane.slot * feature_cap + lane.position % feature_cap;
+    }
+
+    for (int lane_index = 0; lane_index < spec_count; ++lane_index) {
+        Proposal & proposal = proposals[static_cast<size_t>(lane_index)];
+        const Qwen35SlotManager::StepAppend append = slots_.append_tokens(
+            proposal.slot, proposal.path.data(),
+            static_cast<int>(proposal.path.size()));
+        if (!append.ok ||
+            append.physical_rows.size() != proposal.path.size()) {
+            result.error = append.busy
+                ? "paged KV pool exhausted during chain staging"
+                : "accepted chain K/V staging failed";
+            return result;
+        }
+        if (!upload_block_table_delta(
+                proposal.slot, append.first_new_block,
+                append.new_blocks.data(), append.new_blocks.size())) {
+            result.error = "accepted chain block-table update failed";
+            return result;
+        }
+
+        accepted_prefixes[static_cast<size_t>(lane_index)] =
+            static_cast<int32_t>(proposal.path.size());
+        commit_slots[static_cast<size_t>(lane_index)] = proposal.slot;
+        for (size_t depth = 0; depth < proposal.accepted.size(); ++depth) {
+            const int node = proposal.accepted[depth];
+            if (node != static_cast<int>(depth)) {
+                result.error = "DFlash2 chain acceptance is not contiguous";
+                return result;
+            }
+            const int flat = lane_index * tree_width + node;
+            const int graph_row = ar_count + flat;
+            commit_rows[static_cast<size_t>(flat)] =
+                append.physical_rows[depth];
+            feature_commit_rows[static_cast<size_t>(graph_row)] =
+                proposal.slot * feature_cap +
+                (append.position + static_cast<int>(depth)) % feature_cap;
+        }
+        const int seq_len =
+            append.position + static_cast<int>(proposal.path.size());
+        seq_lens_[static_cast<size_t>(proposal.slot)] = seq_len;
+    }
+
+    ggml_backend_tensor_set(
+        graph.accepted_prefixes, accepted_prefixes.data(), 0,
+        sizeof(int32_t) * accepted_prefixes.size());
+    ggml_backend_tensor_set(
+        graph.commit_slot_ids, commit_slots.data(), 0,
+        sizeof(int32_t) * commit_slots.size());
+    ggml_backend_tensor_set(
+        graph.commit_rows, commit_rows.data(), 0,
+        sizeof(int64_t) * commit_rows.size());
+    ggml_backend_tensor_set(
+        graph.feature_commit_rows, feature_commit_rows.data(), 0,
+        sizeof(int32_t) * feature_commit_rows.size());
+
+    const size_t n_delta = b_.cache_.ssm_state.size();
+    if (n_delta == 0 || graph.delta_captures.size() != n_delta ||
+        b_.cache_.conv_state.size() != n_delta ||
+        !graph.tree_features || !b_.cache_.target_feat) {
+        result.error = "fixed chain capture set is incomplete";
+        return result;
+    }
+    std::vector<const ggml_tensor *> journals;
+    std::vector<ggml_tensor *> states;
+    std::vector<const ggml_tensor *> conv_inputs;
+    std::vector<ggml_tensor *> conv_states;
+    journals.reserve(n_delta);
+    states.reserve(n_delta);
+    conv_inputs.reserve(n_delta);
+    conv_states.reserve(n_delta);
+    for (size_t layer = 0; layer < n_delta; ++layer) {
+        const DeltaNetCapture & capture = graph.delta_captures[layer];
+        if (!capture.transition_journal || !capture.conv_input ||
+            !b_.cache_.ssm_state[layer] ||
+            !b_.cache_.conv_state[layer]) {
+            result.error = "fixed chain layer capture is incomplete";
+            return result;
+        }
+        journals.push_back(capture.transition_journal);
+        states.push_back(b_.cache_.ssm_state[layer]);
+        conv_inputs.push_back(capture.conv_input);
+        conv_states.push_back(b_.cache_.conv_state[layer]);
+    }
+
+    std::vector<ggml_tensor *> caches;
+    caches.reserve(b_.cache_.attn_k.size() + b_.cache_.attn_v.size());
+    for (ggml_tensor * tensor : b_.cache_.attn_k) {
+        if (tensor) caches.push_back(tensor);
+    }
+    for (ggml_tensor * tensor : b_.cache_.attn_v) {
+        if (tensor) caches.push_back(tensor);
+    }
+    if (caches.empty()) {
+        result.error = "fixed chain K/V cache set is empty";
+        return result;
+    }
+
+    if (!ggml_backend_cuda_tree_cache_commit_many(
+            caches.data(), static_cast<int>(caches.size()),
+            graph.commit_rows, graph.commit_slot_ids,
+            tree_scratch_base_, tree_scratch_stride_)) {
+        result.error = "fixed chain K/V promotion failed";
+        return result;
+    }
+    if (!ggml_backend_cuda_tree_feature_commit(
+            graph.tree_features, b_.cache_.target_feat,
+            graph.feature_commit_rows)) {
+        result.error = "fixed chain feature promotion failed";
+        return result;
+    }
+    if (!ggml_backend_cuda_gdn_transition_journal_commit_many(
+            journals.data(), states.data(), conv_inputs.data(),
+            conv_states.data(), static_cast<int>(n_delta),
+            graph.accepted_prefixes, graph.commit_slot_ids)) {
+        result.error = "fixed chain recurrent promotion failed";
+        return result;
+    }
+    ggml_backend_tensor_set(
+        b_.cache_.paged_kv_seq_lens, seq_lens_.data(), 0,
+        sizeof(int32_t) * seq_lens_.size());
+
+    for (const StepInput & input : inputs) {
+        slots_.commit_step(input.slot);
+    }
+    for (int lane_index = 0; lane_index < spec_count; ++lane_index) {
+        Proposal & proposal = proposals[static_cast<size_t>(lane_index)];
+        const int graph_row = ar_count + lane_index * tree_width +
+            proposal.accepted.back();
+        proposal.pending = sample_graph_row(
+            proposal.slot, graph_row,
+            &posterior[static_cast<size_t>(graph_row)], &logits_buf_);
+        if (proposal.pending < 0) {
+            result.error = "fixed chain sampling failed";
+            return result;
+        }
+    }
+    for (int lane_index = 0; lane_index < ar_count; ++lane_index) {
+        ArLane & lane = ar_lanes[static_cast<size_t>(lane_index)];
+        lane.pending = sample_graph_row(
+            lane.slot, lane_index,
+            &posterior[static_cast<size_t>(lane_index)], &logits_buf_);
+        if (lane.pending < 0) {
+            result.error = "compact AR sampling failed";
+            return result;
+        }
+    }
+
+    result.decode.reserve(inputs.size());
+    for (size_t i = 0; i < inputs.size(); ++i) {
+        DecodeOutput output;
+        output.slot = inputs[i].slot;
+        if (selected[i]) {
+            Proposal & proposal =
+                proposals[static_cast<size_t>(proposal_for_input[i])];
+            output.token = proposal.pending;
+            output.committed_tokens.assign(
+                proposal.path.begin() + 1, proposal.path.end());
+        } else {
+            output.token =
+                ar_lanes[static_cast<size_t>(ar_for_input[i])].pending;
+        }
+        result.decode.push_back(std::move(output));
+    }
+    return result;
+}
+
 SeqEngine::StepResult Qwen35SeqEngine::step(const StepPlan & plan) {
     StepResult result;
     std::vector<DecodeOutput> & decode_outputs = result.decode;
@@ -206,6 +989,19 @@ SeqEngine::StepResult Qwen35SeqEngine::step(const StepPlan & plan) {
         }
     }
     if (inputs.empty() && plan.prefills.empty()) return result;
+
+    FixedServiceRound service_round = make_fixed_service_round(plan);
+    if (auto * decode_round =
+            std::get_if<SpeculativeDecodeRound>(&service_round)) {
+        const bool has_chain_lane = std::any_of(
+            decode_round->chain_lanes.begin(),
+            decode_round->chain_lanes.end(),
+            [](uint8_t selected) { return selected != 0; });
+        if (has_chain_lane &&
+            prepare_chain_drafts(inputs, decode_round->chain_lanes)) {
+            return step_chain_spec(plan, decode_round->chain_lanes);
+        }
+    }
 
     const TargetWeights & w = b_.w_;
     StepGraph & sg = b_.sg_;
@@ -329,7 +1125,7 @@ SeqEngine::StepResult Qwen35SeqEngine::step(const StepPlan & plan) {
         built = build_target_step(
             sg, w, b_.cache_, b_.target_backend_,
             /*kv_start=*/0, /*n_tokens=*/n_total,
-            /*with_mask=*/false, /*capture=*/false,
+            /*with_mask=*/false, /*capture=*/capture_features_,
             /*capture_delta_intermediate=*/false,
             /*fa_window=*/0, /*logits_tail_rows=*/0,
             b_.cfg_.kq_stride_pad,
@@ -347,7 +1143,7 @@ SeqEngine::StepResult Qwen35SeqEngine::step(const StepPlan & plan) {
         built = build_target_step(
             sg, w, b_.cache_, b_.target_backend_,
             /*kv_start=*/0, /*n_tokens=*/decode_bucket,
-            /*with_mask=*/false, /*capture=*/false,
+            /*with_mask=*/false, /*capture=*/capture_features_,
             /*capture_delta_intermediate=*/false,
             /*fa_window=*/0, /*logits_tail_rows=*/0,
             b_.cfg_.kq_stride_pad,
@@ -365,6 +1161,7 @@ SeqEngine::StepResult Qwen35SeqEngine::step(const StepPlan & plan) {
             /*compact_slots=*/true);
     }
     if (!built || !sg.kv_write_rows ||
+        (capture_features_ && !sg.target_feat_rows) ||
         (with_prefill &&
          (!sg.paged_query_seq_ids || !sg.paged_query_positions ||
           !sg.logits_row_indices))) {
@@ -408,6 +1205,32 @@ SeqEngine::StepResult Qwen35SeqEngine::step(const StepPlan & plan) {
     ggml_backend_tensor_set_async(
         b_.target_backend_, sg.positions, pos_buf_.data(), 0,
         sizeof(int32_t) * pos_buf_.size());
+
+    if (capture_features_) {
+        const int cap = b_.cache_.target_feat_cap;
+        const int dead_row = cap * n_slots;
+        feature_rows_.assign(static_cast<size_t>(n_total), dead_row);
+        token_offset = 0;
+        for (size_t i = 0; i < prefills.size(); ++i) {
+            const PrefillStage & prefill = prefills[i];
+            const int slot = plan.prefills[i].slot;
+            for (int row = 0; row < prefill.chunk; ++row) {
+                feature_rows_[static_cast<size_t>(token_offset + row)] =
+                    slot * cap + (prefill.kv_pos + row) % cap;
+            }
+            token_offset += prefill.chunk;
+        }
+        for (int row = 0; row < live_count; ++row) {
+            const int slot = live_slot_ids_[static_cast<size_t>(row)];
+            feature_rows_[static_cast<size_t>(n_prefill + row)] =
+                slot * cap +
+                live_positions_[static_cast<size_t>(row)] % cap;
+        }
+        ggml_backend_tensor_set_async(
+            b_.target_backend_, sg.target_feat_rows,
+            feature_rows_.data(), 0,
+            sizeof(int32_t) * feature_rows_.size());
+    }
 
     rows_buf_.assign((size_t)n_total * n_head_kv, scratch_row_);
     for (int h = 0; h < n_head_kv; ++h) {
@@ -537,6 +1360,14 @@ SeqEngine::StepResult Qwen35SeqEngine::step(const StepPlan & plan) {
 
 void Qwen35SeqEngine::retire(int slot) {
     if (!slots_.is_active(slot)) return;
+    if (slot >= 0 && slot < static_cast<int>(slot_draft_kv_.size()) &&
+        slot_draft_kv_[static_cast<size_t>(slot)]) {
+        draft_kv_reset(*slot_draft_kv_[static_cast<size_t>(slot)]);
+    }
+    if (slot >= 0 &&
+        slot < static_cast<int>(prepared_chain_drafts_.size())) {
+        prepared_chain_drafts_[static_cast<size_t>(slot)] = {};
+    }
     slots_.retire(slot);
 }
 

--- a/server/src/qwen35/concurrency/qwen35_seq_engine.h
+++ b/server/src/qwen35/concurrency/qwen35_seq_engine.h
@@ -22,10 +22,14 @@
 #pragma once
 
 #include "common/concurrency/seq_engine.h"
+#include "common/dflash_draft_kv.h"
+#include "common/dflash_feature_ring.h"
 #include "qwen35_slot_manager.h"
 
 #include <algorithm>
 #include <cstdint>
+#include <memory>
+#include <variant>
 #include <vector>
 
 namespace dflash::common {
@@ -34,25 +38,21 @@ class Qwen35Backend;
 
 class Qwen35SeqEngine final : public SeqEngine {
 public:
-    // `pool` and `backend` must outlive the engine. `scratch_row` is the
-    // first row of the block appended past the pool's index space, used as
-    // the K/V write destination of graph-bucket padding rows.
+    // `pool` and `backend` must outlive the engine. `scratch_row` is outside
+    // the pool and any per-slot tree slabs; it is the K/V destination of
+    // graph-bucket padding rows.
     // `max_prefills` bounds scheduler-selected prompt slices per traversal.
     Qwen35SeqEngine(Qwen35Backend & backend, PagedKvPool & pool,
                     int max_ctx, int64_t scratch_row,
+                    int tree_width, int tree_scratch_base,
+                    int tree_scratch_stride,
                     int max_prefills = 8,
                     int mixed_prefill_tokens = 2048,
                     int long_mixed_prefill_tokens = 4096,
                     int long_prefill_threshold = 768,
                     int idle_prefill_tokens = 4096,
-                    int prefill_quantum = 512)
-        : max_prefills_(std::max(1, max_prefills)),
-          mixed_prefill_tokens_(std::max(1, mixed_prefill_tokens)),
-          long_mixed_prefill_tokens_(std::max(1, long_mixed_prefill_tokens)),
-          long_prefill_threshold_(std::max(1, long_prefill_threshold)),
-          idle_prefill_tokens_(std::max(1, idle_prefill_tokens)),
-          prefill_quantum_(std::max(1, prefill_quantum)), b_(backend),
-          slots_(pool, max_ctx), scratch_row_(scratch_row) {}
+                    int prefill_quantum = 512);
+    ~Qwen35SeqEngine() override;
 
     int slot_count() const override { return slots_.slot_count(); }
     int max_context() const override { return slots_.max_context(); }
@@ -95,6 +95,20 @@ private:
         std::vector<float> embeddings;
     };
 
+    struct PromptServiceRound {};
+    struct SpeculativeDecodeRound {
+        std::vector<uint8_t> chain_lanes;
+    };
+    using FixedServiceRound =
+        std::variant<PromptServiceRound, SpeculativeDecodeRound>;
+
+    struct PreparedChainDraft {
+        bool valid = false;
+        int generated = -1;
+        int32_t root = -1;
+        std::vector<int32_t> tokens;
+    };
+
     int max_prefills_;
     int mixed_prefill_tokens_;
     int long_mixed_prefill_tokens_;
@@ -112,10 +126,30 @@ private:
     int32_t sample_graph_row(int slot, int logits_row,
                              const int32_t * cached_argmax = nullptr,
                              std::vector<float> * logits_scratch = nullptr);
+    FixedServiceRound make_fixed_service_round(
+        const StepPlan & plan) const;
+    bool chain_spec_input_capable(const StepInput & input) const;
+    DraftFeatureMirror * slot_feature_mirror(int slot);
+    DraftKvState * ensure_slot_draft_kv(int slot);
+    bool prepare_chain_drafts(
+        const std::vector<StepInput> & inputs,
+        const std::vector<uint8_t> & selected);
+    StepResult step_chain_spec(
+        const StepPlan & plan, const std::vector<uint8_t> & selected);
 
     Qwen35Backend & b_;
     Qwen35SlotManager  slots_;
     int64_t         scratch_row_ = 0;
+    int             tree_width_ = 0;
+    int             tree_scratch_base_ = 0;
+    int             tree_scratch_stride_ = 0;
+    bool            capture_features_ = false;
+    ggml_context *  feature_view_ctx_ = nullptr;
+    std::vector<DraftFeatureMirror> slot_feature_mirrors_;
+    std::vector<std::unique_ptr<DraftKvState>> slot_draft_kv_;
+    std::vector<std::unique_ptr<DraftKvState>> dummy_draft_kv_;
+    DraftKvBatchGraph batch_draft_graph_;
+    std::vector<PreparedChainDraft> prepared_chain_drafts_;
 
     // Hoisted per-step buffers (reused across step() calls).
     std::vector<int>         output_rows_;
@@ -131,6 +165,7 @@ private:
     std::vector<int32_t>     query_slot_ids_;
     std::vector<int32_t>     query_positions_;
     std::vector<int32_t>     logits_rows_;
+    std::vector<int32_t>     feature_rows_;
     std::vector<float>       embed_buf_;
     std::vector<int32_t>     pos_buf_;
     std::vector<int64_t>     rows_buf_;

--- a/server/src/qwen35/concurrency/qwen35_seq_engine.h
+++ b/server/src/qwen35/concurrency/qwen35_seq_engine.h
@@ -29,6 +29,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <memory>
+#include <random>
 #include <variant>
 #include <vector>
 
@@ -104,9 +105,11 @@ private:
 
     struct PreparedChainDraft {
         bool valid = false;
+        bool sampled = false;
         int generated = -1;
         int32_t root = -1;
         std::vector<int32_t> tokens;
+        std::mt19937_64 rng_snapshot;
     };
 
     int max_prefills_;

--- a/server/src/qwen35/concurrency/qwen35_slot_manager.cpp
+++ b/server/src/qwen35/concurrency/qwen35_slot_manager.cpp
@@ -230,37 +230,70 @@ void Qwen35SlotManager::commit_prefill(int slot) {
     s.phase = Qwen35SlotPhase::decode;
 }
 
-Qwen35SlotManager::StepAppend Qwen35SlotManager::append_token(int slot,
-                                                        int32_t fed_token) {
+Qwen35SlotManager::StepAppend Qwen35SlotManager::append_tokens(
+        int slot, const int32_t * fed_tokens, int n_tokens) {
     StepAppend out;
-    if (!is_active(slot) || !slots_[(size_t)slot].decoding()) return out;
+    if (!is_active(slot) || !slots_[(size_t)slot].decoding() ||
+        !fed_tokens || n_tokens < 1) return out;
     Qwen35Slot & s = slots_[(size_t)slot];
-    if (s.cur_pos >= max_ctx_) {
-        // No context left; the scheduler should have stopped this slot.
+    if (!s.staged_tokens.empty() || s.cur_pos > max_ctx_ ||
+        n_tokens > max_ctx_ - s.cur_pos) {
         return out;
     }
     PagedKvAppendResult app = pool_.append(
-        s.handle, 1, /*only_first_last_slots=*/true);
-    if (!app || app.token_count != 1 ||
-        app.last.logical_position != (uint32_t)s.cur_pos) {
+        s.handle, static_cast<uint32_t>(n_tokens));
+    if (!app || app.token_count != static_cast<uint32_t>(n_tokens)) {
         out.busy = app.status == PagedKvStatus::BlocksExhausted;
         return out;
     }
-    s.sample_history.push_back(fed_token);
+    if (app.write_slots.size() != static_cast<size_t>(n_tokens) ||
+        app.write_slots.front().logical_position !=
+            static_cast<uint32_t>(s.cur_pos) ||
+        app.write_slots.back().logical_position !=
+            static_cast<uint32_t>(s.cur_pos + n_tokens - 1)) {
+        s.staged_tokens.assign(fed_tokens, fed_tokens + n_tokens);
+        return out;
+    }
 
+    out.physical_rows.reserve(app.write_slots.size());
+    for (const PagedKvWriteSlot & write : app.write_slots) {
+        out.physical_rows.push_back(
+            static_cast<int64_t>(write.physical_token_index));
+        if (write.block_offset == 0) {
+            if (out.first_new_block < 0) {
+                out.first_new_block = static_cast<int>(
+                    write.logical_position / pool_.block_size());
+            }
+            out.new_blocks.push_back(
+                static_cast<int32_t>(write.physical_block));
+        }
+    }
+    s.staged_tokens.assign(fed_tokens, fed_tokens + n_tokens);
     out.ok = true;
-    out.physical_row = (int64_t)app.last.physical_token_index;
+    out.count = n_tokens;
+    out.physical_row = out.physical_rows.front();
     out.position = s.cur_pos;
-    if ((uint32_t)s.cur_pos % pool_.block_size() == 0) {
-        out.new_block = (int32_t)app.last.physical_block;
-        out.new_block_index = s.cur_pos / (int)pool_.block_size();
+    if (!out.new_blocks.empty()) {
+        out.new_block = out.new_blocks.front();
+        out.new_block_index = out.first_new_block;
     }
     return out;
 }
 
+Qwen35SlotManager::StepAppend Qwen35SlotManager::append_token(
+        int slot, int32_t fed_token) {
+    return append_tokens(slot, &fed_token, 1);
+}
+
 void Qwen35SlotManager::commit_step(int slot) {
     if (!is_active(slot)) return;
-    slots_[(size_t)slot].cur_pos += 1;
+    Qwen35Slot & s = slots_[(size_t)slot];
+    if (s.staged_tokens.empty()) return;
+    s.sample_history.insert(
+        s.sample_history.end(), s.staged_tokens.begin(),
+        s.staged_tokens.end());
+    s.cur_pos += static_cast<int>(s.staged_tokens.size());
+    s.staged_tokens.clear();
 }
 
 void Qwen35SlotManager::retire(int slot) {

--- a/server/src/qwen35/concurrency/qwen35_slot_manager.cpp
+++ b/server/src/qwen35/concurrency/qwen35_slot_manager.cpp
@@ -251,7 +251,13 @@ Qwen35SlotManager::StepAppend Qwen35SlotManager::append_tokens(
             static_cast<uint32_t>(s.cur_pos) ||
         app.write_slots.back().logical_position !=
             static_cast<uint32_t>(s.cur_pos + n_tokens - 1)) {
-        s.staged_tokens.assign(fed_tokens, fed_tokens + n_tokens);
+        const PagedKvStatus rollback =
+            pool_.rollback_append(s.handle, static_cast<uint32_t>(n_tokens));
+        if (rollback != PagedKvStatus::Ok) {
+            std::fprintf(stderr,
+                "[parallel] slot %d failed to roll back invalid append: %s\n",
+                slot, paged_kv_status_string(rollback));
+        }
         return out;
     }
 
@@ -294,6 +300,22 @@ void Qwen35SlotManager::commit_step(int slot) {
         s.staged_tokens.end());
     s.cur_pos += static_cast<int>(s.staged_tokens.size());
     s.staged_tokens.clear();
+}
+
+bool Qwen35SlotManager::rollback_step(int slot) {
+    if (!is_active(slot)) return false;
+    Qwen35Slot & s = slots_[(size_t)slot];
+    if (s.staged_tokens.empty()) return false;
+    const PagedKvStatus status = pool_.rollback_append(
+        s.handle, static_cast<uint32_t>(s.staged_tokens.size()));
+    if (status != PagedKvStatus::Ok) {
+        std::fprintf(stderr,
+            "[parallel] slot %d staged append rollback failed: %s\n",
+            slot, paged_kv_status_string(status));
+        return false;
+    }
+    s.staged_tokens.clear();
+    return true;
 }
 
 void Qwen35SlotManager::retire(int slot) {

--- a/server/src/qwen35/concurrency/qwen35_slot_manager.h
+++ b/server/src/qwen35/concurrency/qwen35_slot_manager.h
@@ -45,6 +45,9 @@ struct Qwen35Slot {
     // Penalty history is recorded as fed rather than sampled: the scheduler
     // may override a sample before the model consumes it.
     std::vector<int32_t> sample_history;
+    // Decode rows reserved by the current target graph. They become durable
+    // only after the graph and any speculative promotion succeed.
+    std::vector<int32_t> staged_tokens;
 
     int generated_tokens() const {
         return sample_history.size() > (size_t)prompt_len
@@ -94,13 +97,20 @@ public:
         bool ok = false;
         bool busy = false;    // no physical block available right now
         int64_t physical_row = -1;
+        std::vector<int64_t> physical_rows;
+        int count = 0;
         int position = -1;   // logical position the fed token is written at
         int32_t new_block = -1;
         int new_block_index = -1;
+        std::vector<int32_t> new_blocks;
+        int first_new_block = -1;
     };
 
-    // Allocate the next decode token's cache row, report any new block-table
-    // entry, and log it to sample_history. cur_pos waits for commit_step().
+    StepAppend append_tokens(int slot, const int32_t * fed_tokens,
+                             int n_tokens);
+
+    // Allocate decode cache rows and stage the fed tokens. Both history and
+    // cur_pos wait for commit_step().
     StepAppend append_token(int slot, int32_t fed_token);
 
     // The batched step's compute succeeded: cur_pos++.

--- a/server/src/qwen35/concurrency/qwen35_slot_manager.h
+++ b/server/src/qwen35/concurrency/qwen35_slot_manager.h
@@ -116,6 +116,8 @@ public:
     // The batched step's compute succeeded: cur_pos++.
     void commit_step(int slot);
 
+    bool rollback_step(int slot);
+
     // Release the slot's blocks and clear its state. Safe on inactive slots
     // and after a failed admission/prefill.
     void retire(int slot);

--- a/server/src/qwen35/graph_builders.cpp
+++ b/server/src/qwen35/graph_builders.cpp
@@ -10,6 +10,7 @@
 #include <cstdio>
 #include <limits>
 #include <cstdlib>
+#include <memory>
 #include <vector>
 
 namespace dflash::common {
@@ -437,9 +438,13 @@ bool build_target_step(
     // step-invariant set_rows KV write (kv_write_rows) below.
     ggml_init_params ip{};
     ip.mem_size   = 512 * 1024 * 1024;
-    static thread_local std::vector<uint8_t> g_step_arena;
-    if (g_step_arena.size() < ip.mem_size) g_step_arena.resize(ip.mem_size);
-    ip.mem_buffer = g_step_arena.data();
+    static thread_local std::unique_ptr<uint8_t[]> g_step_arena;
+    static thread_local size_t g_step_arena_size = 0;
+    if (g_step_arena_size < ip.mem_size) {
+        g_step_arena.reset(new uint8_t[ip.mem_size]);
+        g_step_arena_size = ip.mem_size;
+    }
+    ip.mem_buffer = g_step_arena.get();
     ip.no_alloc   = true;
     sg.ctx = ggml_init(ip);
     if (!sg.ctx) return false;
@@ -833,9 +838,13 @@ bool build_target_step_paged_tree(
 
     ggml_init_params ip{};
     ip.mem_size = 512 * 1024 * 1024;
-    static thread_local std::vector<uint8_t> g_tree_arena;
-    if (g_tree_arena.size() < ip.mem_size) g_tree_arena.resize(ip.mem_size);
-    ip.mem_buffer = g_tree_arena.data();
+    static thread_local std::unique_ptr<uint8_t[]> g_tree_arena;
+    static thread_local size_t g_tree_arena_size = 0;
+    if (g_tree_arena_size < ip.mem_size) {
+        g_tree_arena.reset(new uint8_t[ip.mem_size]);
+        g_tree_arena_size = ip.mem_size;
+    }
+    ip.mem_buffer = g_tree_arena.get();
     ip.no_alloc = true;
     sg.ctx = ggml_init(ip);
     if (!sg.ctx) return false;

--- a/server/src/qwen35/graph_builders.cpp
+++ b/server/src/qwen35/graph_builders.cpp
@@ -8,10 +8,90 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstdio>
+#include <limits>
 #include <cstdlib>
 #include <vector>
 
 namespace dflash::common {
+
+bool detail::target_graph_capacity_for_parallel_segments(
+        int n_parallel_segments,
+        size_t & capacity) {
+    static constexpr int k_max_parallel_segments = 64;
+    static constexpr size_t k_base_capacity = 16384;
+    static constexpr int k_segments_per_capacity = 8;
+    static constexpr size_t k_max_capacity =
+        k_base_capacity *
+        (k_max_parallel_segments / k_segments_per_capacity);
+
+    if (n_parallel_segments < 0 ||
+        n_parallel_segments > k_max_parallel_segments) {
+        return false;
+    }
+    const int64_t scale = std::max<int64_t>(
+        1, ((int64_t)n_parallel_segments +
+            k_segments_per_capacity - 1) /
+               k_segments_per_capacity);
+    if ((uint64_t)scale >
+        std::numeric_limits<size_t>::max() / k_base_capacity) {
+        return false;
+    }
+    const size_t computed = k_base_capacity * (size_t)scale;
+    if (computed > k_max_capacity) return false;
+    capacity = computed;
+    return true;
+}
+
+bool detail::target_paged_tree_graph_capacity(
+        int tree_width,
+        int n_tree_seqs,
+        size_t & capacity) {
+    static constexpr int tree_buckets[] = {
+        1, 2, 3, 4, 6, 8, 12, 16, 24, 32, 48, 64,
+    };
+    if (tree_width < 2 || tree_width > 16 ||
+        std::find(std::begin(tree_buckets), std::end(tree_buckets),
+                  n_tree_seqs) == std::end(tree_buckets) ||
+        (int64_t)tree_width * n_tree_seqs > INT32_MAX) {
+        return false;
+    }
+    return target_graph_capacity_for_parallel_segments(
+        n_tree_seqs, capacity);
+}
+
+bool detail::validate_target_paged_tree_layout(
+    const TargetCache & cache,
+    int tree_width,
+    int n_tree_seqs,
+    int paged_max_kv_len,
+    int tree_scratch_base,
+    int tree_scratch_stride) {
+    size_t graph_capacity = 0;
+    if (!target_paged_tree_graph_capacity(
+            tree_width, n_tree_seqs, graph_capacity) ||
+        cache.n_seq_slots <= 1 || !cache.paged_block_table ||
+        !cache.paged_kv_seq_lens || paged_max_kv_len < 1 ||
+        tree_scratch_base <= 0 ||
+        tree_scratch_base % PAGED_BLOCK_SIZE != 0 ||
+        tree_scratch_stride < tree_width) {
+        return false;
+    }
+
+    int physical_kv_rows = 0;
+    for (ggml_tensor * tensor : cache.attn_k) {
+        if (tensor) {
+            physical_kv_rows = (int)tensor->ne[1];
+            break;
+        }
+    }
+    if (physical_kv_rows < 1) return false;
+
+    const int64_t scratch_end =
+        (int64_t)tree_scratch_base +
+        (int64_t)(cache.n_seq_slots - 1) * tree_scratch_stride +
+        tree_width;
+    return scratch_end <= physical_kv_rows;
+}
 
 // ── build_layer_step ────────────────────────────────────────────
 
@@ -345,7 +425,11 @@ bool build_target_step(
     }
     if (segment_total != n_prefill_tokens) return false;
     if (n_logits_rows > 0 && n_prefill_tokens == 0) return false;
-
+    size_t graph_capacity = 0;
+    if (!detail::target_graph_capacity_for_parallel_segments(
+            n_prefill_segments, graph_capacity)) {
+        return false;
+    }
     // Persistent thread_local arena: rebuilt step graphs land at identical
     // addresses, keeping the ggml-cuda CUDA-graph cache key (nodes[0]) and
     // every node property stable across AR decode steps -> captured graph
@@ -503,10 +587,17 @@ bool build_target_step(
         ggml_set_name(sg.logits_row_indices, "logits_row_indices");
         ggml_set_input(sg.logits_row_indices);
     }
+    if (capture && paged_attention && cache.target_feat) {
+        sg.target_feat_rows =
+            ggml_new_tensor_1d(sg.ctx, GGML_TYPE_I32, n_tokens);
+        ggml_set_name(sg.target_feat_rows, "target_feat_rows");
+        ggml_set_input(sg.target_feat_rows);
+    }
 
     // 32k nodes: the chunked delta-net prefill graph (CS = 32) reaches ~17k
     // nodes at a 512-token ubatch.
-    sg.gf = ggml_new_graph_custom(sg.ctx, 32768, false);
+    graph_capacity = std::max<size_t>(graph_capacity, 32768);
+    sg.gf = ggml_new_graph_custom(sg.ctx, graph_capacity, false);
 
     // Step-invariant KV write: only when topology can't vary per step.
     // DFLASH_QWEN35_NO_KVPAD=1 restores the legacy cpy append + exact-length
@@ -567,6 +658,7 @@ bool build_target_step(
     gi.paged_query_seq_ids        = sg.paged_query_seq_ids;
     gi.paged_query_positions      = sg.paged_query_positions;
     gi.logits_row_indices         = sg.logits_row_indices;
+    gi.target_feat_rows           = sg.target_feat_rows;
     gi.prefill_segments           = prefill_segments;
     gi.n_prefill_segments         = n_prefill_segments;
     gi.specla_m_strict            = sg.specla_m_strict;
@@ -706,6 +798,163 @@ bool build_target_step_tree(
             hld_schedule->packed.size()*sizeof(int32_t));
     }
     return true;
+}
+
+bool build_target_step_paged_tree(
+    StepGraph & sg,
+    const TargetWeights & w,
+    TargetCache & cache,
+    ggml_backend_t backend,
+    int tree_width,
+    int n_tree_seqs,
+    int paged_max_kv_len,
+    int tree_scratch_base,
+    int tree_scratch_stride,
+    int kq_stride_pad,
+    int mapped_ar_seqs) {
+    (void)kq_stride_pad;
+    step_graph_free(sg);
+
+    if (mapped_ar_seqs < 0 || mapped_ar_seqs > cache.n_seq_slots) {
+        return false;
+    }
+    if (!detail::validate_target_paged_tree_layout(
+            cache, tree_width, n_tree_seqs, paged_max_kv_len,
+            tree_scratch_base, tree_scratch_stride)) {
+        return false;
+    }
+    size_t graph_capacity = 0;
+    if (!detail::target_paged_tree_graph_capacity(
+            tree_width, n_tree_seqs, graph_capacity)) {
+        return false;
+    }
+    const int n_tokens = mapped_ar_seqs + tree_width * n_tree_seqs;
+    const int n_mapped_seqs = mapped_ar_seqs + n_tree_seqs;
+
+    ggml_init_params ip{};
+    ip.mem_size = 512 * 1024 * 1024;
+    static thread_local std::vector<uint8_t> g_tree_arena;
+    if (g_tree_arena.size() < ip.mem_size) g_tree_arena.resize(ip.mem_size);
+    ip.mem_buffer = g_tree_arena.data();
+    ip.no_alloc = true;
+    sg.ctx = ggml_init(ip);
+    if (!sg.ctx) return false;
+
+    // Salt graph addresses by the stable bucket shape so captured graphs for
+    // different T/S buckets never alias in ggml-cuda's topology cache.
+    for (int i = 0; i < tree_width + n_tree_seqs +
+                        mapped_ar_seqs + n_tokens; ++i) {
+        (void)ggml_new_tensor_1d(sg.ctx, GGML_TYPE_I32, 1);
+    }
+
+    sg.inp_embed = ggml_new_tensor_3d(
+        sg.ctx, GGML_TYPE_F32, w.n_embd, n_tokens, 1);
+    sg.positions =
+        ggml_new_tensor_1d(sg.ctx, GGML_TYPE_I32, 4 * n_tokens);
+    sg.parent_ids = ggml_new_tensor_2d(
+        sg.ctx, GGML_TYPE_I32, tree_width, n_tree_seqs);
+    sg.tree_sizes =
+        ggml_new_tensor_1d(sg.ctx, GGML_TYPE_I32, n_tree_seqs);
+    sg.active_slot_ids =
+        ggml_new_tensor_1d(sg.ctx, GGML_TYPE_I32, n_mapped_seqs);
+    sg.state_slot_ids =
+        ggml_new_tensor_1d(sg.ctx, GGML_TYPE_I32, n_mapped_seqs);
+    sg.paged_query_seq_ids =
+        ggml_new_tensor_1d(sg.ctx, GGML_TYPE_I32, n_tokens);
+    if (mapped_ar_seqs > 0) {
+        sg.paged_query_positions =
+            ggml_new_tensor_1d(sg.ctx, GGML_TYPE_I32, n_tokens);
+    }
+    sg.kv_write_rows = ggml_new_tensor_2d(
+        sg.ctx, GGML_TYPE_I64, n_tokens, w.n_head_kv);
+
+    const struct NamedInput {
+        ggml_tensor * tensor;
+        const char * name;
+    } inputs[] = {
+        {sg.inp_embed, "inp_embed"},
+        {sg.positions, "positions"},
+        {sg.parent_ids, "parent_ids"},
+        {sg.tree_sizes, "tree_sizes"},
+        {sg.active_slot_ids, "active_slot_ids"},
+        {sg.state_slot_ids, "state_slot_ids"},
+        {sg.paged_query_seq_ids, "paged_query_seq_ids"},
+        {sg.paged_query_positions, "paged_query_positions"},
+        {sg.kv_write_rows, "kv_write_rows"},
+    };
+    for (const NamedInput & input : inputs) {
+        if (!input.tensor) continue;
+        ggml_set_name(input.tensor, input.name);
+        ggml_set_input(input.tensor);
+    }
+
+    sg.gf = ggml_new_graph_custom(sg.ctx, graph_capacity, false);
+    QwenGraphInputs gi{};
+    gi.inp_embed = sg.inp_embed;
+    gi.positions = sg.positions;
+    gi.n_tokens = n_tokens;
+    gi.kv_start = 0;
+    gi.capture_layers = true;
+    gi.capture_delta_intermediate = false;
+    gi.capture_tree_commit = true;
+    gi.parent_ids = sg.parent_ids;
+    gi.tree_sizes = sg.tree_sizes;
+    gi.kv_write_rows = sg.kv_write_rows;
+    gi.paged_block_table = cache.paged_block_table;
+    gi.paged_kv_seq_lens = cache.paged_kv_seq_lens;
+    gi.active_slot_ids = sg.active_slot_ids;
+    gi.state_slot_ids = sg.state_slot_ids;
+    gi.paged_query_seq_ids = sg.paged_query_seq_ids;
+    gi.paged_query_positions = sg.paged_query_positions;
+    gi.n_seqs = n_tree_seqs;
+    gi.mapped_ar_seqs = mapped_ar_seqs;
+    gi.paged_max_kv_len = paged_max_kv_len;
+    gi.tree_width = tree_width;
+    gi.tree_scratch_base = tree_scratch_base;
+    gi.tree_scratch_stride = tree_scratch_stride;
+
+    QwenGraphOutputs go = build_qwen35_graph(sg.ctx, sg.gf, w, cache, gi);
+    if (!go.logits) return false;
+    sg.logits = go.logits;
+    sg.delta_captures = std::move(go.delta_captures);
+    sg.tree_features = go.tree_features;
+    if (!sg.tree_features || sg.delta_captures.empty()) {
+        return false;
+    }
+    ggml_set_output(sg.logits);
+    sg.argmax_tokens = ggml_argmax(sg.ctx, sg.logits);
+    ggml_set_name(sg.argmax_tokens, "paged_tree_verify_argmax");
+    ggml_set_output(sg.argmax_tokens);
+    ggml_build_forward_expand(sg.gf, sg.argmax_tokens);
+
+    if (!sg.alloc) {
+        sg.alloc = ggml_gallocr_new(
+            ggml_backend_get_default_buffer_type(backend));
+    }
+    if (!ggml_gallocr_alloc_graph(sg.alloc, sg.gf) ||
+        !detail::target_paged_tree_uploads_ready(sg)) {
+        return false;
+    }
+    ggml_init_params commit_params{};
+    commit_params.mem_size = 16 * ggml_tensor_overhead();
+    commit_params.no_alloc = true;
+    sg.commit_ctx = ggml_init(commit_params);
+    if (!sg.commit_ctx) return false;
+    sg.accepted_prefixes = ggml_new_tensor_1d(
+        sg.commit_ctx, GGML_TYPE_I32, n_tree_seqs);
+    sg.commit_slot_ids = ggml_new_tensor_1d(
+        sg.commit_ctx, GGML_TYPE_I32, n_tree_seqs);
+    sg.commit_rows = ggml_new_tensor_2d(
+        sg.commit_ctx, GGML_TYPE_I64, tree_width, n_tree_seqs);
+    sg.feature_commit_rows = ggml_new_tensor_1d(
+        sg.commit_ctx, GGML_TYPE_I32, n_tokens);
+    ggml_set_name(sg.accepted_prefixes, "accepted_prefixes");
+    ggml_set_name(sg.commit_slot_ids, "commit_slot_ids");
+    ggml_set_name(sg.commit_rows, "commit_rows");
+    ggml_set_name(sg.feature_commit_rows, "feature_commit_rows");
+    sg.commit_buffer = ggml_backend_alloc_ctx_tensors(
+        sg.commit_ctx, backend);
+    return sg.commit_buffer != nullptr;
 }
 
 

--- a/server/src/qwen35/graph_builders.h
+++ b/server/src/qwen35/graph_builders.h
@@ -24,6 +24,60 @@
 
 namespace dflash::common {
 
+namespace detail {
+
+// Qwen's recurrent graph duplicates one small subgraph per ragged sequence.
+// Return a graph capacity that covers every supported concurrent bucket while
+// keeping the legacy allocation for the common <= 8-sequence case.
+bool target_graph_capacity_for_parallel_segments(
+    int n_parallel_segments,
+    size_t & capacity);
+
+// Checked fixed-chain shape/capacity contract. DFlash2 uses widths 2..16, and
+// concurrent serving supports at most 64 slots.
+bool target_paged_tree_graph_capacity(
+    int tree_width,
+    int n_tree_seqs,
+    size_t & capacity);
+
+// Model-free validation shared by the packed-tree builder and its shape
+// tests. paged_max_kv_len is a logical launch bound and may exceed the
+// bounded physical K/V pool; only the per-slot scratch slabs must fit in the
+// physical tensor rows.
+bool validate_target_paged_tree_layout(
+    const TargetCache & cache,
+    int tree_width,
+    int n_tree_seqs,
+    int paged_max_kv_len,
+    int tree_scratch_base,
+    int tree_scratch_stride);
+
+// `active_slot_ids` is a topology marker in mapped-tree graphs. It may be
+// optimized out by gallocr because the actual recurrent and attention row
+// mappings are carried by state_slot_ids and paged_query_seq_ids. Every other
+// tensor listed here is read by a graph node and must have backend storage
+// before the engine uploads metadata.
+inline bool target_paged_tree_uploads_ready(const StepGraph & sg) {
+    const auto allocated = [](const ggml_tensor * tensor) {
+        return tensor && tensor->buffer;
+    };
+    return sg.active_slot_ids &&
+           allocated(sg.inp_embed) && allocated(sg.positions) &&
+           allocated(sg.parent_ids) && allocated(sg.tree_sizes) &&
+           allocated(sg.state_slot_ids) &&
+           allocated(sg.paged_query_seq_ids) &&
+           (!sg.paged_query_positions ||
+            allocated(sg.paged_query_positions)) &&
+           allocated(sg.kv_write_rows);
+}
+
+inline bool target_paged_tree_active_slots_need_upload(
+        const StepGraph & sg) {
+    return sg.active_slot_ids && sg.active_slot_ids->buffer;
+}
+
+}  // namespace detail
+
 // Layer-segmented prefill: process one target layer for chunk_start..chunk_start+n_tokens.
 bool build_layer_step(
     StepGraph & sg,
@@ -110,6 +164,10 @@ bool build_hybrid_full_layer_step(
 //     overrides logits_tail_rows. Multi-prompt steps need it because
 //     committing rows are scattered. 0 keeps the tail-view behavior.
 //   `logits_tail_rows` — logits/argmax only for the last n rows (0 = all).
+// When `capture && paged_attention`, sg.target_feat_rows is an I32 graph
+// input mapping every token to its slot-local feature-ring destination. This
+// keeps accepted-path replay graph-stable and leaves legacy offset capture
+// unchanged for callers that do not use paged serving.
 bool build_target_step(
     StepGraph & sg,
     const TargetWeights & w,
@@ -147,6 +205,27 @@ bool build_target_step_tree(
     int fa_window = 0,
     int kq_stride_pad = KQ_MASK_PAD,
     const SpecLAHLDSchedule * specla_hld = nullptr);
+
+// Packed fixed-chain verify over a paged multi-slot cache. Tokens are
+// flattened after an optional compact one-token AR prefix as
+// [mapped_ar_seqs + tree_width*n_tree_seqs]. n_tree_seqs is a stable graph-
+// bucket width; inactive trees use tree_size=0 and dead/safe row mappings. In
+// particular, state_slot_ids padding must map to a valid harmless slot
+// (normally 0), while active/paged sequence IDs may use -1. Speculative K/V is
+// written into per-slot scratch slabs; recurrent transitions and target
+// features are exposed for post-verification promotion.
+bool build_target_step_paged_tree(
+    StepGraph & sg,
+    const TargetWeights & w,
+    TargetCache & cache,
+    ggml_backend_t backend,
+    int tree_width,
+    int n_tree_seqs,
+    int paged_max_kv_len,
+    int tree_scratch_base,
+    int tree_scratch_stride,
+    int kq_stride_pad = KQ_MASK_PAD,
+    int mapped_ar_seqs = 0);
 
 // LM-head projection: project draft hidden states through the target output matrix.
 bool build_lm_head_projection_step(

--- a/server/src/qwen35/qwen35_backend.cpp
+++ b/server/src/qwen35/qwen35_backend.cpp
@@ -179,7 +179,8 @@ static FILE * open_dflash_floor_log() {
 // staging K/V or staging recurrent slab to reserve.
 static int64_t concurrent_fixed_cache_bytes(
         const TargetWeights & w, int max_ctx, int n_slots,
-        int64_t kv_bytes_per_token) {
+        int64_t kv_bytes_per_token, int64_t scratch_tokens,
+        bool fixed_chain) {
     const int64_t n_full_attn =
         w.n_layer / w.full_attention_interval;
     const int64_t n_delta = w.n_layer - n_full_attn;
@@ -194,7 +195,10 @@ static int64_t concurrent_fixed_cache_bytes(
         state_per_layer * n_delta * (int64_t)n_slots;
     const int64_t target_feat =
         (int64_t)w.n_capture_layers * w.n_embd *
-        std::min(max_ctx, 4096) * (int64_t)sizeof(uint16_t);
+        (fixed_chain
+             ? (int64_t)std::min(max_ctx, 4096) * n_slots + 1
+             : (int64_t)std::min(max_ctx, 4096)) *
+        (int64_t)sizeof(uint16_t);
     const int64_t q_capture =
         (int64_t)w.n_embd_head_k * w.n_head * n_full_attn *
         (int64_t)sizeof(float);
@@ -202,7 +206,7 @@ static int64_t concurrent_fixed_cache_bytes(
         ((int64_t)paged_block_count(max_ctx) * n_slots + n_slots) *
         (int64_t)sizeof(int32_t);
     const int64_t scratch =
-        kv_bytes_per_token * PAGED_BLOCK_SIZE;
+        kv_bytes_per_token * scratch_tokens;
     return recurrent + target_feat + q_capture +
            paged_metadata + scratch;
 }
@@ -465,6 +469,27 @@ bool Qwen35Backend::init() {
         set_last_error("--max-concurrency requires --paged-attention");
         return false;
     }
+    const bool concurrent_local_chain =
+        n_slots > 1 && cfg_.paged_attention && cfg_.fa_window == 0 &&
+        cfg_.draft_path && !cfg_.ddtree_mode && !use_remote_draft &&
+        !tensor_parallel && !split_gpus_ &&
+        target_backend_ == draft_backend_ &&
+        cfg_.device.gpu == cfg_.draft_gpu &&
+        dw_.selector.enabled && dw_.block_size > 1 &&
+        dw_.block_size <= 16 && w_.output;
+    if (n_slots > 1 && cfg_.draft_path && !concurrent_local_chain) {
+        set_last_error(
+            "concurrent paged DFlash2 requires a selector-enabled local "
+            "same-device draft with block size in [2, 16] and a target "
+            "lm_head");
+        return false;
+    }
+    const int tree_width =
+        concurrent_local_chain ? dw_.block_size : 0;
+    const int tree_stride = concurrent_local_chain
+        ? paged_token_capacity(tree_width) : 0;
+    const int64_t scratch_tokens = PAGED_BLOCK_SIZE +
+        (int64_t)n_slots * tree_stride;
     // Concurrent slots share one physical pool. An explicit
     // --kv-pool-tokens is rounded up to a whole block; otherwise capacity is
     // derived from device-free memory after subtracting fixed concurrent cache
@@ -475,9 +500,12 @@ bool Qwen35Backend::init() {
     int64_t pool_tokens = 0;
     if (n_slots > 1) {
         if (cfg_.kv_pool_tokens > 0) {
+            const int64_t max_pool_tokens =
+                ((int64_t)INT32_MAX - scratch_tokens) /
+                PAGED_BLOCK_SIZE * PAGED_BLOCK_SIZE;
             pool_tokens = (int64_t)paged_token_capacity(
                 (int)std::min<int64_t>(
-                    cfg_.kv_pool_tokens, INT32_MAX - PAGED_BLOCK_SIZE));
+                    cfg_.kv_pool_tokens, max_pool_tokens));
         } else {
             PagedKvAutoBudget budget;
             // TODO: Size tensor-parallel pools from each device's free memory
@@ -486,7 +514,8 @@ bool Qwen35Backend::init() {
             budget.bytes_per_token = kvf_budget.bytes_per_token;
             budget.reserve_bytes = kvf_budget.reserve_bytes;
             budget.fixed_cache_bytes = concurrent_fixed_cache_bytes(
-                w_, cfg_.device.max_ctx, n_slots, budget.bytes_per_token);
+                w_, cfg_.device.max_ctx, n_slots, budget.bytes_per_token,
+                scratch_tokens, concurrent_local_chain);
             pool_tokens = paged_kv_auto_pool_tokens(
                 cfg_.device.max_ctx, n_slots, budget);
             const int64_t one_context =
@@ -508,19 +537,20 @@ bool Qwen35Backend::init() {
                 return false;
             }
         }
-        if (pool_tokens + PAGED_BLOCK_SIZE > INT32_MAX) {
+        if (pool_tokens + scratch_tokens > INT32_MAX) {
             set_last_error("paged KV pool exceeds INT32_MAX tokens");
             return false;
         }
     }
     const int ctx_alloc = n_slots > 1
-        ? (int)(pool_tokens + PAGED_BLOCK_SIZE)
+        ? (int)(pool_tokens + scratch_tokens)
         : (cfg_.paged_attention
                ? paged_token_capacity(cfg_.device.max_ctx)
                : kvflash_tokens_);
     if (!create_target_cache(w_, cfg_.device.max_ctx, max_verify_tokens, target_backend_, cache_,
                              /*prefill_only=*/true, ctx_alloc,
-                             cfg_.paged_attention, n_slots)) {
+                             cfg_.paged_attention, n_slots,
+                             concurrent_local_chain)) {
         std::fprintf(stderr, "cache: %s\n", dflash27b_last_error());
         return false;
     }
@@ -552,12 +582,22 @@ bool Qwen35Backend::init() {
             return false;
         }
         if (n_slots > 1) {
+            const int tree_scratch_base = (int)pool_tokens;
+            const int64_t dead_scratch_row =
+                pool_tokens + (int64_t)n_slots * tree_stride;
             seq_engine_ = std::make_unique<Qwen35SeqEngine>(
                 *this, *paged_kv_pool_, cfg_.device.max_ctx,
-                /*scratch_row=*/pool_tokens,
+                dead_scratch_row, tree_width,
+                tree_scratch_base, tree_stride,
                 max_concurrent_prefills, mixed_prefill_tokens,
                 long_mixed_prefill_tokens, long_prefill_threshold,
                 idle_prefill_tokens, prefill_quantum);
+            if (concurrent_local_chain) {
+                std::fprintf(stderr,
+                    "[parallel-chain] fixed DFlash2 width=%d, "
+                    "same-device paged full-attention greedy lanes\n",
+                    tree_width);
+            }
             std::printf("[parallel] %d decode slots, up to %d packed prefills "
                         "(mixed short/long %d/%d at >=%d tokens, "
                         "idle %d, quantum %d), "
@@ -610,7 +650,8 @@ bool Qwen35Backend::init() {
 
     // Init feature mirror when draft model is available (needed for spec decode).
     // On single-GPU, this is an F32 conversion buffer; on split-GPU, a cross-device mirror.
-    if (cfg_.draft_path && !use_remote_draft) {
+    if (cfg_.draft_path && !use_remote_draft &&
+        !concurrent_local_chain) {
         const int mirror_cap = std::min({cfg_.draft_ctx_max, cfg_.device.max_ctx,
                                          cache_.target_feat_cap > 0 ? cache_.target_feat_cap : cfg_.device.max_ctx});
         if (!draft_feature_mirror_init(feature_mirror_, draft_backend_,
@@ -1264,6 +1305,7 @@ DFlashTarget * Qwen35Backend::dflash_target() {
 
 void Qwen35Backend::shutdown() {
     const bool use_remote_draft = cfg_.remote_draft.enabled();
+    seq_engine_.reset();
     end_paged_sequence();
     free_drafter();
     step_graph_destroy(sg_);

--- a/server/src/qwen35/qwen35_backend.cpp
+++ b/server/src/qwen35/qwen35_backend.cpp
@@ -2,6 +2,7 @@
 #include "concurrency/qwen35_seq_engine.h"
 #include "common/chain_rollback_policy.h"
 #include "common/draft_block_size.h"
+#include "common/draft_swa.h"
 #include "placement/skip_park_guard.h"
 #include "qwen35_dflash_target.h"
 #include "graph_builders.h"
@@ -361,11 +362,10 @@ bool Qwen35Backend::init() {
         apply_drafter_capture_layer_ids(dw_, w_);
 
         if (cfg_.draft_swa_window > 0) {
-            dw_.swa_window = cfg_.draft_swa_window;
-            for (int il = 0; il < dw_.n_layer - 1; il++)
-                dw_.layers[il].is_swa = true;
+            const DraftSwaOverrideResult swa =
+                apply_draft_swa_window_override(dw_, cfg_.draft_swa_window);
             std::printf("[draft]  SWA layers: %d/%d (window=%d)\n",
-                        dw_.n_layer - 1, dw_.n_layer, dw_.swa_window);
+                        swa.swa_layers, swa.total_layers, swa.effective_window);
         }
 
         // Legacy 8-layer drafter YaRN from config flags. Applied here AND in
@@ -937,9 +937,10 @@ bool Qwen35Backend::unpark(ParkTarget target) {
                 dw_.rope_n_ctx_orig = cfg_.draft_yarn_orig_ctx;
             }
             if (cfg_.draft_swa_window > 0) {
-                dw_.swa_window = cfg_.draft_swa_window;
-                for (int il = 0; il < dw_.n_layer - 1; il++)
-                    dw_.layers[il].is_swa = true;
+                const DraftSwaOverrideResult swa =
+                    apply_draft_swa_window_override(dw_, cfg_.draft_swa_window);
+                std::printf("[unpark] draft SWA layers: %d/%d (window=%d)\n",
+                            swa.swa_layers, swa.total_layers, swa.effective_window);
             }
             // Re-apply the runtime block-size override: without this a
             // park/unpark cycle silently reverts to checkpoint metadata

--- a/server/src/qwen35/qwen35_layer_split_adapter.cpp
+++ b/server/src/qwen35/qwen35_layer_split_adapter.cpp
@@ -4,6 +4,7 @@
 
 #include "common/backend_precision.h"
 #include "common/chain_rollback_policy.h"
+#include "common/draft_swa.h"
 #include "common/dflash_spec_decode.h"
 #include "common/gguf_inspect.h"
 #include "common/layer_split_utils.h"
@@ -480,7 +481,11 @@ bool Qwen35LayerSplitAdapter::load_draft() {
         return false;
     }
     if (cfg_.draft_swa_window > 0) {
-        draft_weights_.swa_window = cfg_.draft_swa_window;
+        const DraftSwaOverrideResult swa =
+            apply_draft_swa_window_override(
+                draft_weights_, cfg_.draft_swa_window);
+        std::fprintf(stderr, "[target-split] draft SWA layers: %d/%d (window=%d)\n",
+                     swa.swa_layers, swa.total_layers, swa.effective_window);
     }
 
     const int cap = std::min(cfg_.device.max_ctx, cfg_.draft_ctx_max);

--- a/server/src/qwen35/qwen35_target_graph.cpp
+++ b/server/src/qwen35/qwen35_target_graph.cpp
@@ -105,12 +105,14 @@ bool create_target_cache(const TargetWeights & w,
                          bool prefill_only,
                          int ctx_alloc,
                          bool paged_attention,
-                         int n_seq_slots) {
+                         int n_seq_slots,
+                         bool concurrent_tree) {
     return create_target_cache_partial(w, max_ctx, max_verify_tokens, backend,
                                        out, prefill_only,
                                        0, w.n_layer, true, ctx_alloc,
                                        /*f32_ssm_intermediates=*/false,
-                                       paged_attention, n_seq_slots);
+                                       paged_attention, n_seq_slots,
+                                       concurrent_tree);
 }
 
 // concurrent_fixed_cache_bytes() in qwen35_backend.cpp mirrors this
@@ -128,7 +130,8 @@ bool create_target_cache_partial(const TargetWeights & w,
                                  int ctx_alloc,
                                  bool f32_ssm_intermediates,
                                  bool paged_attention,
-                                 int n_seq_slots) {
+                                 int n_seq_slots,
+                                 bool concurrent_tree) {
     if (layer_begin < 0) layer_begin = 0;
     if (layer_end < 0 || layer_end > w.n_layer) layer_end = w.n_layer;
     if (layer_begin > layer_end) {
@@ -138,6 +141,11 @@ bool create_target_cache_partial(const TargetWeights & w,
     if (n_seq_slots < 1) n_seq_slots = 1;
     if (n_seq_slots > 1 && !paged_attention) {
         set_last_error("multi-slot target cache requires paged attention");
+        return false;
+    }
+    if (concurrent_tree && (!paged_attention || n_seq_slots <= 1)) {
+        set_last_error(
+            "concurrent tree cache requires paged multi-slot serving");
         return false;
     }
     out.backend = backend;
@@ -267,7 +275,14 @@ bool create_target_cache_partial(const TargetWeights & w,
         out.target_feat_cap = std::min(max_ctx, TARGET_FEAT_CAP_DEFAULT);
         if (allocate_target_feat) {
             const int fc_in = w.n_capture_layers * w.n_embd;
-            out.target_feat = ggml_new_tensor_2d(out.base_ctx, GGML_TYPE_BF16, fc_in, out.target_feat_cap);
+            // Concurrent slots own disjoint feature rings. The final row is
+            // dead scratch for padded bucket rows because set_rows does not
+            // accept negative destination indices.
+            const int feat_rows = concurrent_tree
+                ? out.target_feat_cap * n_seq_slots + 1
+                : out.target_feat_cap;
+            out.target_feat = ggml_new_tensor_2d(
+                out.base_ctx, GGML_TYPE_BF16, fc_in, feat_rows);
             ggml_set_name(out.target_feat, "target_feat");
         } else {
             out.target_feat = nullptr;
@@ -306,9 +321,9 @@ bool create_target_cache_partial(const TargetWeights & w,
     }
 
     // ── Rollback context: snapshots + intermediates ───────────────────
-    // Multi-slot caches skip these entirely: concurrent serving is paged and
-    // therefore AR-only (no spec-decode rollback), and the tensors are the
-    // single largest optional allocation (~0.8 GB at 48 delta layers).
+    // Multi-slot caches skip these entirely. Fixed chain verification keeps
+    // speculative recurrent transitions in graph scratch and promotes only
+    // accepted prefixes through the compact GPU journal.
     if (!prefill_only && !multi_slot) {
         const int rb_tensors = 4 * n_delta;
         ggml_init_params ip{};
@@ -1140,7 +1155,16 @@ static ggml_tensor * build_full_attn_block(
     int paged_max_kv_len = 0,
     // Compact decode row -> physical block-table column. Negative ids are
     // graph-bucket padding rows.
-    ggml_tensor * active_slot_ids = nullptr
+    ggml_tensor * active_slot_ids = nullptr,
+    // Packed paged-tree verification. Query rows are flattened
+    // sequence-major; row mappings are supplied through
+    // paged_query_seq_ids, while parent/tree metadata describes each tree.
+    ggml_tensor * paged_tree_parent_ids = nullptr,
+    ggml_tensor * paged_tree_sizes = nullptr,
+    int tree_width = 0,
+    int tree_scratch_base = 0,
+    int tree_scratch_stride = 0,
+    int paged_logical_max_ctx = 0
 ) {
     const int head_dim = w.n_embd_head_k;
     const int n_head = w.n_head;
@@ -1228,9 +1252,13 @@ static ggml_tensor * build_full_attn_block(
         Kcur_T = ggml_turbo_wht(ctx, Kcur_T, 0);
     }
 
+    const bool paged_tree = paged_tree_parent_ids || paged_tree_sizes;
+    GGML_ASSERT((paged_tree_parent_ids == nullptr) ==
+                (paged_tree_sizes == nullptr));
     const bool ragged = paged_query_seq_ids != nullptr;
-    GGML_ASSERT(!ragged || (paged_block_table && paged_query_positions &&
-                            kv_write_rows));
+    GGML_ASSERT(!ragged || (paged_block_table && kv_write_rows));
+    GGML_ASSERT(!ragged || paged_tree || paged_query_positions);
+    GGML_ASSERT(!paged_tree || (ragged && tree_width > 0));
     if (kv_write_rows) {
         // Step-invariant: the destination tensor stays fixed while the input
         // indices carry contiguous, KVFlash, or paged physical rows.
@@ -1296,12 +1324,31 @@ static ggml_tensor * build_full_attn_block(
                           ggml_tensor * row_seq_ids,
                           ggml_tensor * row_positions,
                           bool dense_token_layout) {
-        const int padded = ((std::max(1, launch_kv_len) + 255) / 256) * 256;
-        const int launch_len = std::min(padded, (int)cache_k->ne[1]);
+        // max_kv_seq_len sizes the logical partition grid. Paged serving can
+        // map that logical range onto a much smaller physical K/V pool, so
+        // cache_k->ne[1] is not a valid clamp.
+        // Bound against both sources of logical capacity instead, doing the
+        // 256-window rounding in i64 to avoid signed overflow at large
+        // configured contexts. Per-row kv_seq_lens remains the exact runtime
+        // bound, and the paged kernel bounds every resolved physical row.
+        GGML_ASSERT(paged_block_table && cache_k && cache_v);
+        const int64_t table_capacity =
+            (int64_t)paged_block_table->ne[0] * PAGED_BLOCK_SIZE;
+        const int64_t logical_capacity =
+            std::min<int64_t>(paged_logical_max_ctx, table_capacity);
+        GGML_ASSERT(logical_capacity > 0 && logical_capacity <= INT32_MAX);
+        const int64_t requested =
+            std::min<int64_t>(std::max<int64_t>(1, launch_kv_len),
+                              logical_capacity);
+        const int64_t padded = ((requested + 255) / 256) * 256;
+        const int launch_len =
+            (int)std::min<int64_t>(padded, logical_capacity);
         ggml_tensor * out = ggml_paged_attn_ext(
             ctx, q, cache_k, cache_v, paged_block_table,
             paged_kv_seq_lens, row_seq_ids, row_positions, kq_scale,
-            PAGED_BLOCK_SIZE, launch_len);
+            PAGED_BLOCK_SIZE, launch_len,
+            paged_tree_parent_ids, paged_tree_sizes,
+            tree_width, tree_scratch_base, tree_scratch_stride);
         if (dense_token_layout) {
             out = ggml_cont(ctx, ggml_permute(ctx, out, 0, 2, 1, 3));
         }
@@ -1309,7 +1356,20 @@ static ggml_tensor * build_full_attn_block(
     };
 
     ggml_tensor * attn = nullptr;
-    if (ragged) {
+    if (paged_tree) {
+        // ── Packed concurrent tree verify. Every query row selects its
+        // physical sequence/scratch slab. The paged kernel combines the
+        // committed block-table prefix with only this node's ancestor chain.
+        // A mixed graph uses causal positions for the compact AR prefix and
+        // -1 for the tree tail; a pure tree keeps positions absent.
+        ggml_tensor * Qfa = q_segment(0, n_tokens);
+        if (q_fa_out) *q_fa_out = Qfa;
+        const int launch_kv_len = paged_max_kv_len > 0
+            ? paged_max_kv_len : kv_start + n_tokens;
+        attn = paged_read(Qfa, launch_kv_len,
+                          paged_query_seq_ids, paged_query_positions,
+                          /*dense_token_layout=*/n_tokens > 1);
+    } else if (ragged) {
         // ── Ragged concurrent step: prefill chunk rows and decode rows all
         // read the pool through one call, each row clamped to its own
         // inclusive position. This step's chunk rows are visible to their
@@ -1317,6 +1377,7 @@ static ggml_tensor * build_full_attn_block(
         // attention in the graph; cross-sequence isolation is structural
         // (each row's seq id selects its own block-table column).
         ggml_tensor * Qfa = q_segment(0, n_tokens);
+        if (q_fa_out) *q_fa_out = Qfa;
         const int launch_kv_len = paged_max_kv_len > 0 ? paged_max_kv_len
                                                        : kv_start + n_tokens;
         attn = paged_read(Qfa, launch_kv_len,
@@ -1338,8 +1399,8 @@ static ggml_tensor * build_full_attn_block(
         // bound only over-sizes the partition grid, and partitions past the
         // real length exit with a zero-weight sentinel.
         // Batched decode: kv_len (kv_start + n_tokens) describes one sequence;
-        // the launch bound must cover the longest live slot instead. Clamped
-        // because ggml_paged_attn asserts max_kv_seq_len <= k->ne[1].
+        // the launch bound must cover the longest live slot instead. Bounded
+        // paged pools may be physically smaller than this logical span.
         const int launch_kv_len = paged_max_kv_len > 0 ? paged_max_kv_len : kv_len;
         attn = paged_read(
             Qfa, launch_kv_len, active_slot_ids, /*row_positions=*/nullptr,
@@ -1446,6 +1507,7 @@ static ggml_tensor * build_delta_net_block(
     int n_prefill_segments = 0,
     ggml_tensor * active_slot_ids = nullptr,
     ggml_tensor * state_slot_ids = nullptr,
+    int mapped_ar_seqs = 0,
     bool allow_inplace_state = false,
     // SpecLA topology masks (all three non-null together): route the
     // recurrence through the topology-masked factor-capture verify.
@@ -1475,14 +1537,34 @@ static ggml_tensor * build_delta_net_block(
         prefill_total += prefill_segments[i].n_tokens;
     }
     GGML_ASSERT((active_slot_ids == nullptr) == (state_slot_ids == nullptr));
+    const bool mapped_tree = active_slot_ids && parent_ids;
+    GGML_ASSERT(mapped_ar_seqs >= 0);
+    GGML_ASSERT(mapped_ar_seqs == 0 || mapped_tree);
+    GGML_ASSERT(!active_slot_ids || !cap ||
+                (!cap->ssm_intermediate_states && !cap->conv_input));
     GGML_ASSERT(!active_slot_ids ||
-                (!cap && !parent_ids && prefill_total + n_seqs == n_tokens));
+                (mapped_tree
+                     ? (!ragged && prefill_total == 0 &&
+                        n_tokens >= mapped_ar_seqs &&
+                        (n_tokens - mapped_ar_seqs) % n_seqs == 0 &&
+                        active_slot_ids->ne[0] ==
+                            mapped_ar_seqs + n_seqs &&
+                        state_slot_ids->ne[0] ==
+                            mapped_ar_seqs + n_seqs)
+                     : (mapped_ar_seqs == 0 &&
+                        prefill_total + n_seqs == n_tokens)));
     if (!active_slot_ids) {
         GGML_ASSERT(n_seqs == 1);
         GGML_ASSERT(prefill_total == 0 || prefill_total == n_tokens);
     }
     GGML_ASSERT(!ragged || (!cap && !parent_ids));
-    const bool can_skip_gdn_intermediate = skip_gdn_intermediate && !parent_ids && !cap;
+
+    // Row slices of stacked projections are strided for multi-token inputs.
+    // Materialize only the small beta/alpha slices; qkv keeps its explicit
+    // column stride and z is made contiguous at the final per-segment gate.
+    auto contig = [&](ggml_tensor * t) {
+        return ggml_is_contiguous(t) ? t : ggml_cont(ctx, t);
+    };
     // Fully factorized SpecLA fallback: the current candidates do not mutate
     // durable state. The HLD route below may materialize the *previously*
     // accepted pending path while keeping current candidates speculative.
@@ -1495,12 +1577,6 @@ static ggml_tensor * build_delta_net_block(
         specla_max_parallel_chains > 0;
     GGML_ASSERT(!(use_specla_factorized || use_specla_hld) ||
                 (n_seqs == 1 && !ragged && !active_slot_ids));
-
-    // Row-slices of a stacked projection are only contiguous for a single
-    // token; wider batches (verify/prefill) need a copy before reshape/unary.
-    auto contig = [&](ggml_tensor * t) {
-        return ggml_is_contiguous(t) ? t : ggml_cont(ctx, t);
-    };
 
     // ── Whole-batch projections ─────────────────────────────────────
     // qkv_mixed = wqkv @ cur           [10240, n_tokens]
@@ -1525,16 +1601,16 @@ static ggml_tensor * build_delta_net_block(
     // alpha = ssm_alpha @ cur          [dt_rank, n_tokens]
     // One GEMV over the stacked (beta | alpha) alias when available.
     ggml_tensor * beta_2d = nullptr;
-    ggml_tensor * alpha = nullptr;
+    ggml_tensor * alpha_2d = nullptr;
     const bool stacked_ba = L.ssm_ba && L.ssm_beta_s == 1.0f && L.ssm_alpha_s == 1.0f;
     if (stacked_ba) {
         ggml_tensor * ba = ggml_mul_mat(ctx, L.ssm_ba, cur);     // [2 * dt_rank, n_tokens]
         const size_t e = ggml_element_size(ba);
         beta_2d = contig(ggml_view_2d(ctx, ba, num_v_heads, n_tokens, ba->nb[1], 0));
-        alpha   = contig(ggml_view_2d(ctx, ba, num_v_heads, n_tokens, ba->nb[1], (size_t)num_v_heads * e));
+        alpha_2d = contig(ggml_view_2d(ctx, ba, num_v_heads, n_tokens, ba->nb[1], (size_t)num_v_heads * e));
     } else {
         beta_2d = apply_scale2(ctx, ggml_mul_mat(ctx, L.ssm_beta, cur), L.ssm_beta_s);
-        alpha   = apply_scale2(ctx, ggml_mul_mat(ctx, L.ssm_alpha, cur), L.ssm_alpha_s);
+        alpha_2d = apply_scale2(ctx, ggml_mul_mat(ctx, L.ssm_alpha, cur), L.ssm_alpha_s);
     }
 
     // Fused kernels (single-sequence chain path only): the conv step and the
@@ -1556,26 +1632,6 @@ static ggml_tensor * build_delta_net_block(
         const char * s_env = std::getenv("DFLASH27B_CHUNKED");
         return s_env && std::atoi(s_env) == 1;
     }();
-    const bool chunked_call = chunked_env_on && can_skip_gdn_intermediate && !ragged &&
-        !active_slot_ids && !use_specla_factorized && !use_specla_hld && n_tokens > 1;
-    const bool fused_plain = fused_kernels_env && fused_kernel_backend &&
-                             !parent_ids && !ragged && !active_slot_ids &&
-                             !use_specla_factorized && !use_specla_hld;
-    const bool fused_conv  = fused_plain;
-    const bool raw_gates   = fused_plain && !chunked_call && L.ssm_gate_ba != nullptr;
-
-    // beta = sigmoid(beta); g = softplus(alpha + ssm_dt_bias) * ssm_a
-    // (-A_log.exp() * softplus). In raw-gate mode the GDN kernel applies both
-    // itself (dt_bias / A are attached via ggml_gated_delta_net_set_raw_gates).
-    ggml_tensor * g_2d = nullptr;
-    if (raw_gates) {
-        g_2d = alpha;
-    } else {
-        beta_2d = ggml_sigmoid(ctx, beta_2d);
-        alpha = ggml_add(ctx, alpha, L.ssm_dt_bias);
-        alpha = ggml_softplus(ctx, alpha);
-        g_2d = ggml_mul(ctx, alpha, L.ssm_a);
-    }
 
     // ── Token-axis segments: prompt chunks first, then the decode batch ──
     struct DeltaSeg {
@@ -1583,8 +1639,11 @@ static ggml_tensor * build_delta_net_block(
         int T;                    // timesteps per sequence
         int S;                    // sequences
         bool active;              // compact decode segment (slot-mapped)
+        bool tree;                // mapped tree: gather-only, no persistence
         ggml_tensor * conv_st;
         ggml_tensor * ssm_st;
+        ggml_tensor * active_ids;
+        ggml_tensor * state_ids;
     };
     std::vector<DeltaSeg> segs;
     segs.reserve((size_t)n_prefill_segments + 1);
@@ -1600,14 +1659,35 @@ static ggml_tensor * build_delta_net_block(
             ssm_state->ne[0], ssm_state->ne[1], ssm_state->ne[2], 1,
             ssm_state->nb[1], ssm_state->nb[2], ssm_state->nb[3],
             (size_t)pf.seq_slot * ssm_state->nb[3]);
-        segs.push_back({pf.token_offset, pf.n_tokens, 1, false, c, s});
+        segs.push_back({pf.token_offset, pf.n_tokens, 1,
+                        false, false, c, s, nullptr, nullptr});
     }
     if (active_slot_ids) {
-        segs.push_back({prefill_total, 1, n_seqs, true,
-                        conv_state, ssm_state});
+        if (mapped_tree && mapped_ar_seqs > 0) {
+            ggml_tensor * ar_active = ggml_view_1d(
+                ctx, active_slot_ids, mapped_ar_seqs, 0);
+            ggml_tensor * ar_state = ggml_view_1d(
+                ctx, state_slot_ids, mapped_ar_seqs, 0);
+            segs.push_back({0, 1, mapped_ar_seqs, true, false,
+                            conv_state, ssm_state, ar_active, ar_state});
+        }
+        const int tree_tokens = mapped_tree
+            ? (n_tokens - mapped_ar_seqs) / n_seqs : 1;
+        const size_t slot_offset =
+            (size_t)mapped_ar_seqs * active_slot_ids->nb[0];
+        ggml_tensor * segment_active = mapped_ar_seqs > 0
+            ? ggml_view_1d(ctx, active_slot_ids, n_seqs, slot_offset)
+            : active_slot_ids;
+        ggml_tensor * segment_state = mapped_ar_seqs > 0
+            ? ggml_view_1d(ctx, state_slot_ids, n_seqs, slot_offset)
+            : state_slot_ids;
+        segs.push_back({prefill_total + mapped_ar_seqs, tree_tokens,
+                        n_seqs, true, mapped_tree, conv_state, ssm_state,
+                        segment_active, segment_state});
     } else if (segs.empty()) {
         // No general [timesteps x sequences] mode: one multi-token sequence.
-        segs.push_back({0, n_tokens, n_seqs, false, conv_state, ssm_state});
+        segs.push_back({0, n_tokens, n_seqs, false, false,
+                        conv_state, ssm_state, nullptr, nullptr});
     }
     const int n_segs = (int)segs.size();
 
@@ -1627,13 +1707,20 @@ static ggml_tensor * build_delta_net_block(
     const int seg_seqs     = seg.S;
     const int seg_tokens   = seg.T * seg.S;
     const bool seg_active = seg.active;
+    const bool seg_tree = seg.tree;
+    DeltaNetCapture * seg_cap = mapped_tree
+        ? (seg_tree ? cap : nullptr) : cap;
+    ggml_tensor * seg_parent_ids = seg_tree ? parent_ids : nullptr;
+    const bool can_skip_gdn_intermediate =
+        skip_gdn_intermediate && !seg_parent_ids && !seg_cap;
     // Plain one-token decode has no in-graph consumer of the updated state:
     // the next graph evaluation is the first read. Write the final state
     // directly into its persistent slab and avoid materializing/copying a
     // second S_v x S_v x H_v state. The active-aware path also updates each
     // mapped physical slab directly; only its negative bucket-padding rows
     // use the result tensor's retained scratch state region.
-    const bool inplace_state = seg_active ||
+    const bool dense_chain = !ragged && !active_slot_ids && !seg_tree;
+    const bool inplace_state = (seg_active && !seg_tree) ||
         (allow_inplace_state && can_skip_gdn_intermediate &&
          !ragged && n_seq_tokens == 1);
 
@@ -1646,12 +1733,35 @@ static ggml_tensor * build_delta_net_block(
     if (use_specla_hld || use_specla_factorized) {
         qkv_mixed = contig(qkv_mixed);   // the SpecLA conv kernels raw-index x
     }
+    const bool use_chunked = chunked_env_on && can_skip_gdn_intermediate &&
+        !ragged && !active_slot_ids && !seg_tree &&
+        !use_specla_factorized && !use_specla_hld && n_seq_tokens > 1;
+    const bool fused_plain = fused_kernels_env && fused_kernel_backend &&
+        dense_chain &&
+        !parent_ids && !seg_parent_ids && !use_specla_factorized &&
+        !use_specla_hld;
+    const bool fused_conv = fused_plain;
+    const bool raw_gates = fused_plain && !use_chunked && L.ssm_gate_ba;
+
     ggml_tensor * beta = ggml_reshape_4d(ctx,
         seg_cols(beta_2d, seg.off, seg_tokens),
         1, num_v_heads, n_seq_tokens, seg_seqs);
-    ggml_tensor * g_tensor = ggml_reshape_4d(ctx,
-        seg_cols(g_2d, seg.off, seg_tokens),
-        1, num_v_heads, n_seq_tokens, seg_seqs);
+    ggml_tensor * alpha = ggml_reshape_3d(ctx,
+        seg_cols(alpha_2d, seg.off, seg_tokens),
+        num_v_heads, n_seq_tokens, seg_seqs);
+    ggml_tensor * g_tensor = nullptr;
+    if (raw_gates) {
+        // The kernel applies sigmoid(beta) and softplus(alpha + dt_bias) * A.
+        g_tensor = ggml_reshape_4d(
+            ctx, alpha, 1, num_v_heads, n_seq_tokens, seg_seqs);
+    } else {
+        beta = ggml_sigmoid(ctx, beta);
+        alpha = ggml_add(ctx, alpha, L.ssm_dt_bias);
+        alpha = ggml_softplus(ctx, alpha);
+        g_tensor = ggml_mul(ctx, alpha, L.ssm_a);
+        g_tensor = ggml_reshape_4d(
+            ctx, g_tensor, 1, num_v_heads, n_seq_tokens, seg_seqs);
+    }
 
     ggml_tensor * conv_out = nullptr;
     if (use_specla_hld) {
@@ -1678,7 +1788,7 @@ static ggml_tensor * build_delta_net_block(
         ggml_tensor * all_conv = ggml_reshape_2d(
             ctx, seg.conv_st, slab, seg.conv_st->ne[2]);
         ggml_tensor * gathered =
-            ggml_get_rows(ctx, all_conv, state_slot_ids);
+            ggml_get_rows(ctx, all_conv, seg.state_ids);
         conv_states_r = ggml_reshape_3d(
             ctx, gathered, w.ssm_d_conv - 1, conv_channels, seg_seqs);
     } else {
@@ -1686,74 +1796,77 @@ static ggml_tensor * build_delta_net_block(
             w.ssm_d_conv - 1, conv_channels, seg_seqs);
     }
 
-    if (fused_conv) {
+    if (fused_conv && !use_specla_factorized) {
         // One kernel: window = [conv_state | x], silu(conv), history
         // write-back, and (when capturing) the rollback window copy.
         ggml_tensor * ci_dst = nullptr;
-        if (cap && cap->conv_input) {
+        if (seg_cap && seg_cap->conv_input) {
             const int64_t ci_len = (w.ssm_d_conv - 1) + n_tokens;
-            ci_dst = (ci_len == cap->conv_input->ne[0])
-                ? cap->conv_input
-                : ggml_view_3d(ctx, cap->conv_input,
-                      ci_len, cap->conv_input->ne[1], cap->conv_input->ne[2],
-                      cap->conv_input->nb[1], cap->conv_input->nb[2], 0);
+            ci_dst = (ci_len == seg_cap->conv_input->ne[0])
+                ? seg_cap->conv_input
+                : ggml_view_3d(ctx, seg_cap->conv_input,
+                      ci_len, seg_cap->conv_input->ne[1], seg_cap->conv_input->ne[2],
+                      seg_cap->conv_input->nb[1], seg_cap->conv_input->nb[2], 0);
         }
         conv_out = ggml_ssm_conv_step(ctx, qkv_mixed, L.ssm_conv1d, conv_states_r, ci_dst);
     } else {
-    // qkv_mixed currently is [conv_channels, n_tokens, n_seqs]; we need
-    // [n_tokens, conv_channels, n_seqs] to concat on dim 0.
-    ggml_tensor * qkv_T = ggml_transpose(ctx, qkv_mixed);
+        // qkv_mixed currently is [conv_channels, n_tokens, n_seqs]; we need
+        // [n_tokens, conv_channels, n_seqs] to concat on dim 0.
+        ggml_tensor * qkv_T = ggml_transpose(ctx, qkv_mixed);
 
-    ggml_tensor * conv_input = ggml_concat(ctx, conv_states_r, qkv_T, 0);
-    // I0 domain: [0,K_conv-2] are prefix-history rows; tree token flat slot t
-    // (root-inclusive, including synthetic root t=0) is stored at
-    // conv_input row (K_conv-1)+t.
-    // conv_input: [kernel-1 + n_tokens, conv_channels, n_seqs]
+        ggml_tensor * conv_input = ggml_concat(ctx, conv_states_r, qkv_T, 0);
+        // I0 domain: [0,K_conv-2] are prefix-history rows; tree token flat slot t
+        // (root-inclusive, including synthetic root t=0) is stored at
+        // conv_input row (K_conv-1)+t.
+        // conv_input: [kernel-1 + n_tokens, conv_channels, n_seqs]
 
-    // For spec-decode rollback: copy the full conv_input into the persistent
-    // cache buffer via an in-graph ggml_cpy. This avoids marking conv_input as
-    // a graph output (which would force the gallocr to preserve its memory
-    // past graph_compute). After graph_compute, the cache buffer's data is
-    // always valid; the rollback code slices it at commit_n.
-    if (cap && cap->conv_input) {
-        if (use_specla_factorized) {
+        // For spec-decode rollback: copy the full conv_input into the persistent
+        // cache buffer via an in-graph ggml_cpy. This avoids marking conv_input as
+        // a graph output (which would force the gallocr to preserve its memory
+        // past graph_compute). After graph_compute, the cache buffer's data is
+        // always valid; the rollback code slices it at commit_n.
+        if (seg_cap && seg_cap->conv_input && use_specla_factorized) {
             // The consolidated SpecLA bank is [channels, layers, tokens].
             // Capture only the raw current inputs; the compatibility commit
             // shifts the durable K-1 window and appends accepted tokens.
-            GGML_ASSERT(qkv_mixed->ne[0] == cap->conv_input->ne[0]);
-            GGML_ASSERT(n_seq_tokens <= cap->conv_input->ne[1]);
-            ggml_tensor * dst = ggml_view_3d(ctx, cap->conv_input,
-                cap->conv_input->ne[0], n_seq_tokens, 1,
-                cap->conv_input->nb[1], cap->conv_input->nb[2], 0);
+            GGML_ASSERT(qkv_mixed->ne[0] == seg_cap->conv_input->ne[0]);
+            GGML_ASSERT(n_seq_tokens <= seg_cap->conv_input->ne[1]);
+            ggml_tensor * dst = ggml_view_3d(ctx, seg_cap->conv_input,
+                seg_cap->conv_input->ne[0], n_seq_tokens, 1,
+                seg_cap->conv_input->nb[1], seg_cap->conv_input->nb[2], 0);
             GGML_ASSERT(ggml_nelements(qkv_mixed) == ggml_nelements(dst));
             ggml_build_forward_expand(gf, ggml_cpy(ctx, qkv_mixed, dst));
-        } else {
+        } else if (seg_cap && seg_cap->conv_input) {
             // conv_input may be shorter than the pre-allocated cache
             // (e.g. during prefill when n_tokens < max_verify_tokens).
             // Copy into a matching-sized view of the cache destination.
             const int64_t ci_len = conv_input->ne[0];
             ggml_tensor * dst;
-            if (ci_len == cap->conv_input->ne[0]) {
-                dst = cap->conv_input;
+            if (ci_len == seg_cap->conv_input->ne[0]) {
+                dst = seg_cap->conv_input;
             } else {
-                dst = ggml_view_3d(ctx, cap->conv_input,
-                    ci_len, cap->conv_input->ne[1], cap->conv_input->ne[2],
-                    cap->conv_input->nb[1], cap->conv_input->nb[2], 0);
+                dst = ggml_view_3d(ctx, seg_cap->conv_input,
+                    ci_len, seg_cap->conv_input->ne[1], seg_cap->conv_input->ne[2],
+                    seg_cap->conv_input->nb[1], seg_cap->conv_input->nb[2], 0);
             }
             GGML_ASSERT(ggml_nelements(conv_input) == ggml_nelements(dst));
             ggml_build_forward_expand(gf, ggml_cpy(ctx, conv_input, dst));
         }
-    }
 
-    // ── Save the last (kernel-1) steps back to the conv state
-    //    SpecLA: skipped — the window is speculative; the commit path
-    //    shifts conv_state and appends the accepted raw inputs at commit time.
-    if (!use_specla_factorized) {
+        if (seg_cap && seg_tree && !seg_cap->conv_input) {
+            seg_cap->conv_input = conv_input;
+            ggml_set_output(seg_cap->conv_input);
+        }
+
+        // ── Save the last (kernel-1) steps back to conv_state
+        //    SpecLA factorized: skipped — the window is speculative; the
+        //    commit path shifts conv_state and appends accepted raw inputs.
         ggml_tensor * last_conv = ggml_view_3d(ctx, conv_input,
             w.ssm_d_conv - 1, conv_channels, seg_seqs,
             conv_input->nb[1], conv_input->nb[2],
             (conv_input->ne[0] - (w.ssm_d_conv - 1)) * ggml_element_size(conv_input));
-        if (seg_active) {
+        if (!use_specla_factorized) {
+          if (seg_active && !seg_tree) {
             const int64_t slab =
                 (int64_t)(w.ssm_d_conv - 1) * conv_channels;
             ggml_tensor * compact_last = ggml_reshape_2d(
@@ -1762,23 +1875,24 @@ static ggml_tensor * build_delta_net_block(
                 ctx, seg.conv_st, slab, seg.conv_st->ne[2]);
             ggml_build_forward_expand(
                 gf, ggml_set_rows_masked(
-                        ctx, all_conv, compact_last, active_slot_ids));
-        } else {
-            ggml_build_forward_expand(gf, ggml_cpy(ctx, last_conv, seg.conv_st));
+                        ctx, all_conv, compact_last, seg.active_ids));
+          } else if (!seg_tree) {
+            ggml_build_forward_expand(
+                gf, ggml_cpy(ctx, last_conv, seg.conv_st));
+          }
         }
-    }
 
-    // ── 1D conv + silu
-    //    Tree mode: use the parent-chain-aware variant so sibling nodes gather
-    //    their conv window from their actual tree parent instead of the DFS
-    //    predecessor. Without this, siblings get garbage logits (the conv
-    //    output would mix unrelated branches).
-    conv_out = parent_ids
-        ? ggml_ssm_conv_tree(ctx, conv_input, L.ssm_conv1d, parent_ids)
-        : ggml_ssm_conv     (ctx, conv_input, L.ssm_conv1d);
-    conv_out = ggml_silu(ctx, conv_out);
+        // ── 1D conv + silu
+        //    Tree mode: use the parent-chain-aware variant so sibling nodes gather
+        //    their conv window from their actual tree parent instead of the DFS
+        //    predecessor. Without this, siblings get garbage logits (the conv
+        //    output would mix unrelated branches).
+        conv_out = seg_parent_ids
+            ? ggml_ssm_conv_tree(ctx, conv_input, L.ssm_conv1d, seg_parent_ids)
+            : ggml_ssm_conv     (ctx, conv_input, L.ssm_conv1d);
+        conv_out = ggml_silu(ctx, conv_out);
     }
-    }
+    }  // !use_specla_hld
 
     // conv_out: [conv_channels, n_tokens, n_seqs]
     const int64_t q_offset = 0;
@@ -1831,21 +1945,36 @@ static ggml_tensor * build_delta_net_block(
     // produces); the chunked, compact-decode and SpecLA paths take the
     // materialized copies.
     if (num_k_heads != num_v_heads &&
-        (chunked_call || seg_active || use_specla_factorized || use_specla_hld)) {
+        (use_chunked || seg_active || use_specla_factorized || use_specla_hld)) {
         q_c = ggml_repeat_4d(ctx, q_c, head_k_dim, num_v_heads, n_seq_tokens, seg_seqs);
         k_c = ggml_repeat_4d(ctx, k_c, head_k_dim, num_v_heads, n_seq_tokens, seg_seqs);
     }
 
     // ── SSM state (recurrent): reshape to [S_v, S_v, H_v, n_seqs]
-    ggml_tensor * s = seg_active
-        ? seg.ssm_st
-        : ggml_reshape_4d(ctx, seg.ssm_st,
+    ggml_tensor * s = nullptr;
+    if (seg_tree) {
+        // Packed tree verification starts each tree from the owning slot's
+        // base state. Gather compact slabs, then leave the persistent tensor
+        // untouched; accepted paths are committed by later direct promotion.
+        const int64_t slab =
+            (int64_t)head_v_dim * head_v_dim * num_v_heads;
+        ggml_tensor * all_ssm = ggml_reshape_2d(
+            ctx, seg.ssm_st, slab, seg.ssm_st->ne[3]);
+        ggml_tensor * gathered =
+            ggml_get_rows(ctx, all_ssm, seg.state_ids);
+        s = ggml_reshape_4d(ctx, gathered,
             head_v_dim, head_v_dim, num_v_heads, seg_seqs);
+    } else {
+        s = seg_active
+            ? seg.ssm_st
+            : ggml_reshape_4d(ctx, seg.ssm_st,
+                head_v_dim, head_v_dim, num_v_heads, seg_seqs);
+    }
 
     // ── Fused Gated DeltaNet op — returns packed (output | new_state [| intermediates]).
     //    In tree mode, the kernel uses parent_ids to reload state at DFS
     //    branch transitions (ported from sglang's retrieve_parent_token path).
-    //    When `cap->ssm_intermediate_states` is present AND we are in tree
+    //    When `seg_cap->ssm_intermediate_states` is present AND we are in tree
     //    mode, use the _tree_persist variant: the kernel writes per-token
     //    intermediate states DIRECTLY into the persistent cache buffer,
     //    eliminating the downstream ggml_cpy that would otherwise copy them.
@@ -1861,10 +1990,10 @@ static ggml_tensor * build_delta_net_block(
     // path is never quantized. In tree mode, n_seq_tokens is root-inclusive and
     // flat slot t is persisted directly at ne[3] slot t.
     // Q8_0 intermediates fall through to the guarded legacy copy path below.
-    ggml_tensor * persist_inter = (cap && cap->ssm_intermediate_states
-                                   && (cap->ssm_intermediate_states->type == GGML_TYPE_F32
-                                       || cap->ssm_intermediate_states->type == GGML_TYPE_F16))
-        ? cap->ssm_intermediate_states
+    ggml_tensor * persist_inter = (seg_cap && seg_cap->ssm_intermediate_states
+                                   && (seg_cap->ssm_intermediate_states->type == GGML_TYPE_F32
+                                       || seg_cap->ssm_intermediate_states->type == GGML_TYPE_F16))
+        ? seg_cap->ssm_intermediate_states
         : nullptr;
 
     // Chunked delta-net path: chain-only (no parent_ids), no per-token
@@ -1875,11 +2004,6 @@ static ggml_tensor * build_delta_net_block(
     // default — port produces correct shape but slightly wrong final state,
     // causing AL degradation and loopy output. Set DFLASH27B_CHUNKED=1 to
     // opt in for A/B testing while debugging.
-    // Chunked delta-net path (opt-in via DFLASH27B_CHUNKED, chain-only, no
-    // capture): decided whole-batch above; a segment only qualifies with
-    // more than one timestep.
-    const bool use_chunked = chunked_call && n_seq_tokens > 1;
-
     ggml_tensor * output = nullptr;
 
     if (use_specla_hld) {
@@ -1939,14 +2063,14 @@ static ggml_tensor * build_delta_net_block(
         ggml_build_forward_expand(gf, ggml_cpy(ctx, r.new_state, s));
     } else {
     ggml_tensor * result;
-    if (seg_active) {
+    if (seg_active && !seg_tree) {
         result = ggml_gated_delta_net_active_inplace(
-            ctx, q_c, k_c, v_c, g_tensor, beta, s, active_slot_ids);
-    } else if (parent_ids) {
+            ctx, q_c, k_c, v_c, g_tensor, beta, s, seg.active_ids);
+    } else if (seg_parent_ids) {
         // Tree verify: _tree_persist wires src[7] internally.
         result = persist_inter
-            ? ggml_gated_delta_net_tree_persist(ctx, q_c, k_c, v_c, g_tensor, beta, s, parent_ids, persist_inter)
-            : ggml_gated_delta_net_tree(ctx, q_c, k_c, v_c, g_tensor, beta, s, parent_ids);
+            ? ggml_gated_delta_net_tree_persist(ctx, q_c, k_c, v_c, g_tensor, beta, s, seg_parent_ids, persist_inter)
+            : ggml_gated_delta_net_tree(ctx, q_c, k_c, v_c, g_tensor, beta, s, seg_parent_ids);
     } else {
         // Non-tree (chain/prefill). When capture is requested, set src[7] so
         // the kernel writes per-token intermediates directly to the persistent
@@ -1966,6 +2090,16 @@ static ggml_tensor * build_delta_net_block(
             ggml_gated_delta_net_set_raw_gates(result, L.ssm_gate_ba);
         }
     }
+    if (seg_cap && seg_tree) {
+        const int64_t journal_width =
+            g_tensor->ne[0] == head_v_dim ? 3*head_v_dim : 2*head_v_dim + 1;
+        seg_cap->transition_journal = ggml_new_tensor_4d(
+            ctx, GGML_TYPE_F32, journal_width, num_v_heads,
+            n_seq_tokens, seg_seqs);
+        ggml_set_output(seg_cap->transition_journal);
+        ggml_gated_delta_net_set_transition_journal(
+            result, seg_cap->transition_journal);
+    }
     if (can_skip_gdn_intermediate) {
         ggml_gated_delta_net_set_skip_intermediate(result, true);
     }
@@ -1980,7 +2114,7 @@ static ggml_tensor * build_delta_net_block(
         S_v * H_v * r_elt,
         S_v * H_v * n_seq_tokens * r_elt,
         0);
-    if (!inplace_state) {
+    if (!inplace_state && !seg_tree) {
         ggml_tensor * new_state = ggml_view_4d(ctx, result,
             S_v, S_v, H_v, seg_seqs,
             S_v * r_elt,
@@ -1988,8 +2122,8 @@ static ggml_tensor * build_delta_net_block(
             S_v * S_v * H_v * r_elt,
             S_v * H_v * n_seq_tokens * seg_seqs * r_elt);
 
-        // Persist new_state back to cache. Both compact active decode and the
-        // plain in-place AR path write state from the GDN kernel directly.
+        // Persist new_state back to cache. Mapped trees deliberately skip
+        // this branch: their gathered base state is read-only.
         ggml_build_forward_expand(gf, ggml_cpy(ctx, new_state, seg.ssm_st));
     }
 
@@ -2004,10 +2138,10 @@ static ggml_tensor * build_delta_net_block(
     // forces gallocr to preserve ~50 MB per layer × 48 layers of otherwise
     // transient memory and inflates graph_build by ~35 ms), we create a VIEW
     // into the intermediate region and ggml_cpy it into the persistent cache
-    // buffer cap->ssm_intermediate_states. The gallocr is unaware of the
+    // buffer seg_cap->ssm_intermediate_states. The gallocr is unaware of the
     // persistent cache, so verify_build stays cheap. Matches SGLang's
     // mamba_caches.intermediate_ssm pattern.
-    if (cap && cap->ssm_intermediate_states && !persist_inter) {
+    if (seg_cap && seg_cap->ssm_intermediate_states && !persist_inter) {
         // This path is only reachable when the intermediate buffer is a type
         // persist routing can't handle (persist requires F32/F16; the cache
         // allocates F16, so this is normally dead). If the result tensor has no
@@ -2016,7 +2150,7 @@ static ggml_tensor * build_delta_net_block(
         GGML_ABORT(
             "non-tree GDN intermediate capture requires an F32/F16 persist buffer "
             "(got type %d); use F16 intermediates (the default) or the tree-verify path.",
-            (int)cap->ssm_intermediate_states->type);
+            (int)seg_cap->ssm_intermediate_states->type);
     }
     }
 
@@ -2185,7 +2319,7 @@ QwenGraphOutputs build_qwen35_graph(
     // If the caller requested capture, size the output list to the total delta-
     // net layer count so we can index by dn_idx as we iterate the layers.
     QwenGraphOutputs og_early{};
-    if (in.capture_delta_intermediate) {
+    if (in.capture_delta_intermediate || in.capture_tree_commit) {
         const int n_full_attn = w.n_layer / w.full_attention_interval;
         const int n_delta     = w.n_layer - n_full_attn;
         og_early.delta_captures.resize(n_delta);
@@ -2200,6 +2334,14 @@ QwenGraphOutputs build_qwen35_graph(
 
     const int hidden = w.n_embd;
     const float eps  = w.rms_eps;
+    const bool capture_with_rows =
+        in.capture_layers && cache.target_feat && in.target_feat_rows;
+    const bool capture_tree_features =
+        in.capture_layers && in.capture_tree_commit && cache.target_feat;
+    std::vector<ggml_tensor *> capture_slices;
+    if (capture_with_rows || capture_tree_features) {
+        capture_slices.assign((size_t)N_CAPTURE, nullptr);
+    }
 
     for (int il = 0; il < w.n_layer; il++) {
         const TargetLayer & L = w.layers[il];
@@ -2229,7 +2371,13 @@ QwenGraphOutputs build_qwen35_graph(
                                         in.paged_query_seq_ids,
                                         in.paged_query_positions,
                                         in.paged_max_kv_len,
-                                        in.active_slot_ids);
+                                        in.active_slot_ids,
+                                        in.parent_ids,
+                                        in.tree_sizes,
+                                        in.tree_width,
+                                        in.tree_scratch_base,
+                                        in.tree_scratch_stride,
+                                        cache.max_ctx);
             if (want_q_cap && q_fa) {
                 // Last token's Q, all heads: src [head_dim, 1, n_head] view of
                 // [head_dim, n_tokens, n_head]; dst = q_cap plane fa_idx
@@ -2248,37 +2396,39 @@ QwenGraphOutputs build_qwen35_graph(
             fa_idx++;
         } else {
             DeltaNetCapture * cap_ptr = nullptr;
-            if (in.capture_delta_intermediate) {
+            if (in.capture_delta_intermediate || in.capture_tree_commit) {
                 cap_ptr = &og_early.delta_captures[dn_idx];
                 // Point at the persistent per-layer cache buffers so
                 // build_delta_net_block can ggml_cpy into them during graph
                 // execution. The caller (test_dflash.cpp spec loop) reads from
                 // these tensors post-compute; their ->data pointers are always
                 // valid because they're cache-resident, not gallocr-managed.
-                cap_ptr->ssm_intermediate_states = cache.ssm_intermediate[dn_idx];
-                cap_ptr->conv_input              = cache.conv_input_cache[dn_idx];
-                if (!cache.factor_k.empty()) {
-                    const bool pending_alt = cache.specla_pending_bank != 0;
-                    cap_ptr->pending_factor_k = pending_alt
-                        ? cache.factor_k_alt[dn_idx] : cache.factor_k[dn_idx];
-                    cap_ptr->pending_factor_v_new = pending_alt
-                        ? cache.factor_v_new_alt[dn_idx] : cache.factor_v_new[dn_idx];
-                    cap_ptr->pending_factor_g = pending_alt
-                        ? cache.factor_g_ps_alt[dn_idx] : cache.factor_g_ps[dn_idx];
-                    cap_ptr->pending_conv_input = pending_alt
-                        ? cache.conv_input_cache_alt[dn_idx] : cache.conv_input_cache[dn_idx];
-                    cap_ptr->factor_k = pending_alt
-                        ? cache.factor_k[dn_idx] : cache.factor_k_alt[dn_idx];
-                    cap_ptr->factor_v_new = pending_alt
-                        ? cache.factor_v_new[dn_idx] : cache.factor_v_new_alt[dn_idx];
-                    cap_ptr->factor_g_ps = pending_alt
-                        ? cache.factor_g_ps[dn_idx] : cache.factor_g_ps_alt[dn_idx];
-                    cap_ptr->conv_input = pending_alt
-                        ? cache.conv_input_cache[dn_idx] : cache.conv_input_cache_alt[dn_idx];
-                    cap_ptr->factor_ptrs = cache.specla_factor_ptrs;
-                    cap_ptr->factor_n_layers = (int)cache.factor_k.size();
-                    cap_ptr->factor_layer = dn_idx;
-                    cap_ptr->pending_bank = cache.specla_pending_bank;
+                if (in.capture_delta_intermediate) {
+                    cap_ptr->ssm_intermediate_states = cache.ssm_intermediate[dn_idx];
+                    cap_ptr->conv_input              = cache.conv_input_cache[dn_idx];
+                    if (!cache.factor_k.empty()) {
+                        const bool pending_alt = cache.specla_pending_bank != 0;
+                        cap_ptr->pending_factor_k = pending_alt
+                            ? cache.factor_k_alt[dn_idx] : cache.factor_k[dn_idx];
+                        cap_ptr->pending_factor_v_new = pending_alt
+                            ? cache.factor_v_new_alt[dn_idx] : cache.factor_v_new[dn_idx];
+                        cap_ptr->pending_factor_g = pending_alt
+                            ? cache.factor_g_ps_alt[dn_idx] : cache.factor_g_ps[dn_idx];
+                        cap_ptr->pending_conv_input = pending_alt
+                            ? cache.conv_input_cache_alt[dn_idx] : cache.conv_input_cache[dn_idx];
+                        cap_ptr->factor_k = pending_alt
+                            ? cache.factor_k[dn_idx] : cache.factor_k_alt[dn_idx];
+                        cap_ptr->factor_v_new = pending_alt
+                            ? cache.factor_v_new[dn_idx] : cache.factor_v_new_alt[dn_idx];
+                        cap_ptr->factor_g_ps = pending_alt
+                            ? cache.factor_g_ps[dn_idx] : cache.factor_g_ps_alt[dn_idx];
+                        cap_ptr->conv_input = pending_alt
+                            ? cache.conv_input_cache[dn_idx] : cache.conv_input_cache_alt[dn_idx];
+                        cap_ptr->factor_ptrs = cache.specla_factor_ptrs;
+                        cap_ptr->factor_n_layers = (int)cache.factor_k.size();
+                        cap_ptr->factor_layer = dn_idx;
+                        cap_ptr->pending_bank = cache.specla_pending_bank;
+                    }
                 }
             }
             ggml_tensor * conv_st = cache.conv_state[dn_idx];
@@ -2311,6 +2461,7 @@ QwenGraphOutputs build_qwen35_graph(
                                         in.n_prefill_segments,
                                         in.active_slot_ids,
                                         in.state_slot_ids,
+                                        in.mapped_ar_seqs,
                                         /*allow_inplace_state=*/
                                             in.n_prefill_tokens == 0,
                                         in.specla_m_strict, in.specla_m_incl,
@@ -2351,14 +2502,19 @@ QwenGraphOutputs build_qwen35_graph(
                 if (CAPTURE_LAYERS[k] == il) { capture_idx = k; break; }
             }
             if (capture_idx >= 0) {
+                ggml_tensor * cur_2d =
+                    ggml_reshape_2d(ctx, cur, hidden, n_tokens);
+                if (capture_with_rows || capture_tree_features) {
+                    capture_slices[(size_t)capture_idx] = cur_2d;
+                    inpL = cur;
+                    continue;
+                }
                 const size_t elt        = ggml_element_size(cache.target_feat);
                 const size_t col_stride = cache.target_feat->nb[1];
                 const int    cap        = cache.target_feat_cap;
                 const int    slot_start = in.kv_start % cap;
                 const int    pre_n      = std::min(n_tokens, cap - slot_start);
                 const int    post_n    = n_tokens - pre_n;
-
-                ggml_tensor * cur_2d = ggml_reshape_2d(ctx, cur, hidden, n_tokens);
 
                 // First slice: [slot_start..slot_start+pre_n) in the ring.
                 {
@@ -2387,6 +2543,28 @@ QwenGraphOutputs build_qwen35_graph(
         }
 
         inpL = cur;
+    }
+
+    if (capture_with_rows || capture_tree_features) {
+        GGML_ASSERT(!capture_slices.empty());
+        ggml_tensor * feat_cat = capture_slices[0];
+        GGML_ASSERT(feat_cat);
+        for (int k = 1; k < (int)capture_slices.size(); ++k) {
+            GGML_ASSERT(capture_slices[(size_t)k]);
+            feat_cat = ggml_concat(
+                ctx, feat_cat, capture_slices[(size_t)k], 0);
+        }
+        feat_cat = ggml_cont(ctx, feat_cat);
+        if (capture_tree_features) {
+            og_early.tree_features = ggml_cast(ctx, feat_cat, GGML_TYPE_BF16);
+            ggml_set_output(og_early.tree_features);
+            ggml_build_forward_expand(gf, og_early.tree_features);
+        } else {
+            ggml_build_forward_expand(
+                gf, ggml_set_rows(
+                        ctx, cache.target_feat, feat_cat,
+                        in.target_feat_rows));
+        }
     }
 
     // 2. Final norm

--- a/server/src/qwen35/qwen35_target_graph.cpp
+++ b/server/src/qwen35/qwen35_target_graph.cpp
@@ -2095,18 +2095,13 @@ static ggml_tensor * build_delta_net_block(
             ggml_gated_delta_net_set_raw_gates(result, L.ssm_gate_ba);
         }
     }
-    if (seg_cap && seg_tree) {
-        const int64_t journal_width =
-            g_tensor->ne[0] == head_v_dim ? 3*head_v_dim : 2*head_v_dim + 1;
-        seg_cap->transition_journal = ggml_new_tensor_4d(
-            ctx, GGML_TYPE_F32, journal_width, num_v_heads,
-            n_seq_tokens, seg_seqs);
-        ggml_set_output(seg_cap->transition_journal);
-        ggml_gated_delta_net_set_transition_journal(
-            result, seg_cap->transition_journal);
-    }
     if (can_skip_gdn_intermediate) {
         ggml_gated_delta_net_set_skip_intermediate(result, true);
+    }
+    if (seg_cap && seg_tree) {
+        seg_cap->transition_journal =
+            ggml_gated_delta_net_capture_transition_journal(ctx, result);
+        ggml_set_output(seg_cap->transition_journal);
     }
 
     // Slice output and new_state out of the packed result

--- a/server/src/qwen35/qwen35_target_graph.cpp
+++ b/server/src/qwen35/qwen35_target_graph.cpp
@@ -2102,6 +2102,7 @@ static ggml_tensor * build_delta_net_block(
         seg_cap->transition_journal =
             ggml_gated_delta_net_capture_transition_journal(ctx, result);
         ggml_set_output(seg_cap->transition_journal);
+        ggml_build_forward_expand(gf, seg_cap->transition_journal);
     }
 
     // Slice output and new_state out of the packed result

--- a/server/src/qwen35/qwen35_target_graph.cpp
+++ b/server/src/qwen35/qwen35_target_graph.cpp
@@ -323,7 +323,7 @@ bool create_target_cache_partial(const TargetWeights & w,
     // ── Rollback context: snapshots + intermediates ───────────────────
     // Multi-slot caches skip these entirely. Fixed chain verification keeps
     // speculative recurrent transitions in graph scratch and promotes only
-    // accepted prefixes through the compact GPU journal.
+    // accepted prefixes through the compact GPU replay log.
     if (!prefill_only && !multi_slot) {
         const int rb_tensors = 4 * n_delta;
         ggml_init_params ip{};
@@ -2100,10 +2100,10 @@ static ggml_tensor * build_delta_net_block(
         ggml_gated_delta_net_set_skip_intermediate(result, true);
     }
     if (seg_cap && seg_tree) {
-        seg_cap->transition_journal =
-            ggml_gated_delta_net_capture_transition_journal(ctx, result);
-        ggml_set_output(seg_cap->transition_journal);
-        ggml_build_forward_expand(gf, seg_cap->transition_journal);
+        seg_cap->replay_log =
+            ggml_gated_delta_net_capture_replay_log(ctx, result);
+        ggml_set_output(seg_cap->replay_log);
+        ggml_build_forward_expand(gf, seg_cap->replay_log);
     }
 
     // Slice output and new_state out of the packed result

--- a/server/src/qwen35/qwen35_target_graph.cpp
+++ b/server/src/qwen35/qwen35_target_graph.cpp
@@ -1343,12 +1343,17 @@ static ggml_tensor * build_full_attn_block(
         const int64_t padded = ((requested + 255) / 256) * 256;
         const int launch_len =
             (int)std::min<int64_t>(padded, logical_capacity);
-        ggml_tensor * out = ggml_paged_attn_ext(
-            ctx, q, cache_k, cache_v, paged_block_table,
-            paged_kv_seq_lens, row_seq_ids, row_positions, kq_scale,
-            PAGED_BLOCK_SIZE, launch_len,
-            paged_tree_parent_ids, paged_tree_sizes,
-            tree_width, tree_scratch_base, tree_scratch_stride);
+        ggml_tensor * out = paged_tree
+            ? ggml_paged_attn_ext_tree(
+                ctx, q, cache_k, cache_v, paged_block_table,
+                paged_kv_seq_lens, row_seq_ids, row_positions, kq_scale,
+                PAGED_BLOCK_SIZE, launch_len,
+                paged_tree_parent_ids, paged_tree_sizes,
+                tree_scratch_base, tree_scratch_stride)
+            : ggml_paged_attn_ext(
+                ctx, q, cache_k, cache_v, paged_block_table,
+                paged_kv_seq_lens, row_seq_ids, row_positions, kq_scale,
+                PAGED_BLOCK_SIZE, launch_len);
         if (dense_token_layout) {
             out = ggml_cont(ctx, ggml_permute(ctx, out, 0, 2, 1, 3));
         }

--- a/server/src/qwen35/qwen35_target_graph.cpp
+++ b/server/src/qwen35/qwen35_target_graph.cpp
@@ -1715,7 +1715,8 @@ static ggml_tensor * build_delta_net_block(
     const bool seg_tree = seg.tree;
     DeltaNetCapture * seg_cap = mapped_tree
         ? (seg_tree ? cap : nullptr) : cap;
-    ggml_tensor * seg_parent_ids = seg_tree ? parent_ids : nullptr;
+    ggml_tensor * seg_parent_ids = mapped_tree
+        ? (seg_tree ? parent_ids : nullptr) : parent_ids;
     const bool can_skip_gdn_intermediate =
         skip_gdn_intermediate && !seg_parent_ids && !seg_cap;
     // Plain one-token decode has no in-graph consumer of the updated state:
@@ -2373,7 +2374,7 @@ QwenGraphOutputs build_qwen35_graph(
                                         in.paged_query_positions,
                                         in.paged_max_kv_len,
                                         in.active_slot_ids,
-                                        in.parent_ids,
+                                        in.tree_sizes ? in.parent_ids : nullptr,
                                         in.tree_sizes,
                                         in.tree_width,
                                         in.tree_scratch_base,

--- a/server/src/server/scheduler.cpp
+++ b/server/src/server/scheduler.cpp
@@ -618,7 +618,8 @@ void HttpServer::scheduler_loop(SeqEngine & engine) {
         for (int i = 0; i < n_slots; i++) {
             if (slots[(size_t)i].job && !slots[(size_t)i].prefilling) {
                 step_plan.decode.push_back(
-                    {i, slots[(size_t)i].pending_tok});
+                    {i, slots[(size_t)i].pending_tok,
+                     slots[(size_t)i].hook.close_token_ids.empty()});
             } else if (slots[(size_t)i].job) {
                 prefill_candidates.push_back(
                     {i, slots[(size_t)i].admission_order});
@@ -666,7 +667,11 @@ void HttpServer::scheduler_loop(SeqEngine & engine) {
                 s.finished = true;
                 continue;
             }
-            advance_slot(s, out.token);
+            consume_decode_output_tokens(out, [&](int32_t token) {
+                if (s.finished) return false;
+                advance_slot(s, token);
+                return !s.finished;
+            });
         }
         using PrefillStatus = SeqEngine::PrefillOutput::Status;
         for (const auto & out : step_result.prefills) {

--- a/server/src/server/server_main.cpp
+++ b/server/src/server/server_main.cpp
@@ -733,6 +733,7 @@ int main(int argc, char ** argv) {
         sconfig.pflash_mode != ServerConfig::PflashMode::OFF;
     backend_features.pflash_drafter_configured =
         !sconfig.pflash_drafter_path.empty();
+    backend_features.draft_residency = sconfig.draft_residency;
     backend_features.routing_stats_requested =
         sconfig.freq_tracking || !sconfig.collect_routing_path.empty();
     backend_features.adaptive_experts_requested = adaptive_experts_set;

--- a/server/test/test_batched_gdn.cpp
+++ b/server/test/test_batched_gdn.cpp
@@ -48,6 +48,52 @@ constexpr size_t CONV_WEIGHT_ELEMS = static_cast<size_t>(D_CONV) * CONV_CHANNELS
 bool check(const char * name, const float * batched, const float * reference,
            size_t count);
 
+bool test_cpu_gdn_support_matrix(ggml_backend_t backend) {
+    ggml_init_params params{};
+    params.mem_size = 2 * 1024 * 1024;
+    params.no_alloc = true;
+    ggml_context * ctx = ggml_init(params);
+    if (!ctx) return false;
+
+    constexpr int n_tokens = 2;
+    ggml_tensor * q = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F32, S_V, N_HEAD, n_tokens, 1);
+    ggml_tensor * k = ggml_dup_tensor(ctx, q);
+    ggml_tensor * v = ggml_dup_tensor(ctx, q);
+    ggml_tensor * g = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F32, 1, N_HEAD, n_tokens, 1);
+    ggml_tensor * beta = ggml_dup_tensor(ctx, g);
+    ggml_tensor * state = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F32, S_V, S_V, N_HEAD, 1);
+    ggml_tensor * parents = ggml_new_tensor_1d(
+        ctx, GGML_TYPE_I32, n_tokens);
+    ggml_tensor * persistent = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F32, S_V, S_V, N_HEAD, n_tokens);
+    ggml_tensor * active_slots = ggml_new_tensor_1d(
+        ctx, GGML_TYPE_I32, 1);
+
+    ggml_tensor * base = ggml_gated_delta_net(
+        ctx, q, k, v, g, beta, state);
+    ggml_tensor * inplace = ggml_gated_delta_net_inplace(
+        ctx, q, k, v, g, beta, state);
+    ggml_tensor * active = ggml_gated_delta_net_active_inplace(
+        ctx, q, k, v, g, beta, state, active_slots);
+    ggml_tensor * tree = ggml_gated_delta_net_tree(
+        ctx, q, k, v, g, beta, state, parents);
+    ggml_tensor * tree_persistent = ggml_gated_delta_net_tree_persist(
+        ctx, q, k, v, g, beta, state, parents, persistent);
+
+    const bool ok =
+        ggml_backend_supports_op(backend, base) &&
+        ggml_backend_supports_op(backend, inplace) &&
+        ggml_backend_supports_op(backend, active) &&
+        !ggml_backend_supports_op(backend, tree) &&
+        !ggml_backend_supports_op(backend, tree_persistent);
+    std::printf("batched gdn CPU support matrix %s\n", ok ? "PASS" : "FAIL");
+    ggml_free(ctx);
+    return ok;
+}
+
 void fill_uniform(std::mt19937 & rng, float lo, float hi,
                   std::vector<float> & values) {
     std::uniform_real_distribution<float> dist(lo, hi);
@@ -592,7 +638,8 @@ int main(int argc, char ** argv) {
     }
 
     std::mt19937 rng(20260728);
-    bool ok = test_gdn_sequential(backend, rng, /*inplace_batched=*/false);
+    bool ok = !cpu || test_cpu_gdn_support_matrix(backend);
+    ok = test_gdn_sequential(backend, rng, /*inplace_batched=*/false) && ok;
     ok = test_gdn_sequential(backend, rng, /*inplace_batched=*/true) && ok;
     ok = test_gdn_active_slots(backend, rng) && ok;
     ok = test_conv(backend, rng) && ok;

--- a/server/test/test_chain_spec_shapes.cpp
+++ b/server/test/test_chain_spec_shapes.cpp
@@ -9,6 +9,17 @@ using namespace dflash::common;
 static int g_checks = 0;
 
 int main() {
+    const DDTree root_only = make_dspark_chain_tree({10});
+    CHECK(root_only.n_nodes == 0);
+    CHECK((root_only.parents == std::vector<int>{-1}));
+    CHECK(root_only.child_maps.size() == 1);
+    CHECK((root_only.visibility == std::vector<uint8_t>{1}));
+    int root_pending = -1;
+    const int32_t root_posterior[] = {11};
+    CHECK((follow_verified_tree(
+        root_only, root_posterior, root_pending) == std::vector<int>{0}));
+    CHECK(root_pending == 11);
+
     const std::vector<int32_t> draft = {10, 11, 12, 13};
     const DDTree tree = make_chain_verify_tree(draft);
     CHECK(tree.n_nodes == 3);

--- a/server/test/test_chain_spec_shapes.cpp
+++ b/server/test/test_chain_spec_shapes.cpp
@@ -1,0 +1,89 @@
+#include "common/concurrency/chain_spec_shapes.h"
+#include "host_check.h"
+
+#include <cstdio>
+#include <vector>
+
+using namespace dflash::common;
+
+static int g_checks = 0;
+
+int main() {
+    const std::vector<int32_t> draft = {10, 11, 12, 13};
+    const DDTree tree = make_chain_verify_tree(draft);
+    CHECK(tree.n_nodes == 3);
+    CHECK((tree.token_ids == std::vector<int32_t>{11, 12, 13}));
+    CHECK((tree.depths == std::vector<int>{1, 2, 3}));
+    CHECK((tree.parents == std::vector<int>{-1, 0, 1, 2}));
+
+    const std::vector<int> bucket_inputs = {
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 12, 13, 16, 17,
+    };
+    const std::vector<int> bucket_expected = {
+        1, 2, 3, 4, 6, 6, 8, 8, 12, 12, 16, 16, 24,
+    };
+    for (size_t i = 0; i < bucket_inputs.size(); ++i) {
+        CHECK(chain_decode_bucket_width(bucket_inputs[i]) ==
+              bucket_expected[i]);
+    }
+
+    int pending = -1;
+    const int32_t full_posterior[] = {11, 12, 13, 14};
+    std::vector<int> accepted =
+        follow_verified_tree(tree, full_posterior, pending);
+    CHECK((accepted == std::vector<int>{0, 1, 2, 3}));
+    CHECK(pending == 14);
+
+    const int32_t rejected_posterior[] = {11, 99, 13, 14};
+    accepted = follow_verified_tree(tree, rejected_posterior, pending);
+    CHECK((accepted == std::vector<int>{0, 1}));
+    CHECK(pending == 99);
+
+    CHECK(truncate_verified_path(
+        accepted, 1, rejected_posterior, pending));
+    CHECK((accepted == std::vector<int>{0}));
+    CHECK(pending == 11);
+
+    const ChainLaunchShape mixed = chain_launch_shape(
+        {1, 0, 1, 0, 0, 0}, {4, 0, 2, 0, 0, 0}, 16);
+    CHECK(mixed.spec_lanes == 2);
+    CHECK(mixed.tree_bucket == 2);
+    CHECK(mixed.tree_rows == 32);
+    CHECK(mixed.ar_lanes == 4);
+    CHECK(mixed.accepted_rows == 6);
+    CHECK(mixed.commit_rows == 10);
+
+    const ChainLaunchShape all_spec = chain_launch_shape(
+        {1, 1, 1}, {1, 2, 3}, 16);
+    CHECK(all_spec.tree_bucket == 3);
+    CHECK(all_spec.ar_lanes == 0);
+    CHECK(all_spec.commit_rows == 6);
+
+    const ChainLaunchShape ar_after_spec_failures = chain_launch_shape(
+        {0, 0}, {0, 0}, 16);
+    CHECK(ar_after_spec_failures.spec_lanes == 0);
+    CHECK(ar_after_spec_failures.tree_bucket == 0);
+    CHECK(ar_after_spec_failures.tree_rows == 0);
+    CHECK(ar_after_spec_failures.ar_lanes == 2);
+    CHECK(ar_after_spec_failures.commit_rows == 2);
+
+    const auto eos = [](int32_t token) { return token == 2; };
+    const std::vector<int32_t> eos_first_child = {10, 2, 11};
+    CHECK(chain_min_tokens_safe_prefix(
+        eos_first_child, 0, 3, eos) == 1);
+    CHECK(chain_min_tokens_safe_prefix(
+        eos_first_child, 2, 3, eos) == 2);
+    const std::vector<int32_t> eos_second_child = {10, 11, 2, 12};
+    CHECK(chain_min_tokens_safe_prefix(
+        eos_second_child, 0, 3, eos) == 2);
+    CHECK(chain_min_tokens_safe_prefix(
+        eos_second_child, 1, 3, eos) == 3);
+    const std::vector<int32_t> eos_root = {2, 11, 12};
+    CHECK(chain_min_tokens_safe_prefix(
+        eos_root, 0, 3, eos) == eos_root.size());
+    CHECK(chain_min_tokens_safe_prefix(
+        eos_first_child, 0, 0, eos) == 2);
+
+    std::printf("chain spec shape tests passed: %d checks\n", g_checks);
+    return 0;
+}

--- a/server/test/test_chain_spec_shapes.cpp
+++ b/server/test/test_chain_spec_shapes.cpp
@@ -9,7 +9,7 @@ using namespace dflash::common;
 static int g_checks = 0;
 
 int main() {
-    const DDTree root_only = make_dspark_chain_tree({10});
+    const DDTree root_only = make_chain_verify_tree({10});
     CHECK(root_only.n_nodes == 0);
     CHECK((root_only.parents == std::vector<int>{-1}));
     CHECK(root_only.child_maps.size() == 1);

--- a/server/test/test_ddtree_path.cpp
+++ b/server/test/test_ddtree_path.cpp
@@ -1,0 +1,44 @@
+#include "common/ddtree.h"
+#include "host_check.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+using dflash::common::DDTree;
+using dflash::common::follow_verified_tree;
+using dflash::common::truncate_verified_path;
+
+static int g_checks = 0;
+
+int main() {
+    DDTree tree;
+    tree.n_nodes = 2;
+    tree.token_ids = {11, 22};
+    tree.depths = {1, 2};
+    tree.parents = {-1, 0, 1};
+    tree.child_maps.resize(3);
+    tree.child_maps[0][11] = 1;
+    tree.child_maps[1][22] = 2;
+
+    const int32_t posterior[] = {11, 22, 33};
+    int pending = -1;
+    std::vector<int> accepted =
+        follow_verified_tree(tree, posterior, pending);
+    CHECK((accepted == std::vector<int>{0, 1, 2}));
+    CHECK(pending == 33);
+
+    CHECK(truncate_verified_path(accepted, 2, posterior, pending));
+    CHECK((accepted == std::vector<int>{0, 1}));
+    CHECK(pending == 22);
+
+    CHECK(!truncate_verified_path(accepted, 2, posterior, pending));
+    CHECK(pending == 22);
+
+    CHECK(truncate_verified_path(accepted, 0, posterior, pending));
+    CHECK(accepted.empty());
+    CHECK(pending == -1);
+
+    std::puts("ddtree path tests passed");
+    return 0;
+}

--- a/server/test/test_dflash.cpp
+++ b/server/test/test_dflash.cpp
@@ -28,6 +28,7 @@
 #include "qwen3_drafter.h"
 #include "gpu_runtime_compat.h"
 #include "chain_rollback_policy.h"
+#include "draft_swa.h"
 #include "platform_env.h"
 #include "laguna_daemon.h"  // arch dispatch - laguna targets are served by
                             // dflash::common::run_laguna_daemon() instead of the
@@ -442,13 +443,10 @@ static int run_target_layer_split_harness(
                         (dp.size() >= 5 && dp.substr(dp.size() - 5) == ".gguf")
                             ? "gguf" : "safetensors");
             if (g_draft_swa_window > 0) {
-                draft_weights.swa_window = g_draft_swa_window;
-                for (int il = 0; il < draft_weights.n_layer - 1; il++) {
-                    draft_weights.layers[il].is_swa = true;
-                }
+                const DraftSwaOverrideResult swa =
+                    apply_draft_swa_window_override(draft_weights, g_draft_swa_window);
                 std::printf("[target-split] draft SWA layers: %d/%d (window=%d)\n",
-                            draft_weights.n_layer - 1, draft_weights.n_layer,
-                            draft_weights.swa_window);
+                            swa.swa_layers, swa.total_layers, swa.effective_window);
             }
             if (!draft_feature_mirror_init(feature_ring, draft_backend,
                                            draft_gpu, draft_gpu, cap,
@@ -1282,14 +1280,12 @@ int main(int argc, char ** argv) {
         return 2;
     }
 
-    // Apply --draft-swa=N: mark layers 0..n-2 as SWA, last layer stays full.
+    // Apply the runtime window while preserving checkpoint layer metadata.
     if (g_draft_swa_window > 0) {
-        dw.swa_window = g_draft_swa_window;
-        for (int il = 0; il < dw.n_layer - 1; il++) {
-            dw.layers[il].is_swa = true;
-        }
+        const DraftSwaOverrideResult swa =
+            apply_draft_swa_window_override(dw, g_draft_swa_window);
         std::printf("[draft]  SWA layers: %d/%d (window=%d)\n",
-                    dw.n_layer - 1, dw.n_layer, dw.swa_window);
+                    swa.swa_layers, swa.total_layers, swa.effective_window);
     }
 
     const int max_ctx = g_max_ctx_override > 0
@@ -2375,9 +2371,7 @@ int main(int argc, char ** argv) {
                         stream_emit(-1); continue;
                     }
                     if (g_draft_swa_window > 0) {
-                        dw.swa_window = g_draft_swa_window;
-                        for (int il = 0; il < dw.n_layer - 1; il++)
-                            dw.layers[il].is_swa = true;
+                        apply_draft_swa_window_override(dw, g_draft_swa_window);
                     }
                     draft_parked = false;
                     std::printf("[unpark] draft restored\n"); std::fflush(stdout);
@@ -2487,9 +2481,7 @@ int main(int argc, char ** argv) {
                         stream_emit(-1); continue;
                     }
                     if (g_draft_swa_window > 0) {
-                        dw.swa_window = g_draft_swa_window;
-                        for (int il = 0; il < dw.n_layer - 1; il++)
-                            dw.layers[il].is_swa = true;
+                        apply_draft_swa_window_override(dw, g_draft_swa_window);
                     }
                     draft_parked = false;
                     std::printf("[compress] draft restored\n"); std::fflush(stdout);

--- a/server/test/test_dflash2_selector_validation.cpp
+++ b/server/test/test_dflash2_selector_validation.cpp
@@ -28,23 +28,16 @@ int main() {
     CHECK(validate_dflash2_selector_layout(layout, error));
     CHECK(error.empty());
 
-    for (int K = 1; K <= 8; ++K) {
+    for (int K : {1, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17}) {
         layout = valid_layout();
         layout.top_k = K;
         CHECK(validate_dflash2_selector_layout(layout, error));
     }
-    for (int K : {12, 16}) {
-        layout = valid_layout();
-        layout.top_k = K;
-        CHECK(validate_dflash2_selector_layout(layout, error));
-    }
-    for (int K : {0, 9, 10, 11, 13, 14, 15, 17}) {
-        layout = valid_layout();
-        layout.top_k = K;
-        CHECK(!validate_dflash2_selector_layout(layout, error));
-        CHECK(error.find("top_k=") != std::string::npos);
-        CHECK(error.find("unsupported") != std::string::npos);
-    }
+
+    layout = valid_layout();
+    layout.top_k = 0;
+    CHECK(!validate_dflash2_selector_layout(layout, error));
+    CHECK(error.find("top_k must be positive") != std::string::npos);
 
     layout = valid_layout();
     layout.succ_vocab--;
@@ -73,6 +66,7 @@ int main() {
     layout.succ_vocab = 8;
     layout.target_output_vocab = 0;
     layout.target_declared_vocab = 0;
+    layout.top_k = 9;
     CHECK(!validate_dflash2_selector_layout(layout, error));
     CHECK(error.find("exceeds codebook vocab") != std::string::npos);
 

--- a/server/test/test_dflash2_selector_validation.cpp
+++ b/server/test/test_dflash2_selector_validation.cpp
@@ -1,0 +1,86 @@
+#include "common/dflash2_selector_validation.h"
+#include "host_check.h"
+
+#include <cstdio>
+#include <string>
+
+using namespace dflash::common;
+
+static int g_checks = 0;
+
+static DFlash2SelectorLayout valid_layout() {
+    DFlash2SelectorLayout layout;
+    layout.rank = 32;
+    layout.top_k = 16;
+    layout.hproj_rank = 32;
+    layout.pred_rank = 32;
+    layout.pred_vocab = 151936;
+    layout.succ_rank = 32;
+    layout.succ_vocab = 151936;
+    layout.target_output_vocab = 151936;
+    layout.target_declared_vocab = 151936;
+    return layout;
+}
+
+int main() {
+    std::string error;
+    DFlash2SelectorLayout layout = valid_layout();
+    CHECK(validate_dflash2_selector_layout(layout, error));
+    CHECK(error.empty());
+
+    for (int K = 1; K <= 8; ++K) {
+        layout = valid_layout();
+        layout.top_k = K;
+        CHECK(validate_dflash2_selector_layout(layout, error));
+    }
+    for (int K : {12, 16}) {
+        layout = valid_layout();
+        layout.top_k = K;
+        CHECK(validate_dflash2_selector_layout(layout, error));
+    }
+    for (int K : {0, 9, 10, 11, 13, 14, 15, 17}) {
+        layout = valid_layout();
+        layout.top_k = K;
+        CHECK(!validate_dflash2_selector_layout(layout, error));
+        CHECK(error.find("top_k=") != std::string::npos);
+        CHECK(error.find("unsupported") != std::string::npos);
+    }
+
+    layout = valid_layout();
+    layout.succ_vocab--;
+    CHECK(!validate_dflash2_selector_layout(layout, error));
+    CHECK(error.find("codebook vocab mismatch") != std::string::npos);
+
+    layout = valid_layout();
+    layout.target_output_vocab--;
+    CHECK(!validate_dflash2_selector_layout(layout, error));
+    CHECK(error.find("target vocab mismatch") != std::string::npos);
+
+    layout = valid_layout();
+    layout.target_declared_vocab = 0;
+    layout.target_output_vocab--;
+    CHECK(!validate_dflash2_selector_layout(layout, error));
+    CHECK(error.find("target output/lm_head") != std::string::npos);
+
+    layout = valid_layout();
+    layout.target_output_vocab = 0;
+    layout.target_declared_vocab--;
+    CHECK(!validate_dflash2_selector_layout(layout, error));
+    CHECK(error.find("target.n_vocab") != std::string::npos);
+
+    layout = valid_layout();
+    layout.pred_vocab = 8;
+    layout.succ_vocab = 8;
+    layout.target_output_vocab = 0;
+    layout.target_declared_vocab = 0;
+    CHECK(!validate_dflash2_selector_layout(layout, error));
+    CHECK(error.find("exceeds codebook vocab") != std::string::npos);
+
+    layout = valid_layout();
+    layout.succ_rank = 31;
+    CHECK(!validate_dflash2_selector_layout(layout, error));
+    CHECK(error.find("rank mismatch") != std::string::npos);
+
+    std::printf("dflash2 selector validation: %d checks passed\n", g_checks);
+    return 0;
+}

--- a/server/test/test_draft_swa.cpp
+++ b/server/test/test_draft_swa.cpp
@@ -1,0 +1,101 @@
+#include "CppUnitTestFramework.hpp"
+#include "common/draft_swa.h"
+#include "internal.h"
+
+#include <initializer_list>
+#include <vector>
+
+using namespace dflash::common;
+
+namespace {
+
+struct DraftSwaFixture {};
+
+DraftWeights make_weights(std::initializer_list<bool> pattern,
+                          bool pattern_loaded,
+                          int window) {
+    DraftWeights weights;
+    weights.n_layer = static_cast<int>(pattern.size());
+    weights.layers.resize(pattern.size());
+    weights.swa_window = window;
+    weights.swa_pattern_loaded = pattern_loaded;
+    size_t index = 0;
+    for (bool is_swa : pattern) {
+        weights.layers[index++].is_swa = is_swa;
+    }
+    return weights;
+}
+
+std::vector<bool> layer_pattern(const DraftWeights & weights) {
+    std::vector<bool> pattern;
+    pattern.reserve(weights.layers.size());
+    for (const DraftLayer & layer : weights.layers) {
+        pattern.push_back(layer.is_swa);
+    }
+    return pattern;
+}
+
+} // namespace
+
+TEST_CASE(DraftSwaFixture, override_preserves_loaded_mixed_pattern) {
+    DraftWeights weights = make_weights({true, false, true, false}, true, 1024);
+
+    const DraftSwaOverrideResult result =
+        apply_draft_swa_window_override(weights, 2048);
+
+    CHECK(layer_pattern(weights) == std::vector<bool>({true, false, true, false}));
+    CHECK(weights.swa_window == 2048);
+    CHECK(result.effective_window == 2048);
+    CHECK(result.swa_layers == 2);
+    CHECK(result.total_layers == 4);
+    CHECK(!result.inferred_legacy_pattern);
+}
+
+TEST_CASE(DraftSwaFixture, override_preserves_loaded_all_full_pattern) {
+    DraftWeights weights = make_weights({false, false, false}, true, 1024);
+
+    const DraftSwaOverrideResult result =
+        apply_draft_swa_window_override(weights, 2048);
+
+    CHECK(layer_pattern(weights) == std::vector<bool>({false, false, false}));
+    CHECK(result.swa_layers == 0);
+    CHECK(!result.inferred_legacy_pattern);
+}
+
+TEST_CASE(DraftSwaFixture, override_infers_legacy_pattern_when_metadata_is_missing) {
+    DraftWeights weights = make_weights({false, false, false, false, false}, false, 0);
+
+    const DraftSwaOverrideResult result =
+        apply_draft_swa_window_override(weights, 2048);
+
+    CHECK(layer_pattern(weights) == std::vector<bool>({true, true, true, true, false}));
+    CHECK(result.swa_layers == 4);
+    CHECK(result.total_layers == 5);
+    CHECK(result.inferred_legacy_pattern);
+}
+
+TEST_CASE(DraftSwaFixture, nonpositive_override_is_a_noop) {
+    DraftWeights weights = make_weights({false, false, false}, false, 0);
+
+    const DraftSwaOverrideResult result =
+        apply_draft_swa_window_override(weights, 0);
+
+    CHECK(layer_pattern(weights) == std::vector<bool>({false, false, false}));
+    CHECK(weights.swa_window == 0);
+    CHECK(result.swa_layers == 0);
+    CHECK(!result.inferred_legacy_pattern);
+}
+
+TEST_CASE(DraftSwaFixture, override_is_idempotent) {
+    DraftWeights weights = make_weights({false, false, false}, false, 0);
+    apply_draft_swa_window_override(weights, 2048);
+    const std::vector<bool> first_pattern = layer_pattern(weights);
+
+    const DraftSwaOverrideResult result =
+        apply_draft_swa_window_override(weights, 4096);
+
+    CHECK(layer_pattern(weights) == first_pattern);
+    CHECK(weights.swa_window == 4096);
+    CHECK(result.swa_layers == 2);
+    CHECK(!result.inferred_legacy_pattern);
+}

--- a/server/test/test_draft_swa_multilane.cpp
+++ b/server/test/test_draft_swa_multilane.cpp
@@ -1,0 +1,218 @@
+#include "common/dflash_draft_kv.h"
+#include "common/draft_swa.h"
+#include "internal.h"
+
+#include "ggml-backend.h"
+#include "ggml-cuda.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <cstdio>
+#include <vector>
+
+using namespace dflash::common;
+
+namespace {
+
+constexpr int N_LANES = 3;
+constexpr int CAPACITY = 160;
+constexpr int SWA_WINDOW = 64;
+constexpr uint16_t F16_ZERO = 0x0000;
+constexpr uint16_t F16_NEG_INF = 0xFC00;
+constexpr float MAX_ABS_ERROR = 5.0e-4f;
+
+struct Resources {
+    ggml_backend_t backend = nullptr;
+    DraftWeights weights;
+    std::array<DraftKvState, N_LANES> states;
+    DraftKvBatchGraph batch;
+
+    ~Resources() {
+        draft_kv_batch_free(batch);
+        for (DraftKvState & state : states) {
+            draft_kv_free(state);
+        }
+        free_draft_weights(weights);
+        if (backend) {
+            ggml_backend_free(backend);
+        }
+    }
+};
+
+std::vector<bool> layer_pattern(const DraftWeights & weights) {
+    std::vector<bool> pattern;
+    pattern.reserve(weights.layers.size());
+    for (const DraftLayer & layer : weights.layers) {
+        pattern.push_back(layer.is_swa);
+    }
+    return pattern;
+}
+
+bool check_lane_mask(const DraftKvState & state, int committed) {
+    const int window_start = committed - SWA_WINDOW;
+    for (int query = 0; query < state.q_len; ++query) {
+        const size_t row = static_cast<size_t>(query) * state.kv_total;
+        for (int slot = 0; slot < state.cap; ++slot) {
+            const int position = state.slot_pos[static_cast<size_t>(slot)];
+            const bool visible =
+                position >= window_start && position < committed;
+            const uint16_t expected = visible ? F16_ZERO : F16_NEG_INF;
+            if (state.mask_hbuf[row + static_cast<size_t>(slot)] != expected) {
+                std::fprintf(stderr,
+                    "lane mask mismatch committed=%d query=%d slot=%d pos=%d\n",
+                    committed, query, slot, position);
+                return false;
+            }
+        }
+        for (int noise = 0; noise < state.q_len; ++noise) {
+            const uint16_t expected = noise <= query ? F16_ZERO : F16_NEG_INF;
+            if (state.mask_hbuf[
+                    row + static_cast<size_t>(state.cap + noise)] != expected) {
+                std::fprintf(stderr,
+                    "lane causal mask mismatch committed=%d query=%d noise=%d\n",
+                    committed, query, noise);
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+float max_abs_diff(const std::vector<float> & lhs,
+                   const std::vector<float> & rhs) {
+    if (lhs.size() != rhs.size()) {
+        return INFINITY;
+    }
+    float max_diff = 0.0f;
+    for (size_t index = 0; index < lhs.size(); ++index) {
+        if (!std::isfinite(lhs[index]) || !std::isfinite(rhs[index])) {
+            return INFINITY;
+        }
+        max_diff = std::max(max_diff, std::fabs(lhs[index] - rhs[index]));
+    }
+    return max_diff;
+}
+
+} // namespace
+
+int main(int argc, char ** argv) {
+    if (argc == 1) {
+        std::fprintf(stderr,
+            "usage: %s <dflash2.gguf> [gpu]\n", argv[0]);
+        return 77;
+    }
+    if (argc > 3) {
+        return 2;
+    }
+
+    const int gpu = argc == 3 ? std::atoi(argv[2]) : 0;
+    Resources resources;
+    resources.backend = ggml_backend_cuda_init(gpu);
+    if (!resources.backend) {
+        std::fprintf(stderr, "draft SWA qualification: GPU %d unavailable\n", gpu);
+        return 1;
+    }
+    if (!load_draft_gguf(argv[1], resources.backend, resources.weights)) {
+        std::fprintf(stderr, "draft SWA qualification: %s\n",
+                     dflash27b_last_error());
+        return 1;
+    }
+
+    const std::vector<bool> trained_pattern = layer_pattern(resources.weights);
+    if (!resources.weights.swa_pattern_loaded) {
+        std::fprintf(stderr, "draft SWA qualification: GGUF has no SWA pattern\n");
+        return 1;
+    }
+    const DraftSwaOverrideResult swa =
+        apply_draft_swa_window_override(resources.weights, SWA_WINDOW);
+    if (layer_pattern(resources.weights) != trained_pattern ||
+        swa.effective_window != SWA_WINDOW || swa.swa_layers == 0) {
+        std::fprintf(stderr,
+            "draft SWA qualification: override changed the trained pattern\n");
+        return 1;
+    }
+
+    const std::array<int, N_LANES> committed = {65, 81, 133};
+    const size_t hidden_elements =
+        static_cast<size_t>(resources.weights.n_embd) *
+        static_cast<size_t>(resources.weights.block_size);
+    std::array<std::vector<float>, N_LANES> single_hidden;
+    DraftFeatureMirror unused_ring;
+
+    for (int lane = 0; lane < N_LANES; ++lane) {
+        DraftKvState & state = resources.states[static_cast<size_t>(lane)];
+        if (!draft_kv_init(state, resources.weights, resources.backend,
+                           CAPACITY, nullptr)) {
+            std::fprintf(stderr, "draft SWA qualification: lane %d init failed\n", lane);
+            return 1;
+        }
+        for (int position = 0; position < committed[static_cast<size_t>(lane)];
+             ++position) {
+            state.slot_pos[static_cast<size_t>(position % CAPACITY)] = position;
+        }
+        state.next_pos = committed[static_cast<size_t>(lane)];
+        if (!draft_kv_begin_step(
+                state, resources.weights, resources.backend, unused_ring,
+                committed[static_cast<size_t>(lane)]) ||
+            !check_lane_mask(state, committed[static_cast<size_t>(lane)])) {
+            return 1;
+        }
+
+        std::vector<float> embedding(hidden_elements);
+        for (size_t index = 0; index < embedding.size(); ++index) {
+            embedding[index] =
+                0.01f * static_cast<float>(lane + 1) +
+                0.0001f * static_cast<float>(index % 31);
+        }
+        ggml_backend_tensor_set(state.inp_embed, embedding.data(), 0,
+                                embedding.size() * sizeof(float));
+        if (ggml_backend_graph_compute(resources.backend, state.gf) !=
+            GGML_STATUS_SUCCESS) {
+            std::fprintf(stderr,
+                         "draft SWA qualification: lane %d compute failed\n", lane);
+            return 1;
+        }
+        single_hidden[static_cast<size_t>(lane)].resize(hidden_elements);
+        ggml_backend_tensor_get(
+            state.hidden_states,
+            single_hidden[static_cast<size_t>(lane)].data(), 0,
+            hidden_elements * sizeof(float));
+    }
+
+    if (max_abs_diff(single_hidden[0], single_hidden[1]) <= MAX_ABS_ERROR) {
+        std::fprintf(stderr,
+            "draft SWA qualification: distinct lane inputs collapsed\n");
+        return 1;
+    }
+
+    std::vector<DraftKvState *> lane_states;
+    lane_states.reserve(N_LANES);
+    for (DraftKvState & state : resources.states) {
+        lane_states.push_back(&state);
+    }
+    std::vector<std::vector<float>> packed_hidden;
+    if (!draft_kv_batch_compute(resources.batch, resources.weights,
+                                resources.backend, lane_states, packed_hidden)) {
+        return 1;
+    }
+
+    for (int lane = 0; lane < N_LANES; ++lane) {
+        const float error = max_abs_diff(
+            single_hidden[static_cast<size_t>(lane)],
+            packed_hidden[static_cast<size_t>(lane)]);
+        std::printf("draft SWA lane=%d committed=%d max_abs=%.6g\n",
+                    lane, committed[static_cast<size_t>(lane)], error);
+        if (error > MAX_ABS_ERROR) {
+            std::fprintf(stderr,
+                "draft SWA qualification: lane %d exceeds tolerance %.6g\n",
+                lane, MAX_ABS_ERROR);
+            return 1;
+        }
+    }
+
+    std::printf("draft SWA post-window three-lane qualification passed\n");
+    return 0;
+}

--- a/server/test/test_draft_topk_cuda.cpp
+++ b/server/test/test_draft_topk_cuda.cpp
@@ -30,6 +30,7 @@
 
 using dflash::common::extract_draft_topk;
 using dflash::common::geometric_extract_draft_topk_cuda;
+using dflash::common::geometric_draft_topk_cuda_supports_k;
 
 namespace {
 
@@ -124,6 +125,28 @@ namespace {
 struct DraftTopkCudaFixture {};
 }
 
+TEST_CASE(DraftTopkCudaFixture, draft_topk_cuda_dispatch_contract_host_only) {
+    for (int K = -1; K <= 18; ++K) {
+        const bool expected = (K >= 1 && K <= 8) || K == 12 || K == 16;
+        CHECK(geometric_draft_topk_cuda_supports_k(K) == expected);
+    }
+
+    const void * invalid_device_pointer =
+        reinterpret_cast<const void *>(uintptr_t{1});
+    std::vector<float> log_probs(64, 123.0f);
+    std::vector<int32_t> token_ids(64, 456);
+    for (int K : {0, 9, 10, 11, 13, 14, 15, 17, 64}) {
+        CHECK(!geometric_extract_draft_topk_cuda(
+            invalid_device_pointer, 1, 128, K,
+            log_probs.data(), token_ids.data(), 1.0f));
+        CHECK(log_probs[0] == 123.0f);
+        CHECK(token_ids[0] == 456);
+    }
+    CHECK(!geometric_extract_draft_topk_cuda(
+        invalid_device_pointer, 1, 8, 16,
+        log_probs.data(), token_ids.data(), 1.0f));
+}
+
 TEST_CASE(DraftTopkCudaFixture, draft_topk_cuda_suite) {
     int dev_count = 0;
     if (cudaGetDeviceCount(&dev_count) != cudaSuccess || dev_count == 0) {
@@ -131,8 +154,6 @@ TEST_CASE(DraftTopkCudaFixture, draft_topk_cuda_suite) {
         return;
     }
 
-    // The kernel supports K up to kMaxK (=8 in geometric_draft_topk_cuda.cu); larger K is
-    // handled by a documented CPU fallback (returns false), checked separately.
     const Case cases[] = {
         // Realistic decode shape: Qwen3.5 vocab, small position batch.
         {15,  151936, 8,  1.0f},
@@ -145,6 +166,8 @@ TEST_CASE(DraftTopkCudaFixture, draft_topk_cuda_suite) {
         {3,   257,    8,  1.0f},    // vocab barely above K, non-power-of-two
         {1,   151936, 1,  1.0f},    // K=1 (argmax + log_z)
         {15,  151936, 4,  1.0f},
+        {3,   4096,   12, 1.0f},
+        {3,   4096,   16, 1.0f},
     };
 
     int failures = 0;
@@ -154,24 +177,25 @@ TEST_CASE(DraftTopkCudaFixture, draft_topk_cuda_suite) {
         idx++;
     }
 
-    // Fallback contract: K beyond the kernel's supported range must return false
-    // (not silently produce wrong output) so the caller can use the CPU path.
     {
-        const int n = 4, vocab = 4096, big_K = 64;
+        const int n = 4, vocab = 4096;
         std::vector<float> h(n * vocab, 0.f);
         float * d = nullptr;
         if (cudaMalloc(&d, h.size() * sizeof(float)) == cudaSuccess) {
             cudaMemcpy(d, h.data(), h.size() * sizeof(float), cudaMemcpyHostToDevice);
-            std::vector<float>   lp(n * big_K);
-            std::vector<int32_t> ids(n * big_K);
-            bool ret = geometric_extract_draft_topk_cuda(d, n, vocab, big_K,
-                                               lp.data(), ids.data(), 1.0f);
+            for (int K : {9, 10, 11, 13, 14, 15, 64}) {
+                std::vector<float>   lp((size_t)n * K);
+                std::vector<int32_t> ids((size_t)n * K);
+                bool ret = geometric_extract_draft_topk_cuda(
+                    d, n, vocab, K, lp.data(), ids.data(), 1.0f);
+                const bool pass = !ret;
+                printf("  [%s] unsupported K contract: K=%d returned %s\n",
+                       pass ? "PASS" : "FAIL", K,
+                       ret ? "true" : "false");
+                if (!pass) failures++;
+                idx++;
+            }
             cudaFree(d);
-            const bool pass = !ret;  // expect false
-            printf("  [%s] fallback contract: K=%d (>kMaxK) returned %s\n",
-                   pass ? "PASS" : "FAIL", big_K, ret ? "true" : "false");
-            if (!pass) failures++;
-            idx++;
         }
     }
 

--- a/server/test/test_feature_gate.cpp
+++ b/server/test/test_feature_gate.cpp
@@ -427,6 +427,18 @@ void test_feature_gate_paged_attention_allows_fixed_local_chains() {
     CHECK(gate_result(
         concurrent_chain, "qwen35", PlacementBackend::Hip).empty());
 
+    BackendFeatureConfig request_scoped;
+    request_scoped.draft_residency = DraftResidencyPolicy::RequestScoped;
+    CHECK(!gate_result(
+        concurrent_chain, "qwen35", PlacementBackend::Cuda,
+        request_scoped).empty());
+
+    BackendFeatureConfig persistent;
+    persistent.draft_residency = DraftResidencyPolicy::Persistent;
+    CHECK(gate_result(
+        concurrent_chain, "qwen35", PlacementBackend::Cuda,
+        persistent).empty());
+
     BackendArgs remote_chain = concurrent_chain;
     remote_chain.remote_draft.ipc_bin = "/usr/bin/draft-ipc";
     CHECK(!gate_result(

--- a/server/test/test_feature_gate.cpp
+++ b/server/test/test_feature_gate.cpp
@@ -411,7 +411,7 @@ void test_feature_gate_paged_attention_requires_qwen35_monolithic() {
     }
 }
 
-void test_feature_gate_paged_attention_requires_plain_ar_decode() {
+void test_feature_gate_paged_attention_allows_fixed_local_chains() {
     BackendArgs base;
     base.model_path = "/nonexistent/model.gguf";
     base.paged_attention = true;
@@ -419,6 +419,18 @@ void test_feature_gate_paged_attention_requires_plain_ar_decode() {
     BackendArgs draft = base;
     draft.draft_path = "/nonexistent/draft.gguf";
     CHECK(!gate_result(draft, "qwen35", PlacementBackend::Cuda).empty());
+
+    BackendArgs concurrent_chain = draft;
+    concurrent_chain.max_concurrency = 16;
+    CHECK(gate_result(
+        concurrent_chain, "qwen35", PlacementBackend::Cuda).empty());
+    CHECK(gate_result(
+        concurrent_chain, "qwen35", PlacementBackend::Hip).empty());
+
+    BackendArgs remote_chain = concurrent_chain;
+    remote_chain.remote_draft.ipc_bin = "/usr/bin/draft-ipc";
+    CHECK(!gate_result(
+        remote_chain, "qwen35", PlacementBackend::Cuda).empty());
 
     BackendArgs ddtree = base;
     ddtree.ddtree_mode = true;
@@ -523,6 +535,21 @@ void test_feature_gate_parallel_and_kv_pool_rules() {
     CHECK(!gate_result(pool, "qwen35", PlacementBackend::Cuda).empty());
     pool.kv_pool_tokens = max_pool_tokens;
     CHECK(gate_result(pool, "qwen35", PlacementBackend::Cuda).empty());
+
+    BackendArgs chain_pool = paged;
+    chain_pool.max_concurrency = 16;
+    chain_pool.draft_path = "/nonexistent/draft.gguf";
+    const long long chain_scratch =
+        (long long)chain_pool.max_concurrency * paged_token_capacity(16);
+    const long long max_chain_pool_tokens =
+        ((long long)INT_MAX - PAGED_BLOCK_SIZE - chain_scratch) /
+        PAGED_BLOCK_SIZE * PAGED_BLOCK_SIZE;
+    chain_pool.kv_pool_tokens = max_chain_pool_tokens;
+    CHECK(gate_result(
+        chain_pool, "qwen35", PlacementBackend::Hip).empty());
+    chain_pool.kv_pool_tokens = max_chain_pool_tokens + PAGED_BLOCK_SIZE;
+    CHECK(!gate_result(
+        chain_pool, "qwen35", PlacementBackend::Hip).empty());
 
     // The automatic pool is memory-derived, so a logical slot/context product
     // larger than the physical tensor address space is legal.
@@ -703,7 +730,7 @@ TEST_CASE(FeatureGateFixture, feature_gate_suite) {
     test_feature_gate_remote_draft_requires_supported_arch();
     test_feature_gate_layer_split_requires_supported_arch();
     test_feature_gate_paged_attention_requires_qwen35_monolithic();
-    test_feature_gate_paged_attention_requires_plain_ar_decode();
+    test_feature_gate_paged_attention_allows_fixed_local_chains();
     test_feature_gate_parallel_and_kv_pool_rules();
     test_feature_warnings_silent_when_supported();
     test_feature_warnings_report_inert_draft();

--- a/server/test/test_gdn_replay_log.cpp
+++ b/server/test/test_gdn_replay_log.cpp
@@ -77,7 +77,7 @@ size_t state_index(int slot, int head, int col, int row) {
     return (((size_t) slot*H + head)*S + col)*S + row;
 }
 
-size_t journal_index(
+size_t replay_log_index(
         int sequence, int token, int head, int width, int value) {
     return ((((size_t) sequence*T + token)*H + head)*width) + value;
 }
@@ -300,22 +300,22 @@ std::vector<float> ordinary_recurrence(
     return state;
 }
 
-std::vector<float> expected_journal(
+std::vector<float> expected_replay_log(
         const Inputs & in, bool kda, bool raw_gates) {
     const int gate_values = kda ? S : 1;
     const int width = gate_values + 2*S;
-    std::vector<float> journal((size_t) width*H*T*B);
+    std::vector<float> replay_log((size_t) width*H*T*B);
     std::vector<float> state = in.state;
     for (int sequence = 0; sequence < B; ++sequence) {
         for (int token = 0; token < T; ++token) {
             for (int head = 0; head < H; ++head) {
                 for (int row = 0; row < gate_values; ++row) {
-                    journal[journal_index(sequence, token, head, width, row)] =
+                    replay_log[replay_log_index(sequence, token, head, width, row)] =
                         resolved_gate(in, kda, raw_gates,
                                       sequence, token, head, row);
                 }
                 for (int row = 0; row < S; ++row) {
-                    journal[journal_index(
+                    replay_log[replay_log_index(
                         sequence, token, head, width,
                         gate_values + row)] =
                             in.k[key_index(sequence, token, head, row)];
@@ -338,7 +338,7 @@ std::vector<float> expected_journal(
                     const float delta =
                         (in.v[qkv_index(sequence, token, head, col)] -
                          (kda ? projection : scalar_gate*projection))*beta;
-                    journal[journal_index(
+                    replay_log[replay_log_index(
                         sequence, token, head, width,
                         gate_values + S + col)] = delta;
                     for (int row = 0; row < S; ++row) {
@@ -355,13 +355,13 @@ std::vector<float> expected_journal(
             }
         }
     }
-    return journal;
+    return replay_log;
 }
 
 struct CaseTensors {
     ggml_context * ctx = nullptr;
     ggml_backend_buffer_t buffer = nullptr;
-    ggml_tensor * journal = nullptr;
+    ggml_tensor * replay_log = nullptr;
     ggml_tensor * identity_state = nullptr;
     ggml_tensor * mapped_state = nullptr;
     ggml_tensor * conv_input = nullptr;
@@ -372,18 +372,18 @@ struct CaseTensors {
 };
 
 bool commit_many_one_layer(
-        const ggml_tensor * journal,
+        const ggml_tensor * replay_log,
         ggml_tensor * state,
         const ggml_tensor * conv_input,
         ggml_tensor * conv_state,
         const ggml_tensor * accepted,
         const ggml_tensor * slots) {
-    const ggml_tensor * journals[] = {journal};
+    const ggml_tensor * replay_logs[] = {replay_log};
     ggml_tensor * states[] = {state};
     const ggml_tensor * conv_inputs[] = {conv_input};
     ggml_tensor * conv_states[] = {conv_state};
-    return ggml_backend_cuda_gdn_transition_journal_commit_many(
-        journals, states, conv_inputs, conv_states, 1, accepted, slots);
+    return ggml_backend_cuda_gdn_replay_log_commit_many(
+        replay_logs, states, conv_inputs, conv_states, 1, accepted, slots);
 }
 
 void destroy(CaseTensors & tensors) {
@@ -445,11 +445,11 @@ bool run_case(ggml_backend_t backend, bool kda, bool raw_gates) {
     if (raw_gates) {
         ggml_gated_delta_net_set_raw_gates(result, gate_ba);
     }
-    tensors.journal =
-        ggml_gated_delta_net_capture_transition_journal(tensors.ctx, result);
-    ggml_set_output(tensors.journal);
+    tensors.replay_log =
+        ggml_gated_delta_net_capture_replay_log(tensors.ctx, result);
+    ggml_set_output(tensors.replay_log);
     ggml_cgraph * graph = ggml_new_graph(tensors.ctx);
-    ggml_build_forward_expand(graph, tensors.journal);
+    ggml_build_forward_expand(graph, tensors.replay_log);
 
     tensors.buffer = ggml_backend_alloc_ctx_tensors(tensors.ctx, backend);
     if (!tensors.buffer) {
@@ -481,14 +481,14 @@ bool run_case(ggml_backend_t backend, bool kda, bool raw_gates) {
     }
 
     bool ok = ggml_backend_graph_compute(backend, graph) == GGML_STATUS_SUCCESS;
-    std::vector<float> actual_journal((size_t) width*H*T*B);
+    std::vector<float> actual_replay_log((size_t) width*H*T*B);
     if (ok) {
         ggml_backend_tensor_get(
-            tensors.journal, actual_journal.data(), 0,
-            actual_journal.size()*sizeof(float));
+            tensors.replay_log, actual_replay_log.data(), 0,
+            actual_replay_log.size()*sizeof(float));
         ok = compare_vectors(
-            name, actual_journal,
-            expected_journal(inputs, kda, raw_gates), FIELD_TOLERANCE);
+            name, actual_replay_log,
+            expected_replay_log(inputs, kda, raw_gates), FIELD_TOLERANCE);
     }
 
     const std::vector<int32_t> identity_slots{0, 1, 2, 3};
@@ -508,7 +508,7 @@ bool run_case(ggml_backend_t backend, bool kda, bool raw_gates) {
         ggml_backend_tensor_set(tensors.slots, identity_slots.data(), 0,
                                 identity_slots.size()*sizeof(identity_slots[0]));
         ok = commit_many_one_layer(
-            tensors.journal, tensors.identity_state,
+            tensors.replay_log, tensors.identity_state,
             tensors.conv_input, tensors.identity_conv_state,
             tensors.accepted, tensors.slots);
         if (ok) {
@@ -574,7 +574,7 @@ bool run_case(ggml_backend_t backend, bool kda, bool raw_gates) {
         ggml_backend_tensor_set(tensors.slots, mapped_slots.data(), 0,
                                 mapped_slots.size()*sizeof(mapped_slots[0]));
         ok = commit_many_one_layer(
-            tensors.journal, tensors.mapped_state,
+            tensors.replay_log, tensors.mapped_state,
             tensors.conv_input, tensors.mapped_conv_state,
             tensors.accepted, tensors.slots);
         if (ok) {
@@ -603,7 +603,7 @@ bool run_case(ggml_backend_t backend, bool kda, bool raw_gates) {
         ggml_backend_tensor_set(tensors.slots, identity_slots.data(), 0,
                                 identity_slots.size()*sizeof(identity_slots[0]));
         ok = !commit_many_one_layer(
-            tensors.journal, tensors.identity_state,
+            tensors.replay_log, tensors.identity_state,
             tensors.conv_input, tensors.identity_conv_state,
             tensors.accepted, tensors.slots);
         const std::vector<int32_t> out_of_range_slots{0, 99, 2, 3};
@@ -613,14 +613,14 @@ bool run_case(ggml_backend_t backend, bool kda, bool raw_gates) {
         ggml_backend_tensor_set(tensors.slots, out_of_range_slots.data(), 0,
                                 out_of_range_slots.size()*sizeof(out_of_range_slots[0]));
         ok = ok && !commit_many_one_layer(
-            tensors.journal, tensors.identity_state,
+            tensors.replay_log, tensors.identity_state,
             tensors.conv_input, tensors.identity_conv_state,
             tensors.accepted, tensors.slots);
         const std::vector<int32_t> duplicate_slots{0, 0, 2, 3};
         ggml_backend_tensor_set(tensors.slots, duplicate_slots.data(), 0,
                                 duplicate_slots.size()*sizeof(duplicate_slots[0]));
         ok = ok && !commit_many_one_layer(
-            tensors.journal, tensors.identity_state,
+            tensors.replay_log, tensors.identity_state,
             tensors.conv_input, tensors.identity_conv_state,
             tensors.accepted, tensors.slots);
         ggml_backend_tensor_get(
@@ -636,7 +636,7 @@ bool run_case(ggml_backend_t backend, bool kda, bool raw_gates) {
             identity_conv_base, 0.0f);
     }
 
-    std::printf("gdn transition journal %-10s: %s\n", name,
+    std::printf("gdn replay log %-10s: %s\n", name,
                 ok ? "PASS" : "FAIL");
     destroy(tensors);
     return ok;
@@ -680,11 +680,11 @@ bool run_grouped_tree_case(ggml_backend_t backend) {
 
     ggml_tensor * result = ggml_gated_delta_net_tree(
         ctx, q, k, v, g, beta, base_state, parents);
-    ggml_tensor * journal =
-        ggml_gated_delta_net_capture_transition_journal(ctx, result);
-    ggml_set_output(journal);
+    ggml_tensor * replay_log =
+        ggml_gated_delta_net_capture_replay_log(ctx, result);
+    ggml_set_output(replay_log);
     ggml_cgraph * graph = ggml_new_graph(ctx);
-    ggml_build_forward_expand(graph, journal);
+    ggml_build_forward_expand(graph, replay_log);
 
     ggml_backend_buffer_t buffer = ggml_backend_alloc_ctx_tensors(ctx, backend);
     if (!buffer) {
@@ -730,7 +730,7 @@ bool run_grouped_tree_case(ggml_backend_t backend) {
         slots, identity_slots.data(), 0,
         identity_slots.size()*sizeof(identity_slots[0]));
     ok = ok && commit_many_one_layer(
-        journal, committed_state, conv_input, conv_state, accepted, slots);
+        replay_log, committed_state, conv_input, conv_state, accepted, slots);
 
     std::vector<float> expected = inputs.state;
     const size_t slot_elements = (size_t) S*S*H;
@@ -762,14 +762,14 @@ bool run_grouped_tree_case(ggml_backend_t backend) {
             0.0f);
     }
 
-    std::printf("gdn grouped tree journal         : %s\n",
+    std::printf("gdn grouped tree replay log         : %s\n",
                 ok ? "PASS" : "FAIL");
     ggml_backend_buffer_free(buffer);
     ggml_free(ctx);
     return ok;
 }
 
-bool test_journal_capture_owns_storage(ggml_backend_t backend) {
+bool test_replay_log_capture_owns_storage(ggml_backend_t backend) {
     constexpr int state_size = 16;
     constexpr int heads = 1;
     constexpr int tokens = 8;
@@ -797,19 +797,19 @@ bool test_journal_capture_owns_storage(ggml_backend_t backend) {
         ctx, GGML_TYPE_I32, tokens, sequences);
     ggml_tensor * result = ggml_gated_delta_net_tree(
         ctx, q, k, v, g, beta, state, parents);
-    ggml_tensor * journal =
-        ggml_gated_delta_net_capture_transition_journal(ctx, result);
-    ggml_set_output(journal);
+    ggml_tensor * replay_log =
+        ggml_gated_delta_net_capture_replay_log(ctx, result);
+    ggml_set_output(replay_log);
 
     ggml_cgraph * graph = ggml_new_graph(ctx);
     ggml_build_forward_expand(graph, result);
-    ggml_build_forward_expand(graph, journal);
+    ggml_build_forward_expand(graph, replay_log);
     ggml_gallocr_t alloc = ggml_gallocr_new(
         ggml_backend_get_default_buffer_type(backend));
     const bool allocated = alloc && ggml_gallocr_alloc_graph(alloc, graph);
-    const bool ok = allocated && journal->buffer && journal->data &&
-                    journal->view_src == nullptr;
-    std::printf("gdn journal owned C4/W8         : %s\n",
+    const bool ok = allocated && replay_log->buffer && replay_log->data &&
+                    replay_log->view_src == nullptr;
+    std::printf("gdn replay log owned C4/W8         : %s\n",
                 ok ? "PASS" : "FAIL");
     if (alloc) ggml_gallocr_free(alloc);
     ggml_free(ctx);
@@ -843,7 +843,7 @@ bool test_tree_commit_preflight_is_non_mutating(ggml_backend_t backend) {
         ggml_new_tensor_2d(ctx, GGML_TYPE_BF16, 4, 4);
     ggml_tensor * feature_rows =
         ggml_new_tensor_1d(ctx, GGML_TYPE_I32, sequences);
-    ggml_tensor * journal = ggml_new_tensor_4d(
+    ggml_tensor * replay_log = ggml_new_tensor_4d(
         ctx, GGML_TYPE_F32, 2*state_size + 1,
         heads, tokens, sequences);
     ggml_tensor * state = ggml_new_tensor_4d(
@@ -874,7 +874,7 @@ bool test_tree_commit_preflight_is_non_mutating(ggml_backend_t backend) {
         (size_t) ggml_nelements(conv_state), 3.75f);
     std::vector<float> zeros(
         (size_t) std::max(
-            ggml_nelements(journal), ggml_nelements(conv_input)),
+            ggml_nelements(replay_log), ggml_nelements(conv_input)),
         0.0f);
     std::vector<uint16_t> feature_source_values(
         (size_t) ggml_nelements(feature_source), 0x4000);
@@ -899,8 +899,8 @@ bool test_tree_commit_preflight_is_non_mutating(ggml_backend_t backend) {
         conv_state, conv_before.data(), 0,
         conv_before.size()*sizeof(float));
     ggml_backend_tensor_set(
-        journal, zeros.data(), 0,
-        (size_t) ggml_nelements(journal)*sizeof(float));
+        replay_log, zeros.data(), 0,
+        (size_t) ggml_nelements(replay_log)*sizeof(float));
     ggml_backend_tensor_set(
         conv_input, zeros.data(), 0,
         (size_t) ggml_nelements(conv_input)*sizeof(float));
@@ -914,13 +914,13 @@ bool test_tree_commit_preflight_is_non_mutating(ggml_backend_t backend) {
         accepted, &invalid_accepted, 0, sizeof(invalid_accepted));
 
     ggml_tensor * caches[] = {cache};
-    const ggml_tensor * journals[] = {journal};
+    const ggml_tensor * replay_logs[] = {replay_log};
     ggml_tensor * states[] = {state};
     const ggml_tensor * conv_inputs[] = {conv_input};
     ggml_tensor * conv_states[] = {conv_state};
     const bool rejected = !ggml_backend_cuda_tree_commit_transaction(
         caches, 1, feature_source, feature_destination, feature_rows,
-        journals, states, conv_inputs, conv_states, 1,
+        replay_logs, states, conv_inputs, conv_states, 1,
         commit_rows, accepted, active_slots,
         /*tree_scratch_base=*/4, /*tree_scratch_stride=*/1);
 
@@ -965,7 +965,7 @@ int main(int argc, char ** argv) {
         ggml_backend_free(backend);
         return ok ? 0 : 1;
     }
-    const bool gallocr_ok = test_journal_capture_owns_storage(backend);
+    const bool gallocr_ok = test_replay_log_capture_owns_storage(backend);
     if (argc == 2 && std::strcmp(argv[1], "--gallocr-only") == 0) {
         ggml_backend_free(backend);
         return gallocr_ok ? 0 : 1;

--- a/server/test/test_gdn_transition_journal.cpp
+++ b/server/test/test_gdn_transition_journal.cpp
@@ -447,9 +447,9 @@ bool run_case(ggml_backend_t backend, bool kda, bool raw_gates) {
     }
     tensors.journal =
         ggml_gated_delta_net_capture_transition_journal(tensors.ctx, result);
-    ggml_set_output(result);
+    ggml_set_output(tensors.journal);
     ggml_cgraph * graph = ggml_new_graph(tensors.ctx);
-    ggml_build_forward_expand(graph, result);
+    ggml_build_forward_expand(graph, tensors.journal);
 
     tensors.buffer = ggml_backend_alloc_ctx_tensors(tensors.ctx, backend);
     if (!tensors.buffer) {
@@ -682,9 +682,9 @@ bool run_grouped_tree_case(ggml_backend_t backend) {
         ctx, q, k, v, g, beta, base_state, parents);
     ggml_tensor * journal =
         ggml_gated_delta_net_capture_transition_journal(ctx, result);
-    ggml_set_output(result);
+    ggml_set_output(journal);
     ggml_cgraph * graph = ggml_new_graph(ctx);
-    ggml_build_forward_expand(graph, result);
+    ggml_build_forward_expand(graph, journal);
 
     ggml_backend_buffer_t buffer = ggml_backend_alloc_ctx_tensors(ctx, backend);
     if (!buffer) {
@@ -769,7 +769,7 @@ bool run_grouped_tree_case(ggml_backend_t backend) {
     return ok;
 }
 
-bool test_journal_view_is_allocated_with_graph(ggml_backend_t backend) {
+bool test_journal_capture_owns_storage(ggml_backend_t backend) {
     constexpr int state_size = 16;
     constexpr int heads = 1;
     constexpr int tokens = 8;
@@ -807,8 +807,9 @@ bool test_journal_view_is_allocated_with_graph(ggml_backend_t backend) {
     ggml_gallocr_t alloc = ggml_gallocr_new(
         ggml_backend_get_default_buffer_type(backend));
     const bool allocated = alloc && ggml_gallocr_alloc_graph(alloc, graph);
-    const bool ok = allocated && journal->buffer && journal->data;
-    std::printf("gdn journal gallocr C4/W8       : %s\n",
+    const bool ok = allocated && journal->buffer && journal->data &&
+                    journal->view_src == nullptr;
+    std::printf("gdn journal owned C4/W8         : %s\n",
                 ok ? "PASS" : "FAIL");
     if (alloc) ggml_gallocr_free(alloc);
     ggml_free(ctx);
@@ -964,7 +965,7 @@ int main(int argc, char ** argv) {
         ggml_backend_free(backend);
         return ok ? 0 : 1;
     }
-    const bool gallocr_ok = test_journal_view_is_allocated_with_graph(backend);
+    const bool gallocr_ok = test_journal_capture_owns_storage(backend);
     if (argc == 2 && std::strcmp(argv[1], "--gallocr-only") == 0) {
         ggml_backend_free(backend);
         return gallocr_ok ? 0 : 1;

--- a/server/test/test_gdn_transition_journal.cpp
+++ b/server/test/test_gdn_transition_journal.cpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <cstdio>
 #include <random>
 #include <vector>
@@ -768,6 +769,52 @@ bool run_grouped_tree_case(ggml_backend_t backend) {
     return ok;
 }
 
+bool test_journal_view_is_allocated_with_graph(ggml_backend_t backend) {
+    constexpr int state_size = 16;
+    constexpr int heads = 1;
+    constexpr int tokens = 8;
+    constexpr int sequences = 4;
+
+    ggml_init_params params{};
+    params.mem_size = 512*1024;
+    params.no_alloc = true;
+    ggml_context * ctx = ggml_init(params);
+    if (!ctx) return false;
+
+    ggml_tensor * q = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F32, state_size, heads, tokens, sequences);
+    ggml_tensor * k = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F32, state_size, heads, tokens, sequences);
+    ggml_tensor * v = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F32, state_size, heads, tokens, sequences);
+    ggml_tensor * g = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F32, 1, heads, tokens, sequences);
+    ggml_tensor * beta = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F32, 1, heads, tokens, sequences);
+    ggml_tensor * state = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F32, state_size, state_size, heads, sequences);
+    ggml_tensor * parents = ggml_new_tensor_2d(
+        ctx, GGML_TYPE_I32, tokens, sequences);
+    ggml_tensor * result = ggml_gated_delta_net_tree(
+        ctx, q, k, v, g, beta, state, parents);
+    ggml_tensor * journal =
+        ggml_gated_delta_net_capture_transition_journal(ctx, result);
+    ggml_set_output(journal);
+
+    ggml_cgraph * graph = ggml_new_graph(ctx);
+    ggml_build_forward_expand(graph, result);
+    ggml_build_forward_expand(graph, journal);
+    ggml_gallocr_t alloc = ggml_gallocr_new(
+        ggml_backend_get_default_buffer_type(backend));
+    const bool allocated = alloc && ggml_gallocr_alloc_graph(alloc, graph);
+    const bool ok = allocated && journal->buffer && journal->data;
+    std::printf("gdn journal gallocr C4/W8       : %s\n",
+                ok ? "PASS" : "FAIL");
+    if (alloc) ggml_gallocr_free(alloc);
+    ggml_free(ctx);
+    return ok;
+}
+
 bool test_tree_commit_preflight_is_non_mutating(ggml_backend_t backend) {
     constexpr int state_size = 16;
     constexpr int heads = 1;
@@ -903,12 +950,27 @@ bool test_tree_commit_preflight_is_non_mutating(ggml_backend_t backend) {
 }
 } // namespace
 
-int main() {
+int main(int argc, char ** argv) {
     if (!test_raw_gate_protocol()) return 1;
     setenv("DFLASH_GDN_FORCE_GROUPED_COLS", "1", 1);
     ggml_backend_t backend = ggml_backend_cuda_init(0);
     if (!backend) {
         std::fprintf(stderr, "GPU backend unavailable\n");
+        return 1;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--preflight-only") == 0) {
+        const bool ok =
+            test_tree_commit_preflight_is_non_mutating(backend);
+        ggml_backend_free(backend);
+        return ok ? 0 : 1;
+    }
+    const bool gallocr_ok = test_journal_view_is_allocated_with_graph(backend);
+    if (argc == 2 && std::strcmp(argv[1], "--gallocr-only") == 0) {
+        ggml_backend_free(backend);
+        return gallocr_ok ? 0 : 1;
+    }
+    if (!gallocr_ok) {
+        ggml_backend_free(backend);
         return 1;
     }
     bool ok = run_case(backend, false, false);

--- a/server/test/test_gdn_transition_journal.cpp
+++ b/server/test/test_gdn_transition_journal.cpp
@@ -1,0 +1,789 @@
+#include "ggml-backend.h"
+#include "ggml-cuda.h"
+#include "ggml.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstdio>
+#include <random>
+#include <vector>
+
+namespace {
+
+constexpr int S = 128;
+constexpr int H = 48;
+constexpr int KEY_HEADS = 16;
+constexpr int T = 6;
+constexpr int B = 4;
+constexpr int PHYSICAL_SLOTS = 3;
+constexpr int CONV_WINDOW = 3;
+constexpr int CONV_CHANNELS = 7;
+constexpr float FIELD_TOLERANCE = 5.0e-5f;
+constexpr float STATE_TOLERANCE = 2.0e-4f;
+
+bool test_raw_gate_protocol() {
+    ggml_init_params params{};
+    params.mem_size = 128*1024;
+    params.no_alloc = true;
+    ggml_context * ctx = ggml_init(params);
+    if (!ctx) return false;
+
+    ggml_tensor * q = ggml_new_tensor_4d(ctx, GGML_TYPE_F32, S, H, 1, 1);
+    ggml_tensor * k = ggml_new_tensor_4d(ctx, GGML_TYPE_F32, S, H, 1, 1);
+    ggml_tensor * v = ggml_new_tensor_4d(ctx, GGML_TYPE_F32, S, H, 1, 1);
+    ggml_tensor * g = ggml_new_tensor_4d(ctx, GGML_TYPE_F32, 1, H, 1, 1);
+    ggml_tensor * beta = ggml_new_tensor_4d(ctx, GGML_TYPE_F32, 1, H, 1, 1);
+    ggml_tensor * state = ggml_new_tensor_4d(ctx, GGML_TYPE_F32, S, S, H, 1);
+    ggml_tensor * gate_ba = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 2*H);
+    ggml_tensor * result = ggml_gated_delta_net(
+        ctx, q, k, v, g, beta, state);
+
+    ggml_gated_delta_net_set_raw_gates(result, gate_ba);
+    const int32_t * op_params =
+        reinterpret_cast<const int32_t *>(result->op_params);
+    const bool ok = result->src[9] == gate_ba && result->src[10] == nullptr &&
+        ggml_nelements(result->src[9]) == 2*H && op_params[2] == 0 &&
+        op_params[10] == 1;
+    if (!ok) {
+        std::fprintf(
+            stderr,
+            "raw gate protocol: src9=%p src10=%p elements=%lld op2=%d op10=%d\n",
+            static_cast<void *>(result->src[9]),
+            static_cast<void *>(result->src[10]),
+            (long long) ggml_nelements(result->src[9]),
+            op_params[2], op_params[10]);
+    }
+    ggml_free(ctx);
+    return ok;
+}
+
+size_t qkv_index(int sequence, int token, int head, int value) {
+    return (((size_t) sequence*T + token)*H + head)*S + value;
+}
+
+size_t key_index(int sequence, int token, int head, int value) {
+    return (((size_t) sequence*T + token)*KEY_HEADS +
+            head%KEY_HEADS)*S + value;
+}
+
+size_t scalar_index(int sequence, int token, int head) {
+    return ((size_t) sequence*T + token)*H + head;
+}
+
+size_t state_index(int slot, int head, int col, int row) {
+    return (((size_t) slot*H + head)*S + col)*S + row;
+}
+
+size_t journal_index(
+        int sequence, int token, int head, int width, int value) {
+    return ((((size_t) sequence*T + token)*H + head)*width) + value;
+}
+
+size_t conv_input_index(
+        int sequence, int channel, int position) {
+    return ((size_t) sequence*CONV_CHANNELS + channel)*
+        (CONV_WINDOW + T) + position;
+}
+
+size_t conv_state_index(int slot, int channel, int position) {
+    return ((size_t) slot*CONV_CHANNELS + channel)*CONV_WINDOW + position;
+}
+
+std::vector<float> make_conv_input() {
+    std::vector<float> values(
+        (size_t)(CONV_WINDOW + T)*CONV_CHANNELS*B);
+    for (int sequence = 0; sequence < B; ++sequence) {
+        for (int channel = 0; channel < CONV_CHANNELS; ++channel) {
+            for (int position = 0; position < CONV_WINDOW + T; ++position) {
+                values[conv_input_index(sequence, channel, position)] =
+                    0.01f*sequence + 0.001f*channel + 0.0001f*position;
+            }
+        }
+    }
+    return values;
+}
+
+std::vector<float> conv_state_for_slots(
+        const std::vector<float> & input,
+        const std::vector<int32_t> & slots,
+        const std::vector<int32_t> & prefixes,
+        int physical_slots) {
+    std::vector<float> state(
+        (size_t)CONV_WINDOW*CONV_CHANNELS*physical_slots, -1.0f);
+    for (int sequence = 0; sequence < B; ++sequence) {
+        const int slot = slots[(size_t)sequence];
+        if (slot < 0 || slot >= physical_slots) continue;
+        const int prefix = prefixes[(size_t)sequence];
+        for (int channel = 0; channel < CONV_CHANNELS; ++channel) {
+            for (int k = 0; k < CONV_WINDOW; ++k) {
+                state[conv_state_index(slot, channel, k)] =
+                    input[conv_input_index(
+                        sequence, channel, prefix + k)];
+            }
+        }
+    }
+    return state;
+}
+
+float sigmoid(float x) {
+    return 1.0f/(1.0f + std::exp(-x));
+}
+
+float softplus(float x) {
+    return x > 20.0f ? x : std::log1p(std::exp(x));
+}
+
+bool compare_vectors(
+        const char * label,
+        const std::vector<float> & actual,
+        const std::vector<float> & expected,
+        float tolerance) {
+    if (actual.size() != expected.size()) {
+        std::fprintf(stderr, "%s: size mismatch %zu != %zu\n", label,
+                     actual.size(), expected.size());
+        return false;
+    }
+    float max_error = 0.0f;
+    size_t worst = 0;
+    for (size_t i = 0; i < actual.size(); ++i) {
+        if (!std::isfinite(actual[i]) || !std::isfinite(expected[i])) {
+            std::fprintf(stderr,
+                         "%s: non-finite value at %zu (actual %.9g expected %.9g)\n",
+                         label, i, actual[i], expected[i]);
+            return false;
+        }
+        const float error = std::fabs(actual[i] - expected[i]);
+        if (error > max_error) {
+            max_error = error;
+            worst = i;
+        }
+    }
+    if (max_error > tolerance || !std::isfinite(max_error)) {
+        std::fprintf(stderr,
+                     "%s: max error %.9g at %zu (actual %.9g expected %.9g, tolerance %.9g)\n",
+                     label, max_error, worst, actual[worst], expected[worst],
+                     tolerance);
+        return false;
+    }
+    return true;
+}
+
+struct Inputs {
+    std::vector<float> q;
+    std::vector<float> k;
+    std::vector<float> v;
+    std::vector<float> g;
+    std::vector<float> beta;
+    std::vector<float> state;
+    std::vector<float> dt_bias;
+    std::vector<float> gate_A;
+};
+
+Inputs make_inputs(bool kda, bool raw_gates) {
+    std::mt19937 rng(20260819 + 17*kda + 31*raw_gates);
+    std::uniform_real_distribution<float> small(-0.25f, 0.25f);
+    std::uniform_real_distribution<float> state_dist(-0.06f, 0.06f);
+    std::uniform_real_distribution<float> gate_dist(0.82f, 0.98f);
+    std::uniform_real_distribution<float> beta_dist(0.15f, 0.85f);
+    std::uniform_real_distribution<float> raw_dist(-1.5f, 1.5f);
+
+    Inputs in;
+    const size_t qkv_elements = (size_t) S*H*T*B;
+    const size_t qk_elements = (size_t) S*KEY_HEADS*T*B;
+    in.q.resize(qk_elements);
+    in.k.resize(qk_elements);
+    in.v.resize(qkv_elements);
+    in.g.resize((size_t) (kda ? S : 1)*H*T*B);
+    in.beta.resize((size_t) H*T*B);
+    in.state.resize((size_t) S*S*H*B);
+    in.dt_bias.resize(H);
+    in.gate_A.resize(H);
+
+    for (float & value : in.q) value = small(rng);
+    for (float & value : in.v) value = small(rng);
+    for (float & value : in.state) value = state_dist(rng);
+
+    for (int sequence = 0; sequence < B; ++sequence) {
+        for (int token = 0; token < T; ++token) {
+            for (int head = 0; head < KEY_HEADS; ++head) {
+                float norm2 = 0.0f;
+                for (int row = 0; row < S; ++row) {
+                    const float value = small(rng);
+                    in.k[key_index(sequence, token, head, row)] = value;
+                    norm2 += value*value;
+                }
+                const float inverse_norm = 1.0f/std::sqrt(norm2);
+                for (int row = 0; row < S; ++row) {
+                    in.k[key_index(sequence, token, head, row)] *= inverse_norm;
+                }
+            }
+        }
+    }
+
+    if (raw_gates) {
+        for (float & value : in.g) value = raw_dist(rng);
+        for (float & value : in.beta) value = raw_dist(rng);
+        for (int head = 0; head < H; ++head) {
+            in.dt_bias[head] = -0.35f + 0.12f*head;
+            in.gate_A[head] = -0.12f - 0.07f*head;
+        }
+    } else {
+        for (float & value : in.g) value = std::log(gate_dist(rng));
+        for (float & value : in.beta) value = beta_dist(rng);
+    }
+    return in;
+}
+
+float resolved_gate(
+        const Inputs & in, bool kda, bool raw_gates,
+        int sequence, int token, int head, int row) {
+    if (kda) {
+        return std::exp(in.g[qkv_index(sequence, token, head, row)]);
+    }
+    const float raw_or_log = in.g[scalar_index(sequence, token, head)];
+    if (!raw_gates) return std::exp(raw_or_log);
+    return std::exp(
+        softplus(raw_or_log + in.dt_bias[head])*in.gate_A[head]);
+}
+
+float resolved_beta(
+        const Inputs & in, bool raw_gates,
+        int sequence, int token, int head) {
+    const float value = in.beta[scalar_index(sequence, token, head)];
+    return raw_gates ? sigmoid(value) : value;
+}
+
+std::vector<float> ordinary_recurrence(
+        const Inputs & in, bool kda, bool raw_gates,
+        int accepted_prefix) {
+    std::vector<float> state = in.state;
+    for (int sequence = 0; sequence < B; ++sequence) {
+        for (int token = 0; token < accepted_prefix; ++token) {
+            for (int head = 0; head < H; ++head) {
+                const float beta = resolved_beta(
+                    in, raw_gates, sequence, token, head);
+                for (int col = 0; col < S; ++col) {
+                    float projection = 0.0f;
+                    for (int row = 0; row < S; ++row) {
+                        const float gate = resolved_gate(
+                            in, kda, raw_gates,
+                            sequence, token, head, row);
+                        const float state_value =
+                            state[state_index(sequence, head, col, row)];
+                        const float key =
+                            in.k[key_index(sequence, token, head, row)];
+                        projection += (kda ? gate : 1.0f)*state_value*key;
+                    }
+                    const float scalar_gate = resolved_gate(
+                        in, kda, raw_gates,
+                        sequence, token, head, 0);
+                    const float delta =
+                        (in.v[qkv_index(sequence, token, head, col)] -
+                         (kda ? projection : scalar_gate*projection))*beta;
+                    for (int row = 0; row < S; ++row) {
+                        const float gate = resolved_gate(
+                            in, kda, raw_gates,
+                            sequence, token, head, row);
+                        const float key =
+                            in.k[key_index(sequence, token, head, row)];
+                        float & state_value =
+                            state[state_index(sequence, head, col, row)];
+                        state_value = std::fma(key, delta, gate*state_value);
+                    }
+                }
+            }
+        }
+    }
+    return state;
+}
+
+std::vector<float> expected_journal(
+        const Inputs & in, bool kda, bool raw_gates) {
+    const int gate_values = kda ? S : 1;
+    const int width = gate_values + 2*S;
+    std::vector<float> journal((size_t) width*H*T*B);
+    std::vector<float> state = in.state;
+    for (int sequence = 0; sequence < B; ++sequence) {
+        for (int token = 0; token < T; ++token) {
+            for (int head = 0; head < H; ++head) {
+                for (int row = 0; row < gate_values; ++row) {
+                    journal[journal_index(sequence, token, head, width, row)] =
+                        resolved_gate(in, kda, raw_gates,
+                                      sequence, token, head, row);
+                }
+                for (int row = 0; row < S; ++row) {
+                    journal[journal_index(
+                        sequence, token, head, width,
+                        gate_values + row)] =
+                            in.k[key_index(sequence, token, head, row)];
+                }
+                const float beta = resolved_beta(
+                    in, raw_gates, sequence, token, head);
+                for (int col = 0; col < S; ++col) {
+                    float projection = 0.0f;
+                    for (int row = 0; row < S; ++row) {
+                        const float gate = resolved_gate(
+                            in, kda, raw_gates,
+                            sequence, token, head, row);
+                        projection += (kda ? gate : 1.0f)*
+                            state[state_index(sequence, head, col, row)]*
+                            in.k[key_index(sequence, token, head, row)];
+                    }
+                    const float scalar_gate = resolved_gate(
+                        in, kda, raw_gates,
+                        sequence, token, head, 0);
+                    const float delta =
+                        (in.v[qkv_index(sequence, token, head, col)] -
+                         (kda ? projection : scalar_gate*projection))*beta;
+                    journal[journal_index(
+                        sequence, token, head, width,
+                        gate_values + S + col)] = delta;
+                    for (int row = 0; row < S; ++row) {
+                        const float gate = resolved_gate(
+                            in, kda, raw_gates,
+                            sequence, token, head, row);
+                        float & value =
+                            state[state_index(sequence, head, col, row)];
+                        value = std::fma(
+                            in.k[key_index(sequence, token, head, row)],
+                            delta, gate*value);
+                    }
+                }
+            }
+        }
+    }
+    return journal;
+}
+
+struct CaseTensors {
+    ggml_context * ctx = nullptr;
+    ggml_backend_buffer_t buffer = nullptr;
+    ggml_tensor * journal = nullptr;
+    ggml_tensor * identity_state = nullptr;
+    ggml_tensor * mapped_state = nullptr;
+    ggml_tensor * conv_input = nullptr;
+    ggml_tensor * identity_conv_state = nullptr;
+    ggml_tensor * mapped_conv_state = nullptr;
+    ggml_tensor * accepted = nullptr;
+    ggml_tensor * slots = nullptr;
+};
+
+bool commit_many_one_layer(
+        const ggml_tensor * journal,
+        ggml_tensor * state,
+        const ggml_tensor * conv_input,
+        ggml_tensor * conv_state,
+        const ggml_tensor * accepted,
+        const ggml_tensor * slots) {
+    const ggml_tensor * journals[] = {journal};
+    ggml_tensor * states[] = {state};
+    const ggml_tensor * conv_inputs[] = {conv_input};
+    ggml_tensor * conv_states[] = {conv_state};
+    return ggml_backend_cuda_gdn_transition_journal_commit_many(
+        journals, states, conv_inputs, conv_states, 1, accepted, slots);
+}
+
+void destroy(CaseTensors & tensors) {
+    if (tensors.buffer) ggml_backend_buffer_free(tensors.buffer);
+    if (tensors.ctx) ggml_free(tensors.ctx);
+    tensors = {};
+}
+
+bool run_case(ggml_backend_t backend, bool kda, bool raw_gates) {
+    const char * name = raw_gates ? "scalar-raw" : kda ? "kda" : "scalar";
+    const int gate_values = kda ? S : 1;
+    const int width = gate_values + 2*S;
+    const Inputs inputs = make_inputs(kda, raw_gates);
+
+    ggml_init_params params{};
+    params.mem_size = 8*1024*1024;
+    params.no_alloc = true;
+    CaseTensors tensors;
+    tensors.ctx = ggml_init(params);
+    if (!tensors.ctx) return false;
+
+    ggml_tensor * q = ggml_new_tensor_4d(
+        tensors.ctx, GGML_TYPE_F32, S, KEY_HEADS, T, B);
+    ggml_tensor * k = ggml_new_tensor_4d(
+        tensors.ctx, GGML_TYPE_F32, S, KEY_HEADS, T, B);
+    ggml_tensor * v = ggml_new_tensor_4d(
+        tensors.ctx, GGML_TYPE_F32, S, H, T, B);
+    ggml_tensor * g = ggml_new_tensor_4d(
+        tensors.ctx, GGML_TYPE_F32, kda ? S : 1, H, T, B);
+    ggml_tensor * beta = ggml_new_tensor_4d(
+        tensors.ctx, GGML_TYPE_F32, 1, H, T, B);
+    ggml_tensor * capture_state = ggml_new_tensor_4d(
+        tensors.ctx, GGML_TYPE_F32, S, S, H, B);
+    tensors.journal = ggml_new_tensor_4d(
+        tensors.ctx, GGML_TYPE_F32, width, H, T, B);
+    tensors.identity_state = ggml_new_tensor_4d(
+        tensors.ctx, GGML_TYPE_F32, S, S, H, B);
+    tensors.mapped_state = ggml_new_tensor_4d(
+        tensors.ctx, GGML_TYPE_F32, S, S, H, PHYSICAL_SLOTS);
+    tensors.conv_input = ggml_new_tensor_4d(
+        tensors.ctx, GGML_TYPE_F32, CONV_WINDOW + T,
+        CONV_CHANNELS, B, 1);
+    tensors.identity_conv_state = ggml_new_tensor_4d(
+        tensors.ctx, GGML_TYPE_F32, CONV_WINDOW,
+        CONV_CHANNELS, B, 1);
+    tensors.mapped_conv_state = ggml_new_tensor_4d(
+        tensors.ctx, GGML_TYPE_F32, CONV_WINDOW,
+        CONV_CHANNELS, PHYSICAL_SLOTS, 1);
+    tensors.accepted = ggml_new_tensor_1d(
+        tensors.ctx, GGML_TYPE_I32, B);
+    tensors.slots = ggml_new_tensor_1d(
+        tensors.ctx, GGML_TYPE_I32, B);
+    ggml_tensor * gate_ba = nullptr;
+    if (raw_gates) {
+        gate_ba = ggml_new_tensor_1d(tensors.ctx, GGML_TYPE_F32, 2*H);
+    }
+
+    ggml_tensor * result = ggml_gated_delta_net(
+        tensors.ctx, q, k, v, g, beta, capture_state);
+    ggml_gated_delta_net_set_skip_intermediate(result, true);
+    if (raw_gates) {
+        ggml_gated_delta_net_set_raw_gates(result, gate_ba);
+    }
+    ggml_gated_delta_net_set_transition_journal(result, tensors.journal);
+    ggml_set_output(result);
+    ggml_cgraph * graph = ggml_new_graph(tensors.ctx);
+    ggml_build_forward_expand(graph, result);
+
+    tensors.buffer = ggml_backend_alloc_ctx_tensors(tensors.ctx, backend);
+    if (!tensors.buffer) {
+        std::fprintf(stderr, "%s: GPU tensor allocation failed\n", name);
+        destroy(tensors);
+        return false;
+    }
+    auto upload_f32 = [](ggml_tensor * tensor,
+                         const std::vector<float> & values) {
+        ggml_backend_tensor_set(tensor, values.data(), 0,
+                                values.size()*sizeof(float));
+    };
+    upload_f32(q, inputs.q);
+    upload_f32(k, inputs.k);
+    upload_f32(v, inputs.v);
+    upload_f32(g, inputs.g);
+    upload_f32(beta, inputs.beta);
+    upload_f32(capture_state, inputs.state);
+    const std::vector<float> conv_input = make_conv_input();
+    upload_f32(tensors.conv_input, conv_input);
+    if (raw_gates) {
+        std::vector<float> packed_gates;
+        packed_gates.reserve(2*H);
+        packed_gates.insert(
+            packed_gates.end(), inputs.dt_bias.begin(), inputs.dt_bias.end());
+        packed_gates.insert(
+            packed_gates.end(), inputs.gate_A.begin(), inputs.gate_A.end());
+        upload_f32(gate_ba, packed_gates);
+    }
+
+    bool ok = ggml_backend_graph_compute(backend, graph) == GGML_STATUS_SUCCESS;
+    std::vector<float> actual_journal((size_t) width*H*T*B);
+    if (ok) {
+        ggml_backend_tensor_get(
+            tensors.journal, actual_journal.data(), 0,
+            actual_journal.size()*sizeof(float));
+        ok = compare_vectors(
+            name, actual_journal,
+            expected_journal(inputs, kda, raw_gates), FIELD_TOLERANCE);
+    }
+
+    const std::vector<int32_t> identity_slots{0, 1, 2, 3};
+    std::vector<int32_t> accepted(B);
+    std::vector<float> actual_state(inputs.state.size());
+    std::vector<float> actual_conv(
+        (size_t)CONV_WINDOW*CONV_CHANNELS*B);
+    const std::vector<int32_t> zero_prefixes(B, 0);
+    const std::vector<float> identity_conv_base = conv_state_for_slots(
+        conv_input, identity_slots, zero_prefixes, B);
+    for (int prefix = 0; ok && prefix <= T; ++prefix) {
+        std::fill(accepted.begin(), accepted.end(), prefix);
+        upload_f32(tensors.identity_state, inputs.state);
+        upload_f32(tensors.identity_conv_state, identity_conv_base);
+        ggml_backend_tensor_set(tensors.accepted, accepted.data(), 0,
+                                accepted.size()*sizeof(accepted[0]));
+        ggml_backend_tensor_set(tensors.slots, identity_slots.data(), 0,
+                                identity_slots.size()*sizeof(identity_slots[0]));
+        ok = commit_many_one_layer(
+            tensors.journal, tensors.identity_state,
+            tensors.conv_input, tensors.identity_conv_state,
+            tensors.accepted, tensors.slots);
+        if (ok) {
+            ggml_backend_tensor_get(
+                tensors.identity_state, actual_state.data(), 0,
+                actual_state.size()*sizeof(float));
+            char label[64];
+            std::snprintf(label, sizeof(label), "%s prefix %d", name, prefix);
+            ok = compare_vectors(
+                label, actual_state,
+                ordinary_recurrence(inputs, kda, raw_gates, prefix),
+                STATE_TOLERANCE);
+            ggml_backend_tensor_get(
+                tensors.identity_conv_state, actual_conv.data(), 0,
+                actual_conv.size()*sizeof(float));
+            ok = ok && compare_vectors(
+                "convolution prefix", actual_conv,
+                conv_state_for_slots(
+                    conv_input, identity_slots, accepted, B),
+                0.0f);
+        }
+    }
+
+    const std::vector<int32_t> mapped_slots{2, -1, 0, 1};
+    const std::vector<int32_t> mapped_prefixes{T, T, 2, 4};
+    std::vector<float> mapped_base((size_t) S*S*H*PHYSICAL_SLOTS);
+    for (int sequence : {0, 2, 3}) {
+        const int slot = mapped_slots[(size_t) sequence];
+        for (int head = 0; head < H; ++head) {
+            for (int col = 0; col < S; ++col) {
+                for (int row = 0; row < S; ++row) {
+                    mapped_base[state_index(slot, head, col, row)] =
+                        inputs.state[state_index(sequence, head, col, row)];
+                }
+            }
+        }
+    }
+    std::vector<float> mapped_expected = mapped_base;
+    for (int sequence : {0, 2, 3}) {
+        const int slot = mapped_slots[(size_t) sequence];
+        const std::vector<float> lane_state = ordinary_recurrence(
+            inputs, kda, raw_gates, mapped_prefixes[(size_t) sequence]);
+        for (int head = 0; head < H; ++head) {
+            for (int col = 0; col < S; ++col) {
+                for (int row = 0; row < S; ++row) {
+                    mapped_expected[state_index(slot, head, col, row)] =
+                        lane_state[state_index(sequence, head, col, row)];
+                }
+            }
+        }
+    }
+    std::vector<float> mapped_actual(mapped_base.size());
+    const std::vector<float> mapped_conv_base = conv_state_for_slots(
+        conv_input, mapped_slots, zero_prefixes, PHYSICAL_SLOTS);
+    const std::vector<float> mapped_conv_expected = conv_state_for_slots(
+        conv_input, mapped_slots, mapped_prefixes, PHYSICAL_SLOTS);
+    std::vector<float> mapped_conv_actual(mapped_conv_base.size());
+    if (ok) {
+        upload_f32(tensors.mapped_state, mapped_base);
+        upload_f32(tensors.mapped_conv_state, mapped_conv_base);
+        ggml_backend_tensor_set(tensors.accepted, mapped_prefixes.data(), 0,
+                                mapped_prefixes.size()*sizeof(mapped_prefixes[0]));
+        ggml_backend_tensor_set(tensors.slots, mapped_slots.data(), 0,
+                                mapped_slots.size()*sizeof(mapped_slots[0]));
+        ok = commit_many_one_layer(
+            tensors.journal, tensors.mapped_state,
+            tensors.conv_input, tensors.mapped_conv_state,
+            tensors.accepted, tensors.slots);
+        if (ok) {
+            ggml_backend_tensor_get(
+                tensors.mapped_state, mapped_actual.data(), 0,
+                mapped_actual.size()*sizeof(float));
+            ok = compare_vectors(
+                "permuted/padded slots", mapped_actual, mapped_expected,
+                STATE_TOLERANCE);
+            ggml_backend_tensor_get(
+                tensors.mapped_conv_state, mapped_conv_actual.data(), 0,
+                mapped_conv_actual.size()*sizeof(float));
+            ok = ok && compare_vectors(
+                "permuted/padded convolution", mapped_conv_actual,
+                mapped_conv_expected, 0.0f);
+        }
+    }
+    if (ok) {
+        const std::vector<float> unchanged = inputs.state;
+        std::vector<int32_t> invalid_prefix(B, 1);
+        invalid_prefix[0] = T + 1;
+        upload_f32(tensors.identity_state, unchanged);
+        upload_f32(tensors.identity_conv_state, identity_conv_base);
+        ggml_backend_tensor_set(tensors.accepted, invalid_prefix.data(), 0,
+                                invalid_prefix.size()*sizeof(invalid_prefix[0]));
+        ggml_backend_tensor_set(tensors.slots, identity_slots.data(), 0,
+                                identity_slots.size()*sizeof(identity_slots[0]));
+        ok = !commit_many_one_layer(
+            tensors.journal, tensors.identity_state,
+            tensors.conv_input, tensors.identity_conv_state,
+            tensors.accepted, tensors.slots);
+        const std::vector<int32_t> out_of_range_slots{0, 99, 2, 3};
+        accepted.assign(B, 1);
+        ggml_backend_tensor_set(tensors.accepted, accepted.data(), 0,
+                                accepted.size()*sizeof(accepted[0]));
+        ggml_backend_tensor_set(tensors.slots, out_of_range_slots.data(), 0,
+                                out_of_range_slots.size()*sizeof(out_of_range_slots[0]));
+        ok = ok && !commit_many_one_layer(
+            tensors.journal, tensors.identity_state,
+            tensors.conv_input, tensors.identity_conv_state,
+            tensors.accepted, tensors.slots);
+        const std::vector<int32_t> duplicate_slots{0, 0, 2, 3};
+        ggml_backend_tensor_set(tensors.slots, duplicate_slots.data(), 0,
+                                duplicate_slots.size()*sizeof(duplicate_slots[0]));
+        ok = ok && !commit_many_one_layer(
+            tensors.journal, tensors.identity_state,
+            tensors.conv_input, tensors.identity_conv_state,
+            tensors.accepted, tensors.slots);
+        ggml_backend_tensor_get(
+            tensors.identity_state, actual_state.data(), 0,
+            actual_state.size()*sizeof(float));
+        ok = ok && compare_vectors(
+            "transactional validation", actual_state, unchanged, 0.0f);
+        ggml_backend_tensor_get(
+            tensors.identity_conv_state, actual_conv.data(), 0,
+            actual_conv.size()*sizeof(float));
+        ok = ok && compare_vectors(
+            "transactional convolution validation", actual_conv,
+            identity_conv_base, 0.0f);
+    }
+
+    std::printf("gdn transition journal %-10s: %s\n", name,
+                ok ? "PASS" : "FAIL");
+    destroy(tensors);
+    return ok;
+}
+
+
+bool run_grouped_tree_case(ggml_backend_t backend) {
+    const Inputs inputs = make_inputs(/*kda=*/false, /*raw_gates=*/false);
+    constexpr int width = 2*S + 1;
+
+    ggml_init_params params{};
+    params.mem_size = 8*1024*1024;
+    params.no_alloc = true;
+    ggml_context * ctx = ggml_init(params);
+    if (!ctx) return false;
+
+    ggml_tensor * q = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F32, S, KEY_HEADS, T, B);
+    ggml_tensor * k = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F32, S, KEY_HEADS, T, B);
+    ggml_tensor * v = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F32, S, H, T, B);
+    ggml_tensor * g = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F32, 1, H, T, B);
+    ggml_tensor * beta = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F32, 1, H, T, B);
+    ggml_tensor * base_state = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F32, S, S, H, B);
+    ggml_tensor * parents = ggml_new_tensor_2d(
+        ctx, GGML_TYPE_I32, T, B);
+    ggml_tensor * journal = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F32, width, H, T, B);
+    ggml_tensor * committed_state = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F32, S, S, H, B);
+    ggml_tensor * accepted = ggml_new_tensor_1d(
+        ctx, GGML_TYPE_I32, B);
+    ggml_tensor * slots = ggml_new_tensor_1d(
+        ctx, GGML_TYPE_I32, B);
+    ggml_tensor * conv_input = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F32, CONV_WINDOW + T, CONV_CHANNELS, B, 1);
+    ggml_tensor * conv_state = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F32, CONV_WINDOW, CONV_CHANNELS, B, 1);
+
+    ggml_tensor * result = ggml_gated_delta_net_tree(
+        ctx, q, k, v, g, beta, base_state, parents);
+    ggml_gated_delta_net_set_transition_journal(result, journal);
+    ggml_set_output(result);
+    ggml_cgraph * graph = ggml_new_graph(ctx);
+    ggml_build_forward_expand(graph, result);
+
+    ggml_backend_buffer_t buffer = ggml_backend_alloc_ctx_tensors(ctx, backend);
+    if (!buffer) {
+        ggml_free(ctx);
+        return false;
+    }
+    auto upload_f32 = [](ggml_tensor * tensor,
+                         const std::vector<float> & values) {
+        ggml_backend_tensor_set(
+            tensor, values.data(), 0, values.size()*sizeof(float));
+    };
+    upload_f32(q, inputs.q);
+    upload_f32(k, inputs.k);
+    upload_f32(v, inputs.v);
+    upload_f32(g, inputs.g);
+    upload_f32(beta, inputs.beta);
+    upload_f32(base_state, inputs.state);
+    const std::vector<float> conv_values = make_conv_input();
+    upload_f32(conv_input, conv_values);
+
+    std::vector<int32_t> parent_ids((size_t) T*B, -1);
+    for (int sequence : {0, 2}) {
+        for (int token = 1; token < T; ++token) {
+            parent_ids[(size_t) sequence*T + token] = token - 1;
+        }
+    }
+    ggml_backend_tensor_set(
+        parents, parent_ids.data(), 0,
+        parent_ids.size()*sizeof(parent_ids[0]));
+
+    bool ok = ggml_backend_graph_compute(backend, graph) == GGML_STATUS_SUCCESS;
+    const std::vector<int32_t> prefixes{T, 1, T, 1};
+    const std::vector<int32_t> identity_slots{0, 1, 2, 3};
+    const std::vector<int32_t> zero_prefixes(B, 0);
+    upload_f32(committed_state, inputs.state);
+    upload_f32(
+        conv_state,
+        conv_state_for_slots(
+            conv_values, identity_slots, zero_prefixes, B));
+    ggml_backend_tensor_set(
+        accepted, prefixes.data(), 0, prefixes.size()*sizeof(prefixes[0]));
+    ggml_backend_tensor_set(
+        slots, identity_slots.data(), 0,
+        identity_slots.size()*sizeof(identity_slots[0]));
+    ok = ok && commit_many_one_layer(
+        journal, committed_state, conv_input, conv_state, accepted, slots);
+
+    std::vector<float> expected = inputs.state;
+    const size_t slot_elements = (size_t) S*S*H;
+    for (int sequence = 0; sequence < B; ++sequence) {
+        const std::vector<float> lane = ordinary_recurrence(
+            inputs, /*kda=*/false, /*raw_gates=*/false,
+            prefixes[(size_t) sequence]);
+        const size_t offset = (size_t) sequence*slot_elements;
+        std::copy_n(lane.begin() + offset, slot_elements,
+                    expected.begin() + offset);
+    }
+    std::vector<float> actual(expected.size());
+    if (ok) {
+        ggml_backend_tensor_get(
+            committed_state, actual.data(), 0,
+            actual.size()*sizeof(float));
+        ok = compare_vectors(
+            "grouped tree chain/root commit", actual, expected,
+            STATE_TOLERANCE);
+        std::vector<float> actual_conv(
+            (size_t)CONV_WINDOW*CONV_CHANNELS*B);
+        ggml_backend_tensor_get(
+            conv_state, actual_conv.data(), 0,
+            actual_conv.size()*sizeof(float));
+        ok = ok && compare_vectors(
+            "grouped tree convolution commit", actual_conv,
+            conv_state_for_slots(
+                conv_values, identity_slots, prefixes, B),
+            0.0f);
+    }
+
+    std::printf("gdn grouped tree journal         : %s\n",
+                ok ? "PASS" : "FAIL");
+    ggml_backend_buffer_free(buffer);
+    ggml_free(ctx);
+    return ok;
+}
+} // namespace
+
+int main() {
+    if (!test_raw_gate_protocol()) return 1;
+    setenv("DFLASH_GDN_FORCE_GROUPED_COLS", "1", 1);
+    ggml_backend_t backend = ggml_backend_cuda_init(0);
+    if (!backend) {
+        std::fprintf(stderr, "GPU backend unavailable\n");
+        return 1;
+    }
+    bool ok = run_case(backend, false, false);
+    ok = run_case(backend, true, false) && ok;
+    ok = run_case(backend, false, true) && ok;
+    ok = run_grouped_tree_case(backend) && ok;
+    ggml_backend_free(backend);
+    return ok ? 0 : 1;
+}

--- a/server/test/test_gdn_transition_journal.cpp
+++ b/server/test/test_gdn_transition_journal.cpp
@@ -44,15 +44,14 @@ bool test_raw_gate_protocol() {
     ggml_gated_delta_net_set_raw_gates(result, gate_ba);
     const int32_t * op_params =
         reinterpret_cast<const int32_t *>(result->op_params);
-    const bool ok = result->src[9] == gate_ba && result->src[10] == nullptr &&
+    const bool ok = result->src[9] == gate_ba &&
         ggml_nelements(result->src[9]) == 2*H && op_params[2] == 0 &&
         op_params[10] == 1;
     if (!ok) {
         std::fprintf(
             stderr,
-            "raw gate protocol: src9=%p src10=%p elements=%lld op2=%d op10=%d\n",
+            "raw gate protocol: src9=%p elements=%lld op2=%d op10=%d\n",
             static_cast<void *>(result->src[9]),
-            static_cast<void *>(result->src[10]),
             (long long) ggml_nelements(result->src[9]),
             op_params[2], op_params[10]);
     }
@@ -417,8 +416,6 @@ bool run_case(ggml_backend_t backend, bool kda, bool raw_gates) {
         tensors.ctx, GGML_TYPE_F32, 1, H, T, B);
     ggml_tensor * capture_state = ggml_new_tensor_4d(
         tensors.ctx, GGML_TYPE_F32, S, S, H, B);
-    tensors.journal = ggml_new_tensor_4d(
-        tensors.ctx, GGML_TYPE_F32, width, H, T, B);
     tensors.identity_state = ggml_new_tensor_4d(
         tensors.ctx, GGML_TYPE_F32, S, S, H, B);
     tensors.mapped_state = ggml_new_tensor_4d(
@@ -447,7 +444,8 @@ bool run_case(ggml_backend_t backend, bool kda, bool raw_gates) {
     if (raw_gates) {
         ggml_gated_delta_net_set_raw_gates(result, gate_ba);
     }
-    ggml_gated_delta_net_set_transition_journal(result, tensors.journal);
+    tensors.journal =
+        ggml_gated_delta_net_capture_transition_journal(tensors.ctx, result);
     ggml_set_output(result);
     ggml_cgraph * graph = ggml_new_graph(tensors.ctx);
     ggml_build_forward_expand(graph, result);
@@ -668,8 +666,6 @@ bool run_grouped_tree_case(ggml_backend_t backend) {
         ctx, GGML_TYPE_F32, S, S, H, B);
     ggml_tensor * parents = ggml_new_tensor_2d(
         ctx, GGML_TYPE_I32, T, B);
-    ggml_tensor * journal = ggml_new_tensor_4d(
-        ctx, GGML_TYPE_F32, width, H, T, B);
     ggml_tensor * committed_state = ggml_new_tensor_4d(
         ctx, GGML_TYPE_F32, S, S, H, B);
     ggml_tensor * accepted = ggml_new_tensor_1d(
@@ -683,7 +679,8 @@ bool run_grouped_tree_case(ggml_backend_t backend) {
 
     ggml_tensor * result = ggml_gated_delta_net_tree(
         ctx, q, k, v, g, beta, base_state, parents);
-    ggml_gated_delta_net_set_transition_journal(result, journal);
+    ggml_tensor * journal =
+        ggml_gated_delta_net_capture_transition_journal(ctx, result);
     ggml_set_output(result);
     ggml_cgraph * graph = ggml_new_graph(ctx);
     ggml_build_forward_expand(graph, result);
@@ -770,6 +767,140 @@ bool run_grouped_tree_case(ggml_backend_t backend) {
     ggml_free(ctx);
     return ok;
 }
+
+bool test_tree_commit_preflight_is_non_mutating(ggml_backend_t backend) {
+    constexpr int state_size = 16;
+    constexpr int heads = 1;
+    constexpr int tokens = 2;
+    constexpr int sequences = 1;
+    constexpr int state_slots = 1;
+    constexpr int conv_window = 2;
+    constexpr int conv_channels = 3;
+
+    ggml_init_params params{};
+    params.mem_size = 256*1024;
+    params.no_alloc = true;
+    ggml_context * ctx = ggml_init(params);
+    if (!ctx) return false;
+
+    ggml_tensor * cache =
+        ggml_new_tensor_4d(ctx, GGML_TYPE_F32, 4, 8, 1, 1);
+    ggml_tensor * commit_rows =
+        ggml_new_tensor_2d(ctx, GGML_TYPE_I64, 1, sequences);
+    ggml_tensor * active_slots =
+        ggml_new_tensor_1d(ctx, GGML_TYPE_I32, sequences);
+    ggml_tensor * feature_source =
+        ggml_new_tensor_2d(ctx, GGML_TYPE_BF16, 4, sequences);
+    ggml_tensor * feature_destination =
+        ggml_new_tensor_2d(ctx, GGML_TYPE_BF16, 4, 4);
+    ggml_tensor * feature_rows =
+        ggml_new_tensor_1d(ctx, GGML_TYPE_I32, sequences);
+    ggml_tensor * journal = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F32, 2*state_size + 1,
+        heads, tokens, sequences);
+    ggml_tensor * state = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F32, state_size, state_size,
+        heads, state_slots);
+    ggml_tensor * conv_input = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F32, conv_window + tokens,
+        conv_channels, sequences, 1);
+    ggml_tensor * conv_state = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F32, conv_window,
+        conv_channels, state_slots, 1);
+    ggml_tensor * accepted =
+        ggml_new_tensor_1d(ctx, GGML_TYPE_I32, sequences);
+
+    ggml_backend_buffer_t buffer = ggml_backend_alloc_ctx_tensors(ctx, backend);
+    if (!buffer) {
+        ggml_free(ctx);
+        return false;
+    }
+
+    std::vector<float> cache_before(
+        (size_t) ggml_nelements(cache), 1.25f);
+    std::vector<uint16_t> feature_before(
+        (size_t) ggml_nelements(feature_destination), 0x3f80);
+    std::vector<float> state_before(
+        (size_t) ggml_nelements(state), -2.5f);
+    std::vector<float> conv_before(
+        (size_t) ggml_nelements(conv_state), 3.75f);
+    std::vector<float> zeros(
+        (size_t) std::max(
+            ggml_nelements(journal), ggml_nelements(conv_input)),
+        0.0f);
+    std::vector<uint16_t> feature_source_values(
+        (size_t) ggml_nelements(feature_source), 0x4000);
+    const int64_t destination_row = 0;
+    const int32_t active_slot = 0;
+    const int32_t feature_row = 0;
+    const int32_t invalid_accepted = tokens + 1;
+
+    ggml_backend_tensor_set(
+        cache, cache_before.data(), 0,
+        cache_before.size()*sizeof(float));
+    ggml_backend_tensor_set(
+        feature_destination, feature_before.data(), 0,
+        feature_before.size()*sizeof(uint16_t));
+    ggml_backend_tensor_set(
+        feature_source, feature_source_values.data(), 0,
+        feature_source_values.size()*sizeof(uint16_t));
+    ggml_backend_tensor_set(
+        state, state_before.data(), 0,
+        state_before.size()*sizeof(float));
+    ggml_backend_tensor_set(
+        conv_state, conv_before.data(), 0,
+        conv_before.size()*sizeof(float));
+    ggml_backend_tensor_set(
+        journal, zeros.data(), 0,
+        (size_t) ggml_nelements(journal)*sizeof(float));
+    ggml_backend_tensor_set(
+        conv_input, zeros.data(), 0,
+        (size_t) ggml_nelements(conv_input)*sizeof(float));
+    ggml_backend_tensor_set(
+        commit_rows, &destination_row, 0, sizeof(destination_row));
+    ggml_backend_tensor_set(
+        active_slots, &active_slot, 0, sizeof(active_slot));
+    ggml_backend_tensor_set(
+        feature_rows, &feature_row, 0, sizeof(feature_row));
+    ggml_backend_tensor_set(
+        accepted, &invalid_accepted, 0, sizeof(invalid_accepted));
+
+    ggml_tensor * caches[] = {cache};
+    const ggml_tensor * journals[] = {journal};
+    ggml_tensor * states[] = {state};
+    const ggml_tensor * conv_inputs[] = {conv_input};
+    ggml_tensor * conv_states[] = {conv_state};
+    const bool rejected = !ggml_backend_cuda_tree_commit_transaction(
+        caches, 1, feature_source, feature_destination, feature_rows,
+        journals, states, conv_inputs, conv_states, 1,
+        commit_rows, accepted, active_slots,
+        /*tree_scratch_base=*/4, /*tree_scratch_stride=*/1);
+
+    std::vector<float> cache_after(cache_before.size());
+    std::vector<uint16_t> feature_after(feature_before.size());
+    std::vector<float> state_after(state_before.size());
+    std::vector<float> conv_after(conv_before.size());
+    ggml_backend_tensor_get(
+        cache, cache_after.data(), 0, cache_after.size()*sizeof(float));
+    ggml_backend_tensor_get(
+        feature_destination, feature_after.data(), 0,
+        feature_after.size()*sizeof(uint16_t));
+    ggml_backend_tensor_get(
+        state, state_after.data(), 0, state_after.size()*sizeof(float));
+    ggml_backend_tensor_get(
+        conv_state, conv_after.data(), 0, conv_after.size()*sizeof(float));
+
+    const bool ok = rejected &&
+        cache_after == cache_before &&
+        feature_after == feature_before &&
+        state_after == state_before &&
+        conv_after == conv_before;
+    std::printf("gdn tree commit preflight        : %s\n",
+                ok ? "PASS" : "FAIL");
+    ggml_backend_buffer_free(buffer);
+    ggml_free(ctx);
+    return ok;
+}
 } // namespace
 
 int main() {
@@ -784,6 +915,7 @@ int main() {
     ok = run_case(backend, true, false) && ok;
     ok = run_case(backend, false, true) && ok;
     ok = run_grouped_tree_case(backend) && ok;
+    ok = test_tree_commit_preflight_is_non_mutating(backend) && ok;
     ggml_backend_free(backend);
     return ok ? 0 : 1;
 }

--- a/server/test/test_paged_attention.cpp
+++ b/server/test/test_paged_attention.cpp
@@ -188,11 +188,13 @@ std::vector<float> reference_attention(
             ? (seq - tree->ar_rows) % tree->width : -1;
         int kv_seq_len = clamped_seq_len(test_case, physical_seq);
         if (query_positions && !tree_query) {
-            if ((*query_positions)[seq] < 0) continue;
+            const int32_t query_position = (*query_positions)[seq];
+            if (query_position < 0) continue;
             // The inclusive causal clamp: row seq attends its sequence's
             // cached tokens [0, position].
-            kv_seq_len = std::min(
-                kv_seq_len, (*query_positions)[seq] + 1);
+            if (query_position < kv_seq_len) {
+                kv_seq_len = query_position + 1;
+            }
         }
         const int tree_size = tree_query ? tree->tree_sizes[tree_seq] : 0;
         if (tree_query &&

--- a/server/test/test_paged_attention.cpp
+++ b/server/test/test_paged_attention.cpp
@@ -30,6 +30,14 @@ struct TestCase {
     bool corrupt_blocks;
 };
 
+struct TreeMetadata {
+    int width;
+    int scratch_stride;
+    std::vector<int32_t> parent_ids;
+    std::vector<int32_t> tree_sizes;
+    int ar_rows = 0;
+};
+
 int clamped_seq_len(const TestCase & test_case, int seq) {
     return std::max(
         0, std::min(
@@ -49,6 +57,36 @@ int count_physical_blocks(const TestCase & test_case) {
 
 bool block_is_valid(int32_t block, int physical_blocks) {
     return block >= 0 && block < physical_blocks;
+}
+
+bool tree_visible(
+        const TreeMetadata & tree,
+        int tree_seq,
+        int query_node,
+        int candidate) {
+    const int tree_size = tree.tree_sizes[tree_seq];
+    if (tree_size < 0 || tree_size > tree.width ||
+        query_node < 0 || query_node >= tree_size ||
+        candidate < 0 || candidate >= tree_size) {
+        return false;
+    }
+
+    int current = query_node;
+    for (int depth = 0; depth < tree_size; ++depth) {
+        if (current == candidate) {
+            return true;
+        }
+        if (current < 0 || current >= tree_size) {
+            return false;
+        }
+        const int parent =
+            tree.parent_ids[tree_seq * tree.width + current];
+        if (parent == current) {
+            return false;
+        }
+        current = parent;
+    }
+    return false;
 }
 
 std::vector<int32_t> make_block_table(
@@ -127,7 +165,9 @@ std::vector<float> reference_attention(
         const std::vector<float> & k,
         const std::vector<float> & v,
         const std::vector<int32_t> * active_slot_ids = nullptr,
-        const std::vector<int32_t> * query_positions = nullptr) {
+        const std::vector<int32_t> * query_positions = nullptr,
+        const TreeMetadata * tree = nullptr,
+        int tree_scratch_base = 0) {
     std::vector<float> output(q.size(), 0.0f);
     const float scale = 1.0f / std::sqrt(static_cast<float>(D));
     const int q_per_kv = N_HEAD / N_HEAD_KV;
@@ -141,56 +181,86 @@ std::vector<float> reference_attention(
         // Mirrors the kernel: out-of-range slot ids and negative positions
         // are padding rows and leave zero output.
         if (physical_seq < 0 || physical_seq >= physical_n_seq) continue;
+        const bool tree_query = tree && seq >= tree->ar_rows;
+        const int tree_seq = tree_query
+            ? (seq - tree->ar_rows) / tree->width : 0;
+        const int query_node = tree_query
+            ? (seq - tree->ar_rows) % tree->width : -1;
         int kv_seq_len = clamped_seq_len(test_case, physical_seq);
-        if (query_positions && (*query_positions)[seq] < kv_seq_len) {
+        if (query_positions && !tree_query) {
+            if ((*query_positions)[seq] < 0) continue;
             // The inclusive causal clamp: row seq attends its sequence's
             // cached tokens [0, position].
-            kv_seq_len = (*query_positions)[seq] + 1;
+            kv_seq_len = std::min(
+                kv_seq_len, (*query_positions)[seq] + 1);
+        }
+        const int tree_size = tree_query ? tree->tree_sizes[tree_seq] : 0;
+        if (tree_query &&
+            (tree_size < 0 || tree_size > tree->width ||
+             query_node >= tree_size)) {
+            continue;
+        }
+
+        std::vector<int32_t> physical_rows;
+        physical_rows.reserve(
+            kv_seq_len + (tree_query ? tree->width : 0));
+        for (int token = 0; token < kv_seq_len; ++token) {
+            const int block =
+                block_table[
+                    physical_seq * test_case.max_blocks +
+                    token / BLOCK_SIZE];
+            physical_rows.push_back(
+                block_is_valid(block, physical_blocks)
+                    ? block * BLOCK_SIZE + token % BLOCK_SIZE
+                    : -1);
+        }
+        if (tree_query) {
+            for (int candidate = 0; candidate < tree->width; ++candidate) {
+                physical_rows.push_back(
+                    tree_visible(*tree, tree_seq, query_node, candidate)
+                        ? tree_scratch_base +
+                              physical_seq * tree->scratch_stride + candidate
+                        : -1);
+            }
         }
         for (int head = 0; head < N_HEAD; ++head) {
             const int kv_head = head / q_per_kv;
             const float * q_row =
                 q.data() + (static_cast<size_t>(head) * n_seq + seq) * D;
 
-            std::vector<float> scores(kv_seq_len);
+            std::vector<float> scores(physical_rows.size(), -INFINITY);
             float max_score = -INFINITY;
-            for (int token = 0; token < kv_seq_len; ++token) {
-                const int block =
-                    block_table[
-                        physical_seq * test_case.max_blocks + token / BLOCK_SIZE];
-                if (!block_is_valid(block, physical_blocks)) {
-                    // Mirrors the kernel: invalid blocks contribute nothing.
-                    scores[token] = -INFINITY;
-                    continue;
-                }
-                const int physical = block * BLOCK_SIZE + token % BLOCK_SIZE;
+            for (size_t row = 0; row < physical_rows.size(); ++row) {
+                const int physical = physical_rows[row];
+                if (physical < 0) continue;
                 const float * k_row =
                     k.data() +
                     (static_cast<size_t>(kv_head) * pool_tokens + physical) * D;
                 float dot = 0.0f;
                 for (int d = 0; d < D; ++d) dot += q_row[d] * k_row[d];
-                scores[token] = dot * scale;
-                max_score = std::max(max_score, scores[token]);
+                scores[row] = dot * scale;
+                max_score = std::max(max_score, scores[row]);
             }
 
             float denominator = 0.0f;
             for (float & score : scores) {
+                if (!std::isfinite(score)) {
+                    score = 0.0f;
+                    continue;
+                }
                 score = std::exp(score - max_score);
                 denominator += score;
             }
 
             float * out_row =
                 output.data() + (static_cast<size_t>(head) * n_seq + seq) * D;
-            for (int token = 0; token < kv_seq_len; ++token) {
-                const int block =
-                    block_table[
-                        physical_seq * test_case.max_blocks + token / BLOCK_SIZE];
-                if (!block_is_valid(block, physical_blocks)) continue;
-                const int physical = block * BLOCK_SIZE + token % BLOCK_SIZE;
+            for (size_t row = 0; row < physical_rows.size(); ++row) {
+                const int physical = physical_rows[row];
+                if (physical < 0 || denominator == 0.0f) continue;
                 const float * v_row =
                     v.data() +
                     (static_cast<size_t>(kv_head) * pool_tokens + physical) * D;
-                const float probability = scores[token] / denominator;
+                const float probability = scores[row] / denominator;
                 for (int d = 0; d < D; ++d) {
                     out_row[d] += probability * v_row[d];
                 }
@@ -205,7 +275,8 @@ bool run_case(ggml_backend_t backend,
               ggml_type k_type,
               ggml_type v_type,
               const std::vector<int32_t> * active_slot_ids = nullptr,
-              const std::vector<int32_t> * query_positions = nullptr) {
+              const std::vector<int32_t> * query_positions = nullptr,
+              const TreeMetadata * tree = nullptr) {
     const int physical_n_seq = static_cast<int>(test_case.kv_seq_lens.size());
     const int n_seq = active_slot_ids
         ? static_cast<int>(active_slot_ids->size())
@@ -214,8 +285,25 @@ bool run_case(ggml_backend_t backend,
     GGML_ASSERT(!query_positions ||
                 (active_slot_ids &&
                  query_positions->size() == active_slot_ids->size()));
+    GGML_ASSERT(!tree || active_slot_ids);
+    if (tree) {
+        GGML_ASSERT(tree->width > 0);
+        GGML_ASSERT(tree->scratch_stride >= tree->width);
+        GGML_ASSERT(tree->ar_rows >= 0);
+        GGML_ASSERT(tree->ar_rows == 0 || query_positions);
+        GGML_ASSERT(
+            tree->parent_ids.size() ==
+            static_cast<size_t>(tree->width) * tree->tree_sizes.size());
+        GGML_ASSERT(
+            n_seq == tree->ar_rows +
+            tree->width * static_cast<int>(tree->tree_sizes.size()));
+    }
     const int physical_blocks = count_physical_blocks(test_case);
-    const int pool_tokens = physical_blocks * BLOCK_SIZE;
+    const int tree_scratch_base = physical_blocks * BLOCK_SIZE;
+    const int pool_tokens = tree
+        ? tree_scratch_base + physical_n_seq * tree->scratch_stride
+        : tree_scratch_base;
+    GGML_ASSERT(pool_tokens % BLOCK_SIZE == 0);
     const std::vector<int32_t> block_table =
         make_block_table(test_case, physical_blocks);
 
@@ -250,13 +338,26 @@ bool run_case(ggml_backend_t backend,
         positions = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, n_seq);
         ggml_set_input(positions);
     }
+    ggml_tensor * parents = nullptr;
+    ggml_tensor * sizes = nullptr;
+    if (tree) {
+        parents = ggml_new_tensor_2d(
+            ctx, GGML_TYPE_I32, tree->width, tree->tree_sizes.size());
+        sizes = ggml_new_tensor_1d(
+            ctx, GGML_TYPE_I32, tree->tree_sizes.size());
+        ggml_set_input(parents);
+        ggml_set_input(sizes);
+    }
 
     const float scale = 1.0f / std::sqrt(static_cast<float>(D));
     const int max_kv_seq_len = *std::max_element(
         test_case.kv_seq_lens.begin(), test_case.kv_seq_lens.end());
     ggml_tensor * output = ggml_paged_attn_ext(
         ctx, q, k, v, table, kv_seq_lens, active, positions,
-        scale, BLOCK_SIZE, max_kv_seq_len);
+        scale, BLOCK_SIZE, max_kv_seq_len, parents, sizes,
+        tree ? tree->width : 0,
+        tree ? tree_scratch_base : 0,
+        tree ? tree->scratch_stride : 0);
     ggml_set_output(output);
     ggml_cgraph * graph = ggml_new_graph(ctx);
     ggml_build_forward_expand(graph, output);
@@ -315,6 +416,14 @@ bool run_case(ggml_backend_t backend,
                 positions, query_positions->data(), 0,
                 query_positions->size() * sizeof((*query_positions)[0]));
         }
+        if (tree) {
+            ggml_backend_tensor_set(
+                parents, tree->parent_ids.data(), 0,
+                tree->parent_ids.size() * sizeof(tree->parent_ids[0]));
+            ggml_backend_tensor_set(
+                sizes, tree->tree_sizes.data(), 0,
+                tree->tree_sizes.size() * sizeof(tree->tree_sizes[0]));
+        }
         ok = ggml_backend_graph_compute(backend, graph) == GGML_STATUS_SUCCESS;
     }
 
@@ -327,7 +436,7 @@ bool run_case(ggml_backend_t backend,
             reference_attention(
                 test_case, block_table, pool_tokens, physical_blocks,
                 q_data, k_reference, v_reference, active_slot_ids,
-                query_positions);
+                query_positions, tree, tree ? tree_scratch_base : 0);
         max_abs_error = 0.0f;
         for (size_t i = 0; i < actual.size(); ++i) {
             if (!std::isfinite(actual[i])) {
@@ -340,10 +449,11 @@ bool run_case(ggml_backend_t backend,
         ok = ok && max_abs_error < MAX_ABS_ERROR;
     }
 
-    std::printf("paged attention %-11s K=%-4s V=%-4s active=%s pos=%s max_abs=%.6g %s\n",
+    std::printf("paged attention %-11s K=%-4s V=%-4s active=%s pos=%s tree=%s max_abs=%.6g %s\n",
                 test_case.name, ggml_type_name(k_type), ggml_type_name(v_type),
                 active_slot_ids ? "yes" : "no",
                 query_positions ? "yes" : "no",
+                tree ? "yes" : "no",
                 max_abs_error, ok ? "PASS" : "FAIL");
     ggml_gallocr_free(allocator);
     ggml_free(ctx);
@@ -373,7 +483,8 @@ bool rejects_unlaunchable_gqa(ggml_backend_t backend) {
         ggml_new_tensor_1d(ctx, GGML_TYPE_I32, 1);
     ggml_tensor * output = ggml_paged_attn_ext(
         ctx, q, k, v, table, kv_seq_lens, nullptr, nullptr,
-        1.0f / std::sqrt(static_cast<float>(D)), BLOCK_SIZE, 1);
+        1.0f / std::sqrt(static_cast<float>(D)), BLOCK_SIZE, 1,
+        nullptr, nullptr, 0, 0, 0);
 
     const bool rejected = !ggml_backend_supports_op(backend, output);
     std::printf("paged attention unlaunchable GQA support %s\n",
@@ -401,6 +512,57 @@ void run_paged_attention_case(const TestCase & test_case) {
         }
     }
 
+    ggml_backend_free(backend);
+}
+
+void run_tree_case() {
+    ggml_backend_t backend = ggml_backend_cuda_init(0);
+    REQUIRE_NOT_NULL(backend);
+    const TestCase tree_case{"tree", 65, {1025, 17, 257}, false};
+    const TreeMetadata tree_metadata{
+        16, 16,
+        {
+            -1, 0, 1, 2, 3, 4, 5, 6,
+            7, 8, 9, 10, 11, 12, 13, 14,
+            -1, 0, 1, 2, 3, 4, 5, 6,
+            7, -1, -1, -1, -1, -1, -1, -1,
+        },
+        {16, 9},
+    };
+    const std::vector<int32_t> tree_slot_ids{
+        0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0,
+        2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2,
+    };
+    CHECK(run_case(backend, tree_case, GGML_TYPE_F16, GGML_TYPE_F16,
+                   &tree_slot_ids, nullptr, &tree_metadata));
+    CHECK(run_case(backend, tree_case, GGML_TYPE_Q4_0, GGML_TYPE_Q8_0,
+                   &tree_slot_ids, nullptr, &tree_metadata));
+    CHECK(run_case(backend, tree_case, GGML_TYPE_Q8_0, GGML_TYPE_Q4_0,
+                   &tree_slot_ids, nullptr, &tree_metadata));
+    ggml_backend_free(backend);
+}
+
+void run_mixed_tree_case() {
+    ggml_backend_t backend = ggml_backend_cuda_init(0);
+    REQUIRE_NOT_NULL(backend);
+    const TestCase mixed_case{"mixed-tree", 8, {33, 65, 17}, false};
+    const TreeMetadata tree_metadata{
+        16, 16,
+        {
+            -1, 0, 1, 2, 3, 4, 5, 6,
+            7, 8, 9, 10, 11, 12, 13, 14,
+        },
+        {16},
+        2,
+    };
+    std::vector<int32_t> query_slots{1, 0};
+    query_slots.insert(query_slots.end(), 16, 2);
+    std::vector<int32_t> query_positions{7, 15};
+    query_positions.insert(query_positions.end(), 16, -1);
+    CHECK(run_case(backend, mixed_case, GGML_TYPE_F16, GGML_TYPE_F16,
+                   &query_slots, &query_positions, &tree_metadata));
     ggml_backend_free(backend);
 }
 
@@ -464,6 +626,14 @@ TEST_CASE(PagedAttention, CompactThreeSlotBucketMatchesReference) {
         {1, 17, 31},
         false,
     }, {2, 1, 0, -1});
+}
+
+TEST_CASE(PagedAttention, PackedTreesMatchReference) {
+    run_tree_case();
+}
+
+TEST_CASE(PagedAttention, CompactArAndFixedChainMatchReference) {
+    run_mixed_tree_case();
 }
 
 TEST_CASE(PagedAttention, RaggedCausalPositionsMatchReference) {

--- a/server/test/test_paged_attention.cpp
+++ b/server/test/test_paged_attention.cpp
@@ -352,12 +352,14 @@ bool run_case(ggml_backend_t backend,
     const float scale = 1.0f / std::sqrt(static_cast<float>(D));
     const int max_kv_seq_len = *std::max_element(
         test_case.kv_seq_lens.begin(), test_case.kv_seq_lens.end());
-    ggml_tensor * output = ggml_paged_attn_ext(
-        ctx, q, k, v, table, kv_seq_lens, active, positions,
-        scale, BLOCK_SIZE, max_kv_seq_len, parents, sizes,
-        tree ? tree->width : 0,
-        tree ? tree_scratch_base : 0,
-        tree ? tree->scratch_stride : 0);
+    ggml_tensor * output = tree
+        ? ggml_paged_attn_ext_tree(
+            ctx, q, k, v, table, kv_seq_lens, active,
+            positions, scale, BLOCK_SIZE, max_kv_seq_len, parents, sizes,
+            tree_scratch_base, tree->scratch_stride)
+        : ggml_paged_attn_ext(
+            ctx, q, k, v, table, kv_seq_lens, active, positions,
+            scale, BLOCK_SIZE, max_kv_seq_len);
     ggml_set_output(output);
     ggml_cgraph * graph = ggml_new_graph(ctx);
     ggml_build_forward_expand(graph, output);
@@ -483,8 +485,7 @@ bool rejects_unlaunchable_gqa(ggml_backend_t backend) {
         ggml_new_tensor_1d(ctx, GGML_TYPE_I32, 1);
     ggml_tensor * output = ggml_paged_attn_ext(
         ctx, q, k, v, table, kv_seq_lens, nullptr, nullptr,
-        1.0f / std::sqrt(static_cast<float>(D)), BLOCK_SIZE, 1,
-        nullptr, nullptr, 0, 0, 0);
+        1.0f / std::sqrt(static_cast<float>(D)), BLOCK_SIZE, 1);
 
     const bool rejected = !ggml_backend_supports_op(backend, output);
     std::printf("paged attention unlaunchable GQA support %s\n",

--- a/server/test/test_paged_kv_pool.cpp
+++ b/server/test/test_paged_kv_pool.cpp
@@ -275,6 +275,29 @@ TEST_CASE(PagedKvPoolFixture, first_last_slots_append) {
     CHECK(sequence(pool, handle).kv_seq_len == 34);
 }
 
+TEST_CASE(PagedKvPoolFixture, rollback_append_restores_visible_sequence) {
+    PagedKvPool pool(4, 1, 4);
+    PagedKvSequenceHandle handle;
+    CHECK(pool.acquire_reserved(123, 8, handle) == PagedKvStatus::Ok);
+    CHECK(pool.append(handle, 3));
+    const PagedKvSequenceSnapshot before = sequence(pool, handle);
+    const uint32_t free_before = pool.free_block_count();
+
+    CHECK(pool.append(handle, 5));
+    CHECK(sequence(pool, handle).kv_seq_len == 8);
+    CHECK(pool.rollback_append(handle, 5) == PagedKvStatus::Ok);
+
+    const PagedKvSequenceSnapshot after = sequence(pool, handle);
+    CHECK(after.kv_seq_len == before.kv_seq_len);
+    CHECK(after.block_table == before.block_table);
+    CHECK(after.reserved_block_count == before.reserved_block_count);
+    CHECK(pool.free_block_count() == free_before);
+    CHECK(state_unchanged(pool, handle, [&] {
+        CHECK(pool.rollback_append(handle, 4) ==
+              PagedKvStatus::InvalidArgument);
+    }));
+}
+
 TEST_CASE(PagedKvPoolFixture, noncontiguous_reuse_and_isolation) {
     PagedKvPool pool(6, 3, 16);
     const auto first = acquire(pool, 101);

--- a/server/test/test_qwen35_roctx.cpp
+++ b/server/test/test_qwen35_roctx.cpp
@@ -37,6 +37,26 @@ int main() {
     CHECK(events.size() == 2 && events[1] == "pop");
 
     events.clear();
+    {
+        Qwen35RoctxRange service_round(
+            "qwen35.service_round", {4, -1, 0, 0, -1, -1}, true,
+            {push, pop});
+        {
+            Qwen35RoctxRange target_step(
+                "qwen35.concurrent_step", {4, 4, 0, 0, 32, 128}, true,
+                {push, pop});
+        }
+    }
+    CHECK(events.size() == 4);
+    CHECK(events[0] == "qwen35.service_round live=4 "
+                       "prefill_tokens=0 prefill_segments=0");
+    CHECK(events[1] == "qwen35.concurrent_step live=4 bucket=4 "
+                       "prefill_tokens=0 prefill_segments=0 total_rows=32 "
+                       "max_kv_len=128");
+    CHECK(events[2] == "pop");
+    CHECK(events[3] == "pop");
+
+    events.clear();
     { Qwen35RoctxRange disabled("qwen35.graph_compute", {}, false, {push, pop}); }
     CHECK(events.empty());
     return failures == 0 ? 0 : 1;

--- a/server/test/test_recurrent_snapshot.cpp
+++ b/server/test/test_recurrent_snapshot.cpp
@@ -1,5 +1,6 @@
 #include "CppUnitTestFramework.hpp"
 #include "internal.h"
+#include "qwen35/graph_builders.h"
 
 #include "ggml-backend.h"
 #include "ggml-cpu.h"
@@ -11,6 +12,7 @@
 using namespace CppUnitTestFramework;
 
 using dflash::common::TargetCache;
+using dflash::common::StepGraph;
 using dflash::common::restore_ssm_state;
 using dflash::common::snapshot_ssm_state;
 
@@ -32,10 +34,150 @@ static std::vector<float> get_tensor(const ggml_tensor * tensor) {
     return values;
 }
 
+TEST_CASE(RecurrentSnapshotFixture, validates_paged_tree_capacity_and_uploads) {
+    size_t graph_capacity = 0;
+    CHECK(dflash::common::detail::
+              target_graph_capacity_for_parallel_segments(
+                  0, graph_capacity) && graph_capacity == 16384);
+    CHECK(dflash::common::detail::
+              target_graph_capacity_for_parallel_segments(
+                  8, graph_capacity) && graph_capacity == 16384);
+    CHECK(dflash::common::detail::
+              target_graph_capacity_for_parallel_segments(
+                  16, graph_capacity) && graph_capacity == 32768);
+    CHECK(dflash::common::detail::
+              target_graph_capacity_for_parallel_segments(
+                  64, graph_capacity) && graph_capacity == 131072);
+    CHECK(!dflash::common::detail::
+               target_graph_capacity_for_parallel_segments(
+                   65, graph_capacity));
+    CHECK(dflash::common::detail::target_paged_tree_graph_capacity(
+              16, 16, graph_capacity) && graph_capacity == 32768);
+    CHECK(!dflash::common::detail::target_paged_tree_graph_capacity(
+               17, 16, graph_capacity));
+
+    {
+        ggml_backend_t tree_backend = ggml_backend_cpu_init();
+        CHECK(tree_backend != nullptr);
+        ggml_init_params marker_params{};
+        marker_params.mem_size = 4 * ggml_tensor_overhead();
+        marker_params.no_alloc = true;
+        ggml_context * marker_ctx = ggml_init(marker_params);
+        ggml_init_params live_params{};
+        live_params.mem_size = 16 * ggml_tensor_overhead();
+        live_params.no_alloc = true;
+        ggml_context * live_ctx = ggml_init(live_params);
+        CHECK(marker_ctx != nullptr);
+        CHECK(live_ctx != nullptr);
+        if (tree_backend && marker_ctx && live_ctx) {
+            StepGraph tree;
+            tree.active_slot_ids =
+                ggml_new_tensor_1d(marker_ctx, GGML_TYPE_I32, 2);
+            ggml_tensor * unallocated_state_ids =
+                ggml_new_tensor_1d(marker_ctx, GGML_TYPE_I32, 2);
+            tree.inp_embed = ggml_new_tensor_2d(
+                live_ctx, GGML_TYPE_F32, 4, 4);
+            tree.positions =
+                ggml_new_tensor_1d(live_ctx, GGML_TYPE_I32, 16);
+            tree.parent_ids =
+                ggml_new_tensor_2d(live_ctx, GGML_TYPE_I32, 2, 2);
+            tree.tree_sizes =
+                ggml_new_tensor_1d(live_ctx, GGML_TYPE_I32, 2);
+            tree.state_slot_ids =
+                ggml_new_tensor_1d(live_ctx, GGML_TYPE_I32, 2);
+            tree.paged_query_seq_ids =
+                ggml_new_tensor_1d(live_ctx, GGML_TYPE_I32, 4);
+            tree.kv_write_rows =
+                ggml_new_tensor_2d(live_ctx, GGML_TYPE_I64, 4, 1);
+            ggml_backend_buffer_t live_buffer =
+                ggml_backend_alloc_ctx_tensors(live_ctx, tree_backend);
+            CHECK(live_buffer != nullptr);
+            if (live_buffer) {
+                CHECK(tree.active_slot_ids->buffer == nullptr);
+                CHECK(dflash::common::detail::
+                          target_paged_tree_uploads_ready(tree));
+                CHECK(!dflash::common::detail::
+                           target_paged_tree_active_slots_need_upload(tree));
+
+                const int32_t state_ids[] = {0, 1};
+                ggml_backend_tensor_set(tree.state_slot_ids, state_ids, 0,
+                                        sizeof(state_ids));
+                tree.state_slot_ids = unallocated_state_ids;
+                CHECK(!dflash::common::detail::
+                           target_paged_tree_uploads_ready(tree));
+                ggml_backend_buffer_free(live_buffer);
+            }
+        }
+        if (live_ctx) ggml_free(live_ctx);
+        if (marker_ctx) ggml_free(marker_ctx);
+        if (tree_backend) ggml_backend_free(tree_backend);
+    }
+
+}
+
+TEST_CASE(RecurrentSnapshotFixture, validates_paged_tree_layout) {
+    {
+        ggml_init_params shape_params{};
+        shape_params.mem_size = 8 * ggml_tensor_overhead();
+        shape_params.no_alloc = true;
+        ggml_context * shape_ctx = ggml_init(shape_params);
+        CHECK(shape_ctx != nullptr);
+        if (shape_ctx) {
+            TargetCache shape_cache;
+            shape_cache.n_seq_slots = 2;
+            shape_cache.paged_block_table =
+                ggml_new_tensor_2d(shape_ctx, GGML_TYPE_I32, 4, 2);
+            shape_cache.paged_kv_seq_lens =
+                ggml_new_tensor_1d(shape_ctx, GGML_TYPE_I32, 2);
+            shape_cache.attn_k = {
+                ggml_new_tensor_4d(shape_ctx, GGML_TYPE_F16, 4, 64, 1, 1),
+            };
+            CHECK(dflash::common::detail::validate_target_paged_tree_layout(
+                shape_cache, 8, 2, 4096, 32, 16));
+            CHECK(!dflash::common::detail::validate_target_paged_tree_layout(
+                shape_cache, 8, 2, 4096, 48, 16));
+            CHECK(!dflash::common::detail::validate_target_paged_tree_layout(
+                shape_cache, 8, 5, 4096, 32, 16));
+            ggml_free(shape_ctx);
+        }
+    }
+
+}
+
 TEST_CASE(RecurrentSnapshotFixture, snapshot_and_restore_recurrent_state) {
     ggml_backend_t backend = ggml_backend_cpu_init();
     CHECK(backend != nullptr);
     if (!backend) SKIP("CPU backend is unavailable");
+
+    {
+        size_t graph_capacity = 0;
+        CHECK(dflash::common::detail::target_paged_tree_graph_capacity(
+            16, 16, graph_capacity));
+        ggml_init_params graph_params{};
+        graph_params.mem_size = 32 * 1024 * 1024;
+        graph_params.no_alloc = true;
+        ggml_context * graph_ctx = ggml_init(graph_params);
+        CHECK(graph_ctx != nullptr);
+        if (graph_ctx) {
+            ggml_tensor * input =
+                ggml_new_tensor_1d(graph_ctx, GGML_TYPE_F32, 1);
+            ggml_set_input(input);
+            ggml_cgraph * graph = ggml_new_graph_custom(
+                graph_ctx, graph_capacity, false);
+            for (int i = 0; i < 16385; ++i) {
+                ggml_build_forward_expand(
+                    graph, ggml_dup(graph_ctx, input));
+            }
+            CHECK(ggml_graph_n_nodes(graph) == 16385);
+            ggml_gallocr_t graph_alloc = ggml_gallocr_new(
+                ggml_backend_get_default_buffer_type(backend));
+            CHECK(graph_alloc != nullptr);
+            CHECK(graph_alloc &&
+                  ggml_gallocr_alloc_graph(graph_alloc, graph));
+            if (graph_alloc) ggml_gallocr_free(graph_alloc);
+            ggml_free(graph_ctx);
+        }
+    }
 
     ggml_init_params params{};
     params.mem_size = 8 * ggml_tensor_overhead();

--- a/server/test/test_seq_engine_contract.cpp
+++ b/server/test/test_seq_engine_contract.cpp
@@ -23,7 +23,6 @@ struct Faults {
     bool overconsume_prefill = false;
     bool drop_second_completion = false;
     bool retire_leaks = false;
-    bool burst_when_speculation_disabled = false;
 };
 
 struct FakeCapabilities {
@@ -112,10 +111,6 @@ public:
                 100 + input.slot + (int32_t)slot.fed.size(),
                 false, {},
             });
-            if (faults_.burst_when_speculation_disabled &&
-                !input.allow_speculation) {
-                result.decode.back().committed_tokens.push_back(91);
-            }
         }
 
         std::vector<int> completed_this_step;

--- a/server/test/test_seq_engine_contract.cpp
+++ b/server/test/test_seq_engine_contract.cpp
@@ -23,6 +23,7 @@ struct Faults {
     bool overconsume_prefill = false;
     bool drop_second_completion = false;
     bool retire_leaks = false;
+    bool burst_when_speculation_disabled = false;
 };
 
 struct FakeCapabilities {
@@ -111,6 +112,10 @@ public:
                 100 + input.slot + (int32_t)slot.fed.size(),
                 false, {},
             });
+            if (faults_.burst_when_speculation_disabled &&
+                !input.allow_speculation) {
+                result.decode.back().committed_tokens.push_back(91);
+            }
         }
 
         std::vector<int> completed_this_step;
@@ -316,6 +321,18 @@ int main() {
             print_violations(test.label, violations);
         }
         CHECK(mentions(violations, test.expected));
+    }
+
+    {
+        SeqEngine::StepPlan plan;
+        plan.decode.push_back({0, 7, false});
+        SeqEngine::StepResult result;
+        SeqEngine::DecodeOutput output;
+        output.slot = 0;
+        output.token = 8;
+        output.committed_tokens = {9};
+        result.decode.push_back(output);
+        CHECK(!validate_step_result(plan, result, 1).empty());
     }
 
     std::printf("test_seq_engine_contract: %d checks passed\n", g_checks);

--- a/server/test/test_seq_slot_manager.cpp
+++ b/server/test/test_seq_slot_manager.cpp
@@ -85,18 +85,21 @@ int main() {
         mgr.commit_prefill(0);
         CHECK(mgr.slot(0).cur_pos == 20);
 
-        // Decode appends: row allocation + sample_history; cur_pos advances
-        // separately after the step's compute.
+        // Decode rows stage until the target compute succeeds.
         auto st = mgr.append_token(0, /*fed_token=*/42);
         CHECK(st.ok);
         CHECK(st.position == 20);
         CHECK(st.physical_row == 20);     // tail of the prompt's last block
         CHECK(st.new_block < 0 && st.new_block_index < 0);
         CHECK(mgr.slot(0).cur_pos == 20);
-        CHECK(mgr.slot(0).sample_history.size() == 21 &&
-              mgr.slot(0).sample_history.back() == 42);
+        CHECK(mgr.slot(0).sample_history.size() == 20);
+        CHECK(mgr.slot(0).staged_tokens.size() == 1 &&
+              mgr.slot(0).staged_tokens.back() == 42);
         mgr.commit_step(0);
         CHECK(mgr.slot(0).cur_pos == 21);
+        CHECK(mgr.slot(0).sample_history.size() == 21 &&
+              mgr.slot(0).sample_history.back() == 42);
+        CHECK(mgr.slot(0).staged_tokens.empty());
 
         // Second admission lands in slot 1 with non-identity rows.
         auto b = admit(mgr, 2, prompt_tokens(20), greedy_sampler());
@@ -331,6 +334,46 @@ int main() {
         auto boundary_append = mgr.append_token(boundary.slot, 31);
         CHECK(boundary_append.ok && boundary_append.new_block_index == 2);
         CHECK(pool.free_block_count() == 0);
+    }
+
+    // A multi-token stage owns its rows until one atomic commit.
+    {
+        PagedKvPool pool(8, 1, /*block_size=*/4);
+        Qwen35SlotManager mgr(pool, /*max_ctx=*/32);
+        auto a = admit(mgr, 1, prompt_tokens(3), greedy_sampler());
+        CHECK(is_admitted(a));
+        CHECK(mgr.append_prefill(a.slot, 3).ok);
+        mgr.commit_prefill(a.slot);
+
+        const int32_t accepted[] = {41, 42, 43, 44, 45, 46};
+        auto staged = mgr.append_tokens(a.slot, accepted, 6);
+        CHECK(staged.ok && staged.count == 6);
+        CHECK(staged.position == 3 && staged.physical_rows.size() == 6);
+        CHECK(staged.first_new_block == 1 && staged.new_blocks.size() == 2);
+        CHECK(mgr.slot(a.slot).cur_pos == 3);
+        CHECK(mgr.slot(a.slot).sample_history.size() == 3);
+        CHECK(mgr.slot(a.slot).staged_tokens ==
+              std::vector<int32_t>(accepted, accepted + 6));
+        CHECK(!mgr.append_token(a.slot, 99).ok);
+
+        const uint32_t free_while_staged = pool.free_block_count();
+        mgr.retire(a.slot);
+        CHECK(!mgr.is_active(a.slot));
+        CHECK(pool.free_block_count() > free_while_staged);
+
+        a = admit(mgr, 2, prompt_tokens(3), greedy_sampler());
+        CHECK(is_admitted(a));
+        CHECK(mgr.append_prefill(a.slot, 3).ok);
+        mgr.commit_prefill(a.slot);
+        staged = mgr.append_tokens(a.slot, accepted, 6);
+        CHECK(staged.ok);
+        mgr.commit_step(a.slot);
+        CHECK(mgr.slot(a.slot).cur_pos == 9);
+        CHECK(mgr.slot(a.slot).staged_tokens.empty());
+        CHECK(mgr.slot(a.slot).sample_history.size() == 9);
+        CHECK(std::equal(
+            accepted, accepted + 6,
+            mgr.slot(a.slot).sample_history.end() - 6));
     }
 
     // Context exhaustion: append_token refuses past max_ctx.

--- a/server/test/test_seq_slot_manager.cpp
+++ b/server/test/test_seq_slot_manager.cpp
@@ -374,6 +374,41 @@ int main() {
             mgr.slot(a.slot).sample_history.end() - 6));
     }
 
+    {
+        PagedKvPool pool(4, 1, 16);
+        Qwen35SlotManager mgr(pool, 64);
+        auto a = admit(mgr, 1, prompt_tokens(15), greedy_sampler());
+        CHECK(is_admitted(a));
+        CHECK(mgr.append_prefill(a.slot, 15).ok);
+        mgr.commit_prefill(a.slot);
+
+        PagedKvSequenceSnapshot before;
+        CHECK(pool.sequence(mgr.slot(a.slot).handle, before) ==
+              PagedKvStatus::Ok);
+        const uint32_t free_before = pool.free_block_count();
+        const int32_t accepted[] = {41, 42, 43, 44, 45, 46, 47, 48};
+        const auto staged = mgr.append_tokens(a.slot, accepted, 8);
+        CHECK(staged.ok && staged.new_blocks.size() == 1);
+        CHECK(mgr.rollback_step(a.slot));
+        CHECK(mgr.slot(a.slot).cur_pos == 15);
+        CHECK(mgr.slot(a.slot).sample_history == prompt_tokens(15));
+        CHECK(mgr.slot(a.slot).staged_tokens.empty());
+
+        PagedKvSequenceSnapshot after;
+        CHECK(pool.sequence(mgr.slot(a.slot).handle, after) ==
+              PagedKvStatus::Ok);
+        CHECK(after.kv_seq_len == before.kv_seq_len);
+        CHECK(after.block_table == before.block_table);
+        CHECK(after.reserved_block_count == before.reserved_block_count);
+        CHECK(pool.free_block_count() == free_before);
+
+        const auto restaged = mgr.append_tokens(a.slot, accepted, 8);
+        CHECK(restaged.ok);
+        CHECK(restaged.physical_rows == staged.physical_rows);
+        mgr.commit_step(a.slot);
+        CHECK(mgr.slot(a.slot).cur_pos == 23);
+    }
+
     // Context exhaustion: append_token refuses past max_ctx.
     {
         PagedKvPool pool(4, 1, /*block_size=*/16);

--- a/server/test/test_seq_slot_manager.cpp
+++ b/server/test/test_seq_slot_manager.cpp
@@ -85,7 +85,6 @@ int main() {
         mgr.commit_prefill(0);
         CHECK(mgr.slot(0).cur_pos == 20);
 
-        // Decode rows stage until the target compute succeeds.
         auto st = mgr.append_token(0, /*fed_token=*/42);
         CHECK(st.ok);
         CHECK(st.position == 20);
@@ -336,7 +335,6 @@ int main() {
         CHECK(pool.free_block_count() == 0);
     }
 
-    // A multi-token stage owns its rows until one atomic commit.
     {
         PagedKvPool pool(8, 1, /*block_size=*/4);
         Qwen35SlotManager mgr(pool, /*max_ctx=*/32);

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -21,6 +21,7 @@
 #include "server/http_server.h"
 #include "server/chat_template.h"
 #include "common/sampler.h"
+#include "common/concurrency/seq_engine.h"
 #include "common/backend_precision.h"
 #include "common/backend_ipc.h"
 #include "common/moe_hybrid_ffn_eval.h"
@@ -5946,5 +5947,20 @@ TEST_CASE(ServerUnitFixture, test_emitter_function_calls_param_with_literal_thin
     TEST_ASSERT(em.emit_token_count() - em.first_content_token_index() == 1);
 }
 
+TEST_CASE(ServerUnitFixture,
+          test_concurrent_scheduler_burst_stops_at_eos) {
+    SeqEngine::DecodeOutput burst;
+    burst.slot = 0;
+    burst.committed_tokens = {101, 2, 103};
+    burst.token = 104;
 
+    std::vector<int32_t> emitted;
+    const bool consumed_all = consume_decode_output_tokens(
+        burst, [&](int32_t token) {
+            emitted.push_back(token);
+            return token != 2;
+        });
 
+    TEST_ASSERT(!consumed_all);
+    TEST_ASSERT((emitted == std::vector<int32_t>{101, 2}));
+}

--- a/server/test/test_speculative_sampling.cpp
+++ b/server/test/test_speculative_sampling.cpp
@@ -1,0 +1,113 @@
+#include "common/sampler.h"
+#include "common/speculative_sampling.h"
+#include "host_check.h"
+
+#include <cmath>
+#include <cstdio>
+#include <random>
+#include <vector>
+
+using namespace dflash::common;
+
+static int g_checks = 0;
+
+namespace {
+
+bool near(float actual, float expected, float tolerance = 1e-6f) {
+    return std::fabs(actual - expected) <= tolerance;
+}
+
+}  // namespace
+
+int main() {
+    {
+        const float logits[] = {3.0f, 2.0f, 1.0f};
+        SamplerCfg cfg;
+        cfg.temp = 0.0f;
+        cfg.freq_pen = 2.5f;
+        const std::vector<int32_t> history = {0};
+        SamplerDistribution dist;
+        CHECK(build_sampler_distribution(logits, 3, cfg, history, dist));
+        CHECK(dist.valid());
+        CHECK(dist.support.size() == 1);
+        CHECK(dist.support[0] == 1);
+        CHECK(near(dist.probability_of(1), 1.0f));
+    }
+
+    {
+        const float logits[] = {1.2f, -0.5f, 2.1f, 0.3f, 1.7f};
+        SamplerCfg cfg;
+        cfg.temp = 0.7f;
+        cfg.top_k = 4;
+        cfg.top_p = 0.82f;
+        cfg.rep_pen = 1.15f;
+        cfg.freq_pen = 0.2f;
+        cfg.pres_pen = 0.1f;
+        const std::vector<int32_t> history = {2, 4, 2};
+        SamplerDistribution dist;
+        CHECK(build_sampler_distribution(logits, 5, cfg, history, dist));
+        CHECK(dist.valid());
+        CHECK(!dist.support.empty());
+
+        std::mt19937_64 direct_rng(9001);
+        std::mt19937_64 dist_rng(9001);
+        std::uniform_real_distribution<double> uniform(0.0, 1.0);
+        for (int i = 0; i < 64; ++i) {
+            const int direct = sample_logits(logits, 5, cfg, history, direct_rng);
+            const int materialized =
+                sample_distribution(dist, uniform(dist_rng));
+            CHECK(direct == materialized);
+        }
+    }
+
+    {
+        SamplerDistribution dist;
+        dist.probabilities = {0.1f, 0.2f, 0.3f, 0.4f};
+        dist.support = {0, 1, 2, 3};
+        const int32_t eos_ids[] = {1, 3};
+        CHECK(redirect_distribution_mass(dist, eos_ids, 2, 2));
+        CHECK(near(dist.probability_of(0), 0.1f));
+        CHECK(near(dist.probability_of(1), 0.0f));
+        CHECK(near(dist.probability_of(2), 0.9f));
+        CHECK(near(dist.probability_of(3), 0.0f));
+        CHECK(dist.valid());
+    }
+
+    {
+        SamplerDistribution target;
+        target.probabilities = {0.6f, 0.3f, 0.1f};
+        target.support = {0, 1, 2};
+        SparseProposalDistribution proposal;
+        proposal.token_ids = {0, 1, 2};
+        proposal.probabilities = {0.2f, 0.5f, 0.3f};
+        CHECK(proposal.valid(3));
+        CHECK(near(speculative_acceptance_probability(target, proposal, 0), 1.0f));
+        CHECK(near(speculative_acceptance_probability(target, proposal, 1), 0.6f));
+        CHECK(near(speculative_acceptance_probability(target, proposal, 2), 1.0f / 3.0f));
+        int token = -1;
+        CHECK(sample_speculative_residual(target, proposal, 0.0, token));
+        CHECK(token == 0);
+        CHECK(sample_speculative_residual(target, proposal, 0.999, token));
+        CHECK(token == 0);
+    }
+
+    {
+        SamplerDistribution target;
+        target.probabilities = {0.5f, 0.3f, 0.2f};
+        target.support = {0, 1, 2};
+        SparseProposalDistribution proposal;
+        proposal.token_ids = {0, 2};
+        proposal.probabilities = {0.25f, 0.75f};
+        CHECK(proposal.valid(3));
+        CHECK(near(speculative_acceptance_probability(target, proposal, 2),
+                   0.2f / 0.75f));
+        int token = -1;
+        CHECK(sample_speculative_residual(target, proposal, 0.0, token));
+        CHECK(token == 0);
+        CHECK(sample_speculative_residual(target, proposal, 0.999, token));
+        CHECK(token == 1);
+    }
+
+    std::printf("speculative sampling tests passed: %d checks\n", g_checks);
+    return 0;
+}


### PR DESCRIPTION
## Stack

This draft PR is built on top of #651 at `f1c85e05`. It therefore contains the exact current #642 history, #651's projection batching, and the separate replay-log rename.

#654 adds two commits:

1. `0445b161` — `feat(sampler): add distribution-preserving spec verification`
2. `e0647848` — `feat(qwen35): speculate sampled concurrent lanes`

Both commits are patch-equivalent across the final restack.

## Summary

- Keep temperature, top-p, top-k, repetition penalty, frequency penalty, and presence penalty lanes in DFlash2 chain rounds.
- Share one target forward across greedy speculative lanes, sampled speculative lanes, and autoregressive fallback lanes.
- Apply distribution-preserving speculative accept/reject sampling.
- Keep one transactional RNG state per slot and publish it only after prefix promotion succeeds.
- Roll back at the first rejected draft token.
- Commit only the accepted KV, target-feature, GDN, and convolution prefix.
- Batch sampled target-logit transfers by depth, stop transfers after a lane rejects, and reuse sampler buffers.
- Preserve the sparse ordinary AR path for lanes that cannot use the sampled protocol.

For a proposed token `x`, verification accepts with `min(1, p(x) / q(x))`. At the first rejection, it samples from normalized `max(p - q, 0)`. If the chain fully accepts, it samples the bonus token from the target distribution on the final verifier row. Target and residual distributions use the same sampler policy as ordinary generation.

## Three-lane reference benchmark

These measurements were taken on the previous stacked head `13590205`, before the latest #625 refresh. They remain useful as a reference for the unchanged #654 patches, but they are not presented as final-head measurements. A clean rerun was deferred because another user continuously occupied the shared GPU host; contaminated numbers were excluded.

Setup:

- Radeon R9700 (`gfx1201`)
- Qwen3.8-27B Q4_K_M target
- Q8_0 DFlash2 draft with W8 and SWA 2048
- Concurrency 3, context 4,096, and a 12,288-token KV pool
- 96 output tokens per lane with `DFLASH_MIN_TOKENS=96`
- One warmup batch, followed by three measured batches per mode
- Aggregate throughput is 288 completion tokens divided by batch wall time

Sampled lanes use temperature 0.8, top-p 0.9, top-k 40, frequency penalty 0.4, and presence penalty 0.2. The mixed batch is greedy, sampled, greedy.

| Lanes | DFlash2 | One-token AR control | Speedup |
| :-- | --: | --: | --: |
| Greedy / greedy / greedy | 222.33 tok/s | 46.93 tok/s | 4.74x |
| Sampled / sampled / sampled | 149.69 tok/s | 44.33 tok/s | 3.38x |
| Greedy / sampled / greedy | 187.46 tok/s | 45.43 tok/s | 4.13x |

Every measured batch produced exactly 288 tokens. The speculative server reported W8, `SWA layers: 5/5 (window=2048)`, and one packed three-lane draft backbone. The AR control used the same binary without a drafter.

## Verification

- `git range-diff` reports both #654 commits patch-equivalent across the final restack.
- Confirmed that #654's parent is exactly `f1c85e05`, the final #651 head.
- Built the exact final gfx1201 server and server-unit binary at `e0647848`.
- Passed the #625 disk-cache version-2 assertion.
- Passed 92 sampler checks covering parity, acceptance probabilities, residual sampling, and EOS-mass redirection.
- Passed all 189 slot-manager checks and all 15 sequence-engine contract checks.
- Passed five host SWA policy cases.
- Passed batched-GDN CPU/GPU checks, all replay-log modes, and the real Qwen3.8 three-lane SWA qualification with `max_abs=0` before the final test-only parent update.
- The reference benchmark completed 27 measured and 9 warmup speculative requests plus the same AR-control workload; every request produced exactly 96 tokens.
- Passed `git diff --check`.
