### PR TITLE
perf(ds4): batch exact prefill through width-4 vector kernels

### DIFF
--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2787,7 +2787,9 @@ static bool ggml_cuda_try_fuse_mul_mat_glu(
         const int64_t ncols = ids ? src1->ne[2] : src1->ne[1];
         if (ggml_cuda_should_use_mmq(
                 src0->type, cc, ncols,
-                ids ? src0->ne[2] : /*n_experts=*/0)) {
+                ids ? src0->ne[2] : /*n_experts=*/0) &&
+            !(ggml_cuda_mmvq_max_ncols_override > 0 &&
+              ncols <= ggml_cuda_mmvq_max_ncols_override)) {
             ggml_cuda_mul_mat_q_pair(
                 ctx, up->src[0], gate->src[0], src1, ids, up, gate);
             ggml_cuda_op_swiglu_ds4(ctx, glu);

--- a/server/src/deepseek4/deepseek4_backend.cpp
+++ b/server/src/deepseek4/deepseek4_backend.cpp
@@ -1896,8 +1896,9 @@ int DeepSeek4Backend::do_prefill(const std::vector<int32_t> & tokens,
     const bool hybrid_batch_supported =
         !moe_hybrid_ || cfg_.prefill_mode == PrefillAttentionMode::Sparse;
     const int base_chunk =
-        !prefill_attention_mode_is_approximate(cfg_.prefill_mode) ||
-        !hybrid_batch_supported
+        !hybrid_batch_supported ||
+        (cfg_.prefill_mode == PrefillAttentionMode::Exact &&
+         spec_drafter_ != nullptr)
         ? 1
         : std::max(1, std::min(requested_chunk,
                                layer_major_cap));

--- a/server/src/deepseek4/deepseek4_graph.cpp
+++ b/server/src/deepseek4/deepseek4_graph.cpp
@@ -6965,7 +6965,17 @@ bool deepseek4_step_layer_range(
     // each sub-forward then writes at most one window and, if present, its
     // boundary is the final token. This preserves the same pool/rotate order
     // as sequential execution while retaining safe batched prefixes.
-    const int first_chunk = deepseek4_safe_compressor_batch_tokens(w, kv_start, n_tokens);
+    const bool exact_prefill_band =
+        cache.prefill_mode == PrefillAttentionMode::Exact &&
+        allow_decode_graph_reuse && !fused_verify_candidate;
+    const int first_chunk = std::min(
+        deepseek4_safe_compressor_batch_tokens(w, kv_start, n_tokens),
+        exact_prefill_band ? 4 : n_tokens);
+    const bool exact_multi_token_band =
+        exact_prefill_band && n_tokens > 1 && n_tokens <= 4;
+    ScopedCudaGraphOverrides exact_mmvq_scope(
+        /*disable_graphs=*/false,
+        /*mmvq_max_ncols=*/exact_multi_token_band ? 4 : 0);
     if (first_chunk > 0 && first_chunk < n_tokens &&
         !fused_verify_candidate && !heterogeneous_sparse_prefill &&
         !standard_layer_major_prefill) {
@@ -6989,8 +6999,10 @@ bool deepseek4_step_layer_range(
         }
 
         for (int off = 0; off < n_tokens;) {
-            const int chunk = deepseek4_safe_compressor_batch_tokens(
-                w, kv_start + off, n_tokens - off);
+            const int remaining = n_tokens - off;
+            const int chunk = std::min(
+                deepseek4_safe_compressor_batch_tokens(w, kv_start + off, remaining),
+                exact_prefill_band ? 4 : remaining);
             std::vector<float> chunk_hc;
             std::vector<float> chunk_out;
             std::vector<float> chunk_capture;


### PR DESCRIPTION
## Summary

- batch exact DeepSeek4 prefill in compressor-safe groups of at most four tokens
- use the existing quantized matrix-vector path only for those exact width-2-to-4 feed-forward graphs
- keep speculative verification, approximate prefill, and unsupported hybrid paths unchanged
- add no option or environment flag

## Result

Ryzen AI Max+ 395 / gfx1151, ROCm 7.2.2, exact prefill, no drafter or caches.

Fresh current-main smoke (`f5475131`, one warmup then three interleaved runs):

| Prompt | Main median | PR median | Lower time |
|---|---:|---:|---:|
| 64 tokens | 3341.6 ms | 2776.9 ms | 16.90% |
| 128 tokens | 6710.7 ms | 5602.6 ms | 16.51% |

The frozen five-run qualification measured 17.72% and 16.62% lower total prefill time respectively. The expert feed-forward phase was about 37% lower. Its 95% gain intervals were [17.13%, 18.33%] and [16.21%, 17.37%].

## Correctness

The frozen Q=1 versus Q=4 qualification was byte-identical across ordered route IDs, normalized route weights, attention and feed-forward recurrent state, every-position F32 logits, and committed tokens.

After rebasing on current main, the server built with `-j4` and these focused tests passed 4/4:

- `test_deepseek4_hc_cuda`
- `test_rocmfpx_mmq`
- `deepseek4_mmid_grouped_cuda`
- `deepseek4_unit`

All current-main benchmark responses emitted the same first token.

## Scope

Three files, 21 insertions, 6 deletions. This PR claims the exact all-hot M64/M128 prefill result only; long-context and speculative decode are separate qualifications.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

