### PR TITLE
fix(tool_parser): support XML function_call and tool_call with invoke_name and parameters

### DIFF
--- a/server/src/server/tool_parser.cpp
+++ b/server/src/server/tool_parser.cpp
@@ -1046,6 +1046,7 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
             const size_t body_start = pos + 11;
             const size_t close = text.find("</tool_call>", body_start);
             if (close == std::string::npos) break;
+            const std::string body = text.substr(body_start, close - body_start);
             std::string xml_name;
             json xml_args;
             std::string xml_raw;

--- a/server/src/server/tool_parser.cpp
+++ b/server/src/server/tool_parser.cpp
@@ -1111,7 +1111,11 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
             const size_t close = text.find("</tool_call>", body_start);
             if (close == std::string::npos) break;
             const std::string body = text.substr(body_start, close - body_start);
-            if (body.find("<function") != std::string::npos) {
+            const bool is_legacy_qwen =
+                body.find("<function=") != std::string::npos ||
+                body.find("<function>") != std::string::npos ||
+                body.find("<function ") != std::string::npos;
+            if (is_legacy_qwen) {
                 pos = close + 12;
                 continue;
             }
@@ -1131,7 +1135,7 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
             // Laguna bodies are `NAME<arg_key>...` (values may contain JSON —
             // the template serializes non-string args via tojson). Only leave
             // <function=...> and pure-JSON bodies to the Qwen patterns.
-            if (body.find("<function") == std::string::npos &&
+            if (!is_legacy_qwen &&
                 (first_key != std::string::npos ||
                  body.find('{') == std::string::npos)) {
                 std::string name = trim_ws(

--- a/server/src/server/tool_parser.cpp
+++ b/server/src/server/tool_parser.cpp
@@ -626,13 +626,33 @@ static bool parse_xml_tool_call_body(const std::string & body, const json & tool
         return false;
     }
 
-    // 1. Look for function name in <invoke_name>, <name>, <tool_name>, <function_name>, or <invoke name="...">
-    static const std::regex re_name(
-        R"(<(?:invoke_name|name|tool_name|function_name)>\s*([A-Za-z_][\w.\-]*)\s*</(?:invoke_name|name|tool_name|function_name)>|<invoke\s+(?:name|tool)\s*=\s*["']?([A-Za-z_][\w.\-]*)["']?)");
-    std::smatch m_name;
-    if (std::regex_search(body, m_name, re_name)) {
-        name = m_name[1].matched ? m_name[1].str() : m_name[2].str();
+    // Skip legacy Qwen function bodies (<function=...>, <function>, <function >)
+    if (trimmed.find("<function=") != std::string::npos ||
+        trimmed.find("<function>") != std::string::npos ||
+        trimmed.find("<function ") != std::string::npos) {
+        return false;
     }
+
+    // 1. Look for function name in top-level XML envelope:
+    // a. <invoke name="...">...</invoke> or <invoke tool="...">...</invoke>
+    std::string param_section;
+    static const std::regex re_invoke_envelope(
+        R"(^\s*<invoke\s+(?:name|tool)\s*=\s*["']?([A-Za-z_][\w.\-]*)["']?\s*>([\s\S]*?)</invoke>\s*$)");
+    std::smatch m_inv;
+    if (std::regex_match(trimmed, m_inv, re_invoke_envelope)) {
+        name = m_inv[1].str();
+        param_section = m_inv[2].str();
+    } else {
+        // b. <invoke_name>NAME</invoke_name>, <tool_name>NAME</tool_name>, <function_name>NAME</function_name>, or leading <name>NAME</name>
+        static const std::regex re_tag_name(
+            R"(^\s*<(invoke_name|name|tool_name|function_name)>\s*([A-Za-z_][\w.\-]*)\s*</\1>([\s\S]*)$)");
+        std::smatch m_tag;
+        if (std::regex_match(trimmed, m_tag, re_tag_name)) {
+            name = m_tag[2].str();
+            param_section = m_tag[3].str();
+        }
+    }
+
     if (name.empty() || !tool_allowed(tools, name)) {
         return false;
     }
@@ -640,17 +660,23 @@ static bool parse_xml_tool_call_body(const std::string & body, const json & tool
     const json props = find_tool_properties(tools, name);
     args = json::object();
 
-    // 2. Look for parameters section in <parameters>, <arguments>, or the whole body
-    std::string param_section = body;
-    static const std::regex re_section(R"(<(?:parameters|arguments)>([\s\S]*?)</(?:parameters|arguments)>)");
+    // 2. Look for parameters section in <parameters>...</parameters> or <arguments>...</arguments>
+    static const std::regex re_section(R"(^\s*<(parameters|arguments)>([\s\S]*?)</\1>\s*$)");
     std::smatch m_sec;
-    if (std::regex_search(body, m_sec, re_section)) {
-        param_section = m_sec[1].str();
+    std::string trimmed_params_sec = trim_ws(param_section);
+    if (std::regex_match(trimmed_params_sec, m_sec, re_section)) {
+        param_section = m_sec[2].str();
+    }
+
+    std::string trimmed_params = trim_ws(param_section);
+    if (trimmed_params.empty()) {
+        // Genuinely zero-argument call
+        raw_args = "{}";
+        return true;
     }
 
     // Check if param_section is a JSON object
-    std::string trimmed_params = trim_ws(param_section);
-    if (!trimmed_params.empty() && trimmed_params.front() == '{') {
+    if (trimmed_params.front() == '{') {
         json j = json::parse(trimmed_params, nullptr, false);
         if (!j.is_discarded() && j.is_object()) {
             for (auto & [k, v] : j.items()) {
@@ -663,43 +689,76 @@ static bool parse_xml_tool_call_body(const std::string & body, const json & tool
             raw_args = args.dump();
             return true;
         }
+        return false;
     }
 
     // 3. Extract parameter key-value pairs:
     // a. Attribute style: <(param|parameter) name="key">value</...> or <parameter=key>value</parameter>
     static const std::regex re_attr_param(
         R"(<(?:param|parameter)\s+name\s*=\s*["']?([A-Za-z_][\w.\-]*)["']?\s*>([\s\S]*?)</(?:param|parameter)>|<parameter=([A-Za-z_][\w.\-]*)>([\s\S]*?)</parameter>)");
-    auto pbegin = std::sregex_iterator(param_section.begin(), param_section.end(), re_attr_param);
+    auto pbegin = std::sregex_iterator(trimmed_params.begin(), trimmed_params.end(), re_attr_param);
     auto pend = std::sregex_iterator();
-    bool found_any = false;
-    for (auto it = pbegin; it != pend; ++it) {
-        std::string k = (*it)[1].matched ? (*it)[1].str() : (*it)[3].str();
-        std::string v = trim_ws((*it)[2].matched ? (*it)[2].str() : (*it)[4].str());
-        args[k] = convert_param_value(v, k, props);
-        found_any = true;
+    if (pbegin != pend) {
+        size_t cursor = 0;
+        bool valid = true;
+        for (auto it = pbegin; it != pend; ++it) {
+            size_t pos = it->position();
+            if (!trim_ws(trimmed_params.substr(cursor, pos - cursor)).empty()) {
+                valid = false;
+                break;
+            }
+            std::string k = (*it)[1].matched ? (*it)[1].str() : (*it)[3].str();
+            if (args.contains(k)) {
+                valid = false;
+                break;
+            }
+            std::string v = trim_ws((*it)[2].matched ? (*it)[2].str() : (*it)[4].str());
+            args[k] = convert_param_value(v, k, props);
+            cursor = pos + it->length();
+        }
+        if (valid && trim_ws(trimmed_params.substr(cursor)).empty()) {
+            raw_args = args.dump();
+            return true;
+        }
+        return false;
     }
 
     // b. Element tag style: <key>value</key>
-    if (!found_any) {
-        static const std::regex re_elem_param(R"(<([A-Za-z_][\w.\-]*)>([\s\S]*?)</\1>)");
-        auto ebegin = std::sregex_iterator(param_section.begin(), param_section.end(), re_elem_param);
-        auto eend = std::sregex_iterator();
+    static const std::regex re_elem_param(R"(<([A-Za-z_][\w.\-]*)>([\s\S]*?)</\1>)");
+    auto ebegin = std::sregex_iterator(trimmed_params.begin(), trimmed_params.end(), re_elem_param);
+    auto eend = std::sregex_iterator();
+    if (ebegin != eend) {
+        size_t cursor = 0;
+        bool valid = true;
         for (auto it = ebegin; it != eend; ++it) {
+            size_t pos = it->position();
+            if (!trim_ws(trimmed_params.substr(cursor, pos - cursor)).empty()) {
+                valid = false;
+                break;
+            }
             std::string tag = (*it)[1].str();
-            // Ignore outer envelope and section names
             if (tag == "invoke_name" || tag == "name" || tag == "tool_name" ||
                 tag == "function_name" || tag == "parameters" || tag == "arguments" ||
                 tag == "function_call" || tag == "tool_call" || tag == "invoke") {
-                continue;
+                valid = false;
+                break;
+            }
+            if (args.contains(tag)) {
+                valid = false;
+                break;
             }
             std::string v = trim_ws((*it)[2].str());
             args[tag] = convert_param_value(v, tag, props);
-            found_any = true;
+            cursor = pos + it->length();
         }
+        if (valid && trim_ws(trimmed_params.substr(cursor)).empty() && !args.empty()) {
+            raw_args = args.dump();
+            return true;
+        }
+        return false;
     }
 
-    raw_args = args.dump();
-    return true;
+    return false;
 }
 
 // ─── JSON tool call parser ──────────────────────────────────────────────
@@ -1052,6 +1111,10 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
             const size_t close = text.find("</tool_call>", body_start);
             if (close == std::string::npos) break;
             const std::string body = text.substr(body_start, close - body_start);
+            if (body.find("<function") != std::string::npos) {
+                pos = close + 12;
+                continue;
+            }
             std::string xml_name;
             json xml_args;
             std::string xml_raw;

--- a/server/src/server/tool_parser.cpp
+++ b/server/src/server/tool_parser.cpp
@@ -617,6 +617,86 @@ static bool parse_complete_parameter_body(const std::string & body,
     return found_param && trim_ws(body.substr(cursor)).empty();
 }
 
+// ─── XML tool call parser (<function_call> / <tool_call> with tags) ────
+
+static bool parse_xml_tool_call_body(const std::string & body, const json & tools,
+                                     std::string & name, json & args, std::string & raw_args) {
+    // 1. Look for function name in <invoke_name>, <name>, <tool_name>, <function_name>, or <invoke name="...">
+    static const std::regex re_name(
+        R"(<(?:invoke_name|name|tool_name|function_name)>\s*([A-Za-z_][\w.\-]*)\s*</(?:invoke_name|name|tool_name|function_name)>|<invoke\s+(?:name|tool)\s*=\s*["']?([A-Za-z_][\w.\-]*)["']?)");
+    std::smatch m_name;
+    if (std::regex_search(body, m_name, re_name)) {
+        name = m_name[1].matched ? m_name[1].str() : m_name[2].str();
+    }
+    if (name.empty() || !tool_allowed(tools, name)) {
+        return false;
+    }
+
+    const json props = find_tool_properties(tools, name);
+    args = json::object();
+
+    // 2. Look for parameters section in <parameters>, <arguments>, or the whole body
+    std::string param_section = body;
+    static const std::regex re_section(R"(<(?:parameters|arguments)>([\s\S]*?)</(?:parameters|arguments)>)");
+    std::smatch m_sec;
+    if (std::regex_search(body, m_sec, re_section)) {
+        param_section = m_sec[1].str();
+    }
+
+    // Check if param_section is a JSON object
+    std::string trimmed_params = trim_ws(param_section);
+    if (!trimmed_params.empty() && trimmed_params.front() == '{') {
+        json j = json::parse(trimmed_params, nullptr, false);
+        if (!j.is_discarded() && j.is_object()) {
+            for (auto & [k, v] : j.items()) {
+                if (v.is_string()) {
+                    args[k] = convert_param_value(v.get<std::string>(), k, props);
+                } else {
+                    args[k] = v;
+                }
+            }
+            raw_args = args.dump();
+            return true;
+        }
+    }
+
+    // 3. Extract parameter key-value pairs:
+    // a. Attribute style: <(param|parameter) name="key">value</...> or <parameter=key>value</parameter>
+    static const std::regex re_attr_param(
+        R"(<(?:param|parameter)\s+name\s*=\s*["']?([A-Za-z_][\w.\-]*)["']?\s*>([\s\S]*?)</(?:param|parameter)>|<parameter=([A-Za-z_][\w.\-]*)>([\s\S]*?)</parameter>)");
+    auto pbegin = std::sregex_iterator(param_section.begin(), param_section.end(), re_attr_param);
+    auto pend = std::sregex_iterator();
+    bool found_any = false;
+    for (auto it = pbegin; it != pend; ++it) {
+        std::string k = (*it)[1].matched ? (*it)[1].str() : (*it)[3].str();
+        std::string v = trim_ws((*it)[2].matched ? (*it)[2].str() : (*it)[4].str());
+        args[k] = convert_param_value(v, k, props);
+        found_any = true;
+    }
+
+    // b. Element tag style: <key>value</key>
+    if (!found_any) {
+        static const std::regex re_elem_param(R"(<([A-Za-z_][\w.\-]*)>([\s\S]*?)</\1>)");
+        auto ebegin = std::sregex_iterator(param_section.begin(), param_section.end(), re_elem_param);
+        auto eend = std::sregex_iterator();
+        for (auto it = ebegin; it != eend; ++it) {
+            std::string tag = (*it)[1].str();
+            // Ignore outer envelope and section names
+            if (tag == "invoke_name" || tag == "name" || tag == "tool_name" ||
+                tag == "function_name" || tag == "parameters" || tag == "arguments" ||
+                tag == "function_call" || tag == "tool_call" || tag == "invoke") {
+                continue;
+            }
+            std::string v = trim_ws((*it)[2].str());
+            args[tag] = convert_param_value(v, tag, props);
+            found_any = true;
+        }
+    }
+
+    raw_args = args.dump();
+    return true;
+}
+
 // ─── JSON tool call parser ──────────────────────────────────────────────
 
 static bool parse_arg_string_or_obj(const json & val, json & out_args,
@@ -966,7 +1046,15 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
             const size_t body_start = pos + 11;
             const size_t close = text.find("</tool_call>", body_start);
             if (close == std::string::npos) break;
-            const std::string body = text.substr(body_start, close - body_start);
+            std::string xml_name;
+            json xml_args;
+            std::string xml_raw;
+            if (parse_xml_tool_call_body(body, tools, xml_name, xml_args, xml_raw)) {
+                add_call(xml_name, xml_args, pos, close + 12, xml_raw);
+                pos = close + 12;
+                continue;
+            }
+
             const size_t first_key = body.find("<arg_key>");
             // Only claim bodies in the Laguna shape: bare name then arg tags
             // (or a bare name alone for zero-arg calls); leave <function=...>
@@ -1269,6 +1357,8 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
             json args;
             std::string raw_args;
             if (!obj.is_discarded() && parse_json_tool_call(obj, name, args, raw_args)) {
+                add_call(name, args, pos, pos + it->length(), raw_args);
+            } else if (parse_xml_tool_call_body(inner, tools, name, args, raw_args)) {
                 add_call(name, args, pos, pos + it->length(), raw_args);
             } else if (extract_raw_json_tool_fallback(inner, name, raw_args)) {
                 add_call(name, json::object(), pos, pos + it->length(), raw_args);

--- a/server/src/server/tool_parser.cpp
+++ b/server/src/server/tool_parser.cpp
@@ -621,6 +621,11 @@ static bool parse_complete_parameter_body(const std::string & body,
 
 static bool parse_xml_tool_call_body(const std::string & body, const json & tools,
                                      std::string & name, json & args, std::string & raw_args) {
+    std::string trimmed = trim_ws(body);
+    if (trimmed.empty() || trimmed.front() == '{' || trimmed.find('<') == std::string::npos) {
+        return false;
+    }
+
     // 1. Look for function name in <invoke_name>, <name>, <tool_name>, <function_name>, or <invoke name="...">
     static const std::regex re_name(
         R"(<(?:invoke_name|name|tool_name|function_name)>\s*([A-Za-z_][\w.\-]*)\s*</(?:invoke_name|name|tool_name|function_name)>|<invoke\s+(?:name|tool)\s*=\s*["']?([A-Za-z_][\w.\-]*)["']?)");

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -924,6 +924,97 @@ TEST_CASE(ServerUnitFixture, test_parse_bare_function_json_with_parameters) {
     }
 }
 
+TEST_CASE(ServerUnitFixture, test_parse_function_call_xml_invoke_name_parameters) {
+    const std::string text =
+        "Let me read the file.\n\n"
+        "<function_call>\n"
+        "<invoke_name>read</invoke_name>\n"
+        "<parameters>\n"
+        "<path>/home/dpavlin/koha-rfid-go/internal/rfidops/ops.go</path>\n"
+        "</parameters>\n"
+        "</function_call>";
+    json tools = json::array({
+        {{"type", "function"}, {"function", {
+             {"name", "read"},
+             {"parameters", {
+                 {"type", "object"},
+                 {"properties", {
+                     {"path", {{"type", "string"}}}
+                 }}
+             }}
+         }}}
+    });
+    auto result = parse_tool_calls(text, tools);
+    TEST_ASSERT(result.tool_calls.size() == 1);
+    if (!result.tool_calls.empty()) {
+        TEST_ASSERT(result.tool_calls[0].name == "read");
+        auto args = json::parse(result.tool_calls[0].arguments);
+        TEST_ASSERT(args["path"] == "/home/dpavlin/koha-rfid-go/internal/rfidops/ops.go");
+    }
+    TEST_ASSERT(result.cleaned_text == "Let me read the file.");
+}
+
+TEST_CASE(ServerUnitFixture, test_parse_function_call_xml_multiple_parameters) {
+    const std::string text =
+        "<function_call>\n"
+        "<invoke_name>bash</invoke_name>\n"
+        "<parameters>\n"
+        "<command>ls -la /tmp</command>\n"
+        "<timeout>10</timeout>\n"
+        "</parameters>\n"
+        "</function_call>";
+    json tools = json::array({
+        {{"type", "function"}, {"function", {
+             {"name", "bash"},
+             {"parameters", {
+                 {"type", "object"},
+                 {"properties", {
+                     {"command", {{"type", "string"}}},
+                     {"timeout", {{"type", "integer"}}}
+                 }}
+             }}
+         }}}
+    });
+    auto result = parse_tool_calls(text, tools);
+    TEST_ASSERT(result.tool_calls.size() == 1);
+    if (!result.tool_calls.empty()) {
+        TEST_ASSERT(result.tool_calls[0].name == "bash");
+        auto args = json::parse(result.tool_calls[0].arguments);
+        TEST_ASSERT(args["command"] == "ls -la /tmp");
+        TEST_ASSERT(args["timeout"] == 10);
+    }
+    TEST_ASSERT(result.cleaned_text.empty());
+}
+
+TEST_CASE(ServerUnitFixture, test_parse_tool_call_xml_invoke_name_parameters) {
+    const std::string text =
+        "<tool_call>\n"
+        "<invoke_name>read</invoke_name>\n"
+        "<parameters>\n"
+        "<path>/home/dpavlin/test.go</path>\n"
+        "</parameters>\n"
+        "</tool_call>";
+    json tools = json::array({
+        {{"type", "function"}, {"function", {
+             {"name", "read"},
+             {"parameters", {
+                 {"type", "object"},
+                 {"properties", {
+                     {"path", {{"type", "string"}}}
+                 }}
+             }}
+         }}}
+    });
+    auto result = parse_tool_calls(text, tools);
+    TEST_ASSERT(result.tool_calls.size() == 1);
+    if (!result.tool_calls.empty()) {
+        TEST_ASSERT(result.tool_calls[0].name == "read");
+        auto args = json::parse(result.tool_calls[0].arguments);
+        TEST_ASSERT(args["path"] == "/home/dpavlin/test.go");
+    }
+    TEST_ASSERT(result.cleaned_text.empty());
+}
+
 
 
 TEST_CASE(ServerUnitFixture, test_parse_tool_allowed_filter) {

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -1015,6 +1015,119 @@ TEST_CASE(ServerUnitFixture, test_parse_tool_call_xml_invoke_name_parameters) {
     TEST_ASSERT(result.cleaned_text.empty());
 }
 
+TEST_CASE(ServerUnitFixture, test_parse_legacy_tool_call_with_nested_name_tag) {
+    // Regression test for Violation 1:
+    // A legacy <tool_call><function=...> envelope whose parameter contains a nested <name> tag
+    // must NOT be hijacked by parse_xml_tool_call_body as envelope name.
+    const std::string text =
+        "<tool_call>\n"
+        "<function=edit_file>\n"
+        "<parameter=content>\n"
+        "function getTool() { return \"<name>other_tool</name>\"; }\n"
+        "</parameter>\n"
+        "</function>\n"
+        "</tool_call>";
+    json tools = json::array({
+        {{"type", "function"}, {"function", {
+             {"name", "edit_file"},
+             {"parameters", {
+                 {"type", "object"},
+                 {"properties", {
+                     {"content", {{"type", "string"}}}
+                 }}
+             }}
+         }}},
+        {{"type", "function"}, {"function", {
+             {"name", "other_tool"},
+             {"parameters", {{"type", "object"}, {"properties", {}}}}
+         }}}
+    });
+    auto result = parse_tool_calls(text, tools);
+    TEST_ASSERT(result.tool_calls.size() == 1);
+    if (!result.tool_calls.empty()) {
+        TEST_ASSERT(result.tool_calls[0].name == "edit_file");
+        auto args = json::parse(result.tool_calls[0].arguments);
+        TEST_ASSERT(args["content"] == "function getTool() { return \"<name>other_tool</name>\"; }");
+    }
+    TEST_ASSERT(result.cleaned_text.empty());
+}
+
+TEST_CASE(ServerUnitFixture, test_parse_xml_tool_call_malformed_parameters_rejected) {
+    // Regression test for Violation 2:
+    // When the parameter section is non-empty but malformed (unsupported/invalid syntax),
+    // parse_xml_tool_call_body must NOT emit an empty {} tool call.
+    const std::string text =
+        "<function_call>\n"
+        "<invoke_name>edit_file</invoke_name>\n"
+        "<parameters>\n"
+        "random unparseable garbage text\n"
+        "</parameters>\n"
+        "</function_call>";
+    json tools = json::array({
+        {{"type", "function"}, {"function", {
+             {"name", "edit_file"},
+             {"parameters", {
+                 {"type", "object"},
+                 {"properties", {
+                     {"content", {{"type", "string"}}}
+                 }}
+             }}
+         }}}
+    });
+    auto result = parse_tool_calls(text, tools);
+    TEST_ASSERT(result.tool_calls.empty());
+    TEST_ASSERT(!result.cleaned_text.empty());
+}
+
+TEST_CASE(ServerUnitFixture, test_parse_xml_tool_call_zero_arguments_accepted) {
+    // Genuinely zero-argument calls should be accepted.
+    const std::string text =
+        "<function_call>\n"
+        "<invoke_name>get_status</invoke_name>\n"
+        "</function_call>";
+    json tools = json::array({
+        {{"type", "function"}, {"function", {
+             {"name", "get_status"},
+             {"parameters", {{"type", "object"}, {"properties", {}}}}
+         }}}
+    });
+    auto result = parse_tool_calls(text, tools);
+    TEST_ASSERT(result.tool_calls.size() == 1);
+    if (!result.tool_calls.empty()) {
+        TEST_ASSERT(result.tool_calls[0].name == "get_status");
+        TEST_ASSERT(result.tool_calls[0].arguments == "{}");
+    }
+    TEST_ASSERT(result.cleaned_text.empty());
+}
+
+TEST_CASE(ServerUnitFixture, test_parse_xml_tool_call_invoke_envelope_attribute_style) {
+    const std::string text =
+        "<function_call>\n"
+        "<invoke name=\"read\">\n"
+        "<parameter name=\"path\">/tmp/test.txt</parameter>\n"
+        "</invoke>\n"
+        "</function_call>";
+    json tools = json::array({
+        {{"type", "function"}, {"function", {
+             {"name", "read"},
+             {"parameters", {
+                 {"type", "object"},
+                 {"properties", {
+                     {"path", {{"type", "string"}}}
+                 }}
+             }}
+         }}}
+    });
+    auto result = parse_tool_calls(text, tools);
+    TEST_ASSERT(result.tool_calls.size() == 1);
+    if (!result.tool_calls.empty()) {
+        TEST_ASSERT(result.tool_calls[0].name == "read");
+        auto args = json::parse(result.tool_calls[0].arguments);
+        TEST_ASSERT(args["path"] == "/tmp/test.txt");
+    }
+    TEST_ASSERT(result.cleaned_text.empty());
+}
+
 
 
 TEST_CASE(ServerUnitFixture, test_parse_tool_allowed_filter) {

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -1128,6 +1128,37 @@ TEST_CASE(ServerUnitFixture, test_parse_xml_tool_call_invoke_envelope_attribute_
     TEST_ASSERT(result.cleaned_text.empty());
 }
 
+TEST_CASE(ServerUnitFixture, test_parse_tool_call_xml_function_name_tag) {
+    // Regression test for Violation:
+    // <tool_call> envelopes using <function_name> must be parsed cleanly by parse_xml_tool_call_body()
+    const std::string text =
+        "<tool_call>\n"
+        "<function_name>read</function_name>\n"
+        "<parameters>\n"
+        "<path>/tmp/test.txt</path>\n"
+        "</parameters>\n"
+        "</tool_call>";
+    json tools = json::array({
+        {{"type", "function"}, {"function", {
+             {"name", "read"},
+             {"parameters", {
+                 {"type", "object"},
+                 {"properties", {
+                     {"path", {{"type", "string"}}}
+                 }}
+             }}
+         }}}
+    });
+    auto result = parse_tool_calls(text, tools);
+    TEST_ASSERT(result.tool_calls.size() == 1);
+    if (!result.tool_calls.empty()) {
+        TEST_ASSERT(result.tool_calls[0].name == "read");
+        auto args = json::parse(result.tool_calls[0].arguments);
+        TEST_ASSERT(args["path"] == "/tmp/test.txt");
+    }
+    TEST_ASSERT(result.cleaned_text.empty());
+}
+
 
 
 TEST_CASE(ServerUnitFixture, test_parse_tool_allowed_filter) {


### PR DESCRIPTION
Fixes #670

### Summary
During multi-turn tool-calling sessions with DeepSeek-V4 (e.g., autonomous coding agents), the model may output tool calls wrapped in XML `<function_call>` or `<tool_call>` envelopes with `<invoke_name>` and `<parameters>` tags:

```xml
<function_call>
<invoke_name>read</invoke_name>
<parameters>
<path>/home/dpavlin/koha-rfid-go/internal/rfidops/ops.go</path>
</parameters>
</function_call>
```

Previously, `Pattern 4b` and `Pattern 8` in `tool_parser.cpp` did not handle XML parameter blocks, leading to `parse_tool_calls` returning 0 calls, suppressing buffered tool text, and emitting an empty stop response to the client.

### Changes
1. Added helper `parse_xml_tool_call_body()` in [`server/src/server/tool_parser.cpp`](file:///home/dpavlin/lucebox/server/src/server/tool_parser.cpp):
   - Identifies tool name from `<invoke_name>`, `<name>`, `<tool_name>`, `<function_name>`, or `<invoke name="...">`.
   - Extracts parameters from `<parameters>` or `<arguments>` sections (supporting element tags `<key>val</key>` and attribute style `<parameter name="key">val</parameter>`).
   - Coerces parameter types based on declared tool schemas.
2. Hooked `parse_xml_tool_call_body()` into `Pattern 4b` (`<function_call>`) and `Pattern 8` (`<tool_call>`).
3. Added comprehensive unit tests to [`server/test/test_server_unit.cpp`](file:///home/dpavlin/lucebox/server/test/test_server_unit.cpp) covering single and multi-argument XML function/tool calls.

### Verification
- `test_server_unit`: 426/426 passed.
- Verified on live DeepSeek-V4 Flash ROCm server with streaming SSE requests and agent workflows.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

