### PR TITLE
fix(pflash): score the user query and reject non-finite scores

### DIFF
--- a/server/src/common/model_backend.h
+++ b/server/src/common/model_backend.h
@@ -423,6 +423,12 @@ struct ModelBackend {
     struct CompressRequest {
         std::vector<int32_t> input_ids;      // drafter-tokenized prompt
         float                keep_ratio;      // fraction to keep (0.0–1.0)
+        // Exclusive end and width of the user-query token window inside
+        // input_ids. Negative end preserves the legacy trailing-token window.
+        // Keeping this separate from DFLASH_COMPRESS_QUERY_TOKENS matters:
+        // that knob controls lexical anchors, not neural scorer Q rows.
+        int                  score_query_end = -1;
+        int                  score_query_tokens = 8;
         std::string          drafter_path;    // GGUF path (for lazy-load)
         int                  drafter_gpu = 0;  // backend-local GPU for PFlash drafter
         bool                 skip_park = false; // true on >=32GB GPUs

--- a/server/src/common/pflash_drafter_ipc.cpp
+++ b/server/src/common/pflash_drafter_ipc.cpp
@@ -40,9 +40,12 @@ bool PFlashDrafterIpcClient::start(
 bool PFlashDrafterIpcClient::compress(
         const std::vector<int32_t> & input_ids,
         float keep_ratio,
-        std::vector<int32_t> & compressed_ids) {
+        std::vector<int32_t> & compressed_ids,
+        int score_query_end,
+        int score_query_tokens) {
 #if defined(_WIN32)
     (void)input_ids; (void)keep_ratio; (void)compressed_ids;
+    (void)score_query_end; (void)score_query_tokens;
     return false;
 #else
     compressed_ids.clear();
@@ -58,7 +61,9 @@ bool PFlashDrafterIpcClient::compress(
     int keep_x1000 = (int)std::lround(std::max(0.0f, keep_ratio) * 1000.0f);
     keep_x1000 = std::max(0, std::min(1000, keep_x1000));
 
-    std::fprintf(cmd, "compress %d %s\n", keep_x1000, path.c_str());
+    std::fprintf(cmd, "compress %d %d %d %s\n",
+                 keep_x1000, score_query_end, score_query_tokens,
+                 path.c_str());
     std::fflush(cmd);
 
     int32_t status = -1;

--- a/server/src/common/pflash_drafter_ipc.h
+++ b/server/src/common/pflash_drafter_ipc.h
@@ -16,6 +16,10 @@
 
 namespace dflash::common {
 
+inline bool valid_pflash_score_query_tokens(int score_query_tokens) {
+    return score_query_tokens >= 1 && score_query_tokens <= 8;
+}
+
 class PFlashDrafterIpcClient {
 public:
     PFlashDrafterIpcClient() = default;
@@ -30,7 +34,9 @@ public:
 
     bool compress(const std::vector<int32_t> & input_ids,
                   float keep_ratio,
-                  std::vector<int32_t> & compressed_ids);
+                  std::vector<int32_t> & compressed_ids,
+                  int score_query_end = -1,
+                  int score_query_tokens = 8);
 
     bool active() const { return active_; }
     void close();

--- a/server/src/common/pflash_drafter_ipc_daemon.cpp
+++ b/server/src/common/pflash_drafter_ipc_daemon.cpp
@@ -47,9 +47,13 @@ int run_pflash_drafter_ipc_daemon(const char * drafter_path,
         if (cmd == "quit" || cmd == "exit") break;
         if (cmd == "compress") {
             int keep_x1000 = 0;
-            iss >> keep_x1000;
+            int score_query_end = -1;
+            int score_query_tokens = 8;
+            iss >> keep_x1000 >> score_query_end >> score_query_tokens;
             std::string path = read_line_tail(iss);
-            if (keep_x1000 < 0 || keep_x1000 > 1000 || path.empty()) {
+            if (keep_x1000 < 0 || keep_x1000 > 1000 ||
+                !valid_pflash_score_query_tokens(score_query_tokens) ||
+                path.empty()) {
                 std::fprintf(stderr, "[pflash-ipc-daemon] bad compress: %s\n",
                              line.c_str());
                 stream_status(stream_fd, -1);
@@ -63,7 +67,9 @@ int run_pflash_drafter_ipc_daemon(const char * drafter_path,
                 continue;
             }
             const float keep = (float)keep_x1000 / 1000.0f;
-            auto compressed = drafter_score_and_compress(ctx, input_ids, keep);
+            auto compressed = drafter_score_and_compress(
+                ctx, input_ids, keep, /*chunk_size=*/32, score_query_tokens,
+                /*pool_kernel=*/13, score_query_end);
             if (compressed.empty()) {
                 std::fprintf(stderr, "[pflash-ipc-daemon] compress returned empty\n");
                 stream_status(stream_fd, -1);

--- a/server/src/qwen3/qwen3_backend.cpp
+++ b/server/src/qwen3/qwen3_backend.cpp
@@ -968,8 +968,10 @@ ModelBackend::CompressResult Qwen3Backend::compress(const CompressRequest & req)
     }
 
     result.compressed_ids = drafter_score_and_compress(
-        drafter_ctx_, req.input_ids, req.keep_ratio);
-    result.ok = true;
+        drafter_ctx_, req.input_ids, req.keep_ratio,
+        /*chunk_size=*/32, req.score_query_tokens, /*pool_kernel=*/13,
+        req.score_query_end);
+    result.ok = !result.compressed_ids.empty();
 
     if (req.residency_action == DraftResidencyAction::ReleaseAfterUse) {
         free_drafter();

--- a/server/src/qwen3/qwen3_drafter.cpp
+++ b/server/src/qwen3/qwen3_drafter.cpp
@@ -272,11 +272,18 @@ static std::vector<int32_t> qwen35_score_and_compress(
     float keep_ratio,
     int chunk_size,
     int n_lookahead,
-    int pool_kernel) {
+    int pool_kernel,
+    int score_query_end) {
 
     const int S = (int)ids.size();
     const int hidden = w.n_embd;
     if (S < n_lookahead + 1) return ids;
+    const int query_end = score_query_end;
+    if (n_lookahead < 1 || query_end < n_lookahead || query_end > S) {
+        set_last_error("qwen35 scorer query window out of range");
+        return {};
+    }
+    const int query_start = query_end - n_lookahead;
 
     auto t0 = std::chrono::steady_clock::now();
     std::vector<float> running_max((size_t)n_lookahead * S, -INFINITY);
@@ -441,7 +448,7 @@ static std::vector<int32_t> qwen35_score_and_compress(
             }
             const TargetLayer & L = w.layers[il];
             ggml_tensor * inp_tail = ggml_view_2d(sctx, act_in, hidden, n_lookahead,
-                act_in->nb[1], (size_t)(S - n_lookahead) * act_in->nb[1]);
+                act_in->nb[1], (size_t)query_start * act_in->nb[1]);
             ggml_tensor * q_cur = ggml_rms_norm(sctx, inp_tail, w.rms_eps);
             q_cur = ggml_mul(sctx, q_cur, L.attn_norm);
             ggml_tensor * QG = ggml_mul_mat(sctx, L.wq, q_cur);
@@ -473,7 +480,7 @@ static std::vector<int32_t> qwen35_score_and_compress(
             }
             std::vector<int32_t> pos4((size_t)4 * n_lookahead, 0);
             for (int i = 0; i < n_lookahead; ++i) {
-                int p = S - n_lookahead + i;
+                const int p = query_start + i;
                 pos4[(size_t)0 * n_lookahead + i] = p;
                 pos4[(size_t)1 * n_lookahead + i] = p;
                 pos4[(size_t)2 * n_lookahead + i] = p;
@@ -481,7 +488,7 @@ static std::vector<int32_t> qwen35_score_and_compress(
             ggml_backend_tensor_set(pos_tail, pos4.data(), 0, pos4.size() * sizeof(int32_t));
             std::vector<float> mask((size_t)n_lookahead * K_len, 0.0f);
             for (int t = 0; t < n_lookahead; ++t) {
-                const int visible_end = S - n_lookahead + t + 1;
+                const int visible_end = query_start + t + 1;
                 for (int j = 0; j < K_len; ++j) {
                     mask[(size_t)t * K_len + j] = (j < visible_end) ? 0.0f : -INFINITY;
                 }
@@ -495,6 +502,21 @@ static std::vector<int32_t> qwen35_score_and_compress(
             }
             std::vector<float> tmp((size_t)K_len * n_lookahead * w.n_head);
             ggml_backend_tensor_get(probs, tmp.data(), 0, tmp.size() * sizeof(float));
+            const size_t nonfinite =
+                count_nonfinite_scores(tmp.data(), tmp.size());
+            if (nonfinite != 0) {
+                const std::string message =
+                    "non-finite Qwen3.5 PFlash scores at layer " +
+                    std::to_string(il) + ": " + std::to_string(nonfinite) +
+                    "/" + std::to_string(tmp.size());
+                std::fprintf(stderr, "[pflash] ERROR: %s\n", message.c_str());
+                std::fflush(stderr);
+                ggml_gallocr_free(salloc); ggml_free(sctx);
+                ggml_gallocr_free(alloc); ggml_backend_buffer_free(act_buf);
+                ggml_free(act_ctx); free_target_cache(cache);
+                set_last_error(message);
+                return {};
+            }
             for (int h = 0; h < w.n_head; ++h) {
                 for (int t = 0; t < n_lookahead; ++t) {
                     for (int j = 0; j < S; ++j) {
@@ -684,18 +706,24 @@ std::vector<int32_t> drafter_score_and_compress(
     float keep_ratio,
     int chunk_size,
     int n_lookahead,
-    int pool_kernel) {
+    int pool_kernel,
+    int score_query_end) {
     if (!ctx.loaded) {
         set_last_error("drafter not loaded");
         return {};
     }
     if (ctx.arch == DrafterArch::Qwen35_0p8b) {
+        if (score_query_end < 0) {
+            set_last_error("qwen35 scorer query window out of range");
+            return {};
+        }
         if (!ctx.arch_state) {
             set_last_error("qwen35 drafter state missing");
             return {};
         }
         auto * st = static_cast<Qwen35DrafterState *>(ctx.arch_state);
-        return qwen35_score_and_compress(st->weights, ids, keep_ratio, chunk_size, n_lookahead, pool_kernel);
+        return qwen35_score_and_compress(st->weights, ids, keep_ratio, chunk_size,
+                                         n_lookahead, pool_kernel, score_query_end);
     }
     const int S = (int)ids.size();
     if (S < n_lookahead + 1) {
@@ -706,7 +734,8 @@ std::vector<int32_t> drafter_score_and_compress(
     // ── 1. Custom forward + GPU tail-attention scoring ────────────────
     auto t0 = std::chrono::steady_clock::now();
     std::vector<float> running_max;
-    if (!forward_qwen3_drafter_model(ctx.weights, ids, n_lookahead, running_max)) {
+    if (!forward_qwen3_drafter_model(
+            ctx.weights, ids, n_lookahead, running_max, score_query_end)) {
         return {};
     }
     auto t1 = std::chrono::steady_clock::now();

--- a/server/src/qwen3/qwen3_drafter.h
+++ b/server/src/qwen3/qwen3_drafter.h
@@ -69,8 +69,10 @@ void free_drafter_weights(DrafterContext & ctx);
 //   ids          input token IDs of length S
 //   keep_ratio   fraction of `chunk_size`-token chunks to keep
 //   chunk_size   span granularity (default 32)
-//   n_lookahead  trailing Q tokens used for tail attention (default 8)
+//   n_lookahead  Q tokens used for scorer attention (default 8)
 //   pool_kernel  AvgPool kernel for score smoothing (default 13)
+//   score_query_end  exclusive end of Q window in ids; negative means tail
+//                    for Qwen3 and is rejected for Qwen3.5
 //
 // On failure returns empty vector + sets last_error.
 std::vector<int32_t> drafter_score_and_compress(
@@ -79,6 +81,7 @@ std::vector<int32_t> drafter_score_and_compress(
     float  keep_ratio,
     int    chunk_size  = 32,
     int    n_lookahead = 8,
-    int    pool_kernel = 13);
+    int    pool_kernel = 13,
+    int    score_query_end = -1);
 
 } // namespace dflash::common

--- a/server/src/qwen3/qwen3_drafter_model.h
+++ b/server/src/qwen3/qwen3_drafter_model.h
@@ -13,6 +13,8 @@
 
 #include "ggml.h"
 
+#include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -76,11 +78,12 @@ void free_qwen3_drafter_model(Qwen3DrafterWeights & w);
 // Inputs:
 //   w           — loaded weights (must be on the selected GPU backend)
 //   ids         — input token IDs of length S (drafter vocab)
-//   n_lookahead — number of trailing query tokens for tail attention (=8)
+//   n_lookahead — number of query tokens for scorer attention (=8)
+//   score_query_end — exclusive end of query window; negative selects the tail
 //
 // Outputs:
 //   running_max — flat [n_lookahead, S] f32, max-over-heads-and-layers of
-//                 softmax(Q_tail @ K^T / sqrt(D)) per (lookahead, key) pair.
+//                 softmax(Q_query @ K^T / sqrt(D)) per (lookahead, key) pair.
 //                 Caller does AvgPool + chunk-top-K + span merge.
 //
 // Returns true on success. On failure sets last_error and returns false.
@@ -88,6 +91,39 @@ bool forward_qwen3_drafter_model(
     const Qwen3DrafterWeights & w,
     const std::vector<int32_t> & ids,
     int n_lookahead,
-    std::vector<float> & running_max);
+    std::vector<float> & running_max,
+    int score_query_end = -1);
+
+struct QueryCaptureSlice {
+    int chunk_offset = 0;
+    int query_offset = 0;
+    int tokens = 0;
+
+    bool valid() const { return tokens > 0; }
+};
+
+inline QueryCaptureSlice query_capture_slice(
+        int query_start,
+        int query_end,
+        int chunk_start,
+        int chunk_tokens) {
+    const int chunk_end = chunk_start + chunk_tokens;
+    const int overlap_start = query_start > chunk_start ? query_start : chunk_start;
+    const int overlap_end = query_end < chunk_end ? query_end : chunk_end;
+    if (overlap_start >= overlap_end) return {};
+    return {
+        overlap_start - chunk_start,
+        overlap_start - query_start,
+        overlap_end - overlap_start,
+    };
+}
+
+inline size_t count_nonfinite_scores(const float * values, size_t count) {
+    size_t nonfinite = 0;
+    for (size_t index = 0; index < count; ++index) {
+        if (!std::isfinite(values[index])) ++nonfinite;
+    }
+    return nonfinite;
+}
 
 } // namespace dflash::common

--- a/server/src/qwen3/qwen3_graph.cpp
+++ b/server/src/qwen3/qwen3_graph.cpp
@@ -224,7 +224,8 @@ bool forward_qwen3_drafter_model(
     const Qwen3DrafterWeights & w,
     const std::vector<int32_t> & ids,
     int n_lookahead,
-    std::vector<float> & running_max)
+    std::vector<float> & running_max,
+    int score_query_end)
 {
     if (!w.backend || !w.tok_embd) {
         set_last_error("forward_qwen3_drafter_model: weights not loaded");
@@ -250,10 +251,17 @@ bool forward_qwen3_drafter_model(
         return e == nullptr || std::string(e) != "0";
     }();
 
-    if (S < n_lookahead + 1) {
+    if (n_lookahead < 1 || S < n_lookahead + 1) {
         set_last_error("forward_qwen3_drafter_model: S too small");
         return false;
     }
+    const int query_end = score_query_end < 0 ? S : score_query_end;
+    if (query_end < n_lookahead || query_end > S) {
+        set_last_error(
+            "forward_qwen3_drafter_model: scorer query window out of range");
+        return false;
+    }
+    const int query_start = query_end - n_lookahead;
     running_max.assign((size_t)n_lookahead * S, -INFINITY);
 
     // Read scoring/early-exit env vars once; compute alloc range before buffers are created.
@@ -353,7 +361,7 @@ bool forward_qwen3_drafter_model(
     {
         std::vector<float> m((size_t)n_lookahead * S, 0.0f);
         for (int t = 0; t < n_lookahead; ++t) {
-            int visible_end = S - n_lookahead + t + 1;
+            const int visible_end = query_start + t + 1;
             for (int j = 0; j < S; ++j) {
                 m[(size_t)t * S + j] = (j < visible_end) ? 0.0f : -INFINITY;
             }
@@ -463,15 +471,21 @@ bool forward_qwen3_drafter_model(
             // NoPE: capture pre-RoPE Q tail (only for layers that will be scored).
             if (nope_tail && il >= score_layer_start_pre) {
                 const int si = il - score_layer_start_pre;
-                const int tail_lo_nr = S - n_lookahead;
-                if (tail_lo_nr >= cs && tail_lo_nr + n_lookahead <= cs + cl) {
-                    const int local_lo_nr = tail_lo_nr - cs;
+                const auto capture = query_capture_slice(
+                    query_start, query_end, cs, cl);
+                if (capture.valid()) {
                     ggml_tensor * Q_prenrope_tail = ggml_view_3d(
-                        gA, Q, D, H, n_lookahead,
+                        gA, Q, D, H, capture.tokens,
                         Q->nb[1], Q->nb[2],
-                        (size_t)local_lo_nr * Q->nb[2]);
+                        (size_t)capture.chunk_offset * Q->nb[2]);
+                    Q_prenrope_tail = ggml_cont(gA, Q_prenrope_tail);
+                    Q_prenrope_tail = ggml_reshape_1d(
+                        gA, Q_prenrope_tail, D * H * capture.tokens);
+                    ggml_tensor * Q_prenrope_dst = ggml_view_1d(
+                        gA, Q_norope_v[si].t, D * H * capture.tokens,
+                        (size_t)capture.query_offset * Q_norope_v[si].t->nb[2]);
                     ggml_build_forward_expand(gfA,
-                        ggml_cpy(gA, Q_prenrope_tail, Q_norope_v[si].t));
+                        ggml_cpy(gA, Q_prenrope_tail, Q_prenrope_dst));
                 }
             }
             Q = ggml_rope_ext(gA, Q, pos_chunk, nullptr, D,
@@ -515,16 +529,22 @@ bool forward_qwen3_drafter_model(
             ggml_build_forward_expand(gfA, ggml_cpy(gA, K, K_dst));
             ggml_build_forward_expand(gfA, ggml_cpy(gA, V, V_dst));
 
-            // Copy Q tail to Q_last_v[il] in the chunk that contains the tail.
-            const int tail_lo = S - n_lookahead;
-            if (!nope_tail && tail_lo >= cs && tail_lo + n_lookahead <= cs + cl) {
-                int local_lo = tail_lo - cs;
+            // Copy the overlapping Q-query slice; a query can straddle chunks.
+            const auto capture = query_capture_slice(
+                query_start, query_end, cs, cl);
+            if (!nope_tail && capture.valid()) {
                 ggml_tensor * Q_tail_local = ggml_view_3d(
-                    gA, Q, D, H, n_lookahead,
+                    gA, Q, D, H, capture.tokens,
                     Q->nb[1], Q->nb[2],
-                    (size_t)local_lo * Q->nb[2]);
+                    (size_t)capture.chunk_offset * Q->nb[2]);
+                Q_tail_local = ggml_cont(gA, Q_tail_local);
+                Q_tail_local = ggml_reshape_1d(
+                    gA, Q_tail_local, D * H * capture.tokens);
+                ggml_tensor * Q_tail_dst = ggml_view_1d(
+                    gA, Q_last_v[layer_cache_idx].t, D * H * capture.tokens,
+                    (size_t)capture.query_offset * Q_last_v[layer_cache_idx].t->nb[2]);
                 ggml_build_forward_expand(gfA,
-                    ggml_cpy(gA, Q_tail_local, Q_last_v[layer_cache_idx].t));
+                    ggml_cpy(gA, Q_tail_local, Q_tail_dst));
             }
 
             auto tA_setup1 = std::chrono::steady_clock::now();
@@ -827,12 +847,33 @@ bool forward_qwen3_drafter_model(
             cleanup_all();
             return false;
         }
-        ggml_backend_graph_compute(w.backend, gf);
-        ggml_backend_tensor_get(probs, probs_h.data(), 0,
-                                probs_h.size() * sizeof(float));
+        const auto score_status = ggml_backend_graph_compute(w.backend, gf);
+        size_t nonfinite = 0;
+        if (score_status == GGML_STATUS_SUCCESS) {
+            ggml_backend_tensor_get(probs, probs_h.data(), 0,
+                                    probs_h.size() * sizeof(float));
+            nonfinite = count_nonfinite_scores(probs_h.data(), probs_h.size());
+        }
         ggml_gallocr_free(s_galloc);
         if (in_buf) ggml_backend_buffer_free(in_buf);
         ggml_free(gctx);
+        if (score_status != GGML_STATUS_SUCCESS) {
+            set_last_error("tail score graph compute failed at layer " +
+                           std::to_string(il));
+            cleanup_all();
+            return false;
+        }
+        if (nonfinite != 0) {
+            const std::string message =
+                "non-finite PFlash tail scores at layer " +
+                std::to_string(il) + ": " + std::to_string(nonfinite) +
+                "/" + std::to_string(probs_h.size());
+            std::fprintf(stderr, "[pflash] ERROR: %s\n", message.c_str());
+            std::fflush(stderr);
+            set_last_error(message);
+            cleanup_all();
+            return false;
+        }
 
         for (int t = 0; t < n_lookahead; ++t) {
             for (int j = 0; j < S; ++j) {

--- a/server/src/qwen35/qwen35_backend.cpp
+++ b/server/src/qwen35/qwen35_backend.cpp
@@ -1187,7 +1187,9 @@ std::vector<ModelBackend::CompressResult> Qwen35Backend::compress_batch(
 
         auto & result = results[index];
         result.compressed_ids = drafter_score_and_compress(
-            drafter_ctx_, request.input_ids, request.keep_ratio);
+            drafter_ctx_, request.input_ids, request.keep_ratio,
+            /*chunk_size=*/32, request.score_query_tokens, /*pool_kernel=*/13,
+            request.score_query_end);
         result.ok = !result.compressed_ids.empty();
         if (result.ok) {
             std::fprintf(stderr, "[compress] %zu -> %zu tokens\n",

--- a/server/src/qwen35/qwen35_layer_split_adapter.cpp
+++ b/server/src/qwen35/qwen35_layer_split_adapter.cpp
@@ -1384,7 +1384,9 @@ Qwen35LayerSplitAdapter::compress(const ModelBackend::CompressRequest & req) {
     }
 
     result.compressed_ids = drafter_score_and_compress(
-        pflash_drafter_, req.input_ids, req.keep_ratio);
+        pflash_drafter_, req.input_ids, req.keep_ratio,
+        /*chunk_size=*/32, req.score_query_tokens, /*pool_kernel=*/13,
+        req.score_query_end);
     result.ok = !result.compressed_ids.empty();
     if (result.ok) {
         std::fprintf(stderr, "[target-split][compress] %zu -> %zu tokens\n",

--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -186,6 +186,40 @@ HeartbeatSendResult try_send_sse_heartbeat(
     return HeartbeatSendResult::Complete;
 }
 
+std::string pflash_user_query_text(
+        const std::vector<ChatMessage> & messages) {
+    for (auto it = messages.rbegin(); it != messages.rend(); ++it) {
+        if (it->role == "user") return it->content;
+    }
+    return {};
+}
+
+PflashQueryWindow find_pflash_query_window(
+        const std::vector<int32_t> & prompt,
+        const std::vector<int32_t> & query,
+        int search_end,
+        int max_tokens) {
+    if (prompt.empty() || query.empty() || search_end < 1 ||
+        search_end > (int) prompt.size() || max_tokens < 1) {
+        return {};
+    }
+
+    const int widest = (std::min)(max_tokens, (int) query.size());
+    // For a short query, require all available tokens. For a normal query,
+    // four matching suffix tokens are enough to tolerate a BPE boundary
+    // difference without accidentally selecting a lone punctuation token.
+    const int narrowest = (std::min)(4, widest);
+    const auto prompt_end = prompt.begin() + search_end;
+    for (int width = widest; width >= narrowest; --width) {
+        const auto match = std::find_end(
+            prompt.begin(), prompt_end, query.end() - width, query.end());
+        if (match != prompt_end) {
+            return {(int) (match - prompt.begin()) + width, width};
+        }
+    }
+    return {};
+}
+
 }  // namespace http_detail
 
 static std::string context_overflow_message(int max_ctx, int prompt_tokens, int max_output) {
@@ -2819,6 +2853,35 @@ std::string HttpServer::apply_pflash_compression(
     const int prompt_tokens = (int) req.prompt_tokens.size();
     const std::string prompt_text = tokenizer_.decode(req.prompt_tokens);
     auto drafter_ids = drafter_tokenizer_->encode(prompt_text);
+
+    const std::vector<ChatMessage> chat_messages = normalize_chat_messages(
+        req.messages, req.format, tool_memory_);
+    std::string rendered_messages;
+    std::string render_error;
+    if (!render_messages_to_text(
+            chat_messages, req, /*add_generation_prompt=*/false,
+            rendered_messages, render_error)) {
+        std::fprintf(stderr,
+            "[pflash] ERROR: scorer query boundary render failed; "
+            "refusing compression\n");
+        return "PFlash scorer query boundary render failed";
+    }
+    const std::string normalized_messages = tokenizer_.decode(
+        tokenizer_.encode(rendered_messages));
+    const auto rendered_message_ids = drafter_tokenizer_->encode(
+        normalized_messages);
+    const auto shared_end = std::mismatch(
+        drafter_ids.begin(), drafter_ids.end(),
+        rendered_message_ids.begin(), rendered_message_ids.end()).first;
+    const int query_search_end = (int) (shared_end - drafter_ids.begin());
+
+    const std::string last_user_text =
+        http_detail::pflash_user_query_text(chat_messages);
+    const auto query_ids = last_user_text.empty()
+        ? std::vector<int32_t>{}
+        : drafter_tokenizer_->encode(last_user_text);
+    const auto query_window = http_detail::find_pflash_query_window(
+        drafter_ids, query_ids, query_search_end);
     if (drafter_ids.empty()) {
         return "PFlash drafter tokenizer produced an empty prompt";
     }
@@ -2827,6 +2890,19 @@ std::string HttpServer::apply_pflash_compression(
     compress_request.input_ids = std::move(drafter_ids);
     compress_request.keep_ratio = http_detail::resolve_pflash_keep_ratio(
         pflash_keep_ratio(config_, prompt_tokens), req.session_id, sessions_);
+    if (query_window.valid()) {
+        compress_request.score_query_end = query_window.end;
+        compress_request.score_query_tokens = query_window.tokens;
+        std::fprintf(stderr,
+            "[pflash] scorer query mapped to drafter tokens [%d,%d); "
+            "rendered suffix=%zu tokens\n",
+            query_window.end - query_window.tokens, query_window.end,
+            compress_request.input_ids.size() - (size_t) query_window.end);
+    } else {
+        std::fprintf(stderr,
+            "[pflash] ERROR: scorer query mapping failed; refusing compression\n");
+        return "PFlash scorer query mapping failed";
+    }
     compress_request.drafter_path = config_.pflash_drafter_path;
     compress_request.drafter_gpu = config_.pflash_drafter_gpu;
     compress_request.skip_park = config_.pflash_skip_park;
@@ -2850,7 +2926,9 @@ std::string HttpServer::apply_pflash_compression(
         }
         result.ok = pflash_remote_.compress(
             compress_request.input_ids, compress_request.keep_ratio,
-            result.compressed_ids);
+            result.compressed_ids,
+            compress_request.score_query_end,
+            compress_request.score_query_tokens);
         if (residency == DraftResidencyAction::ReleaseAfterUse) {
             pflash_remote_.close();
         }
@@ -2869,28 +2947,7 @@ std::string HttpServer::apply_pflash_compression(
 
     // Compression is allowed to be lossy, but the active user query must
     // survive. Re-append short queries when fewer than 80% of their tokens do.
-    std::string last_user_text;
-    if (req.messages.is_array()) {
-        for (int index = (int) req.messages.size() - 1; index >= 0; --index) {
-            if (req.messages[index].value("role", "") != "user") continue;
-            const auto & content = req.messages[index]["content"];
-            if (content.is_string()) {
-                last_user_text = content.get<std::string>();
-            } else if (content.is_array()) {
-                for (const auto & part : content) {
-                    const std::string type = part.value("type", "");
-                    if (type == "text" || type == "input_text" ||
-                        type == "output_text") {
-                        last_user_text += part.value("text", "");
-                    }
-                }
-            }
-            break;
-        }
-    }
-
     if (!last_user_text.empty()) {
-        const auto query_ids = drafter_tokenizer_->encode(last_user_text);
         int query_kept = 0;
         if (!query_ids.empty()) {
             int query_index = (int) query_ids.size() - 1;

--- a/server/src/server/http_server.h
+++ b/server/src/server/http_server.h
@@ -262,6 +262,26 @@ bool canonical_assistant_content(
     const std::string & generated_text,
     std::string & content);
 
+struct PflashQueryWindow {
+    int end = -1;       // exclusive token offset in the rendered prompt
+    int tokens = 0;     // width of the matching query suffix
+
+    bool valid() const { return end >= tokens && tokens > 0; }
+};
+
+// Select the final normalized user message as the scorer query. Public for
+// model-free coverage of every request shape accepted by prompt rendering.
+std::string pflash_user_query_text(
+    const std::vector<ChatMessage> & messages);
+
+// Find the last sufficiently-specific suffix of the user query before the
+// assistant-generation suffix. Public for model-free regression tests.
+PflashQueryWindow find_pflash_query_window(
+    const std::vector<int32_t> & prompt,
+    const std::vector<int32_t> & query,
+    int search_end,
+    int max_tokens = 8);
+
 }  // namespace http_detail
 
 // ─── Parsed request ─────────────────────────────────────────────────────

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -24,6 +24,7 @@
 #include "common/concurrency/seq_engine.h"
 #include "common/backend_precision.h"
 #include "common/backend_ipc.h"
+#include "common/pflash_drafter_ipc.h"
 #include "common/moe_hybrid_ffn_eval.h"
 #include "common/moe_hybrid_placement.h"
 #include "placement/pflash_placement.h"
@@ -39,6 +40,7 @@
 #include "qwen35/prefill_helpers.h"
 #include "ggml-cpu.h"
 #include "server/prompt_normalize.h"
+#include "qwen3_drafter.h"
 #include "qwen3_drafter_model.h"
 #include "dflash27b.h"
 #include "gguf.h"
@@ -106,6 +108,116 @@ TEST_CASE(ServerUnitFixture, test_api_format_names_are_total) {
     CHECK(std::string(api_format_name(ApiFormat::ANTHROPIC)) == "anthropic");
     CHECK(std::string(api_format_name(ApiFormat::RESPONSES)) == "responses");
     CHECK(std::string(api_format_name(ApiFormat::COMPLETIONS)) == "completions");
+}
+
+TEST_CASE(ServerUnitFixture, test_pflash_scorer_uses_user_query_before_chat_suffix) {
+    const std::vector<int32_t> query{
+        90, 91, 100, 101, 102, 103, 104, 105, 106, 107,
+    };
+    const std::vector<int32_t> rendered{
+        1, 2, 100, 101, 102, 103, 104, 105, 106, 107,
+        200, 201, 100, 101, 102, 103, 104, 105, 106, 107,
+    };
+
+    const auto window = http_detail::find_pflash_query_window(
+        rendered, query, /*search_end=*/12);
+
+    TEST_ASSERT(window.valid());
+    TEST_ASSERT(window.tokens == 8);
+    TEST_ASSERT(window.end == 10);
+    TEST_ASSERT((int)rendered.size() - window.end == 10);
+}
+
+TEST_CASE(ServerUnitFixture, test_pflash_scorer_accepts_responses_string_input) {
+    ToolMemory tool_memory;
+    const auto messages = normalize_chat_messages(
+        json("Which token is the answer?"), ApiFormat::RESPONSES, tool_memory);
+
+    TEST_ASSERT(
+        http_detail::pflash_user_query_text(messages) ==
+        "Which token is the answer?");
+}
+
+TEST_CASE(ServerUnitFixture, test_pflash_query_mapping_tolerates_one_bpe_boundary_token) {
+    const std::vector<int32_t> query{10, 11, 12, 13, 14, 15, 16, 17};
+    const std::vector<int32_t> rendered{
+        1, 2, 999, 11, 12, 13, 14, 15, 16, 17, 200, 201,
+    };
+
+    const auto window = http_detail::find_pflash_query_window(
+        rendered, query, /*search_end=*/10);
+
+    TEST_ASSERT(window.valid());
+    TEST_ASSERT(window.tokens == 7);
+    TEST_ASSERT(window.end == 10);
+}
+
+TEST_CASE(ServerUnitFixture, test_pflash_query_mapping_rejects_weak_punctuation_match) {
+    const std::vector<int32_t> query{10, 11, 12, 13, 14, 15, 16, 17};
+    const std::vector<int32_t> rendered{1, 2, 15, 16, 17, 200, 201};
+    TEST_ASSERT(!http_detail::find_pflash_query_window(
+        rendered, query, /*search_end=*/7).valid());
+
+    const std::vector<int32_t> short_query{30, 31, 32};
+    const std::vector<int32_t> short_rendered{1, 30, 31, 32, 200};
+    const auto short_window =
+        http_detail::find_pflash_query_window(
+            short_rendered, short_query, /*search_end=*/4);
+    TEST_ASSERT(short_window.valid());
+    TEST_ASSERT(short_window.tokens == 3);
+    TEST_ASSERT(short_window.end == 4);
+}
+
+TEST_CASE(ServerUnitFixture, test_pflash_score_validation_counts_nan_and_inf) {
+    const float values[]{
+        0.0f,
+        std::numeric_limits<float>::quiet_NaN(),
+        std::numeric_limits<float>::infinity(),
+        -std::numeric_limits<float>::infinity(),
+        1.0f,
+    };
+    TEST_ASSERT(count_nonfinite_scores(values, 5) == 3);
+    TEST_ASSERT(count_nonfinite_scores(values, 1) == 0);
+}
+
+TEST_CASE(ServerUnitFixture, test_qwen35_pflash_rejects_missing_query_window) {
+    DrafterContext ctx;
+    ctx.loaded = true;
+    ctx.arch = DrafterArch::Qwen35_0p8b;
+    const std::vector<int32_t> ids(16, 1);
+
+    const auto compressed = drafter_score_and_compress(
+        ctx, ids, 0.5f, /*chunk_size=*/32, /*n_lookahead=*/8,
+        /*pool_kernel=*/13, /*score_query_end=*/-1);
+
+    TEST_ASSERT(compressed.empty());
+    TEST_ASSERT(std::string(dflash27b_last_error()) ==
+                "qwen35 scorer query window out of range");
+}
+
+TEST_CASE(ServerUnitFixture, test_pflash_ipc_rejects_unsupported_query_widths) {
+    TEST_ASSERT(valid_pflash_score_query_tokens(1));
+    TEST_ASSERT(valid_pflash_score_query_tokens(8));
+    TEST_ASSERT(!valid_pflash_score_query_tokens(0));
+    TEST_ASSERT(!valid_pflash_score_query_tokens(9));
+    TEST_ASSERT(!valid_pflash_score_query_tokens(
+        (std::numeric_limits<int>::max)()));
+}
+
+TEST_CASE(ServerUnitFixture, test_pflash_query_capture_splits_across_chunks) {
+    const auto first = query_capture_slice(4093, 4101, 0, 4096);
+    TEST_ASSERT(first.valid());
+    TEST_ASSERT(first.chunk_offset == 4093);
+    TEST_ASSERT(first.query_offset == 0);
+    TEST_ASSERT(first.tokens == 3);
+
+    const auto second = query_capture_slice(4093, 4101, 4096, 4096);
+    TEST_ASSERT(second.valid());
+    TEST_ASSERT(second.chunk_offset == 0);
+    TEST_ASSERT(second.query_offset == 3);
+    TEST_ASSERT(second.tokens == 5);
+
+    TEST_ASSERT(!query_capture_slice(4093, 4101, 8192, 4096).valid());
 }
 
 TEST_CASE(ServerUnitFixture, test_daemon_io_external_cancellation_latches) {


### PR DESCRIPTION
## Summary

- maps the final normalized user message, including string `/v1/responses` input, into the drafter-rendered token stream and uses its last eight tokens as the scorer query
- fails closed if that user query cannot be mapped, rather than falling back to the assistant/chat suffix
- keeps scorer-query selection separate from `DFLASH_COMPRESS_QUERY_TOKENS`, which remains the lexical-anchor window
- propagates the query window through local Qwen3/Qwen3.5, layer-split, and IPC paths
- assembles scorer-Q windows that cross a 4,096-token forward chunk boundary
- checks score-graph execution and readback, rejecting NaN/Inf values before top-k reduction

## Why

The previous fixed `lookahead=8` window landed on the rendered assistant suffix rather than on the question. On Strix Halo/gfx1151, corrupted HIP forward values could also reach the scorer; NaN comparisons then left earlier maxima in place and silently produced a selection.

Query selection now starts from the same normalized message stream used by prompt rendering. That keeps OpenAI Chat, Anthropic Messages, Responses arrays, and Responses string input under one user-message contract.

## Changed flow

```mermaid
flowchart LR
    A["HTTP request<br/>chat / messages / responses"] --> B["normalize_chat_messages"]
    B --> C["final user text"]
    C --> D{"map suffix in<br/>drafter tokens"}
    D -->|missing| X["reject compression"]
    D -->|mapped window| E{"drafter placement"}
    E -->|local or layer split| F["Qwen3 / Qwen3.5 scorer"]
    E -->|remote| G["PFlash IPC daemon"]
    G --> F
    F --> H["capture scorer Q<br/>across 4,096-token chunks"]
    H --> I["score graph"]
    I -->|failed or non-finite| X
    I -->|finite| J["pool and chunk top-k"]
```

FlowKV continues to score the tail of each independently compressed aged message. Whole-prompt PFlash supplies the explicit user-query window.

## Verification

Current single-commit tree `78ac6178e`:

- HIP Release build for `gfx1151`: `test_server_unit`
- `HIP_VISIBLE_DEVICES=1 ./build-hip-gfx1151/test_server_unit`: **440 passed, 0 failed**
- regression coverage includes Responses string-input normalization, user-query mapping, weak-match rejection, cross-chunk capture slicing, and NaN/Inf detection
- `git diff --check`

Finite end-to-end Responses string-input validation on Radeon AI PRO R9700/gfx1201, using the supported ROCm Phase 1 q8 fallback:

- input: 12,025 tokens as a plain `/v1/responses` string
- scorer query mapped to the actual user suffix `[12008, 12016)`
- PFlash compressed `12025 -> 6009` tokens (50.0% kept)
- response completed successfully with `ORCHID`; effective input was 6,009 tokens
- PFlash forward+score: 6.50 s; target prefill: 7.45 s; decode: 30.3 tok/s

Fresh CI on `78ac6178e`:

- Linux build, server unit tests, and megakernel imports: passed
- Windows MSVC + CUDA build and smoke: passed
- Radeon AI PRO R9700/gfx1201: passed
- Strix Halo/gfx1151: passed
- RTX 3090/sm_86: passed
- workspace lock/sync/import checks: passed
- speed profile: passed
- DGX GB10/sm_121: cancelled after its self-hosted runner remained unavailable; no test failure

The same long Responses request on the optional ROCm Phase 2 sparse-attention build produced `131072/131072` non-finite tail scores at layer 1 and failed closed as intended. The result was unchanged under the documented legacy `DFLASH_FP_NOPE_TAIL=0` scoring mode.

Earlier live 16K Strix Halo/gfx1151 validation of the same scoring mechanism:

- uncompressed control: 2/2 correct
- PFlash: failed closed with explicit non-finite score diagnostics
- query mapping log identified the actual user-query window, e.g. `[16374, 16382)`, rather than the rendered assistant suffix

Paired long-context benchmark campaign: [Luce-Org/luce_box#85](https://github.com/Luce-Org/luce_box/pull/85).

## Boundaries

The underlying ROCm Phase 2/gfx1151 numeric corruption is intentionally not hidden or fixed here. This change makes it observable and prevents quality results from being reported from invalid scores. The supported ROCm Phase 1 path has a finite successful end-to-end result above.

## Review status

Ready for human review. The implementation, focused contract tests, finite end-to-end proof, and all runnable CI checks are green. The PR remains marked draft until the author chooses to flip the GitHub review state.
