### PR TITLE
fix(server): prefix-cache deepening (stop pinning the restore point + stop truncating at stray end-markers)

### DIFF
--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -3392,11 +3392,17 @@ HttpServer::GenerationCacheState HttpServer::prepare_generation_cache(
     // requests prefer the reusable system/tool boundary; otherwise an
     // enabled exact full-prompt cache retains its existing priority.
     auto prepare_inline = [&]() {
+        // Never let the new snapshot land in the slot this request restores
+        // from: the guard below would cancel it, pinning the restore point at
+        // the deepest slot on linearly-growing conversations.
+        const int restore_source_slot =
+            cache.using_restore ? cache.cache_slot : -1;
         const auto prepared_snapshot = prefix_cache_.prepare_inline_snap(
             effective_prompt,
             cache.using_restore ? logical_prefix_len : 0,
             prefer_tools_boundary,
-            forced_cut);
+            forced_cut,
+            restore_source_slot);
         cache.snap_slot = prepared_snapshot.first;
         cache.snap_cut = prepared_snapshot.second;
     };
@@ -3660,7 +3666,9 @@ void HttpServer::remember_agent_turn(
 
     const int canonical_end = (int) canonical_tokens.size();
     const auto pending = prefix_cache_.prepare_inline_snap(
-        canonical_tokens, source_pos, false, canonical_end);
+        canonical_tokens, source_pos, false, canonical_end, source_slot);
+    // No safe victim (only the restore source and/or protected pins remain)
+    // or no useful boundary: nothing to replay into.
     if (pending.first < 0 || pending.second != canonical_end) return;
 
     const int slot = pending.first;

--- a/server/src/server/prefix_cache.cpp
+++ b/server/src/server/prefix_cache.cpp
@@ -4,6 +4,7 @@
 #include "common/sha1.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cstdio>
 #include <cstring>
 #include <chrono>
@@ -119,6 +120,7 @@ std::vector<int> find_all_boundaries(const std::vector<int32_t> & ids,
     if (sys_idx < 0) return out;
 
     int cursor = sys_idx + (int)markers.sys_role_prefix.size();
+    int stray_skips = 0;
     while (true) {
         auto [end_idx, end_len] = find_first_seq_any(ids, markers.end_msg_seqs, cursor);
         if (end_idx < 0) break;
@@ -136,10 +138,24 @@ std::vector<int> find_all_boundaries(const std::vector<int32_t> & ids,
             }
         }
         found:
-        if (next_match < 0) break;
+        if (next_match < 0) {
+            // Stray end-of-message marker with no following role start — chatml
+            // tokens embedded in message content (file dumps, terminal output,
+            // model-echoed markers). Skip this marker and keep scanning instead
+            // of truncating the whole boundary list. A lone stray previously cut
+            // the walk off here, hiding every real boundary after it; that pinned
+            // the inline-snapshot deepen target (second-to-last boundary) at the
+            // already-restored prefix length, so no snapshot was ever deepened and
+            // every turn re-prefilled the entire tail. Guard against pathological
+            // input (or a marker-family mismatch) by capping consecutive strays.
+            if (++stray_skips > 8192) break;
+            cursor = after_end;
+            continue;
+        }
         int boundary = next_match + next_len;
         out.push_back(boundary);
         cursor = boundary;
+        stray_skips = 0;
     }
     return out;
 }
@@ -385,7 +401,22 @@ std::pair<int, int> PrefixCache::prepare_inline_snap(
         target_cut = select_inline_snapshot_boundary(
             candidates, restored_prefix_len, prefer_tools_boundary);
     }
-    if (target_cut <= 0) return {-1, 0};
+    if (target_cut <= 0) {
+        // An expected no-op when the restored prefix already covers the next
+        // boundary (single-turn prompts, or a cache-primed conversation): log
+        // once only, so the diagnostic — a truncated boundary list from stray
+        // chatml in content — stays visible without flooding long runs. The
+        // HTTP layer may retry within a request, so this can otherwise fire
+        // twice per turn.
+        static std::atomic<bool> s_snap_blocked_logged{false};
+        if (!s_snap_blocked_logged.exchange(true)) {
+            std::fprintf(stderr,
+                "[pc] inline snap blocked: boundaries=%zu restored=%d target<=0 "
+                "(deepen target not past restored prefix; logged once)\n",
+                candidates.size(), restored_prefix_len);
+        }
+        return {-1, 0};
+    }
 
     auto key = hash_prefix(prompt_ids.data(), target_cut);
     if (find_entry(key) >= 0) return {-1, 0};  // already cached

--- a/server/src/server/prefix_cache.cpp
+++ b/server/src/server/prefix_cache.cpp
@@ -171,35 +171,63 @@ static bool is_strict_prefix(const std::vector<int32_t> & a,
 }
 
 int select_inline_evict_victim(const std::vector<const std::vector<int32_t> *> & ids_lru,
-                               const std::vector<bool> * protected_lru) {
+                               const std::vector<bool> * protected_lru,
+                               int skip_index) {
     const int n = (int)ids_lru.size();
     if (n <= 0) return 0;
     auto is_protected = [&](int i) {
         return protected_lru && i >= 0 && i < (int)protected_lru->size() &&
                (*protected_lru)[(size_t)i];
     };
-    // Oldest-first scan: prefer an unprotected leaf so sticky tools pins survive.
-    int oldest_protected_leaf = -1;
-    for (int i = 0; i < n; i++) {
-        bool is_ancestor = false;
+    auto is_ancestor = [&](int i) {
         for (int j = 0; j < n; j++) {
             if (j == i) continue;
-            if (is_strict_prefix(*ids_lru[i], *ids_lru[j])) { is_ancestor = true; break; }
+            if (is_strict_prefix(*ids_lru[i], *ids_lru[j])) return true;
         }
-        if (is_ancestor) continue;
+        return false;
+    };
+    // Oldest-first scan: prefer an unprotected leaf so sticky tools pins
+    // survive. skip_index (the in-flight restore source) is never a victim.
+    int oldest_protected_leaf = -1;
+    for (int i = 0; i < n; i++) {
+        if (i == skip_index) continue;
+        if (is_ancestor(i)) continue;
         if (!is_protected(i)) return i;  // oldest unprotected leaf
         if (oldest_protected_leaf < 0) oldest_protected_leaf = i;
+    }
+    if (skip_index >= 0) {
+        // No unprotected leaf outside the restore source — e.g. a linearly
+        // growing conversation whose only leaf is the restore source itself.
+        // Evict the shallowest non-protected ancestor (its KV is subsumed by
+        // every deeper entry) so the new snapshot lands in a different slot
+        // and the restore point can slide forward. Never the protected tools
+        // pin, never the restore source.
+        int shallowest_ancestor = -1;
+        for (int i = 0; i < n; i++) {
+            if (i == skip_index || is_protected(i)) continue;
+            if (!is_ancestor(i)) continue;
+            if (shallowest_ancestor < 0 ||
+                ids_lru[i]->size() < ids_lru[(size_t)shallowest_ancestor]->size()) {
+                shallowest_ancestor = i;
+            }
+        }
+        if (shallowest_ancestor >= 0) return shallowest_ancestor;
+        // Only the restore source and/or protected pins remain: destroying
+        // either would throw away the stable tools head or the in-flight
+        // restore, so there is no safe victim.
+        return -1;
     }
     if (oldest_protected_leaf >= 0) return oldest_protected_leaf;
     return 0;  // unreachable (the longest entry is always a leaf); pure-LRU fallback
 }
 
 int select_inline_evict_victim(const std::vector<std::vector<int32_t>> & ids_lru,
-                               const std::vector<bool> * protected_lru) {
+                               const std::vector<bool> * protected_lru,
+                               int skip_index) {
     std::vector<const std::vector<int32_t> *> ptrs;
     ptrs.reserve(ids_lru.size());
     for (const auto & v : ids_lru) ptrs.push_back(&v);
-    return select_inline_evict_victim(ptrs, protected_lru);
+    return select_inline_evict_victim(ptrs, protected_lru, skip_index);
 }
 
 int select_inline_snapshot_boundary(const std::vector<int> & boundaries,
@@ -341,7 +369,8 @@ std::pair<int, int> PrefixCache::prepare_inline_snap(
         const std::vector<int32_t> & prompt_ids,
         int restored_prefix_len,
         bool prefer_tools_boundary,
-        int forced_cut) {
+        int forced_cut,
+        int restore_source_slot) {
     if (disabled_) return {-1, 0};
 
     auto candidates = find_all_boundaries(prompt_ids, markers_);
@@ -372,7 +401,10 @@ std::pair<int, int> PrefixCache::prepare_inline_snap(
     if ((int)entries_.size() >= cap_) {
         // At capacity — reserve a slot without evicting yet. Prefix-aware: prefer
         // the oldest leaf so shared ancestor prefixes (reused by later branches)
-        // stay resident. Skip protected tools pins when an unprotected leaf exists.
+        // stay resident. Skip protected tools pins when an unprotected leaf
+        // exists. The in-flight restore source is never a victim, so the new
+        // snapshot lands in a different slot and the restore point can slide
+        // forward past the deepest slot.
         std::vector<const std::vector<int32_t> *> ids_lru;
         std::vector<bool> protected_lru;
         ids_lru.reserve(entries_.size());
@@ -381,7 +413,23 @@ std::pair<int, int> PrefixCache::prepare_inline_snap(
             ids_lru.push_back(&e.ids);
             protected_lru.push_back(e.protect);
         }
-        int victim = select_inline_evict_victim(ids_lru, &protected_lru);
+        int skip_index = -1;
+        if (restore_source_slot >= 0) {
+            for (int i = 0; i < (int)entries_.size(); i++) {
+                if (entries_[i].slot == restore_source_slot) {
+                    skip_index = i;
+                    break;
+                }
+            }
+        }
+        int victim = select_inline_evict_victim(ids_lru, &protected_lru, skip_index);
+        if (victim < 0) {
+            // Nothing safe to evict (only the restore source and/or protected
+            // pins remain). Skip this snapshot; the restore point stays put
+            // rather than being destroyed.
+            pending_protect_ = false;
+            return {-1, 0};
+        }
         pending_evict_key_ = entries_[victim].hash;
         has_pending_evict_ = true;
         slot = entries_[victim].slot;
@@ -393,8 +441,16 @@ std::pair<int, int> PrefixCache::prepare_inline_snap(
                 entries_[victim].ids.size(), entries_.front().ids.size());
         }
     } else {
+        // Skip the in-flight restore source so the new snapshot lands in a
+        // different slot (the http_server/agent-replay guards would cancel
+        // an unlucky collision, leaving the restore point pinned). With a
+        // vacancy and cap >= 2 there is always a non-restore slot to take;
+        // cap == 1 keeps the old guard behavior.
         slot = next_slot_;
-        next_slot_ = (next_slot_ + 1) % cap_;
+        if (slot == restore_source_slot && cap_ > 1) {
+            slot = (slot + 1) % cap_;
+        }
+        next_slot_ = (slot + 1) % cap_;
         has_pending_evict_ = false;
     }
 

--- a/server/src/server/prefix_cache.h
+++ b/server/src/server/prefix_cache.h
@@ -45,23 +45,28 @@ std::vector<int> find_all_boundaries(const std::vector<int32_t> & ids,
 using PrefixHash = std::array<uint8_t, 16>;
 PrefixHash hash_prefix(const int32_t * ids, int count);
 
-// Prefix-aware inline eviction policy. Given the cached prefixes in LRU order
-// (index 0 = oldest), return the index of the eviction victim: the oldest entry
-// whose ids are NOT a strict prefix of any other entry's ids (a "leaf"). Keeping
-// shared ancestor prefixes resident avoids re-prefilling them for later branches.
-// Returns 0 (pure-LRU fallback) when ids_lru is empty or, impossibly, no leaf
-// is found. Pure and model-free so it can be unit-tested without a PrefixCache.
-// The pointer overload is the core (the caller passes pointers into its own
-// entries so no token vectors are copied); the value overload is a convenience
-// wrapper for tests.
+// Prefix-aware inline eviction: given cached prefixes in LRU order (0 = oldest),
+// return the index of the oldest "leaf" — an entry that is not a strict prefix
+// of any other — so shared ancestors stay resident. Pointer overload is the
+// core (no token copies); the value overload is for tests.
 //
-// When `protected_lru` is non-null and same-sized, entries with
-// `(*protected_lru)[i] == true` are skipped unless every leaf is protected
-// (then the oldest protected leaf is chosen as a last resort).
+// protected_lru (optional, same size): entries marked true are skipped.
+// Without skip_index, if every leaf is protected, the oldest protected leaf
+// is the last resort. With skip_index set, protected entries stay ineligible
+// and the function may return -1 instead (see skip_index below).
+// skip_index (default -1): the in-flight restore source, never a victim; if it
+// is the only unprotected leaf, evict the shallowest non-protected ancestor
+// instead so the restore point can slide. The protected pin is never evicted.
+//
+// Returns the victim index [0, n-1]; -1 if skip_index is set and only the
+// restore source and/or protected pins remain; 0 if ids_lru is empty or,
+// impossibly, no leaf exists.
 int select_inline_evict_victim(const std::vector<const std::vector<int32_t> *> & ids_lru,
-                               const std::vector<bool> * protected_lru = nullptr);
+                               const std::vector<bool> * protected_lru = nullptr,
+                               int skip_index = -1);
 int select_inline_evict_victim(const std::vector<std::vector<int32_t>> & ids_lru,
-                               const std::vector<bool> * protected_lru = nullptr);
+                               const std::vector<bool> * protected_lru = nullptr,
+                               int skip_index = -1);
 
 // Pick the inline snapshot boundary for a request.
 // Default: boundary before the current user turn (second-to-last marker),
@@ -121,12 +126,17 @@ public:
     // `prefer_tools_boundary` selects the system/tools head first (see
     // select_inline_snapshot_boundary). When `forced_cut` > restored, that
     // cut is used instead (PPP pin_end, including mid-message LCP cuts).
+    // `restore_source_slot` (default -1) is the slot this request restores
+    // from; at capacity it is never chosen as the eviction victim, so the new
+    // snapshot lands in a different slot and the restore point can slide
+    // forward past the deepest slot.
     // Returns (slot, target_cut) or (-1, 0).
     std::pair<int, int> prepare_inline_snap(
         const std::vector<int32_t> & prompt_ids,
         int restored_prefix_len = 0,
         bool prefer_tools_boundary = false,
-        int forced_cut = 0);
+        int forced_cut = 0,
+        int restore_source_slot = -1);
 
     // Confirm after daemon successfully saved the snapshot.
     // `protect` marks the entry non-evictable by unprotected traffic (tool pin).

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -2197,6 +2197,58 @@ TEST_CASE(ServerUnitFixture, test_tool_schema_is_part_of_stable_system_boundary)
                 hash_prefix(prompt_new_tools.data(), system_end));
 }
 
+TEST_CASE(ServerUnitFixture, test_find_boundaries_stray_end_msg_does_not_truncate) {
+    // A lone end-of-message marker embedded in message content (file dumps,
+    // terminal output, model-echoed chatml) must not truncate the boundary
+    // walk. Before the fix, the first stray \n with no role start within 5
+    // tokens cut the scan off, hiding every real boundary after it and pinning
+    // the inline-snapshot deepen target at the already-restored prefix length.
+    //
+    // Layout (qwen-shaped synthetic markers):
+    //   10=<|im_start|>  11="system"  12=<|im_end|>
+    //   idx: 0:10 1:11 2:100 3:12 4:10 5:20 6:200 7:12(stray) 8:600 9:601
+    //         10:602 11:603 12:604 13:12 14:10 15:30 16:300 17:12 18:10 19:40 20:400
+    // The stray 12 at idx 7 has five content tokens before the next real <|im_end|>
+    // (idx 13), so its 5-token window holds no <|im_start|>.
+    ChatMarkers markers;
+    markers.family = "qwen";
+    markers.sys_role_prefix = {10, 11};
+    markers.end_msg_seqs = {{12}};
+    markers.next_role_starts = {{10}};
+
+    const std::vector<int32_t> prompt = {
+        10, 11, 100, 12, 10, 20, 200,
+        12,             // stray <|im_end|> in user content
+        600, 601, 602, 603, 604,
+        12,             // real end of the user message
+        10, 30, 300, 12, 10, 40, 400,
+    };
+
+    const auto bounds = find_all_boundaries(prompt, markers);
+    // Real boundaries after the stray (assistant start = 15, final user start =
+    // 19) must be found; the stable system head (5) is unchanged.
+    TEST_ASSERT(bounds == (std::vector<int>{5, 15, 19}));
+    TEST_ASSERT(bounds.front() == 5);
+}
+
+TEST_CASE(ServerUnitFixture, test_find_boundaries_clean_prompt_unchanged) {
+    // A clean prompt (no stray markers) must produce the identical boundary
+    // list as before the fix — the stray-skip path must never alter correct
+    // prompts.
+    ChatMarkers markers;
+    markers.family = "qwen";
+    markers.sys_role_prefix = {10, 11};
+    markers.end_msg_seqs = {{12}};
+    markers.next_role_starts = {{10}};
+
+    //  system content  user content  assistant content  user2
+    const std::vector<int32_t> prompt = {
+        10, 11, 100, 101, 12, 10, 20, 200, 12, 10, 30, 300, 12, 10, 40,
+    };
+    const auto bounds = find_all_boundaries(prompt, markers);
+    TEST_ASSERT(bounds == (std::vector<int>{6, 10, 14}));
+}
+
 TEST_CASE(ServerUnitFixture, test_inline_snapshot_boundary_advances_past_restore) {
     const std::vector<int> boundaries = {100, 240, 380, 520};
     // Second-to-last is the boundary before the current user turn.

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -2456,6 +2456,203 @@ TEST_CASE(ServerUnitFixture, test_evict_all_protected_falls_back) {
     TEST_ASSERT(select_inline_evict_victim(ids, &protect) == 0);
 }
 
+// ── Restore-source-aware eviction (prefix-cache slide) ─────────────────
+
+// (a) Linear chain at capacity: the new snapshot must land in a different
+// slot than the restore source, so the restore point can slide forward past
+// the deepest slot.
+TEST_CASE(ServerUnitFixture, test_slide_evicts_ancestor_not_restore_source) {
+    const std::string path = write_deepseek_marker_tokenizer_fixture();
+    Tokenizer tokenizer;
+    TEST_ASSERT(tokenizer.load_from_gguf(path.c_str()));
+    PrefixCache cache(4, tokenizer);
+    TEST_ASSERT(!cache.disabled());
+
+    // Linear chain: each prompt strictly extends the previous one.
+    std::vector<int32_t> p1 = {1, 100, 4, 101};
+    std::vector<int32_t> p2 = p1;
+    p2.insert(p2.end(), {3, 102});
+    std::vector<int32_t> p3 = p2;
+    p3.insert(p3.end(), {4, 103});
+    std::vector<int32_t> p4 = p3;
+    p4.insert(p4.end(), {3, 104});
+
+    auto fill = [&](const std::vector<int32_t> & p) {
+        const auto prepared = cache.prepare_inline_snap(
+            p, 0, false, (int) p.size());
+        TEST_ASSERT(prepared.first >= 0);
+        TEST_ASSERT(prepared.second == (int) p.size());
+        cache.confirm_inline_snap(prepared.first, prepared.second, p);
+        return prepared.first;
+    };
+    const int s1 = fill(p1);
+    const int s2 = fill(p2);
+    const int s3 = fill(p3);
+    const int s4 = fill(p4);
+    TEST_ASSERT(s1 != s2 && s2 != s3 && s3 != s4 && s4 != s1);
+    TEST_ASSERT(s4 == 3);  // deepest slot, like the BUG.md repro
+
+    // Turn 5: restore from the deepest slot and extend the conversation.
+    std::vector<int32_t> p5 = p4;
+    p5.insert(p5.end(), {3, 105});
+    const auto hit = cache.lookup(p5);
+    TEST_ASSERT(hit.first == s4 && hit.second == (int) p4.size());
+
+    const auto snap = cache.prepare_inline_snap(
+        p5, hit.second, false, (int) p5.size(), hit.first);
+    TEST_ASSERT(snap.first >= 0);
+    TEST_ASSERT(snap.first != s4);  // different slot: the restore source
+                                    // was not the victim
+    TEST_ASSERT(snap.second == (int) p5.size());
+    cache.confirm_inline_snap(snap.first, snap.second, p5);
+
+    // The restore point slid forward: the new, deeper prefix now matches.
+    const auto after = cache.lookup(p5);
+    TEST_ASSERT(after.first == snap.first);
+    TEST_ASSERT(after.second == (int) p5.size());
+    // The old deepest entry survived the eviction.
+    std::vector<int32_t> p4b = p4;
+    p4b.insert(p4b.end(), {7, 7});
+    const auto kept = cache.lookup(p4b);
+    TEST_ASSERT(kept.first == s4 && kept.second == (int) p4.size());
+    TEST_ASSERT(cache.stats().in_use == 4);
+    unlink(path.c_str());
+}
+
+// (b) The in-flight restore source is never the eviction victim, at any LRU
+// position, whether it is the only leaf (linear chain) or not.
+TEST_CASE(ServerUnitFixture, test_slide_restore_source_never_evicted) {
+    std::vector<std::vector<int32_t>> ids = {
+        {9}, {9, 1}, {9, 1, 2}, {9, 1, 2, 3},
+    };
+    for (int skip = 0; skip < 4; ++skip) {
+        const int victim = select_inline_evict_victim(ids, nullptr, skip);
+        TEST_ASSERT(victim >= 0 && victim != skip);
+    }
+    // Linear chain whose only leaf is the restore source: evict the
+    // shallowest unprotected ancestor instead of cancelling everything.
+    TEST_ASSERT(select_inline_evict_victim(ids, nullptr, 3) == 0);
+    // With a free leaf the usual leaf preference still applies.
+    TEST_ASSERT(select_inline_evict_victim(ids, nullptr, 0) == 3);
+}
+
+// (c) The protected tools pin is never evicted, even when it is the
+// shallowest ancestor and the only other entry besides the restore source.
+TEST_CASE(ServerUnitFixture, test_slide_protected_pin_never_evicted) {
+    std::vector<std::vector<int32_t>> ids = {
+        {9}, {9, 1}, {9, 1, 2}, {9, 1, 2, 3},
+    };
+    std::vector<bool> protect = {true, false, false, false};
+    TEST_ASSERT(select_inline_evict_victim(ids, &protect, 3) == 1);
+
+    // Only the protected pin and the restore source remain: no safe victim,
+    // so no snapshot is reserved instead of destroying the pin.
+    std::vector<std::vector<int32_t>> two = {{9}, {9, 1}};
+    std::vector<bool> two_prot = {true, false};
+    TEST_ASSERT(select_inline_evict_victim(two, &two_prot, 1) == -1);
+
+    const std::string path = write_deepseek_marker_tokenizer_fixture();
+    Tokenizer tokenizer;
+    TEST_ASSERT(tokenizer.load_from_gguf(path.c_str()));
+    PrefixCache cache(2, tokenizer);
+    TEST_ASSERT(!cache.disabled());
+
+    std::vector<int32_t> pin = {1, 100, 4, 101};
+    std::vector<int32_t> deep = pin;
+    deep.insert(deep.end(), {3, 102});
+    auto prepared = cache.prepare_inline_snap(pin, 0, true, (int) pin.size());
+    TEST_ASSERT(prepared.first == 0);
+    cache.confirm_inline_snap(prepared.first, prepared.second, pin, true);
+    prepared = cache.prepare_inline_snap(deep, 0, false, (int) deep.size());
+    TEST_ASSERT(prepared.first == 1);
+    cache.confirm_inline_snap(prepared.first, prepared.second, deep);
+
+    std::vector<int32_t> deeper = deep;
+    deeper.insert(deeper.end(), {4, 103});
+    const auto hit = cache.lookup(deeper);
+    TEST_ASSERT(hit.first == 1 && hit.second == (int) deep.size());
+    // At capacity the only other entry is the protected pin: refuse rather
+    // than evict it.
+    const auto refused = cache.prepare_inline_snap(
+        deeper, hit.second, false, (int) deeper.size(), hit.first);
+    TEST_ASSERT(refused.first == -1 && refused.second == 0);
+    const auto kept = cache.lookup(deep);
+    TEST_ASSERT(kept.first == 1 && kept.second == (int) deep.size());
+    TEST_ASSERT(cache.stats().in_use == 2);
+    unlink(path.c_str());
+}
+
+// (d) Branching conversations are unchanged: with two leaves, the oldest
+// non-restore-source leaf is still the victim.
+TEST_CASE(ServerUnitFixture, test_slide_branching_oldest_leaf_unchanged) {
+    // [9] is a shared root; leaves are idx 1 ([9,1]) and idx 2 ([9,2]).
+    std::vector<std::vector<int32_t>> ids = {{9}, {9, 1}, {9, 2}};
+    TEST_ASSERT(select_inline_evict_victim(ids) == 1);  // original behavior
+    // Restore source is the newer leaf: the older leaf is still the victim.
+    TEST_ASSERT(select_inline_evict_victim(ids, nullptr, 2) == 1);
+    // Restore source is the older leaf: the remaining leaf is the victim.
+    TEST_ASSERT(select_inline_evict_victim(ids, nullptr, 1) == 2);
+    // A protected leaf is never evicted: with the restore source skipped and
+    // the only remaining leaf protected, the shallowest unprotected ancestor
+    // is the victim instead.
+    std::vector<bool> protect = {false, true, false};
+    TEST_ASSERT(select_inline_evict_victim(ids, &protect, 2) == 0);
+}
+
+// (e) Free-slot path (not at capacity) must skip the restore source too, so
+// the http_server / agent-replay guards do not cancel the reservation and the
+// restore point can advance.
+TEST_CASE(ServerUnitFixture, test_slide_free_slot_skips_restore_source) {
+    const std::string path = write_deepseek_marker_tokenizer_fixture();
+    Tokenizer tokenizer;
+    TEST_ASSERT(tokenizer.load_from_gguf(path.c_str()));
+    PrefixCache cache(4, tokenizer);
+    TEST_ASSERT(!cache.disabled());
+
+    // Two entries with cap 4: vacancy exists, so prepare_inline_snap takes
+    // the free-slot path. Round-robin has next_slot_ at 2.
+    std::vector<int32_t> p1 = {1, 100, 4, 101};
+    std::vector<int32_t> p2 = p1;
+    p2.insert(p2.end(), {3, 102});
+
+    auto fill = [&](const std::vector<int32_t> & p) {
+        const auto prepared = cache.prepare_inline_snap(
+            p, 0, false, (int) p.size());
+        TEST_ASSERT(prepared.first >= 0);
+        TEST_ASSERT(prepared.second == (int) p.size());
+        cache.confirm_inline_snap(prepared.first, prepared.second, p);
+        return prepared.first;
+    };
+    const int s1 = fill(p1);  // slot 0
+    const int s2 = fill(p2);  // slot 1
+    TEST_ASSERT(s1 == 0 && s2 == 1);
+
+    // Drive the round-robin so next_slot_ lands exactly on s2 (the restore
+    // source we will pass in). Three abort-burn steps from slot 2 → 3 → 0 → 1.
+    for (int i = 0; i < 3; ++i) {
+        std::vector<int32_t> scratch = p2;
+        scratch.push_back(7);
+        scratch.push_back(7 + i);
+        const auto prep = cache.prepare_inline_snap(
+            scratch, 0, false, (int) scratch.size());
+        TEST_ASSERT(prep.first >= 0);
+        // Burn the round-robin step without committing an entry.
+        cache.cancel_inline_snap(prep.first);
+    }
+
+    // Restore source is s2 = 1. Free slots are 2 and 3. The next free-slot
+    // allocation must skip s2 (== 1) and pick a non-restore slot.
+    std::vector<int32_t> p3 = p2;
+    p3.insert(p3.end(), {4, 103});
+    const auto hit = cache.lookup(p3);
+    TEST_ASSERT(hit.first == s2);
+    const auto snap = cache.prepare_inline_snap(
+        p3, hit.second, false, (int) p3.size(), hit.first);
+    TEST_ASSERT(snap.first >= 0);
+    TEST_ASSERT(snap.first != hit.first);
+    unlink(path.c_str());
+}
+
 // ═══════════════════════════════════════════════════════════════════════
 // PFlash config tests (model-free)
 // ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
| commit | root cause it fixes |
|---|---|
| `ee398df7` | restore point **pinned at the deepest slot**: the in-flight restore source is evicted, the new snapshot is cancelled by the `snap_slot == cache_slot` guard, so per-turn prefill grew unbounded (observed 1s -> 60s on the 3090s) |
| `4e53532` | `find_all_boundaries()` **truncates the boundary walk** at a stray end-of-message marker embedded in content, so no boundary is recorded past it and the inline snap has nothing to deepen to |

They fail for different reasons: one cancels the snapshot (eviction), the other
leaves no candidate boundary to snapshot (truncation). Both must be fixed for
the restore point to keep sliding forward turn after turn.

### `4e53532` — don't truncate boundaries on stray end-markers in content

`find_all_boundaries()` walks the prompt for end-of-message markers. On an
end-marker **not** followed by a role-start within the 5-token probe window it
`break`ed, cutting the list off at the first stray. Content that legitimately
contains a stray end-marker (file/log dumps, chatml-in-content, tool output)
therefore lost every real message boundary after it. Fix: skip the stray marker
and keep scanning (capped at 8192 consecutive strays to bound pathological
input); clean prompts are byte-for-byte unchanged. `prefix_cache.cpp` +28 -2;
2 regression tests — `test_find_boundaries_stray_end_msg_does_not_truncate`
(`{5,15,19}`) and `test_find_boundaries_clean_prompt_unchanged` (`{6,10,14}`);
plus a one-line diagnostic on the `prepare_inline_snap` blocked path.

### `ee398df7` — slide the restore point past the deepest slot

With `--prefix-cache-slots 4` and a long linearly-growing tool-heavy
conversation, all slots form one chain and the only leaf is the deepest slot =
the current restore source. `select_inline_evict_victim()` evicted that leaf and
`prepare_inline_snap()` re-assigned the snapshot to the same slot; the
`prepare_generation_cache` guard (`snap_slot == cache_slot`) then cancelled it,
pinning the restore point. Fix: thread the restore-source slot into victim
selection so it is never evicted (the snapshot lands in a different slot, so the
restore point slides forward each turn), with a shallowest-ancestor fallback
that never touches the protected tools pin or the restore source. 5 unit tests.

### Verification

- In-image `test_server_unit`: **441/441 pass** (new `lucebox-hub:latest`).
- Standalone harness on the real `find_all_boundaries()`: stray -> `[5,15,19]`,
  clean -> `[6,10,14]`, deepseek -> `[8]`.
- Live 2x3090 service: a conversation with a stray end-marker in content now
  deepens the inline snap to `prefix_len=684` (past the marker) and the next
  turn HITs it — `lookup hit slot=3 prefix_len=684`, `cache_hit=true`,

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

