### PR TITLE
fix(qwen35): trim legacy device pools between requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,7 @@ jobs:
             grep -q '^DFLASH27B_EFFECTIVE_BLACKWELL_CONSUMER:INTERNAL=OFF$' build/CMakeCache.txt
           fi
           targets=(
+            test_cuda_pool_shutdown
             test_deepseek4_mmid_grouped_cuda
             test_deepseek4_unit
             test_rocmfp3_mix_registry
@@ -228,7 +229,7 @@ jobs:
           ./server/build/test_deepseek4_mmid_grouped_cuda
           ./server/build/test_deepseek4_unit
           ctest --test-dir server/build --output-on-failure \
-            -R 'rocmfp3_mix_registry|rocmfp_mix_slice_matvec|rocmfp_mix_gateup_glu|ds4_mix_registry_teardown'
+            -R 'cuda_pool_shutdown|rocmfp3_mix_registry|rocmfp_mix_slice_matvec|rocmfp_mix_gateup_glu|ds4_mix_registry_teardown'
 
       - name: Run concurrent-serving kernel tests
         run: |
@@ -351,11 +352,11 @@ jobs:
               test_recurrent_snapshot test_server_unit test_rocmfp3_mix_registry \
               test_rocmfp_mix_slice_matvec test_rocmfp_mix_gateup_glu \
               test_ds4_mix_registry_teardown test_model_smoke test_batched_gdn \
-              test_concat_transpose \
+              test_concat_transpose test_cuda_pool_shutdown \
             --parallel 8
           ctest --test-dir "$RUNNER_TEMP/rocmfp-build" \
             --output-on-failure \
-            -R 'rocmfp4_reference|rocmfpx_reference|rocmfp4_hip_tail|rocmfpx_mmq|deepseek4_mmid_grouped_cuda|deepseek4_unit|recurrent_snapshot|ChainRollbackPolicy|rocmfp3_mix_registry|rocmfp_mix_slice_matvec|rocmfp_mix_gateup_glu|ds4_mix_registry_teardown|test_model_smoke\.PagedAttention\.|batched_gdn$|concat_transpose$'
+            -R 'cuda_pool_shutdown|rocmfp4_reference|rocmfpx_reference|rocmfp4_hip_tail|rocmfpx_mmq|deepseek4_mmid_grouped_cuda|deepseek4_unit|recurrent_snapshot|ChainRollbackPolicy|rocmfp3_mix_registry|rocmfp_mix_slice_matvec|rocmfp_mix_gateup_glu|ds4_mix_registry_teardown|test_model_smoke\.PagedAttention\.|batched_gdn$|concat_transpose$'
 
       - name: Build + test affine ROCmFP2 GPU paths
         # Keep the default wire-format build above and compile the affine layout

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -860,13 +860,16 @@ if(DFLASH27B_TESTS)
         endif()
     endif()
 
-    if(DFLASH27B_GPU_BACKEND STREQUAL "hip"
+    if((DFLASH27B_GPU_BACKEND STREQUAL "hip" OR
+        DFLASH27B_GPU_BACKEND STREQUAL "cuda")
        AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_cuda_pool_shutdown.cpp")
         add_executable(test_cuda_pool_shutdown
             test/test_unit_main.cpp
             test/test_cuda_pool_shutdown.cpp)
-        set_source_files_properties(test/test_cuda_pool_shutdown.cpp PROPERTIES LANGUAGE HIP)
-        set_target_properties(test_cuda_pool_shutdown PROPERTIES HIP_ARCHITECTURES "${_dflash_archs}")
+        if(DFLASH27B_GPU_BACKEND STREQUAL "hip")
+            set_source_files_properties(test/test_cuda_pool_shutdown.cpp PROPERTIES LANGUAGE HIP)
+            set_target_properties(test_cuda_pool_shutdown PROPERTIES HIP_ARCHITECTURES "${_dflash_archs}")
+        endif()
         target_include_directories(test_cuda_pool_shutdown PRIVATE
             ${CMAKE_CURRENT_SOURCE_DIR}/deps/llama.cpp/ggml/include)
         target_link_libraries(test_cuda_pool_shutdown PRIVATE

--- a/server/deps/llama.cpp/ggml/include/ggml-cuda.h
+++ b/server/deps/llama.cpp/ggml/include/ggml-cuda.h
@@ -50,6 +50,11 @@ GGML_BACKEND_API size_t ggml_backend_cuda_graph_invalidate_range(
         const void *   begin,
         size_t         size);
 
+// Release cached temporary allocations held by a CUDA/HIP backend's legacy
+// device pools. The backend is synchronized first. VMM pools are already a
+// contiguous reusable arena and are left intact. Returns bytes released.
+GGML_BACKEND_API size_t ggml_backend_cuda_trim_pool(ggml_backend_t backend);
+
 // Disable CUDA/HIP graph capture and replay on the calling thread. Returns the
 // previous value so scoped callers can restore nested overrides correctly.
 GGML_BACKEND_API bool ggml_backend_cuda_set_graphs_disabled_override(bool disabled);

--- a/server/deps/llama.cpp/ggml/include/ggml-cuda.h
+++ b/server/deps/llama.cpp/ggml/include/ggml-cuda.h
@@ -50,8 +50,13 @@ GGML_BACKEND_API size_t ggml_backend_cuda_graph_invalidate_range(
         const void *   begin,
         size_t         size);
 
+// Returns true when the backend has instantiated a legacy device pool. This
+// lets callers and tests distinguish a trimmable cache from a VMM arena.
+GGML_BACKEND_API bool ggml_backend_cuda_has_legacy_pool(ggml_backend_t backend);
+
 // Release cached temporary allocations held by a CUDA/HIP backend's legacy
-// device pools. The backend is synchronized first. VMM pools are already a
+// device pools. The backend is synchronized first, and graph executables that
+// may reference released pool blocks are retired. VMM pools are already a
 // contiguous reusable arena and are left intact. Returns bytes released.
 GGML_BACKEND_API size_t ggml_backend_cuda_trim_pool(ggml_backend_t backend);
 

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/common.cuh
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/common.cuh
@@ -1169,6 +1169,7 @@ struct ggml_cuda_pool {
 
     virtual void * alloc(size_t size, size_t * actual_size) = 0;
     virtual void free(void * ptr, size_t size) = 0;
+    virtual size_t trim() = 0;
 };
 
 template<typename T>

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/common.cuh
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/common.cuh
@@ -1169,6 +1169,7 @@ struct ggml_cuda_pool {
 
     virtual void * alloc(size_t size, size_t * actual_size) = 0;
     virtual void free(void * ptr, size_t size) = 0;
+    virtual bool is_legacy() const = 0;
     virtual size_t trim() = 0;
 };
 

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -570,6 +570,23 @@ struct ggml_cuda_pool_leg : public ggml_cuda_pool {
         CUDA_CHECK(cudaFree(ptr));
         pool_size -= size;
     }
+
+    size_t trim() override {
+        ggml_cuda_set_device(device);
+        size_t freed = 0;
+        for (int i = 0; i < MAX_BUFFERS; ++i) {
+            ggml_cuda_buffer & b = buffer_pool[i];
+            if (b.ptr == nullptr) {
+                continue;
+            }
+            CUDA_CHECK(cudaFree(b.ptr));
+            freed += b.size;
+            pool_size -= b.size;
+            b.ptr = nullptr;
+            b.size = 0;
+        }
+        return freed;
+    }
 };
 
 // pool with virtual memory
@@ -703,6 +720,12 @@ struct ggml_cuda_pool_vmm : public ggml_cuda_pool {
 
         // all deallocations must be in reverse order of the allocations
         GGML_ASSERT(ptr == (void *) ((char *)(pool_addr) + pool_used));
+    }
+
+    // VMM mappings form a contiguous reusable arena and do not suffer from
+    // the fragmented legacy-pool failure this hook addresses.
+    size_t trim() override {
+        return 0;
     }
 };
 #endif // defined(GGML_USE_VMM)
@@ -5180,6 +5203,31 @@ extern "C" size_t ggml_backend_cuda_graph_invalidate_range(
     GGML_UNUSED(size);
     return 0;
 #endif
+}
+
+extern "C" size_t ggml_backend_cuda_trim_pool(ggml_backend_t backend) {
+    if (backend == nullptr || !ggml_backend_is_cuda(backend)) {
+        return 0;
+    }
+
+    ggml_backend_synchronize(backend);
+    auto * cuda_ctx = static_cast<ggml_backend_cuda_context *>(backend->context);
+
+    // Per-evaluation activation memos own allocations from these pools.
+    // Release them before destroying cached free blocks.
+    while (!cuda_ctx->luce_q8_memo.empty()) {
+        cuda_ctx->luce_q8_memo.pop_back();
+    }
+
+    size_t freed = 0;
+    for (int device = 0; device < GGML_CUDA_MAX_DEVICES; ++device) {
+        for (int stream = 0; stream < GGML_CUDA_MAX_STREAMS; ++stream) {
+            if (cuda_ctx->pools[device][stream] != nullptr) {
+                freed += cuda_ctx->pools[device][stream]->trim();
+            }
+        }
+    }
+    return freed;
 }
 
 static enum ggml_status ggml_backend_cuda_graph_compute(ggml_backend_t backend, ggml_cgraph * cgraph) {

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -571,6 +571,10 @@ struct ggml_cuda_pool_leg : public ggml_cuda_pool {
         pool_size -= size;
     }
 
+    bool is_legacy() const override {
+        return true;
+    }
+
     size_t trim() override {
         ggml_cuda_set_device(device);
         size_t freed = 0;
@@ -720,6 +724,10 @@ struct ggml_cuda_pool_vmm : public ggml_cuda_pool {
 
         // all deallocations must be in reverse order of the allocations
         GGML_ASSERT(ptr == (void *) ((char *)(pool_addr) + pool_used));
+    }
+
+    bool is_legacy() const override {
+        return false;
     }
 
     // VMM mappings form a contiguous reusable arena and do not suffer from
@@ -5205,6 +5213,27 @@ extern "C" size_t ggml_backend_cuda_graph_invalidate_range(
 #endif
 }
 
+static bool ggml_cuda_has_legacy_pool(const ggml_backend_cuda_context * cuda_ctx) {
+    for (int device = 0; device < GGML_CUDA_MAX_DEVICES; ++device) {
+        for (int stream = 0; stream < GGML_CUDA_MAX_STREAMS; ++stream) {
+            const auto & pool = cuda_ctx->pools[device][stream];
+            if (pool != nullptr && pool->is_legacy()) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+extern "C" bool ggml_backend_cuda_has_legacy_pool(ggml_backend_t backend) {
+    if (backend == nullptr || !ggml_backend_is_cuda(backend)) {
+        return false;
+    }
+
+    const auto * cuda_ctx = static_cast<const ggml_backend_cuda_context *>(backend->context);
+    return ggml_cuda_has_legacy_pool(cuda_ctx);
+}
+
 extern "C" size_t ggml_backend_cuda_trim_pool(ggml_backend_t backend) {
     if (backend == nullptr || !ggml_backend_is_cuda(backend)) {
         return 0;
@@ -5212,6 +5241,17 @@ extern "C" size_t ggml_backend_cuda_trim_pool(ggml_backend_t backend) {
 
     ggml_backend_synchronize(backend);
     auto * cuda_ctx = static_cast<ggml_backend_cuda_context *>(backend->context);
+    const bool has_legacy_pool = ggml_cuda_has_legacy_pool(cuda_ctx);
+
+#ifdef USE_CUDA_GRAPH
+    if (has_legacy_pool) {
+        // Captured kernels retain internal temporary addresses that are not
+        // represented in node_props. Retire every executable before any of
+        // those cached blocks can be returned to the driver.
+        ggml_cuda_set_device(cuda_ctx->device);
+        cuda_ctx->cuda_graphs.clear();
+    }
+#endif
 
     // Per-evaluation activation memos own allocations from these pools.
     // Release them before destroying cached free blocks.

--- a/server/src/qwen35/qwen35_backend.cpp
+++ b/server/src/qwen35/qwen35_backend.cpp
@@ -1317,7 +1317,17 @@ void Qwen35Backend::release_scratch() {
     flashprefill::dflash_bsa_free_persistent();
 #endif
 
-    std::fprintf(stderr, "[vram] released scratch buffers\n");
+    // Gallocr teardown does not release operator temporaries cached by the
+    // legacy CUDA/HIP pools. On non-VMM devices a long prefill can otherwise
+    // leave nearly all VRAM reserved and make the next differently shaped
+    // request fail despite having no live scratch tensors.
+    size_t trimmed = ggml_backend_cuda_trim_pool(target_backend_);
+    if (draft_backend_ && draft_backend_ != target_backend_) {
+        trimmed += ggml_backend_cuda_trim_pool(draft_backend_);
+    }
+
+    std::fprintf(stderr, "[vram] released scratch buffers; trimmed %.1f MiB from device pools\n",
+                 trimmed / (1024.0 * 1024.0));
 }
 
 // ── Generate (speculative decode) ───────────────────────────────────────

--- a/server/test/test_cuda_pool_shutdown.cpp
+++ b/server/test/test_cuda_pool_shutdown.cpp
@@ -54,22 +54,35 @@ TEST_CASE(CudaPoolShutdownFixture, backend_pool_shutdown) {
     ggml_backend_tensor_set(weights, weights_data.data(), 0, weights_data.size());
     ggml_backend_tensor_set(input, input_data.data(), 0, input_data.size() * sizeof(float));
 
-    const ggml_status status = ggml_backend_graph_compute(backend, graph);
-    ggml_backend_synchronize(backend);
-    ggml_backend_buffer_free(buffer);
-    ggml_free(ctx);
-    if (status != GGML_STATUS_SUCCESS) {
-        ggml_backend_free(backend);
-        REQUIRE_TRUE(false);
-    }
+    auto compute = [&]() {
+        const ggml_status status = ggml_backend_graph_compute(backend, graph);
+        ggml_backend_synchronize(backend);
+        return status;
+    };
+
+    // Two stable evaluations warm and capture graph replay when enabled.
+    REQUIRE(compute() == GGML_STATUS_SUCCESS);
+    REQUIRE(compute() == GGML_STATUS_SUCCESS);
 
     // LUCE_Q8_MEMO intentionally retains a pool allocation after compute.
     // Request-boundary trimming must first release that memo, then return its
     // cached block to the driver rather than retaining VRAM indefinitely.
+    const bool has_legacy_pool = ggml_backend_cuda_has_legacy_pool(backend);
     const size_t trimmed = ggml_backend_cuda_trim_pool(backend);
-    REQUIRE(trimmed > 0);
+    if (has_legacy_pool) {
+        REQUIRE(trimmed > 0);
+    } else {
+        REQUIRE(trimmed == 0);
+    }
+
+    // A legacy trim must retire graph executables that captured the released
+    // memo address. Recomputing the same graph must recapture rather than
+    // replaying a stale pointer. VMM pools safely keep the existing replay.
+    REQUIRE(compute() == GGML_STATUS_SUCCESS);
 
     // Backend teardown must remain safe after an explicit trim.
+    ggml_backend_buffer_free(buffer);
+    ggml_free(ctx);
     ggml_backend_free(backend);
     REQUIRE_TRUE(true);
 }

--- a/server/test/test_cuda_pool_shutdown.cpp
+++ b/server/test/test_cuda_pool_shutdown.cpp
@@ -55,6 +55,7 @@ TEST_CASE(CudaPoolShutdownFixture, backend_pool_shutdown) {
     ggml_backend_tensor_set(input, input_data.data(), 0, input_data.size() * sizeof(float));
 
     const ggml_status status = ggml_backend_graph_compute(backend, graph);
+    ggml_backend_synchronize(backend);
     ggml_backend_buffer_free(buffer);
     ggml_free(ctx);
     if (status != GGML_STATUS_SUCCESS) {
@@ -62,8 +63,13 @@ TEST_CASE(CudaPoolShutdownFixture, backend_pool_shutdown) {
         REQUIRE_TRUE(false);
     }
 
-    // LUCE_Q8_MEMO intentionally retains the pool allocation after compute.
-    // Backend teardown must release that allocation before destroying its pool.
+    // LUCE_Q8_MEMO intentionally retains a pool allocation after compute.
+    // Request-boundary trimming must first release that memo, then return its
+    // cached block to the driver rather than retaining VRAM indefinitely.
+    const size_t trimmed = ggml_backend_cuda_trim_pool(backend);
+    REQUIRE(trimmed > 0);
+
+    // Backend teardown must remain safe after an explicit trim.
     ggml_backend_free(backend);
     REQUIRE_TRUE(true);
 }


### PR DESCRIPTION
## Summary

- add an explicit trim hook for legacy CUDA/HIP device pools
- release per-evaluation Q8 memo allocations before trimming cached blocks
- trim target and distinct draft backends when Qwen3.5 request scratch is released
- extend the existing CUDA pool-shutdown regression test through explicit trimming

## Root cause

On non-VMM ROCm devices, long prefills returned operator temporaries to the legacy ggml pool, but the pool retained those blocks indefinitely. A later request with a different allocation shape could require another large contiguous allocation and fatally OOM even though the previous request had released its scratch tensors.

## Validation

- HIP gfx1201 release build completed for dflash_server and test_server_unit
- two independent back-to-back requests completed on an AMD Radeon AI PRO R9700: 40,013 and 39,234 prompt tokens
- request cleanup returned 2,405.3 MiB and 2,243.6 MiB from device pools respectively
- unit suite: 421/423 passed in the restricted workspace; the two socket-permission failures passed when rerun with normal socket permissions
- git diff --check clean

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

