### PR TITLE
feat(server): adopt official DeepSeek V4 DSML tool calling format

### DIFF
--- a/server/src/server/chat_template.cpp
+++ b/server/src/server/chat_template.cpp
@@ -386,16 +386,23 @@ std::string render_chat_template(
             result += "Do not stop reasoning until you have independently verified the solution from multiple angles and are certain that no assumption remains unchecked and no error remains undiscovered.\n\n";
         }
         if (has_tools) {
-            result += "### Tools\n\n"
-                      "You may call functions to assist with the user query. "
-                      "All available function signatures are listed below:\n";
+            result += "## Tools\n\n"
+                      "You have access to a set of tools to help answer the user question. "
+                      "You can invoke tools by writing a \"<｜DSML｜tool_calls>\" block like the following:\n\n"
+                      "<｜DSML｜tool_calls>\n"
+                      "<｜DSML｜invoke name=\"$TOOL_NAME\">\n"
+                      "<｜DSML｜parameter name=\"$PARAMETER_NAME\" string=\"true|false\">$PARAMETER_VALUE</｜DSML｜parameter>\n"
+                      "...\n"
+                      "</｜DSML｜invoke>\n"
+                      "<｜DSML｜invoke name=\"$TOOL_NAME2\">\n"
+                      "...\n"
+                      "</｜DSML｜invoke>\n"
+                      "</｜DSML｜tool_calls>\n\n"
+                      "String parameters should be specified as is and set `string=\"true\"`. "
+                      "For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string=\"false\"`.\n\n"
+                      "### Available Tool Schemas\n\n";
             append_available_tools(result, tools_json);
-            result += "For each function call, you MUST return a single JSON object "
-                      "within '<function_call>' and '</function_call>' tags, "
-                      "containing the function name and arguments, like this:\n"
-                      "<function_call>\n"
-                      "{\"name\": \"function_name\", \"arguments\": {\"param_name\": \"value\"}}\n"
-                      "</function_call>\n\n";
+            result += "\nYou MUST strictly follow the defined tool schemas to invoke tool calls.\n\n";
         }
         result += system_content;
 

--- a/server/src/server/sse_emitter.cpp
+++ b/server/src/server/sse_emitter.cpp
@@ -581,11 +581,13 @@ static size_t find_top_level_think_close(const std::string & buf, const json & t
     };
 
     auto is_tool_tag = [&](const std::string & name) {
-        if (name == "tool_call" || name == "function_call" ||
-            name == "function_calls" || name == "function" ||
-            name == "invoke" || name == "parameter" || name == "param" ||
-            name == "arguments" || name == "params" || name == "tool_code" ||
-            name == "funcname") {
+        if (name.rfind("｜DSML｜", 0) == 0) return true;
+        if (name == "tool_call" || name == "tool_calls" ||
+            name == "function_call" || name == "function_calls" ||
+            name == "function" || name == "invoke" ||
+            name == "parameter" || name == "param" ||
+            name == "arguments" || name == "params" ||
+            name == "tool_code" || name == "funcname") {
             return true;
         }
         if (tools.is_array()) {
@@ -740,6 +742,29 @@ std::vector<std::string> SseEmitter::emit_finish(int completion_tokens,
         tool_calls_ = std::move(parsed.tool_calls);
 
         if (!tool_calls_.empty()) {
+            static const bool log_tools = []() {
+                const char * e = std::getenv("DFLASH_LOG_TOOL_CALLS");
+                if (!e || !*e) return false;
+                std::string v(e);
+                std::transform(v.begin(), v.end(), v.begin(),
+                               [](unsigned char c) { return (char)std::tolower(c); });
+                return v != "0" && v != "false" && v != "no" && v != "off";
+            }();
+            if (log_tools) {
+                std::string escaped_buf = escape_for_logging(tool_buffer_);
+                std::fprintf(stderr,
+                    "[server] [tool_call] request_id=%s count=%zu bytes=%zu raw='%s'\n",
+                    request_id_.c_str(), tool_calls_.size(), tool_buffer_.size(),
+                    escaped_buf.c_str());
+                for (size_t i = 0; i < tool_calls_.size(); ++i) {
+                    const auto & tc = tool_calls_[i];
+                    std::string escaped_args = escape_for_logging(tc.arguments);
+                    std::fprintf(stderr,
+                        "[server] [tool_call]   [%zu] name='%s' id='%s' args='%s'\n",
+                        i, tc.name.c_str(), tc.id.c_str(), escaped_args.c_str());
+                }
+            }
+
             // Remember for tool memory
             if (tool_memory_) {
                 std::vector<std::string> ids;

--- a/server/src/server/tokenizer.cpp
+++ b/server/src/server/tokenizer.cpp
@@ -732,7 +732,14 @@ static std::string decode_gpt2_bpe(const std::string & tok) {
     while (p < end) {
         int cplen;
         uint32_t cp = utf8_decode(p, (size_t)(end - p), &cplen);
-        out.push_back((char)gpt2_unicode_to_byte(cp));
+        if ((cp >= 33 && cp <= 126) || (cp >= 161 && cp <= 172) || (cp >= 174 && cp <= 255)) {
+            out.push_back((char)cp);
+        } else if (cp >= 256 && cp < 256 + 68) {
+            out.push_back((char)gpt2_unicode_to_byte(cp));
+        } else {
+            // Raw Unicode codepoint (e.g. U+FF5C '｜', U+2581 '▁') — emit raw bytes
+            out.append(p, cplen);
+        }
         p += cplen;
     }
     return out;

--- a/server/src/server/tokenizer.cpp
+++ b/server/src/server/tokenizer.cpp
@@ -315,6 +315,17 @@ std::vector<std::string> Tokenizer::pre_tokenize(const std::string & text) const
 
 // ─── BPE encoding ──────────────────────────────────────────────────────
 
+// GPT-2 byte-level BPE maps printable byte ranges directly to codepoints,
+// and all other 68 non-printable bytes into U+0100..U+0143 (256..256+68).
+static constexpr uint32_t GPT2_BPE_OFFSET = 256;
+static constexpr uint32_t GPT2_BPE_NUM_RESERVED = 68;
+
+static inline bool is_gpt2_printable_byte(uint32_t b) {
+    return (b >= 33 && b <= 126) ||
+           (b >= 161 && b <= 172) ||
+           (b >= 174 && b <= 255);
+}
+
 // Forward GPT-2 byte encoding: raw byte → Unicode codepoint (UTF-8 string).
 // This is the inverse of gpt2_unicode_to_byte (defined later, near decode).
 // Bytes in {33-126, 161-172, 174-255} map to themselves as a codepoint;
@@ -325,12 +336,10 @@ static std::string byte_to_gpt2_unicode(uint8_t b) {
         std::array<uint32_t, 256> t{};
         int n = 0;
         for (int i = 0; i < 256; i++) {
-            if ((i >= 33  && i <= 126) ||
-                (i >= 161 && i <= 172) ||
-                (i >= 174 && i <= 255)) {
+            if (is_gpt2_printable_byte(i)) {
                 t[i] = (uint32_t)i;
             } else {
-                t[i] = 256 + n;
+                t[i] = GPT2_BPE_OFFSET + n;
                 n++;
             }
         }
@@ -483,13 +492,13 @@ std::vector<int32_t> Tokenizer::bpe_encode_piece(const std::string & piece) cons
             // back to the original byte before emitting <0xNN>.
             static const auto gpt2_rev = []() {
                 // Build reverse table: codepoint → original byte.
-                std::array<uint8_t, 324> t{};  // covers U+0000..U+0143
+                std::array<uint8_t, GPT2_BPE_OFFSET + GPT2_BPE_NUM_RESERVED> t{};  // covers U+0000..U+0143
                 int n = 0;
                 for (int b = 0; b < 256; b++) {
-                    if ((b >= 33 && b <= 126) || (b >= 161 && b <= 172) || (b >= 174 && b <= 255)) {
+                    if (is_gpt2_printable_byte(b)) {
                         t[b] = (uint8_t)b;
                     } else {
-                        t[256 + n] = (uint8_t)b;
+                        t[GPT2_BPE_OFFSET + n] = (uint8_t)b;
                         n++;
                     }
                 }
@@ -501,9 +510,9 @@ std::vector<int32_t> Tokenizer::bpe_encode_piece(const std::string & piece) cons
                 int cplen;
                 uint32_t cp = utf8_decode(p, (size_t)(end - p), &cplen);
                 uint8_t orig_byte;
-                if ((cp >= 33 && cp <= 126) || (cp >= 161 && cp <= 172) || (cp >= 174 && cp <= 255)) {
+                if (is_gpt2_printable_byte(cp)) {
                     orig_byte = (uint8_t)cp;
-                } else if (cp >= 256 && cp < 256 + 68) {
+                } else if (cp >= GPT2_BPE_OFFSET && cp < GPT2_BPE_OFFSET + GPT2_BPE_NUM_RESERVED) {
                     orig_byte = gpt2_rev[cp];
                 } else {
                     orig_byte = '?';
@@ -698,27 +707,23 @@ std::vector<int32_t> Tokenizer::encode(const std::string & text) const {
 
 static uint8_t gpt2_unicode_to_byte(uint32_t cp) {
     // Direct-mapped ranges: the codepoint IS the byte.
-    if ((cp >= 33  && cp <= 126) ||
-        (cp >= 161 && cp <= 172) ||
-        (cp >= 174 && cp <= 255)) {
+    if (is_gpt2_printable_byte(cp)) {
         return (uint8_t)cp;
     }
     // Offset-mapped range: U+0100..U+0143 → non-printable bytes.
     // Build the reverse table once (thread-safe via C++11 static init).
     static const auto table = []() {
-        std::array<uint8_t, 68> t{};
+        std::array<uint8_t, GPT2_BPE_NUM_RESERVED> t{};
         int n = 0;
         for (int b = 0; b < 256; b++) {
-            if ((b >= 33  && b <= 126) ||
-                (b >= 161 && b <= 172) ||
-                (b >= 174 && b <= 255)) continue;
+            if (is_gpt2_printable_byte(b)) continue;
             t[n] = (uint8_t)b;
             n++;
         }
         return t;
     }();
-    if (cp >= 256 && cp < 256 + 68) {
-        return table[cp - 256];
+    if (cp >= GPT2_BPE_OFFSET && cp < GPT2_BPE_OFFSET + GPT2_BPE_NUM_RESERVED) {
+        return table[cp - GPT2_BPE_OFFSET];
     }
     // Shouldn't happen for valid BPE tokens — return replacement.
     return '?';
@@ -732,9 +737,9 @@ static std::string decode_gpt2_bpe(const std::string & tok) {
     while (p < end) {
         int cplen;
         uint32_t cp = utf8_decode(p, (size_t)(end - p), &cplen);
-        if ((cp >= 33 && cp <= 126) || (cp >= 161 && cp <= 172) || (cp >= 174 && cp <= 255)) {
+        if (is_gpt2_printable_byte(cp)) {
             out.push_back((char)cp);
-        } else if (cp >= 256 && cp < 256 + 68) {
+        } else if (cp >= GPT2_BPE_OFFSET && cp < GPT2_BPE_OFFSET + GPT2_BPE_NUM_RESERVED) {
             out.push_back((char)gpt2_unicode_to_byte(cp));
         } else {
             // Raw Unicode codepoint (e.g. U+FF5C '｜', U+2581 '▁') — emit raw bytes

--- a/server/src/server/tool_parser.cpp
+++ b/server/src/server/tool_parser.cpp
@@ -122,10 +122,21 @@ bool find_tool_syntax_start(const std::string & text, const json & tools,
             text.compare(idx, sizeof(TOOL_CODE_OPEN) - 1, TOOL_CODE_OPEN) == 0 ||
             text.compare(idx, sizeof(ATTRIBUTE_PARAMETER_OPEN) - 1,
                          ATTRIBUTE_PARAMETER_OPEN) == 0 ||
-            text.compare(idx, sizeof(ARG_KEY_OPEN) - 1, ARG_KEY_OPEN) == 0 ||
             declared_tool_open_at(text, idx, tools)) {
             pos = idx;
             return true;
+        }
+        if (text.compare(idx, sizeof(ARG_KEY_OPEN) - 1, ARG_KEY_OPEN) == 0) {
+            size_t start = idx;
+            auto is_ident = [](char c) {
+                return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+                       (c >= '0' && c <= '9') || c == '_' || c == '-';
+            };
+            while (start > 0 && is_ident(text[start - 1])) start--;
+            if (start < idx) {
+                pos = start;
+                return true;
+            }
         }
         // Check for bare tool tag without angle brackets if it follows a newline
         // or start of text, e.g. "tool_name\n<arg_key>..."
@@ -706,7 +717,7 @@ static bool parse_xml_tool_call_body(const std::string & body, const json & tool
     // 3. Extract parameter key-value pairs:
     // a. Attribute style: <(param|parameter) name="key" string="true|false">value</...> or <parameter=key>value</parameter>
     static const std::regex re_attr_param(
-        R"(<(?:｜DSML｜)?(?:param|parameter)\s+name\s*=\s*["']?([A-Za-z_][\w.\-]*)["']?(?:\s+string\s*=\s*["']?(?:true|false)["']?)?\s*>([\s\S]*?)</(?:｜DSML｜)?(?:param|parameter)>|<parameter=([A-Za-z_][\w.\-]*)>([\s\S]*?)</parameter>)");
+        R"(<(?:｜DSML｜)?(?:param|parameter)\s+name\s*=\s*["']?([A-Za-z_][\w.\-]*)["']?(?:\s+string\s*=\s*["']?(true|false)["']?)?\s*>([\s\S]*?)</(?:｜DSML｜)?(?:param|parameter)>|<parameter=([A-Za-z_][\w.\-]*)>([\s\S]*?)</parameter>)");
     auto pbegin = std::sregex_iterator(trimmed_params.begin(), trimmed_params.end(), re_attr_param);
     auto pend = std::sregex_iterator();
     if (pbegin != pend) {
@@ -718,13 +729,28 @@ static bool parse_xml_tool_call_body(const std::string & body, const json & tool
                 valid = false;
                 break;
             }
-            std::string k = (*it)[1].matched ? (*it)[1].str() : (*it)[3].str();
+            std::string k = (*it)[1].matched ? (*it)[1].str() : (*it)[4].str();
             if (args.contains(k)) {
                 valid = false;
                 break;
             }
-            std::string v = trim_ws((*it)[2].matched ? (*it)[2].str() : (*it)[4].str());
-            args[k] = convert_param_value(v, k, props);
+            if ((*it)[1].matched && (*it)[2].matched) {
+                std::string is_str = (*it)[2].str();
+                std::string v = (*it)[3].str();
+                if (is_str == "true") {
+                    args[k] = v;
+                } else {
+                    json j = json::parse(v, nullptr, false);
+                    if (!j.is_discarded()) {
+                        args[k] = std::move(j);
+                    } else {
+                        args[k] = convert_param_value(trim_ws(v), k, props);
+                    }
+                }
+            } else {
+                std::string v = trim_ws((*it)[1].matched ? (*it)[3].str() : (*it)[5].str());
+                args[k] = convert_param_value(v, k, props);
+            }
             cursor = pos + it->length();
         }
         if (valid && trim_ws(trimmed_params.substr(cursor)).empty()) {
@@ -1479,7 +1505,7 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
     {
         static const std::regex re_block(R"(<(?:｜DSML｜)?(?:function_calls|tool_calls)>([\s\S]*?)</(?:｜DSML｜)?(?:function_calls|tool_calls)>)");
         static const std::regex re_invoke(R"(<(?:｜DSML｜)?invoke\s+(?:name|tool)\s*=\s*["']?([A-Za-z_][\w.\-]*)["']?\s*>([\s\S]*?)</(?:｜DSML｜)?invoke>)");
-        static const std::regex re_param(R"(<(?:｜DSML｜)?(param|parameter)\s+name\s*=\s*["']?([A-Za-z_][\w.\-]*)["']?(?:\s+string\s*=\s*["']?(?:true|false)["']?)?\s*>([\s\S]*?)</(?:｜DSML｜)?\1>)");
+        static const std::regex re_param(R"(<(?:｜DSML｜)?(param|parameter)\s+name\s*=\s*["']?([A-Za-z_][\w.\-]*)["']?(?:\s+string\s*=\s*["']?(true|false)["']?)?\s*>([\s\S]*?)</(?:｜DSML｜)?\1>)");
 
         auto fbegin = std::sregex_iterator(text.begin(), text.end(), re_block);
         auto fend = std::sregex_iterator();
@@ -1530,14 +1556,30 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
                         if (!trim_ws(body.substr(cursor, ppos - cursor)).empty()) { valid_body = false; break; }
                         std::string k = (*pit)[2].str();
                         if (args.contains(k)) { valid_body = false; break; }
-                        std::string v = trim_ws((*pit)[3].str());
-                        args[k] = convert_param_value(v, k, find_tool_properties(tools, fn_name));
+                        if ((*pit)[3].matched) {
+                            std::string is_str = (*pit)[3].str();
+                            std::string v = (*pit)[4].str();
+                            if (is_str == "true") {
+                                args[k] = v;
+                            } else {
+                                json j = json::parse(v, nullptr, false);
+                                if (!j.is_discarded()) {
+                                    args[k] = std::move(j);
+                                } else {
+                                    args[k] = convert_param_value(trim_ws(v), k, find_tool_properties(tools, fn_name));
+                                }
+                            }
+                        } else {
+                            std::string v = trim_ws((*pit)[4].str());
+                            args[k] = convert_param_value(v, k, find_tool_properties(tools, fn_name));
+                        }
                         found_param = true;
                         cursor = ppos + pit->length();
                     }
                     if (!valid_body) continue;
                     if (!found_param && !trim_ws(body).empty()) continue;
                     if (!trim_ws(body.substr(cursor)).empty()) continue;
+                    if (raw_args.empty()) raw_args = args.dump();
                 }
                 size_t istart = inner_start + it->position();
                 size_t iend = istart + it->length();

--- a/server/src/server/tool_parser.cpp
+++ b/server/src/server/tool_parser.cpp
@@ -54,6 +54,9 @@ static std::string generate_call_id() {
 }
 
 static const char TOOL_OPEN[] = "<tool_call>";
+static const char TOOL_CALLS_OPEN[] = "<tool_calls>";
+static const char DSML_PREFIX[] = "<｜DSML｜";
+static const char INVOKE_OPEN[] = "<invoke";
 static const char FUNCTION_CALL_OPEN[] = "<function_call>";
 static const char FUNCTION_CALLS_OPEN[] = "<function_calls>";
 static const char FUNCTION_OPEN[] = "<function=";
@@ -106,6 +109,9 @@ bool find_tool_syntax_start(const std::string & text, const json & tools,
     size_t idx = text.find('<');
     while (idx != std::string::npos) {
         if (text.compare(idx, sizeof(TOOL_OPEN) - 1, TOOL_OPEN) == 0 ||
+            text.compare(idx, sizeof(TOOL_CALLS_OPEN) - 1, TOOL_CALLS_OPEN) == 0 ||
+            text.compare(idx, sizeof(DSML_PREFIX) - 1, DSML_PREFIX) == 0 ||
+            text.compare(idx, sizeof(INVOKE_OPEN) - 1, INVOKE_OPEN) == 0 ||
             text.compare(idx, sizeof(FUNCTION_CALL_OPEN) - 1, FUNCTION_CALL_OPEN) == 0 ||
             text.compare(idx, sizeof(FUNCTION_CALLS_OPEN) - 1, FUNCTION_CALLS_OPEN) == 0 ||
             text.compare(idx, sizeof(FUNCTION_OPEN) - 1, FUNCTION_OPEN) == 0 ||
@@ -116,11 +122,14 @@ bool find_tool_syntax_start(const std::string & text, const json & tools,
             text.compare(idx, sizeof(TOOL_CODE_OPEN) - 1, TOOL_CODE_OPEN) == 0 ||
             text.compare(idx, sizeof(ATTRIBUTE_PARAMETER_OPEN) - 1,
                          ATTRIBUTE_PARAMETER_OPEN) == 0 ||
+            text.compare(idx, sizeof(ARG_KEY_OPEN) - 1, ARG_KEY_OPEN) == 0 ||
             declared_tool_open_at(text, idx, tools)) {
             pos = idx;
             return true;
         }
-        if (text.compare(idx, sizeof(ARG_KEY_OPEN) - 1, ARG_KEY_OPEN) == 0) {
+        // Check for bare tool tag without angle brackets if it follows a newline
+        // or start of text, e.g. "tool_name\n<arg_key>..."
+        if (idx == 0 || text[idx - 1] == '\n') {
             size_t start = idx;
             auto is_ident = [](char c) {
                 return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
@@ -138,10 +147,12 @@ bool find_tool_syntax_start(const std::string & text, const json & tools,
 }
 
 size_t tool_syntax_holdback(const json & tools) {
-    // Longest fixed opener is `<parameter name=` (16 bytes).
-    size_t holdback = std::max({sizeof(ATTRIBUTE_PARAMETER_OPEN) - 2,
+    size_t holdback = std::max({(size_t)21,
+                                sizeof(ATTRIBUTE_PARAMETER_OPEN) - 2,
                                 sizeof(FUNCTION_CALLS_OPEN) - 2,
                                 sizeof(FUNCTION_CALL_OPEN) - 2,
+                                sizeof(TOOL_CALLS_OPEN) - 2,
+                                sizeof(TOOL_OPEN) - 2,
                                 sizeof(BARE_FUNCTION_OPEN) - 2});
     if (!tools.is_array()) return holdback;
     for (const auto & tool : tools) {
@@ -617,7 +628,7 @@ static bool parse_complete_parameter_body(const std::string & body,
     return found_param && trim_ws(body.substr(cursor)).empty();
 }
 
-// ─── XML tool call parser (<function_call> / <tool_call> with tags) ────
+// ─── XML tool call parser (<function_call> / <tool_call> / <｜DSML｜tool_calls> with tags) ────
 
 static bool parse_xml_tool_call_body(const std::string & body, const json & tools,
                                      std::string & name, json & args, std::string & raw_args) {
@@ -634,10 +645,10 @@ static bool parse_xml_tool_call_body(const std::string & body, const json & tool
     }
 
     // 1. Look for function name in top-level XML envelope:
-    // a. <invoke name="...">...</invoke> or <invoke tool="...">...</invoke>
+    // a. <invoke name="...">...</invoke> or <invoke tool="...">...</invoke> (with optional ｜DSML｜ prefix)
     std::string param_section;
     static const std::regex re_invoke_envelope(
-        R"(^\s*<invoke\s+(?:name|tool)\s*=\s*["']?([A-Za-z_][\w.\-]*)["']?\s*>([\s\S]*?)</invoke>\s*$)");
+        R"(^\s*<(?:｜DSML｜)?invoke\s+(?:name|tool)\s*=\s*["']?([A-Za-z_][\w.\-]*)["']?\s*>([\s\S]*?)</(?:｜DSML｜)?invoke>\s*$)");
     std::smatch m_inv;
     if (std::regex_match(trimmed, m_inv, re_invoke_envelope)) {
         name = m_inv[1].str();
@@ -645,7 +656,7 @@ static bool parse_xml_tool_call_body(const std::string & body, const json & tool
     } else {
         // b. <invoke_name>NAME</invoke_name>, <tool_name>NAME</tool_name>, <function_name>NAME</function_name>, or leading <name>NAME</name>
         static const std::regex re_tag_name(
-            R"(^\s*<(invoke_name|name|tool_name|function_name)>\s*([A-Za-z_][\w.\-]*)\s*</\1>([\s\S]*)$)");
+            R"(^\s*<(?:｜DSML｜)?(invoke_name|name|tool_name|function_name)>\s*([A-Za-z_][\w.\-]*)\s*</(?:｜DSML｜)?\1>([\s\S]*)$)");
         std::smatch m_tag;
         if (std::regex_match(trimmed, m_tag, re_tag_name)) {
             name = m_tag[2].str();
@@ -660,8 +671,8 @@ static bool parse_xml_tool_call_body(const std::string & body, const json & tool
     const json props = find_tool_properties(tools, name);
     args = json::object();
 
-    // 2. Look for parameters section in <parameters>...</parameters> or <arguments>...</arguments>
-    static const std::regex re_section(R"(^\s*<(parameters|arguments)>([\s\S]*?)</\1>\s*$)");
+    // 2. Look for parameters section in <parameters>, <arguments>, etc.
+    static const std::regex re_section(R"(^\s*<(?:｜DSML｜)?(parameters|arguments|tool_calls|function_calls)>([\s\S]*?)</(?:｜DSML｜)?\1>\s*$)");
     std::smatch m_sec;
     std::string trimmed_params_sec = trim_ws(param_section);
     if (std::regex_match(trimmed_params_sec, m_sec, re_section)) {
@@ -693,9 +704,9 @@ static bool parse_xml_tool_call_body(const std::string & body, const json & tool
     }
 
     // 3. Extract parameter key-value pairs:
-    // a. Attribute style: <(param|parameter) name="key">value</...> or <parameter=key>value</parameter>
+    // a. Attribute style: <(param|parameter) name="key" string="true|false">value</...> or <parameter=key>value</parameter>
     static const std::regex re_attr_param(
-        R"(<(?:param|parameter)\s+name\s*=\s*["']?([A-Za-z_][\w.\-]*)["']?\s*>([\s\S]*?)</(?:param|parameter)>|<parameter=([A-Za-z_][\w.\-]*)>([\s\S]*?)</parameter>)");
+        R"(<(?:｜DSML｜)?(?:param|parameter)\s+name\s*=\s*["']?([A-Za-z_][\w.\-]*)["']?(?:\s+string\s*=\s*["']?(?:true|false)["']?)?\s*>([\s\S]*?)</(?:｜DSML｜)?(?:param|parameter)>|<parameter=([A-Za-z_][\w.\-]*)>([\s\S]*?)</parameter>)");
     auto pbegin = std::sregex_iterator(trimmed_params.begin(), trimmed_params.end(), re_attr_param);
     auto pend = std::sregex_iterator();
     if (pbegin != pend) {
@@ -724,7 +735,7 @@ static bool parse_xml_tool_call_body(const std::string & body, const json & tool
     }
 
     // b. Element tag style: <key>value</key>
-    static const std::regex re_elem_param(R"(<([A-Za-z_][\w.\-]*)>([\s\S]*?)</\1>)");
+    static const std::regex re_elem_param(R"(<(?:｜DSML｜)?([A-Za-z_][\w.\-]*)>([\s\S]*?)</(?:｜DSML｜)?\1>)");
     auto ebegin = std::sregex_iterator(trimmed_params.begin(), trimmed_params.end(), re_elem_param);
     auto eend = std::sregex_iterator();
     if (ebegin != eend) {
@@ -739,7 +750,8 @@ static bool parse_xml_tool_call_body(const std::string & body, const json & tool
             std::string tag = (*it)[1].str();
             if (tag == "invoke_name" || tag == "name" || tag == "tool_name" ||
                 tag == "function_name" || tag == "parameters" || tag == "arguments" ||
-                tag == "function_call" || tag == "tool_call" || tag == "invoke") {
+                tag == "function_call" || tag == "tool_call" || tag == "tool_calls" ||
+                tag == "function_calls" || tag == "invoke") {
                 valid = false;
                 break;
             }
@@ -1463,11 +1475,11 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
         }
     }
 
-    // Pattern 4d: <function_calls> containing <invoke> blocks or JSON lines
+    // Pattern 4d: <function_calls> or <tool_calls> containing <invoke> blocks or JSON lines
     {
-        static const std::regex re_block(R"(<function_calls>([\s\S]*?)</function_calls>)");
-        static const std::regex re_invoke(R"(<invoke\s+(?:name|tool)\s*=\s*["']?([A-Za-z_][\w.\-]*)["']?\s*>([\s\S]*?)</invoke>)");
-        static const std::regex re_param(R"(<(param|parameter)\s+name\s*=\s*["']?([A-Za-z_][\w.\-]*)["']?\s*>([\s\S]*?)</\1>)");
+        static const std::regex re_block(R"(<(?:｜DSML｜)?(?:function_calls|tool_calls)>([\s\S]*?)</(?:｜DSML｜)?(?:function_calls|tool_calls)>)");
+        static const std::regex re_invoke(R"(<(?:｜DSML｜)?invoke\s+(?:name|tool)\s*=\s*["']?([A-Za-z_][\w.\-]*)["']?\s*>([\s\S]*?)</(?:｜DSML｜)?invoke>)");
+        static const std::regex re_param(R"(<(?:｜DSML｜)?(param|parameter)\s+name\s*=\s*["']?([A-Za-z_][\w.\-]*)["']?(?:\s+string\s*=\s*["']?(?:true|false)["']?)?\s*>([\s\S]*?)</(?:｜DSML｜)?\1>)");
 
         auto fbegin = std::sregex_iterator(text.begin(), text.end(), re_block);
         auto fend = std::sregex_iterator();

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -611,7 +611,7 @@ TEST_CASE(ServerUnitFixture, test_tool_syntax_scanner_declared_name_guards) {
 
     json invalid = edit_tools();
     invalid[0]["function"]["name"] = std::string(65, 'x');
-    TEST_ASSERT(tool_syntax_holdback(invalid) == 15);
+    TEST_ASSERT(tool_syntax_holdback(invalid) == 21);
     pos = std::string::npos;
     TEST_ASSERT(!find_tool_syntax_start("<" + std::string(65, 'x') + ">",
                                         invalid, pos));
@@ -1160,6 +1160,110 @@ TEST_CASE(ServerUnitFixture, test_parse_tool_call_xml_function_name_tag) {
     TEST_ASSERT(result.cleaned_text.empty());
 }
 
+TEST_CASE(ServerUnitFixture, test_parse_dsml_tool_calls_with_token) {
+    const std::string text =
+        "Let me read the file.\n\n"
+        "<｜DSML｜tool_calls>\n"
+        "<｜DSML｜invoke name=\"read\">\n"
+        "<｜DSML｜parameter name=\"path\" string=\"true\">/home/dpavlin/koha-rfid-go/internal/rfidops/ops.go</｜DSML｜parameter>\n"
+        "</｜DSML｜invoke>\n"
+        "</｜DSML｜tool_calls>";
+    json tools = json::array({
+        {{"type", "function"}, {"function", {
+             {"name", "read"},
+             {"parameters", {
+                 {"type", "object"},
+                 {"properties", {
+                     {"path", {{"type", "string"}}}
+                 }}
+             }}
+         }}}
+    });
+    auto result = parse_tool_calls(text, tools);
+    TEST_ASSERT(result.tool_calls.size() == 1);
+    if (!result.tool_calls.empty()) {
+        TEST_ASSERT(result.tool_calls[0].name == "read");
+        auto args = json::parse(result.tool_calls[0].arguments);
+        TEST_ASSERT(args["path"] == "/home/dpavlin/koha-rfid-go/internal/rfidops/ops.go");
+    }
+    TEST_ASSERT(result.cleaned_text == "Let me read the file.");
+}
+
+TEST_CASE(ServerUnitFixture, test_parse_dsml_tool_calls_multiple_parameters) {
+    const std::string text =
+        "<｜DSML｜tool_calls>\n"
+        "<｜DSML｜invoke name=\"bash\">\n"
+        "<｜DSML｜parameter name=\"command\" string=\"true\">ls -la /tmp</｜DSML｜parameter>\n"
+        "<｜DSML｜parameter name=\"timeout\" string=\"false\">10</｜DSML｜parameter>\n"
+        "</｜DSML｜invoke>\n"
+        "</｜DSML｜tool_calls>";
+    json tools = json::array({
+        {{"type", "function"}, {"function", {
+             {"name", "bash"},
+             {"parameters", {
+                 {"type", "object"},
+                 {"properties", {
+                     {"command", {{"type", "string"}}},
+                     {"timeout", {{"type", "integer"}}}
+                 }}
+             }}
+         }}}
+    });
+    auto result = parse_tool_calls(text, tools);
+    TEST_ASSERT(result.tool_calls.size() == 1);
+    if (!result.tool_calls.empty()) {
+        TEST_ASSERT(result.tool_calls[0].name == "bash");
+        auto args = json::parse(result.tool_calls[0].arguments);
+        TEST_ASSERT(args["command"] == "ls -la /tmp");
+        TEST_ASSERT(args["timeout"] == 10);
+    }
+    TEST_ASSERT(result.cleaned_text.empty());
+}
+
+TEST_CASE(ServerUnitFixture, test_parse_dsml_tool_calls_edit_tool) {
+    const std::string text =
+        "<｜DSML｜tool_calls>\n"
+        "<｜DSML｜invoke name=\"edit\">\n"
+        "<｜DSML｜parameter name=\"path\" string=\"true\">/home/dpavlin/koha-rfid-go/server.go</｜DSML｜parameter>\n"
+        "<｜DSML｜parameter name=\"edits\" string=\"false\">[{\"oldText\": \"err1\", \"newText\": \"err2\"}]</｜DSML｜parameter>\n"
+        "</｜DSML｜invoke>\n"
+        "</｜DSML｜tool_calls>";
+    json tools = json::array({
+        {{"type", "function"}, {"function", {
+             {"name", "edit"},
+             {"parameters", {
+                 {"type", "object"},
+                 {"properties", {
+                     {"path", {{"type", "string"}}},
+                     {"edits", {{"type", "array"}}}
+                 }}
+             }}
+         }}}
+    });
+    auto result = parse_tool_calls(text, tools);
+    TEST_ASSERT(result.tool_calls.size() == 1);
+    if (!result.tool_calls.empty()) {
+        TEST_ASSERT(result.tool_calls[0].name == "edit");
+        auto args = json::parse(result.tool_calls[0].arguments);
+        TEST_ASSERT(args["path"] == "/home/dpavlin/koha-rfid-go/server.go");
+        TEST_ASSERT(args["edits"].is_array());
+        TEST_ASSERT(args["edits"][0]["oldText"] == "err1");
+        TEST_ASSERT(args["edits"][0]["newText"] == "err2");
+    }
+    TEST_ASSERT(result.cleaned_text.empty());
+}
+
+TEST_CASE(ServerUnitFixture, test_render_deepseek4_chat_template_dsml_tools) {
+    std::vector<ChatMessage> msgs = {
+        {"system", "You are an assistant."},
+        {"user", "Hello"}
+    };
+    std::string tools_json = R"([{"type":"function","function":{"name":"read","parameters":{"type":"object","properties":{"path":{"type":"string"}}}}}}])";
+    std::string rendered = render_chat_template(msgs, ChatFormat::DEEPSEEK4, true, false, tools_json);
+    TEST_ASSERT(rendered.find("<｜DSML｜tool_calls>") != std::string::npos);
+    TEST_ASSERT(rendered.find("<｜DSML｜invoke name=\"$TOOL_NAME\">") != std::string::npos);
+    TEST_ASSERT(rendered.find("\"name\":\"read\"") != std::string::npos);
+}
 
 
 TEST_CASE(ServerUnitFixture, test_parse_tool_allowed_filter) {

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -1258,11 +1258,56 @@ TEST_CASE(ServerUnitFixture, test_render_deepseek4_chat_template_dsml_tools) {
         {"system", "You are an assistant."},
         {"user", "Hello"}
     };
-    std::string tools_json = R"([{"type":"function","function":{"name":"read","parameters":{"type":"object","properties":{"path":{"type":"string"}}}}}}])";
+    std::string tools_json = R"([{"type":"function","function":{"name":"read","parameters":{"type":"object","properties":{"path":{"type":"string"}}}}}])";
     std::string rendered = render_chat_template(msgs, ChatFormat::DEEPSEEK4, true, false, tools_json);
     TEST_ASSERT(rendered.find("<｜DSML｜tool_calls>") != std::string::npos);
     TEST_ASSERT(rendered.find("<｜DSML｜invoke name=\"$TOOL_NAME\">") != std::string::npos);
     TEST_ASSERT(rendered.find("\"name\":\"read\"") != std::string::npos);
+}
+
+TEST_CASE(ServerUnitFixture, test_find_tool_syntax_start_arg_key_backtracking) {
+    std::string text = "Let me edit the file:\nedit<arg_key>path</arg_key><arg_val>/tmp/test.txt</arg_val>";
+    json tools = json::array({
+        {{"type", "function"}, {"function", {{"name", "edit"}}}}
+    });
+    size_t pos = std::string::npos;
+    TEST_ASSERT(find_tool_syntax_start(text, tools, pos));
+    TEST_ASSERT(pos == text.find("edit<arg_key>"));
+}
+
+TEST_CASE(ServerUnitFixture, test_parse_dsml_tool_calls_string_attribute_semantics) {
+    // string="true" should preserve leading/trailing whitespace verbatim
+    // string="false" should parse JSON numbers/booleans/arrays/objects
+    const std::string text =
+        "<｜DSML｜tool_calls>\n"
+        "<｜DSML｜invoke name=\"custom_tool\">\n"
+        "<｜DSML｜parameter name=\"verbatim_str\" string=\"true\">  hello world  \n</｜DSML｜parameter>\n"
+        "<｜DSML｜parameter name=\"json_num\" string=\"false\">42</｜DSML｜parameter>\n"
+        "<｜DSML｜parameter name=\"json_bool\" string=\"false\">true</｜DSML｜parameter>\n"
+        "<｜DSML｜parameter name=\"json_arr\" string=\"false\">[1, 2, 3]</｜DSML｜parameter>\n"
+        "</｜DSML｜invoke>\n"
+        "</｜DSML｜tool_calls>";
+    json tools = json::array({
+        {{"type", "function"}, {"function", {
+             {"name", "custom_tool"},
+             {"parameters", {
+                 {"type", "object"},
+                 {"properties", {
+                     {"verbatim_str", {{"type", "string"}}}
+                 }}
+             }}
+         }}}
+    });
+    auto result = parse_tool_calls(text, tools);
+    TEST_ASSERT(result.tool_calls.size() == 1);
+    if (!result.tool_calls.empty()) {
+        TEST_ASSERT(result.tool_calls[0].name == "custom_tool");
+        auto args = json::parse(result.tool_calls[0].arguments);
+        TEST_ASSERT(args["verbatim_str"] == "  hello world  \n");
+        TEST_ASSERT(args["json_num"] == 42);
+        TEST_ASSERT(args["json_bool"] == true);
+        TEST_ASSERT(args["json_arr"].is_array() && args["json_arr"].size() == 3);
+    }
 }
 
 

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -1293,7 +1293,10 @@ TEST_CASE(ServerUnitFixture, test_parse_dsml_tool_calls_string_attribute_semanti
              {"parameters", {
                  {"type", "object"},
                  {"properties", {
-                     {"verbatim_str", {{"type", "string"}}}
+                     {"verbatim_str", {{"type", "string"}}},
+                     {"json_num", {{"type", "integer"}}},
+                     {"json_bool", {{"type", "boolean"}}},
+                     {"json_arr", {{"type", "array"}}}
                  }}
              }}
          }}}


### PR DESCRIPTION
## Summary
Closes #672

Adopts DeepSeek V4's official **DSML (`｜DSML｜`)** tool calling specification and preserves high-order Unicode codepoints in the GPT-2 BPE decoder.

### Changes
1. **Chat Template (`server/src/server/chat_template.cpp`)**:
   - Updates `ChatFormat::DEEPSEEK4` to prompt using the official `<｜DSML｜tool_calls>` protocol.
   - Reuses `append_available_tools(result, tools_json)` for clean, non-duplicative schema formatting.
2. **Tokenizer Decoder (`server/src/server/tokenizer.cpp`)**:
   - Preserves raw multibyte Unicode codepoints in `decode_gpt2_bpe` (such as `U+FF5C '｜'`) rather than mapping unmapped points $\ge 324$ to `'?'`.
3. **Tool Parser & Stream Holdback (`server/src/server/tool_parser.cpp`, `sse_emitter.cpp`)**:
   - Parses `<｜DSML｜tool_calls>`, `<｜DSML｜invoke name="...">`, and `<｜DSML｜parameter name="..." string="true|false">`.
   - Handles `string="true"` as verbatim raw strings and `string="false"` as JSON primitives/arrays/objects.
   - Updates `tool_syntax_holdback` to 21 bytes and adds `<｜DSML｜` / `｜DSML｜` prefix detection to prevent tag leakage into streaming content/reasoning.
4. **Diagnostic Tool Logging (`server/src/server/sse_emitter.cpp`)**:
   - Adds `DFLASH_LOG_TOOL_CALLS=1` environment variable to dump raw tool buffers and parsed parameters.
5. **Unit Tests (`server/test/test_server_unit.cpp`)**:
   - Added unit tests for DSML tool calls, parameter type coercion, and multiline `edit` tools with nested patch arrays.

### Verification
- **Unit Tests**: All 436 unit tests passing (`./test_server_unit`).
- **Live Testing**: Tested live multi-turn agent sessions on AMD Strix Halo (`gfx1151`, ROCm 7.14 HIP backend) with prefix cache hits across consecutive turns; verified reliable tool invocation (`read`, `bash`, and complex multiline code `edit` patches).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

