### PR TITLE
fix(tokenizer): support up to 3-digit chunking in pre-tokenizer (\p{N}{1,3})

### DIFF
--- a/server/src/server/tokenizer.cpp
+++ b/server/src/server/tokenizer.cpp
@@ -138,10 +138,10 @@ static bool is_newline(uint32_t cp) {
 }
 
 // ─── Pre-tokenizer ─────────────────────────────────────────────────────
-// Matches the Qwen3.5 pattern:
+// Matches the Qwen/DeepSeek pattern:
 //   (?:'[sStTmMdD]|...) |
 //   [^\r\n\p{L}\p{N}]?[\p{L}\p{M}]+ |
-//   \p{N} |
+//   \p{N}{1,3} |
 //   ' '?[^\s\p{L}\p{M}\p{N}]+[\r\n]* |
 //   \s*[\r\n]+ |
 //   \s+(?!\S) |

--- a/server/src/server/tokenizer.cpp
+++ b/server/src/server/tokenizer.cpp
@@ -213,9 +213,14 @@ std::vector<std::string> Tokenizer::pre_tokenize(const std::string & text) const
             }
         }
 
-        // Pattern 3: \p{N}  (single digit)
+        // Pattern 3: \p{N}{1,3}  (up to 3 digits)
         if (is_digit(cp)) {
-            pos += cplen;
+            int digit_count = 0;
+            while (digit_count < 3 && is_digit(cp)) {
+                pos += cplen;
+                digit_count++;
+                cp = peek_cp(pos, &cplen);
+            }
             pieces.push_back(text.substr(start, pos - start));
             continue;
         }


### PR DESCRIPTION
Fixes #660

### Summary

In GGUF models using `tokenizer.ggml.pre = "joyai-llm"` (such as DeepSeek-V3, DeepSeek-V4, and Hunyuan-Dense), upstream `llama.cpp` ([`llama-vocab.cpp:318-326`](https://github.com/ggml-org/llama.cpp/blob/master/src/llama-vocab.cpp#L318-L326)) specifies digit pre-tokenization using `\p{N}{1,3}`.

Previously, `Tokenizer::pre_tokenize` extracted digits as single characters (`\p{N}`), decomposing numeric sequences like `501` into `["5", "0", "1"]` (tokens `[23, 18, 19]`) rather than permitting BPE merges to match atomic vocabulary tokens (such as `19097` for `'501'`). Decomposed single-character digits caused attention optical confusion (e.g., `'0'` $\to$ `'o'`).

### Changes
- Updated `Tokenizer::pre_tokenize` Pattern 3 to chunk up to 3 consecutive digits (`\p{N}{1,3}`).

### Verification
- **Unit Tests**: Ran `test_server_unit` (423/423 tests passed).
- **Target Hardware Benchmark**: Verified on AMD Ryzen AI Max+ 395 (Radeon 8060S / gfx1151) with DeepSeek-V4 Flash across all 4 interaction modes (Tool Calling & Plain Repetition, with and without thinking).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

