### PR TITLE
perf(ds4): unify gfx1151 sparse-prefill stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ These runs use different prompts, quantizations, and inference policies. They sh
 
 See [Recommended server setups](server/docs/RECOMMENDED_SETUPS.md) for the model and hardware matrix, including single-GPU and mixed-GPU profiles.
 
+The DS4 guide also documents the Strix long-context sparse-verifier profile and
+Qwen3-0.6B PFlash integration. PFlash is lossy prompt compression; keep it off
+for exact-retrieval and matched true-context benchmarks.
+
 ## Client Harnesses
 
 [`harness/`](harness/) runs Lucebox through popular coding clients and checks server compatibility.

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -955,6 +955,17 @@ if(DFLASH27B_TESTS)
             ${CMAKE_CURRENT_SOURCE_DIR}/deps/llama.cpp/ggml/include)
         target_link_libraries(bench_rocmfp_mix_gateup_glu PRIVATE
             ggml ggml-base ${DFLASH27B_GGML_BACKEND_TARGET} hip::host)
+
+        # Benchmark, not a test: compares the generic segmented full sort with
+        # the exact two-stage block-radix TOP_K used by the DS4 long-context
+        # indexer. It also checks selected-index set parity at every tile count.
+        add_executable(bench_ds4_topk test/bench_ds4_topk.cpp)
+        set_source_files_properties(test/bench_ds4_topk.cpp PROPERTIES LANGUAGE HIP)
+        set_target_properties(bench_ds4_topk PROPERTIES HIP_ARCHITECTURES "${_dflash_archs}")
+        target_include_directories(bench_ds4_topk PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/deps/llama.cpp/ggml/include)
+        target_link_libraries(bench_ds4_topk PRIVATE
+            ggml ggml-base ${DFLASH27B_GGML_BACKEND_TARGET} hip::host)
     endif()
     add_executable(test_qwen35_tensor_parallel test/test_qwen35_tensor_parallel.cpp)
     target_include_directories(test_qwen35_tensor_parallel PRIVATE ${DFLASH27B_SRC_INCLUDE_DIRS})

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -1626,6 +1626,7 @@ if(DFLASH27B_TESTS)
             test/test_server_unit.cpp
             test/test_anchor_params.cpp
             test/test_derived_scalars.cpp
+            test/test_adaptive_spec_width.cpp
             test/test_adaptive_keep_ratio.cpp
             test/test_skip_park_guard.cpp
             test/test_bandit_integration.cpp

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/ds4-indexer.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/ds4-indexer.cu
@@ -351,12 +351,14 @@ static __global__ void ds4_indexer_score_decode_wmma_kernel(
     }
 }
 
-// The speculative verifier scores exactly four query tokens. The general
-// WMMA kernel places those four tokens in a 16-row tile and executes twelve
-// zero rows for every head. Pack four consecutive heads into the tile instead:
-// row = 4*head_in_group + token. The post-WMMA loop still accumulates heads in
-// their original order, preserving the established F32 numerical topology.
-static __global__ void ds4_indexer_score_wmma_q4_kernel(
+// The speculative verifier scores only a few query tokens. The general WMMA
+// kernel places them in a 16-row tile and executes the unused rows for every
+// head. Pack consecutive heads into the tile instead:
+// row = N_TOKENS*head_in_group + token. The post-WMMA loop still accumulates
+// heads in their original order, preserving the established F32 numerical
+// topology. This is the HIP equivalent of the Vulkan small-CM dispatch.
+template<int N_TOKENS>
+static __global__ void ds4_indexer_score_wmma_small_kernel(
         float       * scores,
         const float * q,
         const float * weights,
@@ -375,7 +377,14 @@ static __global__ void ds4_indexer_score_wmma_q4_kernel(
     __shared__ float c_sh[8 * 16 * 16];
     __shared__ float weight_sh[16];
 
-    float acc[2] = {0.0f, 0.0f};
+    static_assert(N_TOKENS >= 2 && N_TOKENS <= 5,
+                  "small-CM kernel is specialized for verifier widths 2..5");
+    constexpr int HEADS_PER_TILE = 16 / N_TOKENS;
+    constexpr int USED_ROWS = HEADS_PER_TILE * N_TOKENS;
+    constexpr int ACC_SLOTS = (N_TOKENS + 1) / 2;
+    float acc[ACC_SLOTS];
+#pragma unroll
+    for (int slot = 0; slot < ACC_SLOTS; ++slot) acc[slot] = 0.0f;
 
     for (int i = tid; i < 128 * 128; i += 256) {
         const int c = i >> 7;
@@ -387,21 +396,30 @@ static __global__ void ds4_indexer_score_wmma_q4_kernel(
     }
     __syncthreads();
 
-    for (int head_base = 0; head_base < n_head; head_base += 4) {
+    for (int head_base = 0; head_base < n_head;
+         head_base += HEADS_PER_TILE) {
         for (int pair = tid; pair < 16 * 64; pair += 256) {
             const int row = pair >> 6;
             const int d = (pair & 63) * 2;
-            const int token = row & 3;
-            const int head = head_base + (row >> 2);
-            const float2 q_value = *reinterpret_cast<const float2 *>(
-                q + ((size_t) token * n_head + head) * 128 + d);
-            *reinterpret_cast<half2 *>(a_sh + row * 128 + d) =
-                __floats2half2_rn(q_value.x, q_value.y);
+            half2 value = __float2half2_rn(0.0f);
+            if (row < USED_ROWS) {
+                const int token = row % N_TOKENS;
+                const int head = head_base + row / N_TOKENS;
+                if (head < n_head) {
+                    const float2 q_value =
+                        *reinterpret_cast<const float2 *>(
+                            q + ((size_t) token * n_head + head) * 128 + d);
+                    value = __floats2half2_rn(q_value.x, q_value.y);
+                }
+            }
+            *reinterpret_cast<half2 *>(a_sh + row * 128 + d) = value;
         }
         if (tid < 16) {
-            const int token = tid & 3;
-            const int head = head_base + (tid >> 2);
-            weight_sh[tid] = weights[(size_t) token * n_head + head];
+            const int token = tid % N_TOKENS;
+            const int head = head_base + tid / N_TOKENS;
+            weight_sh[tid] = tid < USED_ROWS && head < n_head
+                ? weights[(size_t) token * n_head + head]
+                : 0.0f;
         }
         __syncthreads();
 
@@ -431,16 +449,17 @@ static __global__ void ds4_indexer_score_wmma_q4_kernel(
         __syncthreads();
 
         int slot = 0;
-        for (int output = tid; output < 4 * 128;
+        for (int output = tid; output < N_TOKENS * 128;
              output += 256, ++slot) {
             const int token = output >> 7;
             const int local_comp = output & 127;
             const int comp_tile = local_comp >> 4;
             const int comp_col = local_comp & 15;
 #pragma unroll
-            for (int head_in_group = 0; head_in_group < 4;
+            for (int head_in_group = 0;
+                 head_in_group < HEADS_PER_TILE;
                  ++head_in_group) {
-                const int row = 4 * head_in_group + token;
+                const int row = N_TOKENS * head_in_group + token;
                 const float dot = c_sh[
                     comp_tile * 16 * 16 + row * 16 + comp_col];
                 acc[slot] += fmaxf(dot, 0.0f) * weight_sh[row];
@@ -450,7 +469,7 @@ static __global__ void ds4_indexer_score_wmma_q4_kernel(
     }
 
     int slot = 0;
-    for (int output = tid; output < 4 * 128;
+    for (int output = tid; output < N_TOKENS * 128;
          output += 256, ++slot) {
         const int token = output >> 7;
         const int comp = tile_c + (output & 127);
@@ -553,6 +572,17 @@ void ggml_cuda_op_ds4_indexer_score(
         warp_size == 32 &&
         (!GGML_CUDA_CC_IS_NVIDIA(device_info.cc) ||
          device_info.cc >= GGML_CUDA_CC_VOLTA);
+    const char * packed_small_name = "GGML_DS4_INDEXER_PACK_SMALL";
+    const char * packed_small_env = std::getenv(packed_small_name);
+    if (!packed_small_env) {
+        // Backward-compatible alias for the original q=4-only prototype.
+        packed_small_name = "GGML_DS4_INDEXER_PACK_Q4";
+        packed_small_env = std::getenv(packed_small_name);
+    }
+    const bool use_packed_small = packed_small_env
+        ? ds4_env_flag_enabled(packed_small_name)
+        : GGML_CUDA_CC_IS_RDNA3_5(device_info.cc) ||
+          GGML_CUDA_CC_IS_RDNA4(device_info.cc);
 #if DS4_INDEXER_WMMA_AVAILABLE
     if (wmma_capable && n_tokens == 1) {
         const dim3 grid((unsigned) ((n_comp + 127) / 128), 1, 1);
@@ -564,10 +594,39 @@ void ggml_cuda_op_ds4_indexer_score(
             visibility_mask
                 ? static_cast<const float *>(visibility_mask->data) : nullptr,
             n_comp, kv_start, n_head, ratio);
-    } else if (wmma_capable && n_tokens == 4 && n_head % 4 == 0 &&
-               ds4_env_flag_enabled("GGML_DS4_INDEXER_PACK_Q4")) {
+    } else if (wmma_capable && n_tokens == 2 && use_packed_small) {
         const dim3 grid((unsigned) ((n_comp + 127) / 128), 1, 1);
-        ds4_indexer_score_wmma_q4_kernel<<<grid, 256, 0, stream>>>(
+        ds4_indexer_score_wmma_small_kernel<2><<<grid, 256, 0, stream>>>(
+            static_cast<float *>(dst->data),
+            static_cast<const float *>(q->data),
+            static_cast<const float *>(weights->data),
+            static_cast<const half *>(comp->data),
+            visibility_mask
+                ? static_cast<const float *>(visibility_mask->data) : nullptr,
+            n_comp, kv_start, n_head, ratio);
+    } else if (wmma_capable && n_tokens == 3 && use_packed_small) {
+        const dim3 grid((unsigned) ((n_comp + 127) / 128), 1, 1);
+        ds4_indexer_score_wmma_small_kernel<3><<<grid, 256, 0, stream>>>(
+            static_cast<float *>(dst->data),
+            static_cast<const float *>(q->data),
+            static_cast<const float *>(weights->data),
+            static_cast<const half *>(comp->data),
+            visibility_mask
+                ? static_cast<const float *>(visibility_mask->data) : nullptr,
+            n_comp, kv_start, n_head, ratio);
+    } else if (wmma_capable && n_tokens == 4 && use_packed_small) {
+        const dim3 grid((unsigned) ((n_comp + 127) / 128), 1, 1);
+        ds4_indexer_score_wmma_small_kernel<4><<<grid, 256, 0, stream>>>(
+            static_cast<float *>(dst->data),
+            static_cast<const float *>(q->data),
+            static_cast<const float *>(weights->data),
+            static_cast<const half *>(comp->data),
+            visibility_mask
+                ? static_cast<const float *>(visibility_mask->data) : nullptr,
+            n_comp, kv_start, n_head, ratio);
+    } else if (wmma_capable && n_tokens == 5 && use_packed_small) {
+        const dim3 grid((unsigned) ((n_comp + 127) / 128), 1, 1);
+        ds4_indexer_score_wmma_small_kernel<5><<<grid, 256, 0, stream>>>(
             static_cast<float *>(dst->data),
             static_cast<const float *>(q->data),
             static_cast<const float *>(weights->data),

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/fattn.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/fattn.cu
@@ -1554,6 +1554,202 @@ __global__ static void ds4_flash_attn_d512_shared_kv_grouped_compact_kernel(
     }
 }
 
+// Streaming indexed MLA for long prefill.  The compact grouped kernel above
+// stores every score and then reloads V.  Once the trained indexer has reduced
+// the compressed history to a bounded top-k set, that extra traffic is no
+// longer necessary: stage one latent row in LDS, share it across the heads in
+// a block, and update online-softmax state while the row is resident. Sixteen
+// wave32 heads amortize each LDS load best on gfx1151. The contract is
+// backend-generic (D512 MQA with K == V and direct indexed rows); model policy
+// remains in the graph/backend layer.
+template <typename KV, typename Mask, int HEADS_PER_BLOCK = 16,
+          int KEYS_PER_STAGE = 16>
+__global__ static void ds4_flash_attn_d512_streaming_topk_kernel(
+        float       * dst,
+        const float * q,
+        size_t        q_stride_token,
+        size_t        q_stride_head,
+        const KV    * kv,
+        const Mask  * mask,
+        const float * sinks,
+        int           n_tokens,
+        int           n_heads,
+        int           n_kv,
+        float         scale,
+        const int   * visibility_bounds,
+        const int   * indexed_rows,
+        const int   * indexed_counts,
+        int           indexed_capacity,
+        ds4_inverse_rope_params inverse_rope,
+        const float * inverse_rope_coefficients,
+        const float * forward_rope_coefficients) {
+    constexpr int D = 512;
+    constexpr int WAVE = 32;
+    constexpr int N_THREADS = HEADS_PER_BLOCK * WAVE;
+    constexpr int VALUES_PER_LANE = D / WAVE;
+    static_assert(HEADS_PER_BLOCK == 16);
+    static_assert(KEYS_PER_STAGE == 16);
+    static_assert(N_THREADS == 512);
+
+    const int token = (int) blockIdx.x;
+    const int head_begin = (int) blockIdx.y * HEADS_PER_BLOCK;
+    const int tid = (int) threadIdx.x;
+    const int wave = tid / WAVE;
+    const int lane = tid & (WAVE - 1);
+    const int head = head_begin + wave;
+
+    // The launch gate makes the grid exact.  Keeping every thread live is
+    // required because each stage has workgroup-wide barriers.
+    if (token >= n_tokens || head_begin + HEADS_PER_BLOCK > n_heads) return;
+
+    __shared__ KV staged_kv[KEYS_PER_STAGE * D];
+    __shared__ int staged_rows[KEYS_PER_STAGE];
+    __shared__ float staged_masks[KEYS_PER_STAGE];
+
+    const int * token_visibility = visibility_bounds + (size_t) token * 4;
+    const int raw_first = token_visibility[0];
+    const int raw_last = token_visibility[1];
+    const int raw_count = raw_last >= raw_first
+        ? raw_last - raw_first + 1 : 0;
+    const int indexed_count = indexed_counts[token];
+    const int total_rows = raw_count + indexed_count;
+    const int * token_rows = indexed_rows +
+        (size_t) token * indexed_capacity;
+    const Mask * token_mask = mask + (size_t) token * n_kv;
+
+    const float * qh = q + (size_t) token * q_stride_token +
+        (size_t) head * q_stride_head;
+    float q_values[VALUES_PER_LANE];
+    float accum[VALUES_PER_LANE] = {};
+#pragma unroll
+    for (int i = 0; i < VALUES_PER_LANE; ++i) {
+        const int dim = lane + i * WAVE;
+        float qv = qh[dim];
+        if (inverse_rope.forward_q_enabled && dim >= D - 64) {
+            const int pair = (dim - (D - 64)) / 2;
+            const float x0 = qh[D - 64 + 2 * pair + 0];
+            const float x1 = qh[D - 64 + 2 * pair + 1];
+            const size_t coefficient_index =
+                ((size_t) token * 32 + (size_t) pair) * 2;
+            float y0;
+            float y1;
+            ds4_apply_inverse_rope_pair(
+                x0, x1,
+                forward_rope_coefficients[coefficient_index + 0],
+                forward_rope_coefficients[coefficient_index + 1],
+                y0, y1);
+            qv = (dim & 1) == 0 ? y0 : y1;
+        }
+        q_values[i] = qv;
+    }
+
+    float row_max = -3.402823466e38f;
+    float row_sum = 0.0f;
+    for (int row_base = 0; row_base < total_rows;
+         row_base += KEYS_PER_STAGE) {
+        if (tid < KEYS_PER_STAGE) {
+            const int selected = row_base + tid;
+            int row = -1;
+            if (selected < raw_count) {
+                row = raw_first + selected;
+            } else if (selected < total_rows) {
+                row = token_rows[selected - raw_count];
+            }
+            staged_rows[tid] = row;
+            staged_masks[tid] = row >= 0 && row < n_kv
+                ? ds4_fa_load<Mask, Mask>(token_mask + row)
+                : -3.402823466e38f;
+        }
+        __syncthreads();
+
+        for (int index = tid; index < KEYS_PER_STAGE * D;
+             index += N_THREADS) {
+            const int slot = index / D;
+            const int dim = index - slot * D;
+            const int row = staged_rows[slot];
+            staged_kv[index] = row >= 0 && row < n_kv
+                ? kv[(size_t) row * D + dim] : KV{};
+        }
+        __syncthreads();
+
+#pragma unroll
+        for (int slot = 0; slot < KEYS_PER_STAGE; ++slot) {
+            const int selected = row_base + slot;
+            if (selected >= total_rows) continue;
+            const float mask_value = staged_masks[slot];
+            if (mask_value <= -1.0e20f) continue;
+
+            float partial = 0.0f;
+#pragma unroll
+            for (int i = 0; i < VALUES_PER_LANE; ++i) {
+                const int dim = lane + i * WAVE;
+                partial += q_values[i] *
+                    ds4_fa_load<KV, Mask>(staged_kv + slot * D + dim);
+            }
+            partial = warp_reduce_sum<WAVE>(partial);
+            // XOR reduction can associate operands differently in each lane.
+            // Broadcast lane zero so every output dimension advances one
+            // identical softmax state.
+            partial = __shfl_sync(0xffffffffu, partial, 0, WAVE);
+
+            const float score = partial * scale + mask_value;
+            const float next_max = fmaxf(row_max, score);
+            const float old_scale = row_sum == 0.0f
+                ? 0.0f : expf(row_max - next_max);
+            const float value_scale = expf(score - next_max);
+            row_sum = row_sum * old_scale + value_scale;
+            row_max = next_max;
+#pragma unroll
+            for (int i = 0; i < VALUES_PER_LANE; ++i) {
+                const int dim = lane + i * WAVE;
+                const float value = ds4_fa_load<KV, Mask>(
+                    staged_kv + slot * D + dim);
+                accum[i] = accum[i] * old_scale + value_scale * value;
+            }
+        }
+        __syncthreads();
+    }
+
+    if (sinks) {
+        const float sink = sinks[head];
+        const float next_max = fmaxf(row_max, sink);
+        const float old_scale = row_sum == 0.0f
+            ? 0.0f : expf(row_max - next_max);
+        row_sum = row_sum * old_scale + expf(sink - next_max);
+#pragma unroll
+        for (int i = 0; i < VALUES_PER_LANE; ++i) {
+            accum[i] *= old_scale;
+        }
+    }
+
+    const float inv_sum = row_sum == 0.0f ? 0.0f : 1.0f / row_sum;
+    float * out = dst +
+        ((size_t) token * (size_t) n_heads + (size_t) head) * D;
+#pragma unroll
+    for (int i = 0; i < VALUES_PER_LANE; ++i) {
+        const int dim = lane + i * WAVE;
+        float value = accum[i] * inv_sum;
+        if (inverse_rope.enabled && dim >= D - 64) {
+            const float partner = __shfl_xor_sync(
+                0xffffffffu, value, 1, WAVE);
+            const float x0 = (dim & 1) == 0 ? value : partner;
+            const float x1 = (dim & 1) == 0 ? partner : value;
+            const int pair = (dim - (D - 64)) / 2;
+            const size_t coefficient_index =
+                ((size_t) token * 32 + (size_t) pair) * 2;
+            float y0;
+            float y1;
+            ds4_apply_inverse_rope_pair(
+                x0, x1,
+                inverse_rope_coefficients[coefficient_index + 0],
+                inverse_rope_coefficients[coefficient_index + 1],
+                y0, y1);
+            value = (dim & 1) == 0 ? y0 : y1;
+        }
+        out[dim] = value;
+    }
+}
+
 // Split-KV decode for indexed MLA.  A single grouped block leaves most of a
 // wide RDNA GPU idle when q is small: DS4 has 64 heads, so the four-head
 // kernel exposes only 16 blocks per layer.  Split the bounded raw+top-k row
@@ -2383,6 +2579,50 @@ static bool ggml_cuda_ds4_flash_attn_d512_f32(
                 n_tokens, n_kv, raw_rows);
         }
         CUDA_CHECK(cudaGetLastError());
+        // Vulkan shares each selected latent row across eight subgroup64
+        // heads. HIP tuning selected sixteen wave32 heads for the same K == V
+        // reuse. Keep the native HIP path opt-in until a model-backed A/B
+        // qualifies its online-softmax association. The shape gate is
+        // expressed in terms of the D512 indexed-attention
+        // contract so another model can reuse the kernel without DS4 policy
+        // leaking into it.
+        const char * streaming_topk_env =
+            getenv("GGML_CUDA_MLA_STREAM_TOPK");
+        if (!streaming_topk_env) {
+            streaming_topk_env = getenv("GGML_DS4_FA_STREAM_TOPK");
+        }
+        const bool streaming_topk_enabled = streaming_topk_env &&
+            streaming_topk_env[0] != '\0' &&
+            strcmp(streaming_topk_env, "0") != 0;
+        constexpr int streaming_min_tokens = 64;
+        const int active_row_upper_bound = raw_window + indexed_capacity;
+        const int device_warp_size =
+            ggml_cuda_info().devices[ggml_cuda_get_device()].warp_size;
+        if (streaming_topk_enabled && indexed_mask && indexer_topk &&
+            kv_f16 && mask->type == GGML_TYPE_F16 &&
+            K->data == V->data && n_heads % 16 == 0 &&
+            device_warp_size == 32 && n_tokens >= streaming_min_tokens &&
+            active_row_upper_bound > 0 &&
+            n_kv >= 3 * active_row_upper_bound) {
+            constexpr int streaming_heads = 16;
+            const dim3 streaming_grid(
+                (unsigned) n_tokens,
+                (unsigned) (n_heads / streaming_heads), 1);
+            ds4_flash_attn_d512_streaming_topk_kernel<half, half>
+                <<<streaming_grid, streaming_heads * 32, 0, stream>>>(
+                    (float *) dst->data, (const float *) Q->data,
+                    q_stride_token, q_stride_head,
+                    (const half *) K->data,
+                    (const half *) mask->data,
+                    sinks ? (const float *) sinks->data : nullptr,
+                    n_tokens, n_heads, n_kv, scale,
+                    visibility_bounds, indexed_rows, indexed_counts,
+                    indexed_capacity, inverse_rope,
+                    inverse_rope_coefficients,
+                    forward_rope_coefficients);
+            CUDA_CHECK(cudaGetLastError());
+            return true;
+        }
         // AITER-style split-KV schedule, implemented directly in the native HIP
         // backend. Matched Strix Halo profiling showed a bit-identical output,
         // about -58% attention time and +2-3% decode throughput, so make it the

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/fattn.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/fattn.cu
@@ -1565,7 +1565,8 @@ __global__ static void ds4_flash_attn_d512_shared_kv_grouped_compact_kernel(
 // backend-generic (D512 MQA with K == V and direct indexed rows); model policy
 // remains in the graph/backend layer.
 template <typename KV, typename Mask, int HEADS_PER_BLOCK = 16,
-          int KEYS_PER_STAGE = 16, bool STAGE_F32 = false>
+          int KEYS_PER_STAGE = 16, bool STAGE_F32 = false,
+          bool FAST_EXP = false>
 __global__ static void ds4_flash_attn_d512_streaming_topk_kernel(
         float       * dst,
         const float * q,
@@ -1721,8 +1722,13 @@ __global__ static void ds4_flash_attn_d512_streaming_topk_kernel(
             const float score = partial * scale + mask_value;
             const float next_max = fmaxf(row_max, score);
             const float old_scale = row_sum == 0.0f
-                ? 0.0f : expf(row_max - next_max);
-            const float value_scale = expf(score - next_max);
+                ? 0.0f
+                : (FAST_EXP
+                    ? __expf(row_max - next_max)
+                    : expf(row_max - next_max));
+            const float value_scale = FAST_EXP
+                ? __expf(score - next_max)
+                : expf(score - next_max);
             row_sum = row_sum * old_scale + value_scale;
             row_max = next_max;
 #pragma unroll
@@ -1740,8 +1746,12 @@ __global__ static void ds4_flash_attn_d512_streaming_topk_kernel(
         const float sink = sinks[head];
         const float next_max = fmaxf(row_max, sink);
         const float old_scale = row_sum == 0.0f
-            ? 0.0f : expf(row_max - next_max);
-        row_sum = row_sum * old_scale + expf(sink - next_max);
+            ? 0.0f
+            : (FAST_EXP
+                ? __expf(row_max - next_max)
+                : expf(row_max - next_max));
+        row_sum = row_sum * old_scale +
+            (FAST_EXP ? __expf(sink - next_max) : expf(sink - next_max));
 #pragma unroll
         for (int i = 0; i < VALUES_PER_LANE; ++i) {
             accum[i] *= old_scale;
@@ -2634,11 +2644,29 @@ static bool ggml_cuda_ds4_flash_attn_d512_f32(
                 getenv("GGML_CUDA_MLA_STREAM_F32_STAGE");
             const bool f32_stage = f32_stage_env && f32_stage_env[0] != '\0' &&
                 strcmp(f32_stage_env, "0") != 0;
+            const char * fast_exp_env =
+                getenv("GGML_CUDA_MLA_STREAM_FAST_EXP");
+            const bool fast_exp = fast_exp_env && fast_exp_env[0] != '\0' &&
+                strcmp(fast_exp_env, "0") != 0;
             constexpr int streaming_heads = 16;
             const dim3 streaming_grid(
                 (unsigned) n_tokens,
                 (unsigned) (n_heads / streaming_heads), 1);
-            if (f32_stage) {
+            if (f32_stage && fast_exp) {
+                ds4_flash_attn_d512_streaming_topk_kernel<
+                    half, half, streaming_heads, 16, true, true>
+                    <<<streaming_grid, streaming_heads * 32, 0, stream>>>(
+                        (float *) dst->data, (const float *) Q->data,
+                        q_stride_token, q_stride_head,
+                        (const half *) K->data,
+                        (const half *) mask->data,
+                        sinks ? (const float *) sinks->data : nullptr,
+                        n_tokens, n_heads, n_kv, scale,
+                        visibility_bounds, indexed_rows, indexed_counts,
+                        indexed_capacity, inverse_rope,
+                        inverse_rope_coefficients,
+                        forward_rope_coefficients);
+            } else if (f32_stage) {
                 ds4_flash_attn_d512_streaming_topk_kernel<
                     half, half, streaming_heads, 16, true>
                     <<<streaming_grid, streaming_heads * 32, 0, stream>>>(

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/fattn.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/fattn.cu
@@ -7,6 +7,8 @@
 #include "fattn-chunked.cuh"
 #include "fattn.cuh"
 
+#include <type_traits>
+
 #if defined(GGML_USE_HIP)
 
 __device__ static float ds4_fa_block_sum(float v) {
@@ -1563,7 +1565,7 @@ __global__ static void ds4_flash_attn_d512_shared_kv_grouped_compact_kernel(
 // backend-generic (D512 MQA with K == V and direct indexed rows); model policy
 // remains in the graph/backend layer.
 template <typename KV, typename Mask, int HEADS_PER_BLOCK = 16,
-          int KEYS_PER_STAGE = 16>
+          int KEYS_PER_STAGE = 16, bool STAGE_F32 = false>
 __global__ static void ds4_flash_attn_d512_streaming_topk_kernel(
         float       * dst,
         const float * q,
@@ -1602,7 +1604,8 @@ __global__ static void ds4_flash_attn_d512_streaming_topk_kernel(
     // required because each stage has workgroup-wide barriers.
     if (token >= n_tokens || head_begin + HEADS_PER_BLOCK > n_heads) return;
 
-    __shared__ KV staged_kv[KEYS_PER_STAGE * D];
+    using stage_type = std::conditional_t<STAGE_F32, float, KV>;
+    __shared__ __align__(16) stage_type staged_kv[KEYS_PER_STAGE * D];
     __shared__ int staged_rows[KEYS_PER_STAGE];
     __shared__ float staged_masks[KEYS_PER_STAGE];
 
@@ -1662,13 +1665,35 @@ __global__ static void ds4_flash_attn_d512_streaming_topk_kernel(
         }
         __syncthreads();
 
-        for (int index = tid; index < KEYS_PER_STAGE * D;
-             index += N_THREADS) {
-            const int slot = index / D;
-            const int dim = index - slot * D;
-            const int row = staged_rows[slot];
-            staged_kv[index] = row >= 0 && row < n_kv
-                ? kv[(size_t) row * D + dim] : KV{};
+        // Convert aligned half2 pairs once while loading them. Every head in
+        // the block then consumes the same F32 LDS values without repeating
+        // half conversion in both the score and value passes.
+        if constexpr (STAGE_F32 && std::is_same_v<KV, half>) {
+            constexpr int PAIRS_PER_ROW = D / 2;
+            for (int pair_index = tid;
+                 pair_index < KEYS_PER_STAGE * PAIRS_PER_ROW;
+                 pair_index += N_THREADS) {
+                const int slot = pair_index / PAIRS_PER_ROW;
+                const int pair = pair_index - slot * PAIRS_PER_ROW;
+                const int row = staged_rows[slot];
+                float2 unpacked = make_float2(0.0f, 0.0f);
+                if (row >= 0 && row < n_kv) {
+                    ds4_fa_load_pair(
+                        kv + (size_t) row * D + 2 * pair,
+                        unpacked.x, unpacked.y);
+                }
+                reinterpret_cast<float2 *>(staged_kv)[pair_index] = unpacked;
+            }
+        } else {
+            for (int index = tid; index < KEYS_PER_STAGE * D;
+                 index += N_THREADS) {
+                const int slot = index / D;
+                const int dim = index - slot * D;
+                const int row = staged_rows[slot];
+                staged_kv[index] = row >= 0 && row < n_kv
+                    ? static_cast<stage_type>(kv[(size_t) row * D + dim])
+                    : stage_type{};
+            }
         }
         __syncthreads();
 
@@ -1684,7 +1709,8 @@ __global__ static void ds4_flash_attn_d512_streaming_topk_kernel(
             for (int i = 0; i < VALUES_PER_LANE; ++i) {
                 const int dim = lane + i * WAVE;
                 partial += q_values[i] *
-                    ds4_fa_load<KV, Mask>(staged_kv + slot * D + dim);
+                    ds4_fa_load<stage_type, stage_type>(
+                        staged_kv + slot * D + dim);
             }
             partial = warp_reduce_sum<WAVE>(partial);
             // XOR reduction can associate operands differently in each lane.
@@ -1702,7 +1728,7 @@ __global__ static void ds4_flash_attn_d512_streaming_topk_kernel(
 #pragma unroll
             for (int i = 0; i < VALUES_PER_LANE; ++i) {
                 const int dim = lane + i * WAVE;
-                const float value = ds4_fa_load<KV, Mask>(
+                const float value = ds4_fa_load<stage_type, stage_type>(
                     staged_kv + slot * D + dim);
                 accum[i] = accum[i] * old_scale + value_scale * value;
             }
@@ -2604,22 +2630,42 @@ static bool ggml_cuda_ds4_flash_attn_d512_f32(
             device_warp_size == 32 && n_tokens >= streaming_min_tokens &&
             active_row_upper_bound > 0 &&
             n_kv >= 3 * active_row_upper_bound) {
+            const char * f32_stage_env =
+                getenv("GGML_CUDA_MLA_STREAM_F32_STAGE");
+            const bool f32_stage = f32_stage_env && f32_stage_env[0] != '\0' &&
+                strcmp(f32_stage_env, "0") != 0;
             constexpr int streaming_heads = 16;
             const dim3 streaming_grid(
                 (unsigned) n_tokens,
                 (unsigned) (n_heads / streaming_heads), 1);
-            ds4_flash_attn_d512_streaming_topk_kernel<half, half>
-                <<<streaming_grid, streaming_heads * 32, 0, stream>>>(
-                    (float *) dst->data, (const float *) Q->data,
-                    q_stride_token, q_stride_head,
-                    (const half *) K->data,
-                    (const half *) mask->data,
-                    sinks ? (const float *) sinks->data : nullptr,
-                    n_tokens, n_heads, n_kv, scale,
-                    visibility_bounds, indexed_rows, indexed_counts,
-                    indexed_capacity, inverse_rope,
-                    inverse_rope_coefficients,
-                    forward_rope_coefficients);
+            if (f32_stage) {
+                ds4_flash_attn_d512_streaming_topk_kernel<
+                    half, half, streaming_heads, 16, true>
+                    <<<streaming_grid, streaming_heads * 32, 0, stream>>>(
+                        (float *) dst->data, (const float *) Q->data,
+                        q_stride_token, q_stride_head,
+                        (const half *) K->data,
+                        (const half *) mask->data,
+                        sinks ? (const float *) sinks->data : nullptr,
+                        n_tokens, n_heads, n_kv, scale,
+                        visibility_bounds, indexed_rows, indexed_counts,
+                        indexed_capacity, inverse_rope,
+                        inverse_rope_coefficients,
+                        forward_rope_coefficients);
+            } else {
+                ds4_flash_attn_d512_streaming_topk_kernel<half, half>
+                    <<<streaming_grid, streaming_heads * 32, 0, stream>>>(
+                        (float *) dst->data, (const float *) Q->data,
+                        q_stride_token, q_stride_head,
+                        (const half *) K->data,
+                        (const half *) mask->data,
+                        sinks ? (const float *) sinks->data : nullptr,
+                        n_tokens, n_heads, n_kv, scale,
+                        visibility_bounds, indexed_rows, indexed_counts,
+                        indexed_capacity, inverse_rope,
+                        inverse_rope_coefficients,
+                        forward_rope_coefficients);
+            }
             CUDA_CHECK(cudaGetLastError());
             return true;
         }

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/fattn.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/fattn.cu
@@ -1364,9 +1364,6 @@ __global__ static void ds4_flash_attn_d512_shared_kv_grouped_compact_kernel(
         inv_denom[j] = 1.0f / reduction[(size_t) j * N_THREADS];
     }
 
-    // Finish the shared envelope before the value phase reads it.
-    __syncthreads();
-
     int raw_first = raw_rows;
     int raw_last = -1;
     int comp_first = INDEXED_MASK ? indexed_count : n_kv;
@@ -1375,6 +1372,8 @@ __global__ static void ds4_flash_attn_d512_shared_kv_grouped_compact_kernel(
     int head_raw_last[HEADS_PER_BLOCK];
     int head_comp_first[HEADS_PER_BLOCK];
     int head_comp_last[HEADS_PER_BLOCK];
+    // Finish the shared envelope before the value phase reads it.
+    __syncthreads();
 #pragma unroll
     for (int j = 0; j < HEADS_PER_BLOCK; ++j) {
         const int * bounds = value_bounds + 4 * j;
@@ -1553,6 +1552,343 @@ __global__ static void ds4_flash_attn_d512_shared_kv_grouped_compact_kernel(
             out[2 * pair + 1] = y1;
         }
     }
+}
+
+// Split-KV decode for indexed MLA.  A single grouped block leaves most of a
+// wide RDNA GPU idle when q is small: DS4 has 64 heads, so the four-head
+// kernel exposes only 16 blocks per layer.  Split the bounded raw+top-k row
+// set across four blocks, retain online-softmax state per split, then combine
+// the states in a second kernel.  The implementation is expressed in terms of
+// the D512 latent-attention contract rather than model weights, so future MLA
+// models using the same layout can reuse it.
+template <typename KV, typename Mask, int HEADS_PER_BLOCK, int N_SPLITS>
+__global__ static void ds4_flash_attn_d512_indexed_split_stage1_kernel(
+        float       * partial,
+        const float * q,
+        size_t        q_stride_token,
+        size_t        q_stride_head,
+        const KV    * k,
+        const KV    * v,
+        const Mask  * mask,
+        const float * sinks,
+        int           n_tokens,
+        int           n_heads,
+        int           n_kv,
+        float         scale,
+        int           raw_rows,
+        int           split_stride,
+        const int   * visibility_bounds,
+        const int   * indexed_rows,
+        const int   * indexed_counts,
+        int           indexed_capacity,
+        ds4_inverse_rope_params inverse_rope,
+        const float * forward_rope_coefficients) {
+    constexpr int D = 512;
+    constexpr int N_THREADS = 256;
+    constexpr int VALUES_PER_THREAD = 4;
+
+    const int token = (int) blockIdx.x;
+    const int head_begin = (int) blockIdx.y * HEADS_PER_BLOCK;
+    const int split = (int) blockIdx.z;
+    const int tid = (int) threadIdx.x;
+    if (token >= n_tokens || head_begin >= n_heads) return;
+
+    extern __shared__ float scratch[];
+    float * scores = scratch;
+    float * reduction = scores + (size_t) HEADS_PER_BLOCK * split_stride;
+    float * q_rope_tail = reduction + (size_t) HEADS_PER_BLOCK * N_THREADS;
+
+    const int raw_first = visibility_bounds
+        ? visibility_bounds[(size_t) token * 4 + 0] : 0;
+    const int raw_last = visibility_bounds
+        ? visibility_bounds[(size_t) token * 4 + 1] : raw_rows - 1;
+    const int raw_count = raw_last >= raw_first
+        ? raw_last - raw_first + 1 : 0;
+    const int indexed_count = indexed_counts[token];
+    const int total_rows = raw_count + indexed_count;
+    const int rows_per_split = (total_rows + N_SPLITS - 1) / N_SPLITS;
+    const int split_begin = split * rows_per_split;
+    const int split_end = min(total_rows, split_begin + rows_per_split);
+    const int * token_indexed_rows = indexed_rows +
+        (size_t) token * indexed_capacity;
+
+    const float * qh[HEADS_PER_BLOCK];
+#pragma unroll
+    for (int j = 0; j < HEADS_PER_BLOCK; ++j) {
+        qh[j] = q + (size_t) token * q_stride_token +
+                (size_t) (head_begin + j) * q_stride_head;
+    }
+
+    if (inverse_rope.forward_q_enabled) {
+        for (int index = tid; index < HEADS_PER_BLOCK * 64;
+             index += N_THREADS) {
+            const int j = index / 64;
+            const int tail_d = index % 64;
+            const int pair = tail_d >> 1;
+            const float x0 = qh[j][D - 64 + 2 * pair + 0];
+            const float x1 = qh[j][D - 64 + 2 * pair + 1];
+            const size_t coefficient =
+                ((size_t) token * 32 + (size_t) pair) * 2;
+            const float cos_theta = forward_rope_coefficients[coefficient + 0];
+            const float sin_theta = forward_rope_coefficients[coefficient + 1];
+            q_rope_tail[(size_t) j * 64 + tail_d] = (tail_d & 1)
+                ? x0 * sin_theta + x1 * cos_theta
+                : x0 * cos_theta - x1 * sin_theta;
+        }
+        __syncthreads();
+    }
+
+    float local_max[HEADS_PER_BLOCK];
+#pragma unroll
+    for (int j = 0; j < HEADS_PER_BLOCK; ++j) {
+        local_max[j] = split == 0 && sinks
+            ? sinks[head_begin + j] : -3.402823466e38f;
+    }
+
+    for (int slot = split_begin + tid; slot < split_end;
+         slot += N_THREADS) {
+        const int row = slot < raw_count
+            ? raw_first + slot
+            : token_indexed_rows[slot - raw_count];
+        const float mask_v = ds4_fa_load<Mask, Mask>(
+            mask + (size_t) token * n_kv + row);
+        const KV * kr = k + (size_t) row * D;
+        float dot[HEADS_PER_BLOCK] = {};
+#pragma unroll
+        for (int d = 0; d < D; ++d) {
+            const float kv = ds4_fa_load<KV, Mask>(kr + d);
+#pragma unroll
+            for (int j = 0; j < HEADS_PER_BLOCK; ++j) {
+                const float qv =
+                    inverse_rope.forward_q_enabled && d >= D - 64
+                        ? q_rope_tail[(size_t) j * 64 + d - (D - 64)]
+                        : qh[j][d];
+                dot[j] += qv * kv;
+            }
+        }
+        const int score_index = slot - split_begin;
+#pragma unroll
+        for (int j = 0; j < HEADS_PER_BLOCK; ++j) {
+            const float score = dot[j] * scale + mask_v;
+            scores[(size_t) j * split_stride + score_index] = score;
+            local_max[j] = fmaxf(local_max[j], score);
+        }
+    }
+
+#pragma unroll
+    for (int j = 0; j < HEADS_PER_BLOCK; ++j) {
+        reduction[(size_t) j * N_THREADS + tid] = local_max[j];
+    }
+    __syncthreads();
+    for (int stride = N_THREADS / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+#pragma unroll
+            for (int j = 0; j < HEADS_PER_BLOCK; ++j) {
+                float * row = reduction + (size_t) j * N_THREADS;
+                row[tid] = fmaxf(row[tid], row[tid + stride]);
+            }
+        }
+        __syncthreads();
+    }
+
+    float split_max[HEADS_PER_BLOCK];
+    float local_sum[HEADS_PER_BLOCK] = {};
+#pragma unroll
+    for (int j = 0; j < HEADS_PER_BLOCK; ++j) {
+        split_max[j] = reduction[(size_t) j * N_THREADS];
+    }
+    for (int slot = split_begin + tid; slot < split_end;
+         slot += N_THREADS) {
+        const int score_index = slot - split_begin;
+#pragma unroll
+        for (int j = 0; j < HEADS_PER_BLOCK; ++j) {
+            float * score = scores + (size_t) j * split_stride + score_index;
+            const float weight = expf(*score - split_max[j]);
+            *score = weight;
+            local_sum[j] += weight;
+        }
+    }
+    if (tid == 0 && split == 0 && sinks) {
+#pragma unroll
+        for (int j = 0; j < HEADS_PER_BLOCK; ++j) {
+            local_sum[j] += expf(sinks[head_begin + j] - split_max[j]);
+        }
+    }
+#pragma unroll
+    for (int j = 0; j < HEADS_PER_BLOCK; ++j) {
+        reduction[(size_t) j * N_THREADS + tid] = local_sum[j];
+    }
+    __syncthreads();
+    for (int stride = N_THREADS / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+#pragma unroll
+            for (int j = 0; j < HEADS_PER_BLOCK; ++j) {
+                float * row = reduction + (size_t) j * N_THREADS;
+                row[tid] += row[tid + stride];
+            }
+        }
+        __syncthreads();
+    }
+
+    const int d0 = VALUES_PER_THREAD * tid;
+    if (d0 < D) {
+        float acc0[HEADS_PER_BLOCK] = {};
+        float acc1[HEADS_PER_BLOCK] = {};
+        float acc2[HEADS_PER_BLOCK] = {};
+        float acc3[HEADS_PER_BLOCK] = {};
+        for (int slot = split_begin; slot < split_end; ++slot) {
+            const int row = slot < raw_count
+                ? raw_first + slot
+                : token_indexed_rows[slot - raw_count];
+            float vv0, vv1, vv2, vv3;
+            ds4_fa_load_quad<KV>(v + (size_t) row * D + d0,
+                                 vv0, vv1, vv2, vv3);
+            const int score_index = slot - split_begin;
+#pragma unroll
+            for (int j = 0; j < HEADS_PER_BLOCK; ++j) {
+                const float weight =
+                    scores[(size_t) j * split_stride + score_index];
+                acc0[j] += weight * vv0;
+                acc1[j] += weight * vv1;
+                acc2[j] += weight * vv2;
+                acc3[j] += weight * vv3;
+            }
+        }
+#pragma unroll
+        for (int j = 0; j < HEADS_PER_BLOCK; ++j) {
+            float * out = partial +
+                (((size_t) token * n_heads + head_begin + j) * N_SPLITS +
+                 split) * (D + 2);
+            out[d0 + 0] = acc0[j];
+            out[d0 + 1] = acc1[j];
+            out[d0 + 2] = acc2[j];
+            out[d0 + 3] = acc3[j];
+        }
+    }
+    if (tid < HEADS_PER_BLOCK) {
+        float * out = partial +
+            (((size_t) token * n_heads + head_begin + tid) * N_SPLITS +
+             split) * (D + 2);
+        out[D + 0] = split_max[tid];
+        out[D + 1] = reduction[(size_t) tid * N_THREADS];
+    }
+}
+
+template <int N_SPLITS>
+__global__ static void ds4_flash_attn_d512_indexed_split_stage2_kernel(
+        float       * dst,
+        const float * partial,
+        int           n_tokens,
+        int           n_heads,
+        ds4_inverse_rope_params inverse_rope,
+        const float * inverse_rope_coefficients) {
+    constexpr int D = 512;
+    const int token = (int) blockIdx.x;
+    const int head = (int) blockIdx.y;
+    const int tid = (int) threadIdx.x;
+    if (token >= n_tokens || head >= n_heads) return;
+
+    __shared__ float global_max;
+    __shared__ float inverse_denom;
+    const float * head_partial = partial +
+        ((size_t) token * n_heads + head) * N_SPLITS * (D + 2);
+    if (tid == 0) {
+        float max_value = -3.402823466e38f;
+#pragma unroll
+        for (int split = 0; split < N_SPLITS; ++split) {
+            max_value = fmaxf(max_value,
+                head_partial[(size_t) split * (D + 2) + D]);
+        }
+        float denom = 0.0f;
+#pragma unroll
+        for (int split = 0; split < N_SPLITS; ++split) {
+            const float * state = head_partial + (size_t) split * (D + 2);
+            denom += state[D + 1] * expf(state[D] - max_value);
+        }
+        global_max = max_value;
+        inverse_denom = 1.0f / denom;
+    }
+    __syncthreads();
+
+    const int d0 = 2 * tid;
+    float x0 = 0.0f;
+    float x1 = 0.0f;
+#pragma unroll
+    for (int split = 0; split < N_SPLITS; ++split) {
+        const float * state = head_partial + (size_t) split * (D + 2);
+        const float rescale = expf(state[D] - global_max);
+        x0 += state[d0 + 0] * rescale;
+        x1 += state[d0 + 1] * rescale;
+    }
+    x0 *= inverse_denom;
+    x1 *= inverse_denom;
+
+    float * out = dst + ((size_t) token * n_heads + head) * D + d0;
+    if (inverse_rope.enabled && d0 >= D - 64) {
+        const int pair = (d0 - (D - 64)) / 2;
+        const size_t coefficient =
+            ((size_t) token * 32 + (size_t) pair) * 2;
+        const float cos_theta = inverse_rope_coefficients[coefficient + 0];
+        const float sin_theta = inverse_rope_coefficients[coefficient + 1];
+        float y0;
+        float y1;
+        ds4_apply_inverse_rope_pair(
+            x0, x1, cos_theta, sin_theta, y0, y1);
+        out[0] = y0;
+        out[1] = y1;
+    } else {
+        out[0] = x0;
+        out[1] = x1;
+    }
+}
+
+template <typename KV, typename Mask, int N_SPLITS>
+static void ds4_launch_flash_attn_d512_indexed_split(
+        float             * dst,
+        float             * partial,
+        const float       * q,
+        size_t              q_stride_token,
+        size_t              q_stride_head,
+        const KV          * k,
+        const KV          * v,
+        const Mask        * mask,
+        const float       * sinks,
+        int                 n_tokens,
+        int                 n_heads,
+        int                 n_kv,
+        float               scale,
+        int                 raw_rows,
+        int                 split_stride,
+        const int         * visibility_bounds,
+        const int         * indexed_rows,
+        const int         * indexed_counts,
+        int                 indexed_capacity,
+        ds4_inverse_rope_params inverse_rope,
+        const float       * inverse_rope_coefficients,
+        const float       * forward_rope_coefficients,
+        cudaStream_t        stream) {
+    constexpr int HEADS_PER_BLOCK = 4;
+    const size_t shmem =
+        ((size_t) HEADS_PER_BLOCK * split_stride +
+         (size_t) HEADS_PER_BLOCK * 256 +
+         (inverse_rope.forward_q_enabled
+             ? (size_t) HEADS_PER_BLOCK * 64 : 0)) * sizeof(float);
+    const dim3 stage1_grid(
+        (unsigned) n_tokens,
+        (unsigned) (n_heads / HEADS_PER_BLOCK),
+        (unsigned) N_SPLITS);
+    ds4_flash_attn_d512_indexed_split_stage1_kernel<
+        KV, Mask, HEADS_PER_BLOCK, N_SPLITS>
+        <<<stage1_grid, 256, shmem, stream>>>(
+            partial, q, q_stride_token, q_stride_head, k, v, mask, sinks,
+            n_tokens, n_heads, n_kv, scale, raw_rows, split_stride,
+            visibility_bounds, indexed_rows, indexed_counts,
+            indexed_capacity, inverse_rope, forward_rope_coefficients);
+    const dim3 stage2_grid((unsigned) n_tokens, (unsigned) n_heads, 1);
+    ds4_flash_attn_d512_indexed_split_stage2_kernel<N_SPLITS>
+        <<<stage2_grid, 256, 0, stream>>>(
+            dst, partial, n_tokens, n_heads, inverse_rope,
+            inverse_rope_coefficients);
 }
 
 template <int HEADS_PER_BLOCK>
@@ -2047,6 +2383,74 @@ static bool ggml_cuda_ds4_flash_attn_d512_f32(
                 n_tokens, n_kv, raw_rows);
         }
         CUDA_CHECK(cudaGetLastError());
+        // AITER-style split-KV schedule, implemented directly in the native HIP
+        // backend. Matched Strix Halo profiling showed a bit-identical output,
+        // about -58% attention time and +2-3% decode throughput, so make it the
+        // gfx1151 default. Other devices remain opt-in until measured.
+        constexpr int split_kv_max_decode_tokens = 8;
+        const int cc = ggml_cuda_info().devices[ggml_cuda_get_device()].cc;
+        const bool split_kv_default =
+            cc == GGML_CUDA_CC_OFFSET_AMD + 0x1151;
+        const bool split_kv_forced =
+            getenv("GGML_CUDA_MLA_SPLIT_KV") != nullptr ||
+            getenv("GGML_DS4_FA_SPLIT_KV") != nullptr;
+        const bool split_kv_disabled =
+            getenv("GGML_CUDA_MLA_NO_SPLIT_KV") != nullptr ||
+            getenv("GGML_DS4_FA_NO_SPLIT_KV") != nullptr;
+        if (indexed_mask && n_tokens <= split_kv_max_decode_tokens &&
+            !split_kv_disabled && (split_kv_forced || split_kv_default)) {
+            constexpr int split_count = 2;
+            const int split_stride =
+                (raw_window + indexed_capacity + split_count - 1) /
+                split_count;
+            ggml_cuda_pool_alloc<float> partial_alloc(ctx.pool());
+            float * partial = partial_alloc.alloc(
+                (size_t) n_tokens * n_heads * split_count * (512 + 2));
+            if (kv_f16 && mask->type == GGML_TYPE_F16) {
+                ds4_launch_flash_attn_d512_indexed_split<
+                    half, half, split_count>(
+                    (float *) dst->data, partial, (const float *) Q->data,
+                    q_stride_token, q_stride_head,
+                    (const half *) K->data, (const half *) V->data,
+                    (const half *) mask->data,
+                    sinks ? (const float *) sinks->data : nullptr,
+                    n_tokens, n_heads, n_kv, scale, raw_rows, split_stride,
+                    visibility_bounds, indexed_rows, indexed_counts,
+                    indexed_capacity, inverse_rope,
+                    inverse_rope_coefficients, forward_rope_coefficients,
+                    stream);
+            } else if (kv_f32 && mask->type == GGML_TYPE_F32) {
+                ds4_launch_flash_attn_d512_indexed_split<
+                    float, float, split_count>(
+                    (float *) dst->data, partial, (const float *) Q->data,
+                    q_stride_token, q_stride_head,
+                    (const float *) K->data, (const float *) V->data,
+                    (const float *) mask->data,
+                    sinks ? (const float *) sinks->data : nullptr,
+                    n_tokens, n_heads, n_kv, scale, raw_rows, split_stride,
+                    visibility_bounds, indexed_rows, indexed_counts,
+                    indexed_capacity, inverse_rope,
+                    inverse_rope_coefficients, forward_rope_coefficients,
+                    stream);
+            } else if (kv_f32 && mask->type == GGML_TYPE_F16) {
+                ds4_launch_flash_attn_d512_indexed_split<
+                    float, half, split_count>(
+                    (float *) dst->data, partial, (const float *) Q->data,
+                    q_stride_token, q_stride_head,
+                    (const float *) K->data, (const float *) V->data,
+                    (const half *) mask->data,
+                    sinks ? (const float *) sinks->data : nullptr,
+                    n_tokens, n_heads, n_kv, scale, raw_rows, split_stride,
+                    visibility_bounds, indexed_rows, indexed_counts,
+                    indexed_capacity, inverse_rope,
+                    inverse_rope_coefficients, forward_rope_coefficients,
+                    stream);
+            } else {
+                return false;
+            }
+            CUDA_CHECK(cudaGetLastError());
+            return true;
+        }
         if (indexed_mask) {
             return ds4_launch_flash_attn_d512_grouped_compact<
                 group4, true, 4>(

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2870,9 +2870,9 @@ static void ggml_cuda_mul_mat(ggml_backend_cuda_context & ctx, const ggml_tensor
         : luce_mmvq_max_ncols_env;
     // The mix qtypes have no generic MMVQ path because their per-expert
     // codebooks live in an out-of-band registry. Decode uses the dedicated
-    // fused kernels below. Sparse prefill can opt into their registry-aware
-    // MMQ loaders; otherwise should_use_mmq rejects them and they retain the
-    // exact dequantize->cuBLAS fallback.
+    // fused kernels below. Approximate prefill modes can select their
+    // registry-aware MMQ loaders; otherwise should_use_mmq rejects them and
+    // they retain the exact dequantize->cuBLAS fallback.
     const bool is_rocmfp3_mix = src0->type == GGML_TYPE_Q3_1_ROCMFP3_MIX;
     const bool is_rocmfp2_mix = src0->type == GGML_TYPE_Q2_1_ROCMFP2_MIX;
     const bool is_mix_qtype    = is_rocmfp3_mix || is_rocmfp2_mix;

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/mmq.cuh
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/mmq.cuh
@@ -7,6 +7,7 @@
 
 #include <climits>
 #include <cstdint>
+#include <cstdlib>
 
 using namespace ggml_cuda_mma;
 
@@ -4922,7 +4923,52 @@ void mul_mat_q_case(ggml_backend_cuda_context & ctx, const mmq_args & args, cuda
     int mmq_x_best  = 0;
     int ntiles_x_best = INT_MAX;
 
-    for (int mmq_x = 8; mmq_x <= mmq_x_max && ntiles_x_best > 1; mmq_x += 8) {
+    static const int forced_mmq_x = []() {
+        const char * raw = std::getenv("GGML_CUDA_MMQ_X");
+        if (!raw || !*raw) return 0;
+        char * end = nullptr;
+        const long parsed = std::strtol(raw, &end, 10);
+        return end && end != raw && *end == '\0' && parsed >= 8 &&
+                parsed <= 128 && parsed % 8 == 0
+            ? (int)parsed : 0;
+    }();
+    static const bool adaptive_moe_x_enabled = []() {
+        const char * raw = std::getenv("GGML_CUDA_MMQ_MOE_ADAPTIVE_X");
+        return raw && *raw && !(raw[0] == '0' && raw[1] == '\0');
+    }();
+    int requested_mmq_x = forced_mmq_x;
+    if (requested_mmq_x == 0 && adaptive_moe_x_enabled &&
+        cc == GGML_CUDA_CC_OFFSET_AMD + 0x1151 &&
+        args.expert_bounds != nullptr && args.nchannels_x > 0) {
+        // Grouped MoE routes are sparse across experts. Sizing the X tile from
+        // the full token width makes almost every workgroup carry padding. Use
+        // the mean live-route density as a model-neutral trigger, then select
+        // the measured gfx1151 tile for each unpack format. The grid still
+        // spans ncols_max, so skewed experts remain fully covered.
+        const int64_t routes_per_expert =
+            (args.ncols_y + args.nchannels_x - 1) / args.nchannels_x;
+        if (routes_per_expert <= 16) {
+            switch (type) {
+                case GGML_TYPE_Q2_0_ROCMFP2:      requested_mmq_x = 32; break;
+                case GGML_TYPE_Q3_0_ROCMFPX:      requested_mmq_x = 48; break;
+                case GGML_TYPE_Q4_0_ROCMFP4_FAST: requested_mmq_x = 16; break;
+                default: break;
+            }
+        }
+    }
+    if (requested_mmq_x > 0 && requested_mmq_x <= mmq_x_max) {
+        const int granularity = mmq_get_granularity_host(requested_mmq_x, cc);
+        if (requested_mmq_x % granularity == 0 &&
+            mmq_get_nbytes_shared<type>(
+                requested_mmq_x, mmq_y, cc, warp_size, nwarps) <= smpbo) {
+            mmq_x_best = requested_mmq_x;
+            ntiles_x_best = 1;
+        }
+    }
+
+    for (int mmq_x = 8;
+         mmq_x_best == 0 && mmq_x <= mmq_x_max && ntiles_x_best > 1;
+         mmq_x += 8) {
         const int granularity = mmq_get_granularity_host(mmq_x, cc);
 
         if (mmq_x % granularity != 0 || mmq_get_nbytes_shared<type>(mmq_x, mmq_y, cc, warp_size, nwarps) > smpbo) {

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/mmq.cuh
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/mmq.cuh
@@ -4659,6 +4659,112 @@ static __global__ void mul_mat_q(
          mix_codebooks, mix_modes, fastdiv(zt, channel_ratio));
 }
 
+#if defined(GGML_USE_HIP)
+template <int mmq_x>
+static __global__ void mul_mat_q_moe_build_tasks(
+        const int32_t * __restrict__ expert_bounds,
+        int2 * __restrict__ tasks,
+        int * __restrict__ task_count,
+        int n_experts) {
+    const int expert = blockIdx.x*blockDim.x + threadIdx.x;
+    if (expert >= n_experts) {
+        return;
+    }
+    const int route_count =
+        expert_bounds[expert + 1] - expert_bounds[expert];
+    const int tile_count = (route_count + mmq_x - 1)/mmq_x;
+    if (tile_count == 0) {
+        return;
+    }
+    const int task_begin = atomicAdd(task_count, tile_count);
+    for (int tile = 0; tile < tile_count; ++tile) {
+        tasks[task_begin + tile] = make_int2(tile, expert);
+    }
+}
+
+// Sparse grouped MoE has a deliberately wide upper-bound grid: every expert
+// receives enough Y tiles for the full token batch even though only top-k
+// routes are live. Build a compact device-side task list, then keep a bounded
+// set of workgroups resident to consume only non-empty expert tiles. No host
+// count readback or synchronization is required.
+template <ggml_type type, int mmq_x, bool need_check>
+__launch_bounds__(ggml_cuda_get_physical_warp_size()*mmq_get_nwarps_device(), 1)
+static __global__ void mul_mat_q_moe_persistent(
+        const char * __restrict__ x,
+        const int * __restrict__ y,
+        const int32_t * __restrict__ ids_dst,
+        const int32_t * __restrict__ expert_bounds,
+        const nv_bfloat16 * __restrict__ mix_codebooks,
+        const uint8_t * __restrict__ mix_modes,
+        float * __restrict__ dst,
+        const int2 * __restrict__ tasks,
+        const int * __restrict__ task_count,
+        const uint3 blocks_per_ne00,
+        const int nrows_x,
+        const int stride_row_x,
+        const int ncols_y,
+        const int stride_col_dst,
+        const uint3 channel_ratio,
+        const int stride_channel_x) {
+    if (mmq_x > get_mmq_x_max_device() ||
+        mmq_x % mmq_get_granularity_device(mmq_x) != 0) {
+        NO_DEVICE_CODE;
+        return;
+    }
+
+    constexpr int nwarps = mmq_get_nwarps_device();
+    constexpr int warp_size = ggml_cuda_get_physical_warp_size();
+    constexpr int mmq_y = get_mmq_y_device();
+
+    extern __shared__ int ids_dst_shared[];
+    const int it = blockIdx.x;
+    const int total_tasks = *task_count;
+
+    for (int task_index = blockIdx.y; task_index < total_tasks;
+         task_index += gridDim.y) {
+        const int2 task = tasks[task_index];
+        const int jt = task.x;
+        const int zt = task.y;
+
+        const int col_low = expert_bounds[zt + 0];
+        const int col_high = expert_bounds[zt + 1];
+        const int col_diff = col_high - col_low;
+        if (jt*mmq_x >= col_diff) {
+            continue;
+        }
+
+        __syncthreads();
+#pragma unroll
+        for (int j0 = 0; j0 < mmq_x; j0 += nwarps*warp_size) {
+            const int j = j0 + threadIdx.y*warp_size + threadIdx.x;
+            if (j0 + nwarps*warp_size > mmq_x && j >= mmq_x) {
+                break;
+            }
+            ids_dst_shared[j] = ids_dst[col_low + jt*mmq_x + j];
+        }
+        __syncthreads();
+
+        const int offset_y =
+            (col_low + jt*mmq_x)*(sizeof(block_q8_1_mmq)/sizeof(int));
+        const int offset_dst = it*mmq_y;
+        const int offset_x =
+            fastdiv(zt, channel_ratio)*stride_channel_x +
+            it*mmq_y*stride_row_x;
+        const int tile_x_max_i = nrows_x - it*mmq_y - 1;
+        const int tile_y_max_j = col_diff - jt*mmq_x - 1;
+
+        constexpr bool fixup = false;
+        mul_mat_q_process_tile<type, mmq_x, need_check, fixup>(
+            x, offset_x, y + offset_y, ids_dst_shared,
+            dst + offset_dst, nullptr, stride_row_x, ncols_y,
+            stride_col_dst, tile_x_max_i, tile_y_max_j,
+            0, blocks_per_ne00.z, mix_codebooks, mix_modes,
+            fastdiv(zt, channel_ratio));
+        __syncthreads();
+    }
+}
+#endif
+
 template <ggml_type type, int mmq_x, bool need_check>
 __launch_bounds__(ggml_cuda_get_physical_warp_size()*mmq_get_nwarps_device()/2, 1)
 static __global__ void mul_mat_q_stream_k_fixup(
@@ -4855,6 +4961,76 @@ static void launch_mul_mat_q(ggml_backend_cuda_context & ctx, const mmq_args & a
     const uint3 nsamples_y_fd      = init_fastdiv_values(args.nsamples_y);
     const uint3 channel_ratio_fd   = init_fastdiv_values(channel_ratio);
     const uint3 sample_ratio_fd    = init_fastdiv_values(sample_ratio);
+
+#if defined(GGML_USE_HIP)
+    if constexpr (type == GGML_TYPE_Q2_0_ROCMFP2 ||
+                  type == GGML_TYPE_Q3_0_ROCMFPX ||
+                  type == GGML_TYPE_Q4_0_ROCMFP4_FAST) {
+        const char * persistent_env =
+            std::getenv("GGML_CUDA_MMQ_MOE_PERSISTENT");
+        const bool persistent_enabled = persistent_env && *persistent_env &&
+            !(persistent_env[0] == '0' && persistent_env[1] == '\0');
+        // The compact queue amortizes its builder and bounded-worker launch at
+        // prefill widths. Below 256 source columns the ordinary grouped grid is
+        // already efficient, and is marginally faster for some formats.
+        if (persistent_enabled && args.ncols_max >= 256 && !args.use_stream_k &&
+            args.ids_dst != nullptr && args.expert_bounds != nullptr &&
+            args.nsamples_y == 1 &&
+            cc == GGML_CUDA_CC_OFFSET_AMD + 0x1151) {
+            int blocks_per_cu = 32;
+            if (const char * raw =
+                    std::getenv("GGML_CUDA_MMQ_MOE_PERSISTENT_BLOCKS_PER_CU")) {
+                const int parsed = std::atoi(raw);
+                if (parsed >= 1 && parsed <= 32) {
+                    blocks_per_cu = parsed;
+                }
+            }
+            ggml_cuda_pool_alloc<int2> tasks(ctx.pool(), args.ncols_y);
+            ggml_cuda_pool_alloc<int> task_count(ctx.pool(), 1);
+            CUDA_CHECK(cudaMemsetAsync(
+                task_count.get(), 0, sizeof(int), stream));
+            constexpr int task_builder_threads = 256;
+            const int task_builder_blocks =
+                (args.nchannels_y + task_builder_threads - 1)/
+                task_builder_threads;
+            mul_mat_q_moe_build_tasks<mmq_x>
+                <<<task_builder_blocks, task_builder_threads, 0, stream>>>(
+                    args.expert_bounds, tasks.get(), task_count.get(),
+                    args.nchannels_y);
+
+            const int workers = std::max(
+                1, std::min((int) args.ncols_y, nsm*blocks_per_cu));
+            const dim3 persistent_grid(nty, workers, 1);
+            CUDA_SET_SHARED_MEMORY_LIMIT(
+                (mul_mat_q_moe_persistent<type, mmq_x, false>),
+                nbytes_shared);
+            CUDA_SET_SHARED_MEMORY_LIMIT(
+                (mul_mat_q_moe_persistent<type, mmq_x, true>),
+                nbytes_shared);
+            if (args.nrows_x % mmq_y == 0) {
+                mul_mat_q_moe_persistent<type, mmq_x, false>
+                    <<<persistent_grid, block_dims, nbytes_shared, stream>>>(
+                        args.x, args.y, args.ids_dst, args.expert_bounds,
+                        args.mix_codebooks, args.mix_modes, args.dst,
+                        tasks.get(), task_count.get(),
+                        blocks_per_ne00_fd, args.nrows_x, args.stride_row_x,
+                        args.ncols_y, args.nrows_dst, channel_ratio_fd,
+                        args.stride_channel_x);
+            } else {
+                mul_mat_q_moe_persistent<type, mmq_x, true>
+                    <<<persistent_grid, block_dims, nbytes_shared, stream>>>(
+                        args.x, args.y, args.ids_dst, args.expert_bounds,
+                        args.mix_codebooks, args.mix_modes, args.dst,
+                        tasks.get(), task_count.get(),
+                        blocks_per_ne00_fd, args.nrows_x, args.stride_row_x,
+                        args.ncols_y, args.nrows_dst, channel_ratio_fd,
+                        args.stride_channel_x);
+            }
+            CUDA_CHECK(cudaGetLastError());
+            return;
+        }
+    }
+#endif
 
     if (!args.use_stream_k) {
         if (args.nrows_x % mmq_y == 0) {

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/mmq.cuh
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/mmq.cuh
@@ -1086,11 +1086,21 @@ static __device__ __forceinline__ void load_tiles_rocmfpx_dual(
             q1 = rocmfpx_pack4_fp3_bits12_vec_cuda((bits24 >> 12) & 0x0fffu);
             q1_offset = 1;
         } else {
-            k0 = kbx*groups_per_block + group;
-            q0 = traits::pack4(block, 4*group);
-            q1 = traits::pack4(
-                block, 4*(group + groups_per_block/2));
-            q1_offset = groups_per_block/2;
+            // FP2 stores each four-value group in one byte. Pair adjacent
+            // groups so HIP can issue one aligned 16-bit load per lane.
+            const int byte = 2*group;
+#if defined(GGML_USE_HIP)
+            uint16_t bits16;
+            __builtin_memcpy(&bits16, block->qs + byte, sizeof(bits16));
+#else
+            const uint16_t bits16 =
+                (uint16_t) block->qs[byte + 0] |
+                ((uint16_t) block->qs[byte + 1] << 8);
+#endif
+            k0 = kbx*groups_per_block + 2*group;
+            q0 = rocmfpx_pack4_fp2_bits8_vec_cuda(bits16 & 0x00ffu);
+            q1 = rocmfpx_pack4_fp2_bits8_vec_cuda((bits16 >> 8) & 0x00ffu);
+            q1_offset = 1;
         }
 
 #if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/mmq.cuh
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/mmq.cuh
@@ -1062,17 +1062,43 @@ static __device__ __forceinline__ void load_tiles_rocmfpx_dual(
         }
 
         const block_t * block = (const block_t *) x + kbx0 + i*stride + kbx;
-        const int k0 = kbx*groups_per_block + group;
-        const int q0 = traits::pack4(block, 4*group);
-        const int q1 = traits::pack4(
-            block, 4*(group + groups_per_block/2));
+        int k0;
+        int q0;
+        int q1;
+        int q1_offset;
+        if constexpr (type == GGML_TYPE_Q3_0_ROCMFPX) {
+            // Eight FP3 weights occupy exactly three bytes. Assign adjacent
+            // four-value groups to one lane so the wave reads every packed
+            // byte once instead of overlapping the two-byte group windows.
+            const int byte = 3*group;
+#if defined(GGML_USE_HIP)
+            uint32_t packed32;
+            __builtin_memcpy(&packed32, block->qs + byte, sizeof(packed32));
+            const uint32_t bits24 = packed32 & 0x00ffffffu;
+#else
+            const uint32_t bits24 =
+                (uint32_t) block->qs[byte + 0] |
+                ((uint32_t) block->qs[byte + 1] << 8) |
+                ((uint32_t) block->qs[byte + 2] << 16);
+#endif
+            k0 = kbx*groups_per_block + 2*group;
+            q0 = rocmfpx_pack4_fp3_bits12_vec_cuda(bits24 & 0x0fffu);
+            q1 = rocmfpx_pack4_fp3_bits12_vec_cuda((bits24 >> 12) & 0x0fffu);
+            q1_offset = 1;
+        } else {
+            k0 = kbx*groups_per_block + group;
+            q0 = traits::pack4(block, 4*group);
+            q1 = traits::pack4(
+                block, 4*(group + groups_per_block/2));
+            q1_offset = groups_per_block/2;
+        }
 
 #if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
         x_qs[i*MMQ_MMA_TILE_X_K_Q3_K + k0]                      = q0;
-        x_qs[i*MMQ_MMA_TILE_X_K_Q3_K + k0 + groups_per_block/2] = q1;
+        x_qs[i*MMQ_MMA_TILE_X_K_Q3_K + k0 + q1_offset]          = q1;
 #else
         x_qs[i*(2*MMQ_TILE_NE_K + 1) + k0]                      = q0;
-        x_qs[i*(2*MMQ_TILE_NE_K + 1) + k0 + groups_per_block/2] = q1;
+        x_qs[i*(2*MMQ_TILE_NE_K + 1) + k0 + q1_offset]          = q1;
 #endif // defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
 
     }

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/mmq.cuh
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/mmq.cuh
@@ -1102,8 +1102,9 @@ static __device__ __forceinline__ void load_tiles_rocmfpx_dual(
 // qtype-107, but each expert supplies two learned four-level codebooks.  MMQ
 // needs int8 tiles, so quantize those tiny codebooks once per K tile, then fold
 // the codebook scale into the block's ordinary UE4M3 scale.  The additional
-// error is bounded to half an int8 step (measured below 0.4% of codebook range)
-// and this path is opt-in because sparse prefill is already approximate.
+// error is bounded to half an int8 step (measured below 0.4% of codebook range).
+// Backend policy selects this path only for prefill modes that are already
+// approximate; exact prefill retains the dequantize-to-F16 fallback.
 struct rocmfp2_mix_mmq_lut {
     int   packed[2];
     float scale[2];

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/mmvf.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/mmvf.cu
@@ -4,6 +4,8 @@
 #include "mmvf.cuh"
 #include "convert.cuh"
 
+#include <cstdlib>
+
 template <typename T, typename type_acc, int ncols_dst, int block_size, bool has_fusion = false, bool is_multi_token_id = false>
 static __global__ void mul_mat_vec_f(
         const T * __restrict__ x, const float * __restrict__ y, const int32_t * __restrict__ ids, const ggml_cuda_mm_fusion_args_device fusion, float * __restrict__ dst,
@@ -834,6 +836,23 @@ bool ggml_cuda_should_use_mmvf(enum ggml_type type, int cc, const int64_t * src0
                 }
                 return ne11 <= 8;
             } else if (GGML_CUDA_CC_IS_AMD(cc)) {
+                // DeepSeek V4's hyper-connection projection is a very thin
+                // [16384, 24] F16 matrix.  Speculative verification normally
+                // reaches it with four columns.  gfx1151 is classified as
+                // RDNA 3.5 below, where the generic crossover stops at three
+                // columns and sends q=4 to hipBLAS.  On Strix Halo that tiny
+                // GEMM is launch/tiling bound; the row-split Wave32 MMVF path
+                // is the better fit.  Keep this narrowly scoped until wider
+                // RDNA 3.5 shapes have their own measurements.
+                static const bool gfx1151_hc_q4_mmvf = [] {
+                    const char * value = std::getenv(
+                        "DFLASH_GFX1151_HC_MMVF_Q4");
+                    return !value || std::atoi(value) != 0;
+                }();
+                if (gfx1151_hc_q4_mmvf && GGML_CUDA_CC_IS_RDNA3_5(cc) &&
+                    src0_ne[0] == 16384 && src0_ne[1] == 24 && ne11 == 4) {
+                    return true;
+                }
                 if (fp16_mma_hardware_available(cc)) {
                     if (GGML_CUDA_CC_IS_RDNA3(cc)) {
                         return ne11 <= 3;

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/moe-fused.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/moe-fused.cu
@@ -4,6 +4,8 @@
 #include "ggml-cuda/mmvq.cuh"
 
 #include <climits>
+#include <cstdint>
+#include <cstdlib>
 #include <cstring>
 
 static __device__ __forceinline__ float silu_f32(float x) {
@@ -310,6 +312,115 @@ static __global__ void laguna_moe_combine_kernel(
         (size_t)t * output_nb1) = sum;
 }
 
+static __global__ void moe_combine_vec4_kernel(
+    const char * __restrict__ experts,
+    const char * __restrict__ weights,
+    char * __restrict__ output,
+    const int n_embd_vec4,
+    const int n_used,
+    const int n_tokens,
+    const size_t experts_nb1,
+    const size_t experts_nb2,
+    const size_t weights_nb0,
+    const size_t weights_nb1,
+    const size_t output_nb1,
+    const float value_scale) {
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    const int total = n_embd_vec4 * n_tokens;
+    if (idx >= total) return;
+
+    const int h4 = idx % n_embd_vec4;
+    const int t = idx / n_embd_vec4;
+    float4 sum = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+    for (int e = 0; e < n_used; ++e) {
+        const float w = *(const float *)(weights +
+            (size_t)e * weights_nb0 +
+            (size_t)t * weights_nb1);
+        if (w == 0.0f) {
+            if (e == 0) sum = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+            continue;
+        }
+        const float4 value = *(const float4 *)(experts +
+            (size_t)h4 * sizeof(float4) +
+            (size_t)e * experts_nb1 +
+            (size_t)t * experts_nb2);
+        const float4 scaled = value_scale == 1.0f
+            ? value
+            : make_float4(
+                __fmul_rn(value.x, value_scale),
+                __fmul_rn(value.y, value_scale),
+                __fmul_rn(value.z, value_scale),
+                __fmul_rn(value.w, value_scale));
+        const float4 product = make_float4(
+            __fmul_rn(scaled.x, w),
+            __fmul_rn(scaled.y, w),
+            __fmul_rn(scaled.z, w),
+            __fmul_rn(scaled.w, w));
+        if (e == 0) {
+            sum = product;
+        } else {
+            sum.x = __fadd_rn(sum.x, product.x);
+            sum.y = __fadd_rn(sum.y, product.y);
+            sum.z = __fadd_rn(sum.z, product.z);
+            sum.w = __fadd_rn(sum.w, product.w);
+        }
+    }
+    *(float4 *)(output +
+        (size_t)h4 * sizeof(float4) +
+        (size_t)t * output_nb1) = sum;
+}
+
+static void launch_moe_combine(
+        cudaStream_t stream,
+        const char * experts,
+        const char * weights,
+        char * output,
+        int n_embd,
+        int n_used,
+        int n_tokens,
+        size_t experts_nb0,
+        size_t experts_nb1,
+        size_t experts_nb2,
+        size_t weights_nb0,
+        size_t weights_nb1,
+        size_t output_nb0,
+        size_t output_nb1,
+        float value_scale) {
+    static const bool vec4_requested = []() {
+        const char * raw = std::getenv("DFLASH_MOE_COMBINE_VEC4");
+        return raw && *raw && std::strcmp(raw, "0") != 0;
+    }();
+    static_assert(sizeof(float4) == 4 * sizeof(float));
+    constexpr size_t vec4_alignment = sizeof(float4);
+    const bool aligned =
+        (reinterpret_cast<uintptr_t>(experts) % vec4_alignment) == 0 &&
+        (reinterpret_cast<uintptr_t>(output) % vec4_alignment) == 0 &&
+        experts_nb1 % vec4_alignment == 0 &&
+        experts_nb2 % vec4_alignment == 0 &&
+        output_nb1 % vec4_alignment == 0;
+    const bool use_vec4 = vec4_requested && n_embd % 4 == 0 && aligned &&
+        experts_nb0 == sizeof(float) && output_nb0 == sizeof(float);
+    constexpr int block = 256;
+    if (use_vec4) {
+        const int n_embd_vec4 = n_embd / 4;
+        const int total = n_embd_vec4 * n_tokens;
+        const int grid = (total + block - 1) / block;
+        moe_combine_vec4_kernel<<<grid, block, 0, stream>>>(
+            experts, weights, output, n_embd_vec4, n_used, n_tokens,
+            experts_nb1, experts_nb2, weights_nb0, weights_nb1,
+            output_nb1, value_scale);
+        return;
+    }
+
+    const int total = n_embd * n_tokens;
+    const int grid = (total + block - 1) / block;
+    laguna_moe_combine_kernel<<<grid, block, 0, stream>>>(
+        experts, weights, output, n_embd, n_used, n_tokens,
+        experts_nb0, experts_nb1, experts_nb2,
+        weights_nb0, weights_nb1, output_nb0, output_nb1,
+        value_scale);
+}
+
 static __global__ void ds4_peer_copy_f32_kernel(
         const float * __restrict__ src,
         float * __restrict__ dst,
@@ -561,10 +672,8 @@ static void ggml_cuda_op_ds4_moe_owner(
     ggml_cuda_mul_mat_vec_q(
         ctx, down_w, &gu, expert_ids, &experts, nullptr);
 
-    const int total = n_embd * n_tokens;
-    const int block = 256;
-    const int grid = (total + block - 1) / block;
-    laguna_moe_combine_kernel<<<grid, block, 0, ctx.stream()>>>(
+    launch_moe_combine(
+        ctx.stream(),
         (const char *) experts.data,
         (const char *) weights->data,
         (char *) dst->data,
@@ -634,10 +743,8 @@ static void ggml_cuda_op_ds4_moe_owner_split(
     ggml_cuda_mul_mat_vec_q(
         ctx, down_w, &gu, expert_ids, &experts, nullptr);
 
-    const int total = n_embd * n_tokens;
-    const int block = 256;
-    const int grid = (total + block - 1) / block;
-    laguna_moe_combine_kernel<<<grid, block, 0, ctx.stream()>>>(
+    launch_moe_combine(
+        ctx.stream(),
         (const char *) experts.data,
         (const char *) weights->data,
         (char *) dst->data,
@@ -760,11 +867,8 @@ void ggml_cuda_op_moe_fused(ggml_backend_cuda_context & ctx, ggml_tensor * dst) 
         const int n_embd   = (int) experts->ne[0];
         const int n_used   = (int) experts->ne[1];
         const int n_tokens = (int) experts->ne[2];
-        const int total = n_embd * n_tokens;
-
-        const int block = 256;
-        const int grid = (total + block - 1) / block;
-        laguna_moe_combine_kernel<<<grid, block, 0, ctx.stream()>>>(
+        launch_moe_combine(
+            ctx.stream(),
             (const char *) experts->data,
             (const char *) weights->data,
             (char *) dst->data,

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/rocmfp2_mix.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/rocmfp2_mix.cu
@@ -7,7 +7,9 @@
 // For ggml_cuda_op_swiglu_ds4_single: the fused path must apply the EXACT function the
 // standalone swiglu_ds4 kernel applies, not a re-derivation of the formula.
 #include "unary.cuh"
+#include <cstdlib>
 #include <cstdint>
+#include <cstring>
 #include <limits>
 #include <mutex>
 #include <vector>
@@ -56,6 +58,7 @@ struct MixEntry {
     const nv_bfloat16 * codebooks;  // n_experts * 2 * 4
     const uint8_t * modes;          // n_experts
     int  device;          // device the side-data lives on; frees must happen in that context
+    bool gfx1151;         // registration-time dispatch tuning; no hot-path device query
 };
 // Dispatch wrappers keep this lock from lookup through kernel enqueue. It is
 // recursive because MMQ takes the public dispatch lock and then calls the
@@ -81,6 +84,28 @@ static int mix_device_of(const void * p) {
     }
     cudaGetLastError();   // clear the error a non-device pointer sets
     return dev;
+}
+
+static bool mix_device_is_gfx1151(int device) {
+#if defined(GGML_USE_HIP)
+    cudaDeviceProp prop{};
+    return cudaGetDeviceProperties(&prop, device) == cudaSuccess &&
+           std::strncmp(prop.gcnArchName, "gfx1151", 7) == 0;
+#else
+    (void) device;
+    return false;
+#endif
+}
+
+static bool mix_gfx1151_row4_enabled() {
+    static const bool enabled = [] {
+        const char * value = std::getenv("DFLASH_ROCMFP2_ROW4");
+        // Qualified on gfx1151 for verifier-width matvecs. Keep an explicit
+        // burn-in kill switch while leaving every other architecture and q<=2
+        // on the existing two-row kernel.
+        return value == nullptr || std::strcmp(value, "0") != 0;
+    }();
+    return enabled;
 }
 
 // RAII device switch: restores the previous device even on the early-return error paths.
@@ -187,7 +212,7 @@ void mix_register_impl(const void * base, size_t nb02, int n_experts, int out, i
     const size_t expert_bytes =
         (size_t) out * (size_t) (in / MIX_QK) * MIX_BLOCK_BYTES;
     MixEntry ne{base, nb02, expert_bytes, n_experts, out, in, codebooks, modes,
-                device};
+                device, mix_device_is_gfx1151(device)};
     for (auto & e : g_mix_registry) {
         if (e.base == base) {  // update in place — free the old owned buffers first
             mix_free_entry_device(e);
@@ -464,6 +489,22 @@ __device__ __forceinline__ void mix_block_accum(
     // block reads up to 6 B past the tensor end. That is now REJECTED AT REGISTRATION
     // (see the in % 128 guard in ggml_cuda_rocmfp2_mix_register_host) rather than
     // left to chance, so this loop can stay branch-free.
+#if defined(__HIP_PLATFORM_AMD__) && defined(__gfx1151__)
+    // gfx1151 supports unaligned flat loads. Read the exact 10-byte payload as
+    // one 8-byte code word plus the 2-byte metadata tail. The old aligned-floor
+    // path fetched two overlapping 8-byte windows for every 10-byte block, so
+    // adjacent lanes requested 16 bytes for 10 bytes of useful weights. Keeping
+    // the packed code word in one register also preserves the existing decode
+    // and accumulation order exactly.
+    uint64_t codes;
+    uint16_t meta;
+    MIX_MEMCPY(&codes, b, sizeof(codes));
+    MIX_MEMCPY(&meta, b + MIX_QS, sizeof(meta));
+    const uint8_t m0 = (uint8_t) meta;
+    const uint8_t m1 = (uint8_t) (meta >> 8);
+#else
+    // Portable fallback: load the two aligned 8-byte windows bracketing this
+    // 10-byte block, then extract the payload in registers.
     const uintptr_t addr  = (uintptr_t) b;
     const uint8_t * base8 = (const uint8_t *) MIX_ASSUME_ALIGNED(
             (const void *) (addr & ~(uintptr_t) 7), 8);
@@ -474,6 +515,7 @@ __device__ __forceinline__ void mix_block_accum(
     const uint64_t codes = (sh == 0) ? lo : ((lo >> sh) | (hi << (64 - sh)));
     const uint8_t  m0    = (uint8_t) (hi >> sh);         // block byte MIX_QS+0
     const uint8_t  m1    = (uint8_t) (hi >> (sh + 8));   // block byte MIX_QS+1
+#endif
     if (mode == 0) {
         const float s0 = mix_ue4m3(m0), s1 = mix_ue4m3(m1);
         #pragma unroll
@@ -503,6 +545,153 @@ __device__ __forceinline__ void mix_block_accum(
             acc += s * bk[mix_fp2_code_u64(codes, j)] * xc[col0 + j];
         }
     }
+}
+
+// Accumulate the same activation block into two output rows. Keeping the two
+// row folds in one j-loop makes activation reuse explicit: xc[col0 + j] has one
+// live range and feeds both independent accumulators. Each accumulator still
+// sees exactly the same ascending-j sequence and expression as
+// mix_block_accum(), so this does not reassociate either dot product.
+__device__ __forceinline__ void mix_block_accum2(
+        const uint8_t * __restrict__ b0, const uint8_t * __restrict__ b1,
+        const float * __restrict__ xc, int col0,
+        int mode, const float * __restrict__ lut, float & acc0, float & acc1) {
+#if defined(__HIP_PLATFORM_AMD__) && defined(__gfx1151__)
+    uint64_t codes0, codes1;
+    uint16_t meta0, meta1;
+    MIX_MEMCPY(&codes0, b0, sizeof(codes0));
+    MIX_MEMCPY(&meta0, b0 + MIX_QS, sizeof(meta0));
+    MIX_MEMCPY(&codes1, b1, sizeof(codes1));
+    MIX_MEMCPY(&meta1, b1 + MIX_QS, sizeof(meta1));
+    const uint8_t m00 = (uint8_t) meta0;
+    const uint8_t m01 = (uint8_t) (meta0 >> 8);
+    const uint8_t m10 = (uint8_t) meta1;
+    const uint8_t m11 = (uint8_t) (meta1 >> 8);
+#else
+    const uintptr_t addr0 = (uintptr_t) b0;
+    const uintptr_t addr1 = (uintptr_t) b1;
+    const uint8_t * base80 = (const uint8_t *) MIX_ASSUME_ALIGNED(
+            (const void *) (addr0 & ~(uintptr_t) 7), 8);
+    const uint8_t * base81 = (const uint8_t *) MIX_ASSUME_ALIGNED(
+            (const void *) (addr1 & ~(uintptr_t) 7), 8);
+    const int sh0 = (int) (addr0 & 7) * 8;
+    const int sh1 = (int) (addr1 & 7) * 8;
+    uint64_t lo0, hi0, lo1, hi1;
+    MIX_MEMCPY(&lo0, base80, 8);
+    MIX_MEMCPY(&hi0, base80 + 8, 8);
+    MIX_MEMCPY(&lo1, base81, 8);
+    MIX_MEMCPY(&hi1, base81 + 8, 8);
+    const uint64_t codes0 = (sh0 == 0) ? lo0 : ((lo0 >> sh0) | (hi0 << (64 - sh0)));
+    const uint64_t codes1 = (sh1 == 0) ? lo1 : ((lo1 >> sh1) | (hi1 << (64 - sh1)));
+    const uint8_t m00 = (uint8_t) (hi0 >> sh0);
+    const uint8_t m01 = (uint8_t) (hi0 >> (sh0 + 8));
+    const uint8_t m10 = (uint8_t) (hi1 >> sh1);
+    const uint8_t m11 = (uint8_t) (hi1 >> (sh1 + 8));
+#endif
+    if (mode == 0) {
+        const float s00 = mix_ue4m3(m00), s01 = mix_ue4m3(m01);
+        const float s10 = mix_ue4m3(m10), s11 = mix_ue4m3(m11);
+        #pragma unroll
+        for (int j = 0; j < MIX_QK; ++j) {
+            const float x = xc[col0 + j];
+            const float rs0 = (j < MIX_QK/2) ? s00 : s01;
+            const float rs1 = (j < MIX_QK/2) ? s10 : s11;
+            acc0 += rs0 * mix_fp2_fixed(mix_fp2_code_u64(codes0, j)) * x;
+            acc1 += rs1 * mix_fp2_fixed(mix_fp2_code_u64(codes1, j)) * x;
+        }
+    } else {
+        const float s00 = mix_ue4m3(m00 & 0x7F), s01 = mix_ue4m3(m01 & 0x7F);
+        const float s10 = mix_ue4m3(m10 & 0x7F), s11 = mix_ue4m3(m11 & 0x7F);
+        const float * bk00 = lut + (m00 >> 7) * MIX_K;
+        const float * bk01 = lut + (m01 >> 7) * MIX_K;
+        const float * bk10 = lut + (m10 >> 7) * MIX_K;
+        const float * bk11 = lut + (m11 >> 7) * MIX_K;
+        #pragma unroll
+        for (int j = 0; j < MIX_QK; ++j) {
+            const float x = xc[col0 + j];
+            const float rs0 = (j < MIX_QK/2) ? s00 : s01;
+            const float rs1 = (j < MIX_QK/2) ? s10 : s11;
+            const float * rbk0 = (j < MIX_QK/2) ? bk00 : bk01;
+            const float * rbk1 = (j < MIX_QK/2) ? bk10 : bk11;
+            acc0 += rs0 * rbk0[mix_fp2_code_u64(codes0, j)] * x;
+            acc1 += rs1 * rbk1[mix_fp2_code_u64(codes1, j)] * x;
+        }
+    }
+}
+
+// The gfx1151 verifier exposes enough independent workgroups that a wave can
+// spend a few more registers to reuse each activation across four output rows.
+// Each accumulator keeps the exact per-row operation and summation order of
+// mix_block_accum(), so the optimization is bit-preserving rather than an
+// approximate reduction change.
+__device__ __forceinline__ void mix_block_accum4(
+        const uint8_t * __restrict__ b0, const uint8_t * __restrict__ b1,
+        const uint8_t * __restrict__ b2, const uint8_t * __restrict__ b3,
+        const float * __restrict__ xc, int col0,
+        int mode, const float * __restrict__ lut,
+        float & acc0, float & acc1, float & acc2, float & acc3) {
+#if defined(__HIP_PLATFORM_AMD__) && defined(__gfx1151__)
+    uint64_t codes0, codes1, codes2, codes3;
+    uint16_t meta0, meta1, meta2, meta3;
+    MIX_MEMCPY(&codes0, b0, sizeof(codes0));
+    MIX_MEMCPY(&meta0, b0 + MIX_QS, sizeof(meta0));
+    MIX_MEMCPY(&codes1, b1, sizeof(codes1));
+    MIX_MEMCPY(&meta1, b1 + MIX_QS, sizeof(meta1));
+    MIX_MEMCPY(&codes2, b2, sizeof(codes2));
+    MIX_MEMCPY(&meta2, b2 + MIX_QS, sizeof(meta2));
+    MIX_MEMCPY(&codes3, b3, sizeof(codes3));
+    MIX_MEMCPY(&meta3, b3 + MIX_QS, sizeof(meta3));
+    const uint8_t m00 = (uint8_t) meta0, m01 = (uint8_t) (meta0 >> 8);
+    const uint8_t m10 = (uint8_t) meta1, m11 = (uint8_t) (meta1 >> 8);
+    const uint8_t m20 = (uint8_t) meta2, m21 = (uint8_t) (meta2 >> 8);
+    const uint8_t m30 = (uint8_t) meta3, m31 = (uint8_t) (meta3 >> 8);
+    if (mode == 0) {
+        const float s00 = mix_ue4m3(m00), s01 = mix_ue4m3(m01);
+        const float s10 = mix_ue4m3(m10), s11 = mix_ue4m3(m11);
+        const float s20 = mix_ue4m3(m20), s21 = mix_ue4m3(m21);
+        const float s30 = mix_ue4m3(m30), s31 = mix_ue4m3(m31);
+        #pragma unroll
+        for (int j = 0; j < MIX_QK; ++j) {
+            const float x = xc[col0 + j];
+            acc0 += ((j < MIX_QK/2) ? s00 : s01) *
+                    mix_fp2_fixed(mix_fp2_code_u64(codes0, j)) * x;
+            acc1 += ((j < MIX_QK/2) ? s10 : s11) *
+                    mix_fp2_fixed(mix_fp2_code_u64(codes1, j)) * x;
+            acc2 += ((j < MIX_QK/2) ? s20 : s21) *
+                    mix_fp2_fixed(mix_fp2_code_u64(codes2, j)) * x;
+            acc3 += ((j < MIX_QK/2) ? s30 : s31) *
+                    mix_fp2_fixed(mix_fp2_code_u64(codes3, j)) * x;
+        }
+    } else {
+        const float s00 = mix_ue4m3(m00 & 0x7F), s01 = mix_ue4m3(m01 & 0x7F);
+        const float s10 = mix_ue4m3(m10 & 0x7F), s11 = mix_ue4m3(m11 & 0x7F);
+        const float s20 = mix_ue4m3(m20 & 0x7F), s21 = mix_ue4m3(m21 & 0x7F);
+        const float s30 = mix_ue4m3(m30 & 0x7F), s31 = mix_ue4m3(m31 & 0x7F);
+        const float * bk00 = lut + (m00 >> 7) * MIX_K;
+        const float * bk01 = lut + (m01 >> 7) * MIX_K;
+        const float * bk10 = lut + (m10 >> 7) * MIX_K;
+        const float * bk11 = lut + (m11 >> 7) * MIX_K;
+        const float * bk20 = lut + (m20 >> 7) * MIX_K;
+        const float * bk21 = lut + (m21 >> 7) * MIX_K;
+        const float * bk30 = lut + (m30 >> 7) * MIX_K;
+        const float * bk31 = lut + (m31 >> 7) * MIX_K;
+        #pragma unroll
+        for (int j = 0; j < MIX_QK; ++j) {
+            const float x = xc[col0 + j];
+            acc0 += ((j < MIX_QK/2) ? s00 : s01) *
+                    ((j < MIX_QK/2) ? bk00 : bk01)[mix_fp2_code_u64(codes0, j)] * x;
+            acc1 += ((j < MIX_QK/2) ? s10 : s11) *
+                    ((j < MIX_QK/2) ? bk10 : bk11)[mix_fp2_code_u64(codes1, j)] * x;
+            acc2 += ((j < MIX_QK/2) ? s20 : s21) *
+                    ((j < MIX_QK/2) ? bk20 : bk21)[mix_fp2_code_u64(codes2, j)] * x;
+            acc3 += ((j < MIX_QK/2) ? s30 : s31) *
+                    ((j < MIX_QK/2) ? bk30 : bk31)[mix_fp2_code_u64(codes3, j)] * x;
+        }
+    }
+#else
+    mix_block_accum2(b0, b1, xc, col0, mode, lut, acc0, acc1);
+    mix_block_accum2(b2, b3, xc, col0, mode, lut, acc2, acc3);
+#endif
 }
 
 // The lane's block loop is unrolled by MIX_UNROLL into a SINGLE accumulator kept
@@ -658,13 +847,15 @@ __global__ void mix_matvec_rocmfp2_slice_kernel(
         #pragma unroll
         for (int u = 0; u < MIX_UNROLL; ++u) {
             const int b = blk + u * MIX_WARP;
-            mix_block_accum(rowbase0 + (int64_t) b * MIX_BLOCK_BYTES, xcol, b * MIX_QK, mode, s_lut, acc0);
-            mix_block_accum(rowbase1 + (int64_t) b * MIX_BLOCK_BYTES, xcol, b * MIX_QK, mode, s_lut, acc1);
+            mix_block_accum2(rowbase0 + (int64_t) b * MIX_BLOCK_BYTES,
+                             rowbase1 + (int64_t) b * MIX_BLOCK_BYTES,
+                             xcol, b * MIX_QK, mode, s_lut, acc0, acc1);
         }
     }
     for (; blk < nb; blk += MIX_WARP) {
-        mix_block_accum(rowbase0 + (int64_t) blk * MIX_BLOCK_BYTES, xcol, blk * MIX_QK, mode, s_lut, acc0);
-        mix_block_accum(rowbase1 + (int64_t) blk * MIX_BLOCK_BYTES, xcol, blk * MIX_QK, mode, s_lut, acc1);
+        mix_block_accum2(rowbase0 + (int64_t) blk * MIX_BLOCK_BYTES,
+                         rowbase1 + (int64_t) blk * MIX_BLOCK_BYTES,
+                         xcol, blk * MIX_QK, mode, s_lut, acc0, acc1);
     }
     #pragma unroll
     for (int off = MIX_WARP/2; off > 0; off >>= 1) {
@@ -677,21 +868,27 @@ __global__ void mix_matvec_rocmfp2_slice_kernel(
     }
 }
 
-// FUSE_GLU folds the SECOND mul_mat_id of a DeepSeek4 gate/up pair plus the SwiGLU into this
-// launch. The unfused shape is two matvec launches writing two [n_ff_exp, n_used, ntok]
-// intermediates, then a third kernel reading both back to apply the GLU. qtype 107 never paid
-// that: ggml_cuda_try_fuse_mul_mat_glu collapses the trio into one mul_mat_vec_q, which is why
-// the profile showed 107 at 15050 launches against 106's 30100 plus a 28 ms swiglu_ds4 pass.
+// GLU_MODE folds a DeepSeek4 gate/up pair plus SwiGLU into the MoE matvec path:
 //
-// TEMPLATED rather than a second kernel on purpose: both instantiations run the SAME
+//   0: ordinary one-tensor matvec;
+//   1: one-pass gate+up matvec and SwiGLU (best for q <= 2);
+//   2: gate matvec that reads a preceding up result from dst and overwrites it
+//      with SwiGLU(gate, up) (paired with mode 0 for wider verification).
+//
+// The two-pass form keeps each kernel at the lower register footprint of a
+// one-tensor matvec. On gfx1151 the one-pass kernel wins through q=2 by
+// avoiding a launch, but loses once wider verification exposes its occupancy cost.
+// Both forms remove the old third, standalone SwiGLU launch.
+//
+// TEMPLATED rather than copied kernels on purpose: all instantiations run the SAME
 // accumulation over the SAME fixed block order, so each dot product is bit-identical to what
-// the unfused path computes, and the fused result is bit-identical to
+// the unfused path computes, and either fused result is bit-identical to
 // swiglu_ds4(unfused_gate, unfused_up). A copy-pasted kernel would only *probably* stay that way.
 //
 // Naming follows the mmvq fusion convention: the PRIMARY tensor is `up` (src0 of the surviving
 // mul_mat_id) and `gate` arrives as the extra operand, because
 // ggml_cuda_op_swiglu_ds4_single(gate, up, limit) is not symmetric -- silu() is applied to gate.
-template <bool FUSE_GLU>
+template <int GLU_MODE, int ROWS_PER_WARP = 2>
 __global__ void mix_matvec_rocmfp2_moe_kernel(
         const uint8_t * __restrict__ data, size_t nb02,
         const nv_bfloat16 * __restrict__ codebooks, const uint8_t * __restrict__ modes,
@@ -700,15 +897,19 @@ __global__ void mix_matvec_rocmfp2_moe_kernel(
         int64_t ids_s0, int64_t ids_s1,       // element strides (int32) over slot, token
         int64_t src1_s1, int64_t src1_s2,     // element strides (float) over ne11, token
         int64_t dst_s1, int64_t dst_s2,       // element strides (float) over slot, token
-        // FUSE_GLU only. The gate tensor's own registry entry -- separate codebooks and modes,
+        // GLU_MODE=1 only. The gate tensor's own registry entry -- separate codebooks and modes,
         // NOT assumed equal to up's. Producers may emit identical codebooks for the two
         // halves, but the kernel does not rely on that and staging both costs 32 B of LDS.
         const uint8_t * __restrict__ gdata, size_t gnb02,
         const nv_bfloat16 * __restrict__ gcodebooks, const uint8_t * __restrict__ gmodes,
         float glu_limit) {
+    constexpr bool DUAL_GLU     = GLU_MODE == 1;
+    constexpr bool FINALIZE_GLU = GLU_MODE == 2;
+    static_assert(ROWS_PER_WARP == 2 || ROWS_PER_WARP == 4,
+                  "ROCmFP2 MoE rows per wave must be 2 or 4");
     const int warps_per_block = blockDim.x / MIX_WARP;
     const int warp  = blockIdx.x * warps_per_block + (threadIdx.x / MIX_WARP);
-    const int row0  = warp * 2;                 // two output rows per warp
+    const int row0  = warp * ROWS_PER_WARP;
     const int lane  = threadIdx.x % MIX_WARP;
     const int slot  = blockIdx.y;
     const int token = blockIdx.z;
@@ -727,12 +928,12 @@ __global__ void mix_matvec_rocmfp2_moe_kernel(
     const bool bad_expert = expert < 0 || expert >= n_experts;
     // Both tables in one array so the staging stays a single guarded write per thread and one
     // barrier. Gate's table occupies [2*MIX_K, 4*MIX_K).
-    __shared__ float s_lut[FUSE_GLU ? 4 * MIX_K : 2 * MIX_K];
+    __shared__ float s_lut[DUAL_GLU ? 4 * MIX_K : 2 * MIX_K];
     if (!bad_expert && (int) threadIdx.x < 2 * MIX_K) {
         s_lut[threadIdx.x] =
             __bfloat162float(codebooks[(int64_t) expert * 2 * MIX_K + threadIdx.x]);
     }
-    if (FUSE_GLU) {
+    if (DUAL_GLU) {
         const int gt = (int) threadIdx.x - 2 * MIX_K;
         if (!bad_expert && gt >= 0 && gt < 2 * MIX_K) {
             s_lut[2 * MIX_K + gt] =
@@ -746,11 +947,17 @@ __global__ void mix_matvec_rocmfp2_moe_kernel(
             const int64_t o = (int64_t) token * dst_s2 + (int64_t) slot * dst_s1 + row0;
             dst[o] = 0.0f;
             if (row0 + 1 < out) dst[o + 1] = 0.0f;
+            if constexpr (ROWS_PER_WARP == 4) {
+                if (row0 + 2 < out) dst[o + 2] = 0.0f;
+                if (row0 + 3 < out) dst[o + 3] = 0.0f;
+            }
         }
         return;
     }
 
     const bool two  = (row0 + 1) < out;         // false only for an odd-out tail warp
+    const bool three = (row0 + 2) < out;
+    const bool four  = (row0 + 3) < out;
     const uint8_t     * edata   = data + (int64_t) expert * nb02;
     const int           mode    = (int) modes[expert];
     const int           nb      = in / MIX_QK;
@@ -760,14 +967,24 @@ __global__ void mix_matvec_rocmfp2_moe_kernel(
     // true across the whole warp (no divergence in the hot loop).
     const uint8_t     * rowbase1 = two ? edata + (int64_t) (row0 + 1) * nb * MIX_BLOCK_BYTES
                                        : rowbase0;
+    const uint8_t     * rowbase2 = three ? edata + (int64_t) (row0 + 2) * nb * MIX_BLOCK_BYTES
+                                         : rowbase0;
+    const uint8_t     * rowbase3 = four ? edata + (int64_t) (row0 + 3) * nb * MIX_BLOCK_BYTES
+                                        : rowbase0;
     // Gate shares the shape, the expert and the row indices -- only the bytes and the table
     // differ -- so it reuses `nb`, `two`, `row0` and the same activation column below.
-    const uint8_t * gedata    = FUSE_GLU ? gdata + (int64_t) expert * gnb02 : nullptr;
-    const int       gmode     = FUSE_GLU ? (int) gmodes[expert] : 0;
-    const uint8_t * growbase0 = FUSE_GLU ? gedata + (int64_t) row0 * nb * MIX_BLOCK_BYTES
+    const uint8_t * gedata    = DUAL_GLU ? gdata + (int64_t) expert * gnb02 : nullptr;
+    const int       gmode     = DUAL_GLU ? (int) gmodes[expert] : 0;
+    const uint8_t * growbase0 = DUAL_GLU ? gedata + (int64_t) row0 * nb * MIX_BLOCK_BYTES
                                          : nullptr;
-    const uint8_t * growbase1 = FUSE_GLU ? (two ? gedata + (int64_t) (row0 + 1) * nb * MIX_BLOCK_BYTES
+    const uint8_t * growbase1 = DUAL_GLU ? (two ? gedata + (int64_t) (row0 + 1) * nb * MIX_BLOCK_BYTES
                                                 : growbase0)
+                                         : nullptr;
+    const uint8_t * growbase2 = DUAL_GLU ? (three ? gedata + (int64_t) (row0 + 2) * nb * MIX_BLOCK_BYTES
+                                                   : growbase0)
+                                         : nullptr;
+    const uint8_t * growbase3 = DUAL_GLU ? (four ? gedata + (int64_t) (row0 + 3) * nb * MIX_BLOCK_BYTES
+                                                  : growbase0)
                                          : nullptr;
     // src1 is [in, ne11, ntok]; the get_rows-equivalent row for (slot, token)
     // is token*ne11 + slot%ne11 — i.e. token column + the slot%ne11 broadcast.
@@ -779,52 +996,120 @@ __global__ void mix_matvec_rocmfp2_moe_kernel(
     // same __restrict__ xcol + col0, so the compiler CSEs the strided activation
     // loads to one issue per element — halving activation LSU issue on this partly
     // load-instruction-bound matvec — WITHOUT reordering either row's summation.
-    float acc0 = 0.0f, acc1 = 0.0f;
+    float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f, acc3 = 0.0f;
     // Gate accumulates in its own registers over the SAME block order, so gacc is bit-identical
     // to what the separate gate launch produced. All four folds share one `xcol`, so the fused
     // form reads the activation column once for four rows instead of once for two -- on a launch
     // that is partly load-issue bound, that is the second saving after the launch itself.
-    float gacc0 = 0.0f, gacc1 = 0.0f;
+    float gacc0 = 0.0f, gacc1 = 0.0f, gacc2 = 0.0f, gacc3 = 0.0f;
     int blk = lane;
     for (; blk + (MIX_UNROLL - 1) * MIX_WARP < nb; blk += MIX_UNROLL * MIX_WARP) {
         #pragma unroll
         for (int u = 0; u < MIX_UNROLL; ++u) {
             const int b = blk + u * MIX_WARP;
-            mix_block_accum(rowbase0 + (int64_t) b * MIX_BLOCK_BYTES, xcol, b * MIX_QK, mode, s_lut, acc0);
-            mix_block_accum(rowbase1 + (int64_t) b * MIX_BLOCK_BYTES, xcol, b * MIX_QK, mode, s_lut, acc1);
-            if (FUSE_GLU) {
-                mix_block_accum(growbase0 + (int64_t) b * MIX_BLOCK_BYTES, xcol, b * MIX_QK, gmode, s_lut + 2 * MIX_K, gacc0);
-                mix_block_accum(growbase1 + (int64_t) b * MIX_BLOCK_BYTES, xcol, b * MIX_QK, gmode, s_lut + 2 * MIX_K, gacc1);
+            if constexpr (ROWS_PER_WARP == 4) {
+                mix_block_accum4(rowbase0 + (int64_t) b * MIX_BLOCK_BYTES,
+                                 rowbase1 + (int64_t) b * MIX_BLOCK_BYTES,
+                                 rowbase2 + (int64_t) b * MIX_BLOCK_BYTES,
+                                 rowbase3 + (int64_t) b * MIX_BLOCK_BYTES,
+                                 xcol, b * MIX_QK, mode, s_lut,
+                                 acc0, acc1, acc2, acc3);
+            } else {
+                mix_block_accum2(rowbase0 + (int64_t) b * MIX_BLOCK_BYTES,
+                                 rowbase1 + (int64_t) b * MIX_BLOCK_BYTES,
+                                 xcol, b * MIX_QK, mode, s_lut, acc0, acc1);
+            }
+            if (DUAL_GLU) {
+                if constexpr (ROWS_PER_WARP == 4) {
+                    mix_block_accum4(growbase0 + (int64_t) b * MIX_BLOCK_BYTES,
+                                     growbase1 + (int64_t) b * MIX_BLOCK_BYTES,
+                                     growbase2 + (int64_t) b * MIX_BLOCK_BYTES,
+                                     growbase3 + (int64_t) b * MIX_BLOCK_BYTES,
+                                     xcol, b * MIX_QK, gmode, s_lut + 2 * MIX_K,
+                                     gacc0, gacc1, gacc2, gacc3);
+                } else {
+                    mix_block_accum2(growbase0 + (int64_t) b * MIX_BLOCK_BYTES,
+                                     growbase1 + (int64_t) b * MIX_BLOCK_BYTES,
+                                     xcol, b * MIX_QK, gmode, s_lut + 2 * MIX_K,
+                                     gacc0, gacc1);
+                }
             }
         }
     }
     for (; blk < nb; blk += MIX_WARP) {
-        mix_block_accum(rowbase0 + (int64_t) blk * MIX_BLOCK_BYTES, xcol, blk * MIX_QK, mode, s_lut, acc0);
-        mix_block_accum(rowbase1 + (int64_t) blk * MIX_BLOCK_BYTES, xcol, blk * MIX_QK, mode, s_lut, acc1);
-        if (FUSE_GLU) {
-            mix_block_accum(growbase0 + (int64_t) blk * MIX_BLOCK_BYTES, xcol, blk * MIX_QK, gmode, s_lut + 2 * MIX_K, gacc0);
-            mix_block_accum(growbase1 + (int64_t) blk * MIX_BLOCK_BYTES, xcol, blk * MIX_QK, gmode, s_lut + 2 * MIX_K, gacc1);
+        if constexpr (ROWS_PER_WARP == 4) {
+            mix_block_accum4(rowbase0 + (int64_t) blk * MIX_BLOCK_BYTES,
+                             rowbase1 + (int64_t) blk * MIX_BLOCK_BYTES,
+                             rowbase2 + (int64_t) blk * MIX_BLOCK_BYTES,
+                             rowbase3 + (int64_t) blk * MIX_BLOCK_BYTES,
+                             xcol, blk * MIX_QK, mode, s_lut,
+                             acc0, acc1, acc2, acc3);
+        } else {
+            mix_block_accum2(rowbase0 + (int64_t) blk * MIX_BLOCK_BYTES,
+                             rowbase1 + (int64_t) blk * MIX_BLOCK_BYTES,
+                             xcol, blk * MIX_QK, mode, s_lut, acc0, acc1);
+        }
+        if (DUAL_GLU) {
+            if constexpr (ROWS_PER_WARP == 4) {
+                mix_block_accum4(growbase0 + (int64_t) blk * MIX_BLOCK_BYTES,
+                                 growbase1 + (int64_t) blk * MIX_BLOCK_BYTES,
+                                 growbase2 + (int64_t) blk * MIX_BLOCK_BYTES,
+                                 growbase3 + (int64_t) blk * MIX_BLOCK_BYTES,
+                                 xcol, blk * MIX_QK, gmode, s_lut + 2 * MIX_K,
+                                 gacc0, gacc1, gacc2, gacc3);
+            } else {
+                mix_block_accum2(growbase0 + (int64_t) blk * MIX_BLOCK_BYTES,
+                                 growbase1 + (int64_t) blk * MIX_BLOCK_BYTES,
+                                 xcol, blk * MIX_QK, gmode, s_lut + 2 * MIX_K,
+                                 gacc0, gacc1);
+            }
         }
     }
     #pragma unroll
     for (int off = MIX_WARP/2; off > 0; off >>= 1) {
         acc0 += mix_warp_shfl_down(acc0, off);
         acc1 += mix_warp_shfl_down(acc1, off);
-        if (FUSE_GLU) {
+        if constexpr (ROWS_PER_WARP == 4) {
+            acc2 += mix_warp_shfl_down(acc2, off);
+            acc3 += mix_warp_shfl_down(acc3, off);
+        }
+        if (DUAL_GLU) {
             gacc0 += mix_warp_shfl_down(gacc0, off);
             gacc1 += mix_warp_shfl_down(gacc1, off);
+            if constexpr (ROWS_PER_WARP == 4) {
+                gacc2 += mix_warp_shfl_down(gacc2, off);
+                gacc3 += mix_warp_shfl_down(gacc3, off);
+            }
         }
     }
     if (lane == 0) {
         const int64_t o = (int64_t) token * dst_s2 + (int64_t) slot * dst_s1 + row0;
-        if (FUSE_GLU) {
+        if (DUAL_GLU) {
             // The SAME function the standalone swiglu_ds4 kernel applies, on inputs bit-identical
             // to the ones it would have read back from the two intermediates.
             dst[o]                = ggml_cuda_op_swiglu_ds4_single(gacc0, acc0, glu_limit);
             if (two) dst[o + 1]   = ggml_cuda_op_swiglu_ds4_single(gacc1, acc1, glu_limit);
+            if constexpr (ROWS_PER_WARP == 4) {
+                if (three) dst[o + 2] = ggml_cuda_op_swiglu_ds4_single(gacc2, acc2, glu_limit);
+                if (four)  dst[o + 3] = ggml_cuda_op_swiglu_ds4_single(gacc3, acc3, glu_limit);
+            }
+        } else if (FINALIZE_GLU) {
+            // The preceding mode-0 launch left the up projection in dst. Same-stream
+            // launch ordering makes it visible here; each lane-0 owns distinct rows,
+            // so reading and replacing those values needs no extra synchronization.
+            dst[o]                = ggml_cuda_op_swiglu_ds4_single(acc0, dst[o], glu_limit);
+            if (two) dst[o + 1]   = ggml_cuda_op_swiglu_ds4_single(acc1, dst[o + 1], glu_limit);
+            if constexpr (ROWS_PER_WARP == 4) {
+                if (three) dst[o + 2] = ggml_cuda_op_swiglu_ds4_single(acc2, dst[o + 2], glu_limit);
+                if (four)  dst[o + 3] = ggml_cuda_op_swiglu_ds4_single(acc3, dst[o + 3], glu_limit);
+            }
         } else {
             dst[o]                = acc0;
             if (two) dst[o + 1]   = acc1;
+            if constexpr (ROWS_PER_WARP == 4) {
+                if (three) dst[o + 2] = acc2;
+                if (four)  dst[o + 3] = acc3;
+            }
         }
     }
 }
@@ -889,17 +1174,24 @@ bool ggml_cuda_rocmfp2_mix_mul_mat_id(
         n_expert_used <= 0 || n_tokens <= 0 || ne11 <= 0) {
         return false;
     }
-    const int warps_per_block = 2;               // 64 threads (mirror the mmvq path)
+    const bool row4 = e.gfx1151 && n_tokens > 2 && mix_gfx1151_row4_enabled();
+    const int warps_per_block = row4 ? 2 : (e.gfx1151 ? (n_tokens <= 2 ? 8 : 4) : 2);
     const int threads = warps_per_block * MIX_WARP;
-    // Two output rows per warp (register-blocked activation reuse), so a workgroup
-    // of `warps_per_block` warps covers 2*warps_per_block rows.
-    const int rows_per_block = 2 * warps_per_block;
+    const int rows_per_block = (row4 ? 4 : 2) * warps_per_block;
     dim3 grid((out + rows_per_block - 1) / rows_per_block, n_expert_used, n_tokens);
-    mix_matvec_rocmfp2_moe_kernel<false><<<grid, dim3(threads), 0, stream>>>(
-        (const uint8_t *) e.base, e.nb02, e.codebooks, e.modes,
-        src1, ids, dst, in, out, e.n_experts, ne11,
-        ids_s0, ids_s1, src1_s1, src1_s2, dst_s1, dst_s2,
-        nullptr, 0, nullptr, nullptr, 0.0f);
+    if (row4) {
+        mix_matvec_rocmfp2_moe_kernel<0, 4><<<grid, dim3(threads), 0, stream>>>(
+            (const uint8_t *) e.base, e.nb02, e.codebooks, e.modes,
+            src1, ids, dst, in, out, e.n_experts, ne11,
+            ids_s0, ids_s1, src1_s1, src1_s2, dst_s1, dst_s2,
+            nullptr, 0, nullptr, nullptr, 0.0f);
+    } else {
+        mix_matvec_rocmfp2_moe_kernel<0, 2><<<grid, dim3(threads), 0, stream>>>(
+            (const uint8_t *) e.base, e.nb02, e.codebooks, e.modes,
+            src1, ids, dst, in, out, e.n_experts, ne11,
+            ids_s0, ids_s1, src1_s1, src1_s2, dst_s1, dst_s2,
+            nullptr, 0, nullptr, nullptr, 0.0f);
+    }
     return true;
 }
 
@@ -931,15 +1223,46 @@ bool ggml_cuda_rocmfp2_mix_mul_mat_id_glu(
         n_expert_used <= 0 || n_tokens <= 0 || ne11 <= 0) {
         return false;   // not a matched pair; the caller's two-launch path is still correct
     }
-    const int warps_per_block = 2;
+    const bool strix_tuned = eu.gfx1151 && eg.gfx1151;
+    const bool row4 = strix_tuned && n_tokens > 2 && mix_gfx1151_row4_enabled();
+    const int warps_per_block = row4 ? 2 : (strix_tuned ? (n_tokens <= 2 ? 8 : 4) : 2);
     const int threads = warps_per_block * MIX_WARP;
-    const int rows_per_block = 2 * warps_per_block;
+    const int rows_per_block = (row4 ? 4 : 2) * warps_per_block;
     dim3 grid((out + rows_per_block - 1) / rows_per_block, n_expert_used, n_tokens);
-    mix_matvec_rocmfp2_moe_kernel<true><<<grid, dim3(threads), 0, stream>>>(
-        (const uint8_t *) eu.base, eu.nb02, eu.codebooks, eu.modes,
-        src1, ids, dst, in, out, eu.n_experts, ne11,
-        ids_s0, ids_s1, src1_s1, src1_s2, dst_s1, dst_s2,
-        (const uint8_t *) eg.base, eg.nb02, eg.codebooks, eg.modes, glu_limit);
+    if (!strix_tuned || n_tokens <= 2) {
+        mix_matvec_rocmfp2_moe_kernel<1, 2><<<grid, dim3(threads), 0, stream>>>(
+            (const uint8_t *) eu.base, eu.nb02, eu.codebooks, eu.modes,
+            src1, ids, dst, in, out, eu.n_experts, ne11,
+            ids_s0, ids_s1, src1_s1, src1_s2, dst_s1, dst_s2,
+            (const uint8_t *) eg.base, eg.nb02, eg.codebooks, eg.modes, glu_limit);
+    } else {
+        // A wide verifier makes the dual-tensor kernel's register pressure more
+        // expensive than its saved launch. Keep both projections at the ordinary
+        // kernel's occupancy and fold SwiGLU into the second launch in-place.
+        if (row4) {
+            mix_matvec_rocmfp2_moe_kernel<0, 4><<<grid, dim3(threads), 0, stream>>>(
+                (const uint8_t *) eu.base, eu.nb02, eu.codebooks, eu.modes,
+                src1, ids, dst, in, out, eu.n_experts, ne11,
+                ids_s0, ids_s1, src1_s1, src1_s2, dst_s1, dst_s2,
+                nullptr, 0, nullptr, nullptr, 0.0f);
+            mix_matvec_rocmfp2_moe_kernel<2, 4><<<grid, dim3(threads), 0, stream>>>(
+                (const uint8_t *) eg.base, eg.nb02, eg.codebooks, eg.modes,
+                src1, ids, dst, in, out, eg.n_experts, ne11,
+                ids_s0, ids_s1, src1_s1, src1_s2, dst_s1, dst_s2,
+                nullptr, 0, nullptr, nullptr, glu_limit);
+        } else {
+            mix_matvec_rocmfp2_moe_kernel<0, 2><<<grid, dim3(threads), 0, stream>>>(
+                (const uint8_t *) eu.base, eu.nb02, eu.codebooks, eu.modes,
+                src1, ids, dst, in, out, eu.n_experts, ne11,
+                ids_s0, ids_s1, src1_s1, src1_s2, dst_s1, dst_s2,
+                nullptr, 0, nullptr, nullptr, 0.0f);
+            mix_matvec_rocmfp2_moe_kernel<2, 2><<<grid, dim3(threads), 0, stream>>>(
+                (const uint8_t *) eg.base, eg.nb02, eg.codebooks, eg.modes,
+                src1, ids, dst, in, out, eg.n_experts, ne11,
+                ids_s0, ids_s1, src1_s1, src1_s2, dst_s1, dst_s2,
+                nullptr, 0, nullptr, nullptr, glu_limit);
+        }
+    }
     return true;
 }
 

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/rocmfp3_mix.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/rocmfp3_mix.cu
@@ -276,10 +276,18 @@ static bool mix_lookup_expert_base(
 }
 
 __device__ __forceinline__ float mix_ue4m3(uint8_t e) {
+#if defined(__HIP_PLATFORM_AMD__) && defined(__gfx1151__)
+    int exp = e >> 3, mant = e & 7;
+    const float normal = ldexpf((float) (8 + mant), exp - 11);
+    const float sub = (float) mant * 0.0009765625f;  // 2^-10
+    const float value = (exp == 0) ? sub : normal;
+    return (e > 0x7E) ? 0.0f : value;
+#else
     if (e > 0x7E) return 0.0f;
     int exp = e >> 3, mant = e & 7;
     if (exp == 0) return (float) mant * 0.0009765625f;  // 2^-10
     return ldexpf((float) (8 + mant), exp - 11);
+#endif
 }
 
 __device__ __forceinline__ uint32_t mix_fp3_code(const uint8_t * qs, int i) {
@@ -288,6 +296,22 @@ __device__ __forceinline__ uint32_t mix_fp3_code(const uint8_t * qs, int i) {
     if (byte + 1 < MIX_QS) v |= (uint32_t) qs[byte + 1] << 8;
     if (byte + 2 < MIX_QS) v |= (uint32_t) qs[byte + 2] << 16;
     return (v >> shift) & 7u;
+}
+
+struct MixFp3Words {
+    uint64_t lo;  // code bytes 0..7
+    uint32_t hi;  // code bytes 8..11
+};
+
+// Decode the same 96-bit fp3 stream from three registers. The only code that
+// crosses the 64-bit boundary is i=21 (bit 63); the unrolled caller makes all
+// three cases compile-time constants. This avoids materializing a 14-byte
+// private array in the gfx1151 matvec while preserving every packed bit.
+__device__ __forceinline__ uint32_t mix_fp3_code(const MixFp3Words & qs, int i) {
+    const int bit = 3 * i;
+    if (bit <= 60) return (uint32_t) (qs.lo >> bit) & 7u;
+    if (bit == 63) return (uint32_t) ((qs.lo >> 63) | ((uint64_t) qs.hi << 1)) & 7u;
+    return (qs.hi >> (bit - 64)) & 7u;
 }
 
 __device__ __forceinline__ float mix_fp3_fixed(uint32_t code) {
@@ -373,6 +397,14 @@ void dequantize_rocmfp3_mix_to_fp16_cuda(const void * vx, half * y, int64_t k, c
 // quantized blocks once avoids the ~10x f16 round-trip of the dequant fallback.
 #define MIX_WARP 32
 #define MIX_UNROLL 4
+#if defined(__HIP_PLATFORM_AMD__) && defined(__gfx1151__)
+// The two-row MoE kernel already exposes thousands of independent workgroups.
+// Keeping only one strided block live at a time cuts the large q3 decode body
+// and is faster on gfx1151 than duplicating it four times for local MLP.
+#define MIX_MOE_UNROLL 1
+#else
+#define MIX_MOE_UNROLL MIX_UNROLL
+#endif
 
 // Down-shift warp shuffle confined to a 32-lane logical group. width=MIX_WARP
 // keeps the reduction self-contained on wave64 (GFX8/9, physical wave = 64) and
@@ -409,16 +441,25 @@ __device__ __forceinline__ void mix_block_accum(
     // decode arithmetic and the fixed j accumulation order are untouched, so
     // acc is bit-for-bit identical to the per-byte path (the correctness gate
     // hashes the greedy output; any reassociation flips a token).
+#if defined(__HIP_PLATFORM_AMD__) && defined(__gfx1151__)
+    MixFp3Words qs;
+    uint16_t meta;
+    MIX_MEMCPY(&qs.lo, b, sizeof(qs.lo));
+    MIX_MEMCPY(&qs.hi, b + sizeof(qs.lo), sizeof(qs.hi));
+    MIX_MEMCPY(&meta, b + MIX_QS, sizeof(meta));
+    const uint8_t m0 = (uint8_t) meta, m1 = (uint8_t) (meta >> 8);
+#else
     const uint8_t * ba = (const uint8_t *) MIX_ASSUME_ALIGNED(b, 2);
-    uint8_t buf[MIX_BLOCK_BYTES];
-    MIX_MEMCPY(buf, ba, MIX_BLOCK_BYTES);
-    const uint8_t m0 = buf[MIX_QS + 0], m1 = buf[MIX_QS + 1];
+    uint8_t qs[MIX_BLOCK_BYTES];
+    MIX_MEMCPY(qs, ba, MIX_BLOCK_BYTES);
+    const uint8_t m0 = qs[MIX_QS + 0], m1 = qs[MIX_QS + 1];
+#endif
     if (mode == 0) {
         const float s0 = mix_ue4m3(m0), s1 = mix_ue4m3(m1);
         #pragma unroll
         for (int j = 0; j < MIX_QK; ++j) {
             const float s = (j < MIX_QK/2) ? s0 : s1;
-            acc += s * mix_fp3_fixed(mix_fp3_code(buf, j)) * xc[col0 + j];
+            acc += s * mix_fp3_fixed(mix_fp3_code(qs, j)) * xc[col0 + j];
         }
     } else {
         const float s0 = mix_ue4m3(m0 & 0x7F), s1 = mix_ue4m3(m1 & 0x7F);
@@ -435,7 +476,65 @@ __device__ __forceinline__ void mix_block_accum(
         for (int j = 0; j < MIX_QK; ++j) {
             const float s = (j < MIX_QK/2) ? s0 : s1;
             const float * bk = (j < MIX_QK/2) ? bk0 : bk1;
-            acc += s * bk[mix_fp3_code(buf, j)] * xc[col0 + j];
+            acc += s * bk[mix_fp3_code(qs, j)] * xc[col0 + j];
+        }
+    }
+}
+
+// Two-row variant of mix_block_accum. The activation value for each j is
+// loaded once and feeds two independent row accumulators. Each accumulator
+// retains the original ascending-j expression and rounding order.
+__device__ __forceinline__ void mix_block_accum2(
+        const uint8_t * __restrict__ b0, const uint8_t * __restrict__ b1,
+        const float * __restrict__ xc, int col0,
+        int mode, const float * __restrict__ lut, float & acc0, float & acc1) {
+#if defined(__HIP_PLATFORM_AMD__) && defined(__gfx1151__)
+    MixFp3Words qs0, qs1;
+    uint16_t meta0, meta1;
+    MIX_MEMCPY(&qs0.lo, b0, sizeof(qs0.lo));
+    MIX_MEMCPY(&qs0.hi, b0 + sizeof(qs0.lo), sizeof(qs0.hi));
+    MIX_MEMCPY(&meta0, b0 + MIX_QS, sizeof(meta0));
+    MIX_MEMCPY(&qs1.lo, b1, sizeof(qs1.lo));
+    MIX_MEMCPY(&qs1.hi, b1 + sizeof(qs1.lo), sizeof(qs1.hi));
+    MIX_MEMCPY(&meta1, b1 + MIX_QS, sizeof(meta1));
+    const uint8_t m00 = (uint8_t) meta0, m01 = (uint8_t) (meta0 >> 8);
+    const uint8_t m10 = (uint8_t) meta1, m11 = (uint8_t) (meta1 >> 8);
+#else
+    const uint8_t * ba0 = (const uint8_t *) MIX_ASSUME_ALIGNED(b0, 2);
+    const uint8_t * ba1 = (const uint8_t *) MIX_ASSUME_ALIGNED(b1, 2);
+    uint8_t qs0[MIX_BLOCK_BYTES], qs1[MIX_BLOCK_BYTES];
+    MIX_MEMCPY(qs0, ba0, MIX_BLOCK_BYTES);
+    MIX_MEMCPY(qs1, ba1, MIX_BLOCK_BYTES);
+    const uint8_t m00 = qs0[MIX_QS + 0], m01 = qs0[MIX_QS + 1];
+    const uint8_t m10 = qs1[MIX_QS + 0], m11 = qs1[MIX_QS + 1];
+#endif
+    if (mode == 0) {
+        const float s00 = mix_ue4m3(m00), s01 = mix_ue4m3(m01);
+        const float s10 = mix_ue4m3(m10), s11 = mix_ue4m3(m11);
+        #pragma unroll
+        for (int j = 0; j < MIX_QK; ++j) {
+            const float x = xc[col0 + j];
+            const float rs0 = (j < MIX_QK/2) ? s00 : s01;
+            const float rs1 = (j < MIX_QK/2) ? s10 : s11;
+            acc0 = fmaf(rs0 * mix_fp3_fixed(mix_fp3_code(qs0, j)), x, acc0);
+            acc1 = fmaf(rs1 * mix_fp3_fixed(mix_fp3_code(qs1, j)), x, acc1);
+        }
+    } else {
+        const float s00 = mix_ue4m3(m00 & 0x7F), s01 = mix_ue4m3(m01 & 0x7F);
+        const float s10 = mix_ue4m3(m10 & 0x7F), s11 = mix_ue4m3(m11 & 0x7F);
+        const float * bk00 = lut + (m00 >> 7) * MIX_K;
+        const float * bk01 = lut + (m01 >> 7) * MIX_K;
+        const float * bk10 = lut + (m10 >> 7) * MIX_K;
+        const float * bk11 = lut + (m11 >> 7) * MIX_K;
+        #pragma unroll
+        for (int j = 0; j < MIX_QK; ++j) {
+            const float x = xc[col0 + j];
+            const float rs0 = (j < MIX_QK/2) ? s00 : s01;
+            const float rs1 = (j < MIX_QK/2) ? s10 : s11;
+            const float * rbk0 = (j < MIX_QK/2) ? bk00 : bk01;
+            const float * rbk1 = (j < MIX_QK/2) ? bk10 : bk11;
+            acc0 = fmaf(rs0 * rbk0[mix_fp3_code(qs0, j)], x, acc0);
+            acc1 = fmaf(rs1 * rbk1[mix_fp3_code(qs1, j)], x, acc1);
         }
     }
 }
@@ -569,30 +668,31 @@ __global__ void mix_matvec_rocmfp3_slice_kernel(
     // src1 is [in, ne11, ntok]; the get_rows-equivalent row for (slot, token)
     // is token*ne11 + slot%ne11 — i.e. token column + the slot%ne11 broadcast.
     const float * xcol = src1 + (int64_t) token * src1_s2 + (int64_t) (slot % ne11) * src1_s1;
-    // Two output rows in one warp. Each row is folded by the SAME mix_block_accum
-    // that the single-row path uses (byte-identical inlined body, same fixed j
-    // order, same acc-add chain) so acc0/acc1 are bit-for-bit identical to the
-    // single-row kernel's output for those rows. The two calls per block share the
-    // same __restrict__ xcol + col0, so the compiler CSEs the strided activation
-    // loads to one issue per element — halving activation LSU issue on this partly
-    // load-instruction-bound matvec — WITHOUT reordering either row's summation.
+    // Two output rows in one warp. mix_block_accum2 explicitly loads each
+    // activation once and feeds both independent row accumulators. Each row keeps
+    // the same fixed j order and acc-add chain as the single-row path.
     float acc0 = 0.0f, acc1 = 0.0f;
     int blk = lane;
     for (; blk + 3 * MIX_WARP < nb; blk += MIX_UNROLL * MIX_WARP) {
         const int b0 = blk, b1 = blk + MIX_WARP;
         const int b2 = blk + 2 * MIX_WARP, b3 = blk + 3 * MIX_WARP;
-        mix_block_accum(rowbase0 + (int64_t) b0 * MIX_BLOCK_BYTES, xcol, b0 * MIX_QK, mode, s_lut, acc0);
-        mix_block_accum(rowbase1 + (int64_t) b0 * MIX_BLOCK_BYTES, xcol, b0 * MIX_QK, mode, s_lut, acc1);
-        mix_block_accum(rowbase0 + (int64_t) b1 * MIX_BLOCK_BYTES, xcol, b1 * MIX_QK, mode, s_lut, acc0);
-        mix_block_accum(rowbase1 + (int64_t) b1 * MIX_BLOCK_BYTES, xcol, b1 * MIX_QK, mode, s_lut, acc1);
-        mix_block_accum(rowbase0 + (int64_t) b2 * MIX_BLOCK_BYTES, xcol, b2 * MIX_QK, mode, s_lut, acc0);
-        mix_block_accum(rowbase1 + (int64_t) b2 * MIX_BLOCK_BYTES, xcol, b2 * MIX_QK, mode, s_lut, acc1);
-        mix_block_accum(rowbase0 + (int64_t) b3 * MIX_BLOCK_BYTES, xcol, b3 * MIX_QK, mode, s_lut, acc0);
-        mix_block_accum(rowbase1 + (int64_t) b3 * MIX_BLOCK_BYTES, xcol, b3 * MIX_QK, mode, s_lut, acc1);
+        mix_block_accum2(rowbase0 + (int64_t) b0 * MIX_BLOCK_BYTES,
+                         rowbase1 + (int64_t) b0 * MIX_BLOCK_BYTES,
+                         xcol, b0 * MIX_QK, mode, s_lut, acc0, acc1);
+        mix_block_accum2(rowbase0 + (int64_t) b1 * MIX_BLOCK_BYTES,
+                         rowbase1 + (int64_t) b1 * MIX_BLOCK_BYTES,
+                         xcol, b1 * MIX_QK, mode, s_lut, acc0, acc1);
+        mix_block_accum2(rowbase0 + (int64_t) b2 * MIX_BLOCK_BYTES,
+                         rowbase1 + (int64_t) b2 * MIX_BLOCK_BYTES,
+                         xcol, b2 * MIX_QK, mode, s_lut, acc0, acc1);
+        mix_block_accum2(rowbase0 + (int64_t) b3 * MIX_BLOCK_BYTES,
+                         rowbase1 + (int64_t) b3 * MIX_BLOCK_BYTES,
+                         xcol, b3 * MIX_QK, mode, s_lut, acc0, acc1);
     }
     for (; blk < nb; blk += MIX_WARP) {
-        mix_block_accum(rowbase0 + (int64_t) blk * MIX_BLOCK_BYTES, xcol, blk * MIX_QK, mode, s_lut, acc0);
-        mix_block_accum(rowbase1 + (int64_t) blk * MIX_BLOCK_BYTES, xcol, blk * MIX_QK, mode, s_lut, acc1);
+        mix_block_accum2(rowbase0 + (int64_t) blk * MIX_BLOCK_BYTES,
+                         rowbase1 + (int64_t) blk * MIX_BLOCK_BYTES,
+                         xcol, blk * MIX_QK, mode, s_lut, acc0, acc1);
     }
     #pragma unroll
     for (int off = MIX_WARP/2; off > 0; off >>= 1) {
@@ -679,50 +779,50 @@ __global__ void mix_matvec_rocmfp3_moe_kernel(
     // src1 is [in, ne11, ntok]; the get_rows-equivalent row for (slot, token)
     // is token*ne11 + slot%ne11 — i.e. token column + the slot%ne11 broadcast.
     const float * xcol = src1 + (int64_t) token * src1_s2 + (int64_t) (slot % ne11) * src1_s1;
-    // Two output rows in one warp. Each row is folded by the SAME mix_block_accum
-    // that the single-row path uses (byte-identical inlined body, same fixed j
-    // order, same acc-add chain) so acc0/acc1 are bit-for-bit identical to the
-    // single-row kernel's output for those rows. The two calls per block share the
-    // same __restrict__ xcol + col0, so the compiler CSEs the strided activation
-    // loads to one issue per element — halving activation LSU issue on this partly
-    // load-instruction-bound matvec — WITHOUT reordering either row's summation.
+    // Explicitly share each activation load across the two independent output-row
+    // folds in the ordinary projection. The fused-GLU specialization below keeps
+    // its lower-register path because four paired accumulators reduce occupancy.
     float acc0 = 0.0f, acc1 = 0.0f;
     float gacc0 = 0.0f, gacc1 = 0.0f;   // same block order as acc*, so bit-identical per row
     int blk = lane;
-    for (; blk + 3 * MIX_WARP < nb; blk += MIX_UNROLL * MIX_WARP) {
-        const int b0 = blk, b1 = blk + MIX_WARP;
-        const int b2 = blk + 2 * MIX_WARP, b3 = blk + 3 * MIX_WARP;
-        mix_block_accum(rowbase0 + (int64_t) b0 * MIX_BLOCK_BYTES, xcol, b0 * MIX_QK, mode, s_lut, acc0);
-        mix_block_accum(rowbase1 + (int64_t) b0 * MIX_BLOCK_BYTES, xcol, b0 * MIX_QK, mode, s_lut, acc1);
-        if (FUSE_GLU) {
-            mix_block_accum(growbase0 + (int64_t) b0 * MIX_BLOCK_BYTES, xcol, b0 * MIX_QK, gmode, s_lut + 2 * MIX_K, gacc0);
-            mix_block_accum(growbase1 + (int64_t) b0 * MIX_BLOCK_BYTES, xcol, b0 * MIX_QK, gmode, s_lut + 2 * MIX_K, gacc1);
-        }
-        mix_block_accum(rowbase0 + (int64_t) b1 * MIX_BLOCK_BYTES, xcol, b1 * MIX_QK, mode, s_lut, acc0);
-        mix_block_accum(rowbase1 + (int64_t) b1 * MIX_BLOCK_BYTES, xcol, b1 * MIX_QK, mode, s_lut, acc1);
-        if (FUSE_GLU) {
-            mix_block_accum(growbase0 + (int64_t) b1 * MIX_BLOCK_BYTES, xcol, b1 * MIX_QK, gmode, s_lut + 2 * MIX_K, gacc0);
-            mix_block_accum(growbase1 + (int64_t) b1 * MIX_BLOCK_BYTES, xcol, b1 * MIX_QK, gmode, s_lut + 2 * MIX_K, gacc1);
-        }
-        mix_block_accum(rowbase0 + (int64_t) b2 * MIX_BLOCK_BYTES, xcol, b2 * MIX_QK, mode, s_lut, acc0);
-        mix_block_accum(rowbase1 + (int64_t) b2 * MIX_BLOCK_BYTES, xcol, b2 * MIX_QK, mode, s_lut, acc1);
-        if (FUSE_GLU) {
-            mix_block_accum(growbase0 + (int64_t) b2 * MIX_BLOCK_BYTES, xcol, b2 * MIX_QK, gmode, s_lut + 2 * MIX_K, gacc0);
-            mix_block_accum(growbase1 + (int64_t) b2 * MIX_BLOCK_BYTES, xcol, b2 * MIX_QK, gmode, s_lut + 2 * MIX_K, gacc1);
-        }
-        mix_block_accum(rowbase0 + (int64_t) b3 * MIX_BLOCK_BYTES, xcol, b3 * MIX_QK, mode, s_lut, acc0);
-        mix_block_accum(rowbase1 + (int64_t) b3 * MIX_BLOCK_BYTES, xcol, b3 * MIX_QK, mode, s_lut, acc1);
-        if (FUSE_GLU) {
-            mix_block_accum(growbase0 + (int64_t) b3 * MIX_BLOCK_BYTES, xcol, b3 * MIX_QK, gmode, s_lut + 2 * MIX_K, gacc0);
-            mix_block_accum(growbase1 + (int64_t) b3 * MIX_BLOCK_BYTES, xcol, b3 * MIX_QK, gmode, s_lut + 2 * MIX_K, gacc1);
+    for (; blk + (MIX_MOE_UNROLL - 1) * MIX_WARP < nb;
+           blk += MIX_MOE_UNROLL * MIX_WARP) {
+        #pragma unroll
+        for (int u = 0; u < MIX_MOE_UNROLL; ++u) {
+            const int b = blk + u * MIX_WARP;
+            if (FUSE_GLU) {
+                // Four independent row folds have too much register pressure for
+                // the paired helper on gfx1151. Keep the exact lower-pressure
+                // path for the fused gate/up specialization.
+                mix_block_accum(rowbase0 + (int64_t) b * MIX_BLOCK_BYTES, xcol,
+                                b * MIX_QK, mode, s_lut, acc0);
+                mix_block_accum(rowbase1 + (int64_t) b * MIX_BLOCK_BYTES, xcol,
+                                b * MIX_QK, mode, s_lut, acc1);
+                mix_block_accum(growbase0 + (int64_t) b * MIX_BLOCK_BYTES, xcol,
+                                b * MIX_QK, gmode, s_lut + 2 * MIX_K, gacc0);
+                mix_block_accum(growbase1 + (int64_t) b * MIX_BLOCK_BYTES, xcol,
+                                b * MIX_QK, gmode, s_lut + 2 * MIX_K, gacc1);
+            } else {
+                mix_block_accum2(rowbase0 + (int64_t) b * MIX_BLOCK_BYTES,
+                                 rowbase1 + (int64_t) b * MIX_BLOCK_BYTES,
+                                 xcol, b * MIX_QK, mode, s_lut, acc0, acc1);
+            }
         }
     }
     for (; blk < nb; blk += MIX_WARP) {
-        mix_block_accum(rowbase0 + (int64_t) blk * MIX_BLOCK_BYTES, xcol, blk * MIX_QK, mode, s_lut, acc0);
-        mix_block_accum(rowbase1 + (int64_t) blk * MIX_BLOCK_BYTES, xcol, blk * MIX_QK, mode, s_lut, acc1);
         if (FUSE_GLU) {
-            mix_block_accum(growbase0 + (int64_t) blk * MIX_BLOCK_BYTES, xcol, blk * MIX_QK, gmode, s_lut + 2 * MIX_K, gacc0);
-            mix_block_accum(growbase1 + (int64_t) blk * MIX_BLOCK_BYTES, xcol, blk * MIX_QK, gmode, s_lut + 2 * MIX_K, gacc1);
+            mix_block_accum(rowbase0 + (int64_t) blk * MIX_BLOCK_BYTES, xcol,
+                            blk * MIX_QK, mode, s_lut, acc0);
+            mix_block_accum(rowbase1 + (int64_t) blk * MIX_BLOCK_BYTES, xcol,
+                            blk * MIX_QK, mode, s_lut, acc1);
+            mix_block_accum(growbase0 + (int64_t) blk * MIX_BLOCK_BYTES, xcol,
+                            blk * MIX_QK, gmode, s_lut + 2 * MIX_K, gacc0);
+            mix_block_accum(growbase1 + (int64_t) blk * MIX_BLOCK_BYTES, xcol,
+                            blk * MIX_QK, gmode, s_lut + 2 * MIX_K, gacc1);
+        } else {
+            mix_block_accum2(rowbase0 + (int64_t) blk * MIX_BLOCK_BYTES,
+                             rowbase1 + (int64_t) blk * MIX_BLOCK_BYTES,
+                             xcol, blk * MIX_QK, mode, s_lut, acc0, acc1);
         }
     }
     #pragma unroll
@@ -806,7 +906,7 @@ bool ggml_cuda_rocmfp3_mix_mul_mat_id(
         n_expert_used <= 0 || n_tokens <= 0 || ne11 <= 0) {
         return false;
     }
-    const int warps_per_block = 2;               // 64 threads (mirror the mmvq path)
+    const int warps_per_block = 2;
     const int threads = warps_per_block * MIX_WARP;
     // Two output rows per warp (register-blocked activation reuse), so a workgroup
     // of `warps_per_block` warps covers 2*warps_per_block rows.

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/top-k.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/top-k.cu
@@ -1319,6 +1319,161 @@ static void topk_block_radix_cuda(
     CUDA_CHECK(cudaGetLastError());
 }
 
+// Long-context DS4 indexer shape: select 512 compressed KV rows from as many
+// as 32K scores. A full segmented sort materializes and orders every score even
+// though only 512 survive. Instead, select 512 candidates independently from
+// each 4K tile, then select the final 512 from the at-most-4K candidates. Any
+// global top-512 element must be in its tile's local top 512, so this is exact.
+//
+// Both stages retain the original global indices as values. TOP_K only requires
+// the selected set; ordering among equal scores is intentionally unspecified.
+// Keeping tiles and candidates in increasing source order nevertheless gives
+// BlockRadixSort the same natural tie order as the flat input.
+template <int ITEMS_PER_THREAD>
+static __global__ void k_topk_block_radix_tiles_f32_i32(
+        const float * x,
+        int         * candidates,
+        int           ncols,
+        int           ntiles,
+        int           k) {
+    constexpr int BLOCK_THREADS = 256;
+    constexpr int TILE_COLS = BLOCK_THREADS * ITEMS_PER_THREAD;
+    using block_sort = hipcub::BlockRadixSort<
+        uint32_t, BLOCK_THREADS, ITEMS_PER_THREAD, int>;
+    __shared__ typename block_sort::TempStorage storage;
+
+    const int tile_block = (int) blockIdx.x;
+    const int row = tile_block / ntiles;
+    const int tile = tile_block - row * ntiles;
+    const int tile_begin = tile * TILE_COLS;
+    const int first = tile_begin + (int) threadIdx.x * ITEMS_PER_THREAD;
+    const float * x_row = x + (size_t) row * ncols;
+    uint32_t keys[ITEMS_PER_THREAD];
+    int indices[ITEMS_PER_THREAD];
+#pragma unroll
+    for (int item = 0; item < ITEMS_PER_THREAD; ++item) {
+        const int col = first + item;
+        if (col < ncols) {
+            const uint32_t bits = (uint32_t) __float_as_int(x_row[col]);
+            const uint32_t ordered = (bits & 0x80000000u)
+                ? ~bits : (bits ^ 0x80000000u);
+            keys[item] = ordered == 0 ? 1 : ordered;
+        } else {
+            keys[item] = 0;
+        }
+        indices[item] = col;
+    }
+
+    block_sort(storage).SortDescending(keys, indices);
+
+#pragma unroll
+    for (int item = 0; item < ITEMS_PER_THREAD; ++item) {
+        const int rank = (int) threadIdx.x * ITEMS_PER_THREAD + item;
+        if (rank < k) {
+            candidates[((size_t) row * ntiles + tile) * k + rank] = indices[item];
+        }
+    }
+}
+
+template <int ITEMS_PER_THREAD>
+static __global__ void k_topk_block_radix_merge_f32_i32(
+        const float * x,
+        const int   * candidates,
+        int         * dst,
+        int           ncols,
+        int           ncandidates,
+        int           k) {
+    constexpr int BLOCK_THREADS = 256;
+    using block_sort = hipcub::BlockRadixSort<
+        uint32_t, BLOCK_THREADS, ITEMS_PER_THREAD, int>;
+    __shared__ typename block_sort::TempStorage storage;
+
+    const int row = (int) blockIdx.x;
+    const int first = (int) threadIdx.x * ITEMS_PER_THREAD;
+    const float * x_row = x + (size_t) row * ncols;
+    const int * candidate_row = candidates + (size_t) row * ncandidates;
+    uint32_t keys[ITEMS_PER_THREAD];
+    int indices[ITEMS_PER_THREAD];
+#pragma unroll
+    for (int item = 0; item < ITEMS_PER_THREAD; ++item) {
+        const int rank = first + item;
+        if (rank < ncandidates) {
+            const int col = candidate_row[rank];
+            if (col < ncols) {
+                const uint32_t bits = (uint32_t) __float_as_int(x_row[col]);
+                const uint32_t ordered = (bits & 0x80000000u)
+                    ? ~bits : (bits ^ 0x80000000u);
+                keys[item] = ordered == 0 ? 1 : ordered;
+                indices[item] = col;
+            } else {
+                // The final 4K tile may contain fewer than k real columns.
+                // Its local selection then contains padded indices; keep them
+                // below every real score and never dereference them.
+                keys[item] = 0;
+                indices[item] = ncols;
+            }
+        } else {
+            keys[item] = 0;
+            indices[item] = ncols;
+        }
+    }
+
+    block_sort(storage).SortDescending(keys, indices);
+
+#pragma unroll
+    for (int item = 0; item < ITEMS_PER_THREAD; ++item) {
+        const int rank = first + item;
+        if (rank < k) {
+            dst[(size_t) row * k + rank] = indices[item];
+        }
+    }
+}
+
+static void topk_hierarchical_block_radix_cuda(
+        ggml_cuda_pool & pool,
+        const float  * x,
+        int          * dst,
+        int            ncols,
+        int            nrows,
+        int            k,
+        cudaStream_t   stream) {
+    constexpr int TILE_COLS = 4096;
+    constexpr int TILE_ITEMS_PER_THREAD = 16;
+    const int ntiles = (ncols + TILE_COLS - 1) / TILE_COLS;
+    const int ncandidates = ntiles * k;
+
+    GGML_ASSERT(k == 512);
+    GGML_ASSERT(ntiles >= 2 && ntiles <= 8);
+    ggml_cuda_pool_alloc<int> candidates_alloc(
+        pool, (size_t) nrows * ncandidates);
+    int * candidates = candidates_alloc.get();
+
+    const dim3 tile_blocks((unsigned) (nrows * ntiles), 1, 1);
+    constexpr int threads = 256;
+    k_topk_block_radix_tiles_f32_i32<TILE_ITEMS_PER_THREAD>
+        <<<tile_blocks, threads, 0, stream>>>(
+            x, candidates, ncols, ntiles, k);
+
+    const dim3 merge_blocks((unsigned) nrows, 1, 1);
+    if (ntiles <= 2) {
+        k_topk_block_radix_merge_f32_i32<4><<<merge_blocks, threads, 0, stream>>>(
+            x, candidates, dst, ncols, ncandidates, k);
+    } else if (ntiles <= 3) {
+        k_topk_block_radix_merge_f32_i32<6><<<merge_blocks, threads, 0, stream>>>(
+            x, candidates, dst, ncols, ncandidates, k);
+    } else if (ntiles <= 4) {
+        k_topk_block_radix_merge_f32_i32<8><<<merge_blocks, threads, 0, stream>>>(
+            x, candidates, dst, ncols, ncandidates, k);
+    } else if (ntiles <= 6) {
+        k_topk_block_radix_merge_f32_i32<12><<<merge_blocks, threads, 0, stream>>>(
+            x, candidates, dst, ncols, ncandidates, k);
+    } else {
+        k_topk_block_radix_merge_f32_i32<16><<<merge_blocks, threads, 0, stream>>>(
+            x, candidates, dst, ncols, ncandidates, k);
+    }
+    CUDA_CHECK(cudaGetLastError());
+}
+
 #endif  // GGML_CUDA_USE_HIPCUB
 
 void ggml_cuda_op_top_k(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
@@ -1345,10 +1500,23 @@ void ggml_cuda_op_top_k(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     }
 #elif defined(GGML_CUDA_USE_CUB) || defined(GGML_CUDA_USE_HIPCUB)  // CUB_TOP_K_AVAILABLE
 #ifdef GGML_CUDA_USE_HIPCUB
-    if (ds4_env_flag_enabled("GGML_DS4_TOPK_BLOCK_RADIX") &&
-        k == 512 && ncols > 1024 && ncols <= 5120) {
-        topk_block_radix_cuda(
-            src0_d, dst_d, (int) ncols, (int) nrows, (int) k, stream);
+    const char * block_radix_env = getenv("GGML_DS4_TOPK_BLOCK_RADIX");
+    const int block_radix_cc =
+        ggml_cuda_info().devices[ggml_cuda_get_device()].cc;
+    const bool block_radix_default =
+        block_radix_cc == GGML_CUDA_CC_OFFSET_AMD + 0x1151;
+    const bool block_radix_enabled = block_radix_env
+        ? block_radix_env[0] != '\0' && strcmp(block_radix_env, "0") != 0
+        : block_radix_default;
+    if (block_radix_enabled &&
+        k == 512 && ncols > 1024 && ncols <= 32768) {
+        if (ncols <= 5120) {
+            topk_block_radix_cuda(
+                src0_d, dst_d, (int) ncols, (int) nrows, (int) k, stream);
+        } else {
+            topk_hierarchical_block_radix_cuda(
+                pool, src0_d, dst_d, (int) ncols, (int) nrows, (int) k, stream);
+        }
         return;
     }
 #endif

--- a/server/docs/DS4.md
+++ b/server/docs/DS4.md
@@ -494,7 +494,11 @@ selected latent row across wave32 heads and avoids materializing scores. It is
 currently limited to F16 caches on native wave32 devices and otherwise falls
 back to the existing path. Because its online softmax changes floating-point
 association, keep it opt-in until the target model passes a matched output and
-throughput A/B. `GGML_DS4_FA_STREAM_TOPK` remains a compatibility alias.
+throughput A/B. `GGML_DS4_FA_STREAM_TOPK` remains a compatibility alias. Add
+`GGML_CUDA_MLA_STREAM_F32_STAGE=1` to convert each selected F16 latent once
+while staging aligned pairs in shared memory instead of repeating conversion
+for every head. The isolated gfx1151 qualification is byte-identical to F16
+staging and reduced alternating-run kernel time by about 9%.
 
 Indexed verifier attention with at most eight query rows also uses a two-way
 split-KV schedule on gfx1151. Set `GGML_CUDA_MLA_NO_SPLIT_KV=1` to restore the

--- a/server/docs/DS4.md
+++ b/server/docs/DS4.md
@@ -498,7 +498,11 @@ throughput A/B. `GGML_DS4_FA_STREAM_TOPK` remains a compatibility alias. Add
 `GGML_CUDA_MLA_STREAM_F32_STAGE=1` to convert each selected F16 latent once
 while staging aligned pairs in shared memory instead of repeating conversion
 for every head. The isolated gfx1151 qualification is byte-identical to F16
-staging and reduced alternating-run kernel time by about 9%.
+staging and reduced alternating-run kernel time by about 9%. Add
+`GGML_CUDA_MLA_STREAM_FAST_EXP=1` to use the HIP hardware exponential in that
+FP32-staged online softmax. It reduced the remaining kernel time by another
+7–9% in isolation; keep it opt-in with the streaming path because it uses an
+approximate hardware exponential instead of the default implementation.
 
 Indexed verifier attention with at most eight query rows also uses a two-way
 split-KV schedule on gfx1151. Set `GGML_CUDA_MLA_NO_SPLIT_KV=1` to restore the

--- a/server/docs/DS4.md
+++ b/server/docs/DS4.md
@@ -455,7 +455,6 @@ Run the converted drafter against a DeepSeek4 target with:
 ```bash
 export DFLASH_DS4_SPEC=1
 export DFLASH_DS4_FUSED_VERIFY=1
-export DFLASH_DS4_SPARSE_DECODE_FLASH=1
 export DFLASH_DS4_DRAFT=/path/to/dflash-draft.gguf
 export DFLASH_DS4_SPEC_Q=4
 
@@ -467,20 +466,37 @@ export DFLASH_DS4_SPEC_Q=4
 
 `--ds4-fused-verify-f16-kv` feeds the persistent F16 MLA cache directly to
 batched explicit or sparse verifier attention instead of converting the full
-cache to F32 on every speculative step. With
-`DFLASH_DS4_SPARSE_DECODE_FLASH=1`, the verifier keeps explicit attention for
-short histories and switches each layer to the model's sparse top-k attention
-once it removes at least half of the compressed rows. Key-side accumulation
-remains F32 through 512 attention rows to preserve the short-context quality
-baseline. The option is currently qualified only for a single HIP target and
-remains off by default. It changes verifier floating-point inputs and can
-change generated tokens, so re-run workload quality checks before enabling it
-for another checkpoint.
+cache to F32 on every speculative step. On gfx1151 DSpark targets, adaptive
+sparse decode flash attention is enabled by default. The verifier keeps
+explicit attention for short histories and switches each layer to the model's
+sparse top-k attention once it removes at least half of the compressed rows.
+Key-side accumulation remains F32 through 512 attention rows to preserve the
+short-context quality baseline. Set `DFLASH_DS4_SPARSE_DECODE_FLASH=0` to use
+explicit attention throughout; other targets can opt in with value `1`.
+Sparse attention changes verifier floating-point inputs and can change
+generated tokens, so re-run workload quality checks before enabling it for
+another checkpoint.
 
 On RDNA3.5 and RDNA4, speculative widths 2–5 use the packed small-CM rocWMMA
 indexer by default. It is bit-identical to the generic indexer in the GPU unit
 test and can be disabled with `GGML_DS4_INDEXER_PACK_SMALL=0` for diagnosis.
 The legacy `GGML_DS4_INDEXER_PACK_Q4` variable remains an alias.
+
+On gfx1151, the exact block-radix selector is also the default for the DS4
+512-row long-context top-k. Set `GGML_DS4_TOPK_BLOCK_RADIX=0` to restore the
+hipCUB full-sort path. The qualification benchmark checks selected-set parity
+before reporting selector timing.
+
+Indexed verifier attention with at most eight query rows also uses a two-way
+split-KV schedule on gfx1151. Set `GGML_CUDA_MLA_NO_SPLIT_KV=1` to restore the
+single-block schedule. For fused-verifier masks of at least 4 MiB, the runtime
+zeros the existing device tensor and transfers only its negative ranges; set
+`DFLASH_DS4_INCREMENTAL_VERIFY_MASK=0` to restore the full host transfer.
+
+Two narrow verifier projections have gfx1151 defaults as well: q4 uses MMVF
+for the `[16384,24]` hyper-connection matrix, and q3/q4 ROCmFP2 matvecs reuse
+each activation across four output rows. Their diagnostic kill switches are
+`DFLASH_GFX1151_HC_MMVF_Q4=0` and `DFLASH_ROCMFP2_ROW4=0`.
 
 ### PFlash prompt compression
 
@@ -707,18 +723,14 @@ DSpark alone therefore does not guarantee 30 tok/s. Set
 `LUCE_MMVQ_MAX_NCOLS` explicitly to override the platform default. AR, NVIDIA,
 and other HIP architectures retain the shared dispatch default.
 
-Adaptive width is automatic. When the draft artifact has a compatible
-confidence projection, the runtime selects q=2, q=3, or q=4 from the cumulative
-confidence of the proposed prefix. It adds the projection to the same fused
-Markov graph and reads its scores in the existing token-id synchronization; no
-additional host round trip is introduced. Artifacts without a compatible
-confidence head transparently retain the existing acceptance-EWMA policy.
-
-On the gfx1151 validation host, confidence-adaptive width retained 10/10
-GSM+Math accuracy and measured 31.94 tok/s weighted, within 0.6% of fixed q=4
-at 32.12 tok/s. These numbers are workload-specific; the confidence policy is
-enabled only when DSpark is explicitly enabled and the draft artifact contains
-a compatible confidence head.
+Adaptive width is available but opt-in. Set
+`DFLASH_ADAPTIVE_SPEC_WIDTH=1`, or `DFLASH_DS4_ADAPTIVE_WIDTH=1` to enable it
+only for DS4. A compatible confidence projection selects q=2, q=3, or q=4
+from cumulative proposal confidence; artifacts without one use target
+acceptance feedback. Fixed width remains the production default because
+switching q=3/q=4 did not reduce verifier time on the qualified gfx1151
+kernels. Re-run workload-level speed and quality checks before enabling it on
+another target or drafter.
 
 ## Example: CUDA + Halo Layer Split
 

--- a/server/docs/DS4.md
+++ b/server/docs/DS4.md
@@ -455,6 +455,7 @@ Run the converted drafter against a DeepSeek4 target with:
 ```bash
 export DFLASH_DS4_SPEC=1
 export DFLASH_DS4_FUSED_VERIFY=1
+export DFLASH_DS4_SPARSE_DECODE_FLASH=1
 export DFLASH_DS4_DRAFT=/path/to/dflash-draft.gguf
 export DFLASH_DS4_SPEC_Q=4
 
@@ -465,12 +466,43 @@ export DFLASH_DS4_SPEC_Q=4
 ```
 
 `--ds4-fused-verify-f16-kv` feeds the persistent F16 MLA cache directly to
-batched explicit verifier attention instead of converting the full cache to
-F32 on every speculative step. Key-side accumulation remains F32 through 512
-attention rows to preserve the short-context quality baseline. The option is
-currently qualified only for a single HIP target and remains off by default.
-It changes verifier floating-point inputs and can change generated tokens, so
-re-run workload quality checks before enabling it for another checkpoint.
+batched explicit or sparse verifier attention instead of converting the full
+cache to F32 on every speculative step. With
+`DFLASH_DS4_SPARSE_DECODE_FLASH=1`, the verifier keeps explicit attention for
+short histories and switches each layer to the model's sparse top-k attention
+once it removes at least half of the compressed rows. Key-side accumulation
+remains F32 through 512 attention rows to preserve the short-context quality
+baseline. The option is currently qualified only for a single HIP target and
+remains off by default. It changes verifier floating-point inputs and can
+change generated tokens, so re-run workload quality checks before enabling it
+for another checkpoint.
+
+On RDNA3.5 and RDNA4, speculative widths 2–5 use the packed small-CM rocWMMA
+indexer by default. It is bit-identical to the generic indexer in the GPU unit
+test and can be disabled with `GGML_DS4_INDEXER_PACK_SMALL=0` for diagnosis.
+The legacy `GGML_DS4_INDEXER_PACK_Q4` variable remains an alias.
+
+### PFlash prompt compression
+
+DeepSeek4 supports the shared in-process Qwen3-0.6B PFlash scorer:
+
+```bash
+./server/build-hip/dflash_server /path/to/deepseek4-target.gguf \
+  --target-device hip:0 \
+  --prefill-compression auto \
+  --prefill-drafter /path/to/Qwen3-0.6B-BF16.gguf \
+  --prefill-skip-park
+```
+
+The HTTP path converts target tokens to text, scores Qwen tokens, decodes the
+kept Qwen spans, and tokenizes that text for DeepSeek4. This cross-tokenizer
+round trip is required; drafter token IDs are never passed directly to the
+target. Omit `--prefill-skip-park` when the target, DSpark drafter, and PFlash
+drafter do not fit together.
+
+PFlash reduces TTFT and the effective context used during generation, but it
+is lossy prompt compression. Disable it for matched true-context throughput
+or exact-retrieval comparisons.
 
 `DFLASH_DS4_FUSED_VERIFY=1` is the opt-in throughput profile. Its persistent
 whole-model GPU graph uses stable padded reduction shapes, so near-tied greedy

--- a/server/docs/DS4.md
+++ b/server/docs/DS4.md
@@ -487,6 +487,15 @@ On gfx1151, the exact block-radix selector is also the default for the DS4
 hipCUB full-sort path. The qualification benchmark checks selected-set parity
 before reporting selector timing.
 
+For experimental long sparse prefill, set both
+`DFLASH_DS4_DIRECT_INDEXER_TOPK=1` and `GGML_CUDA_MLA_STREAM_TOPK=1`. This
+enables a reusable D512 K-equals-V streaming attention path that shares each
+selected latent row across wave32 heads and avoids materializing scores. It is
+currently limited to F16 caches on native wave32 devices and otherwise falls
+back to the existing path. Because its online softmax changes floating-point
+association, keep it opt-in until the target model passes a matched output and
+throughput A/B. `GGML_DS4_FA_STREAM_TOPK` remains a compatibility alias.
+
 Indexed verifier attention with at most eight query rows also uses a two-way
 split-KV schedule on gfx1151. Set `GGML_CUDA_MLA_NO_SPLIT_KV=1` to restore the
 single-block schedule. For fused-verifier masks of at least 4 MiB, the runtime

--- a/server/docs/ENVIRONMENT.md
+++ b/server/docs/ENVIRONMENT.md
@@ -51,6 +51,7 @@ consolidation of this list into CLI flags is tracked as follow-up work.
 | `DFLASH_GFX1151_HC_MMVF_Q4` | 1 on gfx1151 for the DS4 `[16384,24]` q4 projection | BURN-IN KILL SWITCH: =0 restores the generic hipBLAS dispatch decision. |
 | `GGML_CUDA_MMQ_X` | unset | DEBUG: force a supported MMQ output-column tile width (8–128) for architecture tuning; invalid or over-budget values fall back to automatic selection. |
 | `GGML_CUDA_MMQ_MOE_ADAPTIVE_X` | unset | BURN-IN: on sparse-route gfx1151 grouped MoE MMQ, choose the measured ROCmFP2/3/4 output tile from routed rows per expert; ordinary matmuls, unmeasured formats, and other devices are unchanged. |
+| `GGML_CUDA_MLA_STREAM_F32_STAGE` | unset | EXPERIMENTAL: with streaming D512 indexed attention, convert aligned F16 pairs once while staging them in shared memory instead of repeating conversion for every head. |
 | `GGML_CUDA_MLA_SPLIT_KV` / `GGML_DS4_FA_SPLIT_KV` | 1 on gfx1151 indexed decode; unset elsewhere | BURN-IN: force the reusable split-KV MLA schedule. Set `GGML_CUDA_MLA_NO_SPLIT_KV=1` (or legacy `GGML_DS4_FA_NO_SPLIT_KV=1`) to disable it. |
 | `GGML_DS4_TOPK_BLOCK_RADIX` | 1 on gfx1151 | BURN-IN KILL SWITCH: =0 restores hipCUB full sort for DS4-shaped 512-row top-k selection. |
 | `GGML_DS4_FA_SERIAL_INDEX_SCAN` | unset | DEBUG/A-B: restore the serial indexed-attention mask scan instead of the long-context HIP parallel scan. |

--- a/server/docs/ENVIRONMENT.md
+++ b/server/docs/ENVIRONMENT.md
@@ -51,6 +51,8 @@ consolidation of this list into CLI flags is tracked as follow-up work.
 | `DFLASH_GFX1151_HC_MMVF_Q4` | 1 on gfx1151 for the DS4 `[16384,24]` q4 projection | BURN-IN KILL SWITCH: =0 restores the generic hipBLAS dispatch decision. |
 | `GGML_CUDA_MMQ_X` | unset | DEBUG: force a supported MMQ output-column tile width (8–128) for architecture tuning; invalid or over-budget values fall back to automatic selection. |
 | `GGML_CUDA_MMQ_MOE_ADAPTIVE_X` | unset | BURN-IN: on sparse-route gfx1151 grouped MoE MMQ, choose the measured ROCmFP2/3/4 output tile from routed rows per expert; ordinary matmuls, unmeasured formats, and other devices are unchanged. |
+| `GGML_CUDA_MMQ_MOE_PERSISTENT` | unset | EXPERIMENTAL: on prefill-sized (at least 256-token) sparse grouped ROCmFP2/3/4 MMQ on gfx1151, build a compact device-side expert-tile queue and consume it with bounded persistent workers. Short batches, ordinary matmuls, unmeasured formats, and other devices are unchanged. |
+| `GGML_CUDA_MMQ_MOE_PERSISTENT_BLOCKS_PER_CU` | 32 | DEBUG: set the compact grouped-MoE worker budget per gfx1151 CU from 1–32. Invalid values use 32. |
 | `GGML_CUDA_MLA_STREAM_F32_STAGE` | unset | EXPERIMENTAL: with streaming D512 indexed attention, convert aligned F16 pairs once while staging them in shared memory instead of repeating conversion for every head. |
 | `GGML_CUDA_MLA_SPLIT_KV` / `GGML_DS4_FA_SPLIT_KV` | 1 on gfx1151 indexed decode; unset elsewhere | BURN-IN: force the reusable split-KV MLA schedule. Set `GGML_CUDA_MLA_NO_SPLIT_KV=1` (or legacy `GGML_DS4_FA_NO_SPLIT_KV=1`) to disable it. |
 | `GGML_DS4_TOPK_BLOCK_RADIX` | 1 on gfx1151 | BURN-IN KILL SWITCH: =0 restores hipCUB full sort for DS4-shaped 512-row top-k selection. |

--- a/server/docs/ENVIRONMENT.md
+++ b/server/docs/ENVIRONMENT.md
@@ -49,6 +49,8 @@ consolidation of this list into CLI flags is tracked as follow-up work.
 | `DFLASH_DS4_ROCTX` | unset | DEBUG: on HIP builds, dynamically load ROCTX and emit semantic DS4 prefill, speculative-decode, and layer-range markers for external rocprof traces. No events, timing, or device synchronization are added. |
 | `DFLASH_QWEN35_ROCTX` | unset | DEBUG: on HIP builds, dynamically load ROCTX and mark Qwen concurrent steps, graph compute, and argmax readback with live, padded, and packed-prefill shape metadata. |
 | `DFLASH_GFX1151_HC_MMVF_Q4` | 1 on gfx1151 for the DS4 `[16384,24]` q4 projection | BURN-IN KILL SWITCH: =0 restores the generic hipBLAS dispatch decision. |
+| `GGML_CUDA_MMQ_X` | unset | DEBUG: force a supported MMQ output-column tile width (8–128) for architecture tuning; invalid or over-budget values fall back to automatic selection. |
+| `GGML_CUDA_MMQ_MOE_ADAPTIVE_X` | unset | BURN-IN: on sparse-route gfx1151 grouped MoE MMQ, choose the measured ROCmFP2/3/4 output tile from routed rows per expert; ordinary matmuls, unmeasured formats, and other devices are unchanged. |
 | `GGML_CUDA_MLA_SPLIT_KV` / `GGML_DS4_FA_SPLIT_KV` | 1 on gfx1151 indexed decode; unset elsewhere | BURN-IN: force the reusable split-KV MLA schedule. Set `GGML_CUDA_MLA_NO_SPLIT_KV=1` (or legacy `GGML_DS4_FA_NO_SPLIT_KV=1`) to disable it. |
 | `GGML_DS4_TOPK_BLOCK_RADIX` | 1 on gfx1151 | BURN-IN KILL SWITCH: =0 restores hipCUB full sort for DS4-shaped 512-row top-k selection. |
 | `GGML_DS4_FA_SERIAL_INDEX_SCAN` | unset | DEBUG/A-B: restore the serial indexed-attention mask scan instead of the long-context HIP parallel scan. |
@@ -202,6 +204,7 @@ consolidation of this list into CLI flags is tracked as follow-up work.
 - `DFLASH_MMQ_SUB_BATCH` - moe_hybrid_ffn_eval.cpp
 - `DFLASH_MODEL_CARDS_DIR` - model_card.cpp
 - `DFLASH_MOE_COLD_BACKEND` - deepseek4_loader.cpp
+- `DFLASH_MOE_COMBINE_VEC4` - opt in to aligned four-lane GPU route reduction; scalar fallback remains available
 - `DFLASH_MOE_COMPACT_MATERIALIZED` - moe_hybrid_ffn_eval.cpp
 - `DFLASH_MOE_DUPLICATE_HOT_ON_COLD` - moe_hybrid_storage.cpp
 - `DFLASH_MOE_EXPERT_COMPUTE_DAEMON_TOKEN_LOOP` - moe_expert_compute_ipc.cpp

--- a/server/docs/ENVIRONMENT.md
+++ b/server/docs/ENVIRONMENT.md
@@ -54,6 +54,7 @@ consolidation of this list into CLI flags is tracked as follow-up work.
 | `GGML_CUDA_MMQ_MOE_PERSISTENT` | unset | EXPERIMENTAL: on prefill-sized (at least 256-token) sparse grouped ROCmFP2/3/4 MMQ on gfx1151, build a compact device-side expert-tile queue and consume it with bounded persistent workers. Short batches, ordinary matmuls, unmeasured formats, and other devices are unchanged. |
 | `GGML_CUDA_MMQ_MOE_PERSISTENT_BLOCKS_PER_CU` | 32 | DEBUG: set the compact grouped-MoE worker budget per gfx1151 CU from 1–32. Invalid values use 32. |
 | `GGML_CUDA_MLA_STREAM_F32_STAGE` | unset | EXPERIMENTAL: with streaming D512 indexed attention, convert aligned F16 pairs once while staging them in shared memory instead of repeating conversion for every head. |
+| `GGML_CUDA_MLA_STREAM_FAST_EXP` | unset | EXPERIMENTAL: with FP32-staged streaming D512 indexed attention, use the HIP hardware exponential intrinsic for online softmax. Other attention paths are unchanged. |
 | `GGML_CUDA_MLA_SPLIT_KV` / `GGML_DS4_FA_SPLIT_KV` | 1 on gfx1151 indexed decode; unset elsewhere | BURN-IN: force the reusable split-KV MLA schedule. Set `GGML_CUDA_MLA_NO_SPLIT_KV=1` (or legacy `GGML_DS4_FA_NO_SPLIT_KV=1`) to disable it. |
 | `GGML_DS4_TOPK_BLOCK_RADIX` | 1 on gfx1151 | BURN-IN KILL SWITCH: =0 restores hipCUB full sort for DS4-shaped 512-row top-k selection. |
 | `GGML_DS4_FA_SERIAL_INDEX_SCAN` | unset | DEBUG/A-B: restore the serial indexed-attention mask scan instead of the long-context HIP parallel scan. |

--- a/server/docs/ENVIRONMENT.md
+++ b/server/docs/ENVIRONMENT.md
@@ -16,6 +16,7 @@ consolidation of this list into CLI flags is tracked as follow-up work.
 
 | Variable | Default | Purpose |
 |---|---|---|
+| `DFLASH_ADAPTIVE_SPEC_WIDTH` | unset | BURN-IN: =1 enables the shared acceptance-feedback verify-width controller. Fixed width is the production default; backend-specific overrides take precedence. |
 | `DFLASH_DRAFT_KV` | 1 | KILL SWITCH (remove after burn-in): =0 restores the legacy per-step drafter window recompute instead of the ring cache. |
 | `DFLASH_LAGUNA_SWA_RING` | 1 | KILL SWITCH (remove after burn-in): =0 keeps SWA layers on pool-sized caches under KVFlash. |
 | `DFLASH_PROF` | unset | DEBUG: comma list of profilers (step,verify,prefill). Replaces DFLASH_LAGUNA_{STEP,VERIFY,PREFILL}_PROF. |
@@ -35,6 +36,9 @@ consolidation of this list into CLI flags is tracked as follow-up work.
 | `DFLASH_DS4_TP_SCHEDULE_BRANCHES` | unset | BURN-IN: expose independent mixed-vendor expert branches to the common multi-backend scheduler. |
 | `DFLASH_DS4_TP_TARGETED_JOIN_SPLIT` / `DFLASH_MOE_TP_TARGETED_JOIN_SPLIT` | unset | BURN-IN: start a main-GPU split only at each peer-result join, avoiding an extra peer fence per MoE layer. |
 | `DFLASH_DS4_COMP_PAD_STRIDE` | 16 | BURN-IN: compressed-KV padding bucket (`16`, `32`, `64`, or `128`); wider exact-masked buckets reduce verifier graph recapture churn. |
+| `DFLASH_DS4_INCREMENTAL_VERIFY_MASK` | 1 for masks at least 4 MiB | BURN-IN KILL SWITCH: =0 rebuilds and transfers the complete fused-verifier attention mask from the host on every step. |
+| `DFLASH_DS4_INCREMENTAL_VERIFY_MASK_MIN_BYTES` | 4194304 | DEBUG/A-B: minimum fused-verifier mask size for GPU zeroing plus negative-range updates. |
+| `DFLASH_DS4_SPARSE_DECODE_FLASH` | 1 for gfx1151 DSpark; unset elsewhere | BURN-IN KILL SWITCH: =0 restores explicit verifier attention. The adaptive path stays explicit at short history and selects model sparse top-k attention only when it removes at least half of the compressed rows. |
 | `DFLASH_DS4_DISABLE_GROUPED_OUTPUT_PROJECTION` | unset | DEBUG: restore the materialized output projection when diagnosing grouped-view copies across unlike runtimes. |
 | `DFLASH_DS4_DRAFT_BACKEND` / `DFLASH_DS4_DRAFT_GPU` | compiled backend / target device | Select the in-process DSpark backend and device. |
 | `DFLASH_CUDA_BACKEND_PATH` / `DFLASH_HIP_BACKEND_PATH` | auto-discovered beside the executable | Explicit peer module file path for a mixed CUDA+HIP build. |
@@ -44,6 +48,9 @@ consolidation of this list into CLI flags is tracked as follow-up work.
 | `DFLASH_DS4_VERIFY_FORCE_GRAPH_REPLAY` | unset | OPT-IN: bypass graph property scans only after warmup; scheduler-generation checks remain mandatory. |
 | `DFLASH_DS4_ROCTX` | unset | DEBUG: on HIP builds, dynamically load ROCTX and emit semantic DS4 prefill, speculative-decode, and layer-range markers for external rocprof traces. No events, timing, or device synchronization are added. |
 | `DFLASH_QWEN35_ROCTX` | unset | DEBUG: on HIP builds, dynamically load ROCTX and mark Qwen concurrent steps, graph compute, and argmax readback with live, padded, and packed-prefill shape metadata. |
+| `DFLASH_GFX1151_HC_MMVF_Q4` | 1 on gfx1151 for the DS4 `[16384,24]` q4 projection | BURN-IN KILL SWITCH: =0 restores the generic hipBLAS dispatch decision. |
+| `GGML_CUDA_MLA_SPLIT_KV` / `GGML_DS4_FA_SPLIT_KV` | 1 on gfx1151 indexed decode; unset elsewhere | BURN-IN: force the reusable split-KV MLA schedule. Set `GGML_CUDA_MLA_NO_SPLIT_KV=1` (or legacy `GGML_DS4_FA_NO_SPLIT_KV=1`) to disable it. |
+| `GGML_DS4_TOPK_BLOCK_RADIX` | 1 on gfx1151 | BURN-IN KILL SWITCH: =0 restores hipCUB full sort for DS4-shaped 512-row top-k selection. |
 | `GGML_DS4_FA_SERIAL_INDEX_SCAN` | unset | DEBUG/A-B: restore the serial indexed-attention mask scan instead of the long-context HIP parallel scan. |
 | `DFLASH_MOE_PREFILL_PERSISTENT_OWNER_ALLOC` | 1 for qualified long heterogeneous prefill | KILL SWITCH: =0 restores per-layer route/owner scratch allocation. |
 | `DFLASH_MOE_TP_*` / `DFLASH_MOE_HYBRID_PREFILL_EAGER` | unset | BURN-IN: model-neutral names for common heterogeneous-MoE scheduling and kernel policy. Existing `DFLASH_DS4_*` names remain compatibility aliases. |
@@ -55,6 +62,7 @@ consolidation of this list into CLI flags is tracked as follow-up work.
 | `DFLASH_STALL_TOOL_PREFIX` | unset | OPT-IN: recover a stalled tool call by injecting the prepared tool prefix when generation stops after an action suffix. |
 | `DFLASH_DS4_SPEC` / `DFLASH_DS4_DRAFT` / `DFLASH_DS4_DRAFT_BACKEND` / `DFLASH_DS4_DRAFT_GPU` | unset | OPT-IN: enable DeepSeek4 DSpark, select its draft GGUF, and optionally select the local drafter backend/device. See `DS4.md`. |
 | `DFLASH_DS4_CUDA_LAYERS` | auto | Override the DeepSeek4 heterogeneous layer-split heuristic. See `DS4.md`. |
+| `DFLASH_ROCMFP2_ROW4` | 1 on gfx1151 for q>2; legacy two-row kernel elsewhere | BURN-IN KILL SWITCH: =0 restores two-row-per-wave ROCmFP2 verification kernels. |
 
 ## Full inventory (generated)
 
@@ -72,6 +80,7 @@ consolidation of this list into CLI flags is tracked as follow-up work.
 - `DFLASH27B_PREFILL_UBATCH` - layer_split_daemon.cpp, qwen35_backend.cpp, qwen35_layer_split_adapter.cpp
 - `DFLASH_ADAPTIVE_K_DENSE` - mmid_adaptive_k.h
 - `DFLASH_ADAPTIVE_K_TAU` - mmid_adaptive_k.h
+- `DFLASH_ADAPTIVE_SPEC_WIDTH` - adaptive_spec_width.h
 - `DFLASH_ADAPTIVE_WIDTH_MIN` - adaptive_verify_width.h
 - `DFLASH_ADAPTIVE_WIDTH_THETA` - adaptive_verify_width.h
 - `DFLASH_COLD_THREADS` - moe_expert_compute_cpu.cpp
@@ -102,6 +111,8 @@ consolidation of this list into CLI flags is tracked as follow-up work.
 - `DFLASH_DS4_DSPARK_DEBUG` - deepseek4_graph.cpp
 - `DFLASH_DS4_FUSED_VERIFY` - deepseek4_dspark_spec.cpp, deepseek4_loader.cpp
 - `DFLASH_DS4_HOTNESS_CSV` - deepseek4_backend.cpp
+- `DFLASH_DS4_INCREMENTAL_VERIFY_MASK` - deepseek4_fused_verify.inc
+- `DFLASH_DS4_INCREMENTAL_VERIFY_MASK_MIN_BYTES` - deepseek4_fused_verify.inc
 - `DFLASH_DS4_MOE_TP` - deepseek4_backend.cpp
 - `DFLASH_DS4_MOE_TP_BACKEND` - deepseek4_backend.cpp
 - `DFLASH_DS4_MOE_TP_CONCENTRATE_COLD` - deepseek4_backend.cpp
@@ -115,6 +126,7 @@ consolidation of this list into CLI flags is tracked as follow-up work.
 - `DFLASH_DS4_SPEC` - deepseek4_backend.cpp
 - `DFLASH_DS4_SPEC_REFERENCE_EXACT` - deepseek4_dspark_spec.cpp
 - `DFLASH_DS4_SPEC_Q` - deepseek4_dspark_spec.cpp
+- `DFLASH_DS4_SPARSE_DECODE_FLASH` - deepseek4_backend.cpp, deepseek4_fused_verify.inc, deepseek4_graph.cpp
 - `DFLASH_DS4_TIMING` - deepseek4_backend.cpp, deepseek4_target_shard_ipc_daemon.cpp
 - `DFLASH_DS4_TP_CAPTURE_CACHE_SLOTS` - deepseek4_fused_verify.inc
 - `DFLASH_DS4_TP_FUSED_CACHE_SLOTS` - deepseek4_fused_verify.inc

--- a/server/src/common/adaptive_spec_width.h
+++ b/server/src/common/adaptive_spec_width.h
@@ -1,0 +1,101 @@
+#pragma once
+
+// Shared feedback controller for chain speculative decoding.
+//
+// A rejection reveals the exact useful draft depth, so back off with an EMA.
+// An all-accepted draft is censored: it only proves that the useful depth was
+// at least the offered width.  Averaging that lower bound would strand the
+// controller at a narrow width, so clean drafts probe upward additively.
+//
+// Widths are seed-inclusive throughout this API.  For example, width 4 means
+// one always-committed seed plus three speculative candidates.
+//
+// Opt in with DFLASH_ADAPTIVE_SPEC_WIDTH=1. Fixed width remains the production
+// default because narrower verification is not automatically cheaper on every
+// backend. Backend-specific fixed-width overrides still take precedence.
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+
+namespace dflash::common {
+
+inline bool adaptive_spec_width_globally_enabled() {
+    static const bool enabled = [] {
+        const char * value = std::getenv("DFLASH_ADAPTIVE_SPEC_WIDTH");
+        return value != nullptr && value[0] != '\0' &&
+               std::strcmp(value, "0") != 0;
+    }();
+    return enabled;
+}
+
+class AdaptiveSpecWidth {
+public:
+    AdaptiveSpecWidth(int max_width, int min_width = 2, bool enabled = true,
+                      float initial_accepted_candidates = 2.0f,
+                      float backoff_alpha = 0.25f,
+                      float full_accept_probe = 1.0f)
+        : max_width_(std::max(1, max_width)),
+          min_width_(std::clamp(min_width, 1, std::max(1, max_width))),
+          enabled_(enabled),
+          initial_accepted_candidates_(std::clamp(
+              initial_accepted_candidates, 0.0f,
+              static_cast<float>(std::max(0, max_width_ - 1)))),
+          backoff_alpha_(std::clamp(backoff_alpha, 0.0f, 1.0f)),
+          full_accept_probe_(std::max(0.0f, full_accept_probe)),
+          accepted_candidates_ema_(initial_accepted_candidates_) {}
+
+    // Apply both this feedback cap and an optional model-specific cap.
+    int next_width(int proposed_width) const {
+        const int proposed = std::clamp(proposed_width, 1, max_width_);
+        if (!enabled_ || max_width_ <= 1) return proposed;
+
+        const int feedback_width = std::clamp(
+            static_cast<int>(std::lround(accepted_candidates_ema_)) + 1,
+            min_width_, max_width_);
+        return std::min(proposed, feedback_width);
+    }
+
+    int next_width() const { return next_width(max_width_); }
+
+    // accepted_width and offered_width both include the seed row.
+    void observe(int accepted_width, int offered_width) {
+        if (!enabled_ || offered_width <= 1 || max_width_ <= 1) return;
+
+        const int offered = std::clamp(offered_width, 1, max_width_);
+        const int accepted = std::clamp(accepted_width, 1, offered);
+        const int offered_candidates = offered - 1;
+        const int accepted_candidates = accepted - 1;
+
+        if (accepted_candidates >= offered_candidates) {
+            // Censored lower bound: do not average it downward; probe wider.
+            accepted_candidates_ema_ = std::min(
+                static_cast<float>(max_width_ - 1),
+                accepted_candidates_ema_ + full_accept_probe_);
+        } else {
+            // The first rejection exposes the exact accepted prefix length.
+            accepted_candidates_ema_ =
+                (1.0f - backoff_alpha_) * accepted_candidates_ema_ +
+                backoff_alpha_ * static_cast<float>(accepted_candidates);
+        }
+    }
+
+    void reset() { accepted_candidates_ema_ = initial_accepted_candidates_; }
+
+    bool enabled() const { return enabled_; }
+    float accepted_candidates_ema() const { return accepted_candidates_ema_; }
+    int min_width() const { return min_width_; }
+    int max_width() const { return max_width_; }
+
+private:
+    int max_width_;
+    int min_width_;
+    bool enabled_;
+    float initial_accepted_candidates_;
+    float backoff_alpha_;
+    float full_accept_probe_;
+    float accepted_candidates_ema_;
+};
+
+} // namespace dflash::common

--- a/server/src/common/dflash_spec_decode.cpp
+++ b/server/src/common/dflash_spec_decode.cpp
@@ -6,6 +6,7 @@
 #include "io_utils.h"
 #include "dflash_draft_graph.h"  // build_draft_step
 #include "step_graph.h"
+#include "adaptive_spec_width.h"
 
 #include <algorithm>
 #include <chrono>
@@ -66,6 +67,8 @@ bool run_dflash_spec_decode(
 
     const int hidden = draft_weights.n_embd;
     const int q_len  = draft_weights.block_size;
+    AdaptiveSpecWidth width_controller(
+        q_len, 2, adaptive_spec_width_globally_enabled());
 
     StepGraph draft_sg;
     StepGraphGuard draft_sg_guard{draft_sg};
@@ -84,6 +87,7 @@ bool run_dflash_spec_decode(
     int n_generated     = 0;
     int n_draft_steps   = 0;
     int n_accept_sum    = 0;
+    int n_offered_sum   = 0;
     int n_hint_proposed = 0;
     int n_hint_accepted = 0;
     const ChainRollbackPolicy rollback_policy =
@@ -162,6 +166,10 @@ bool run_dflash_spec_decode(
             return false;
         }
         draft_tok[0] = last_tok;
+        const int verify_width = width_controller.next_width(q_len);
+        if ((int)draft_tok.size() > verify_width) {
+            draft_tok.resize((size_t)verify_width);
+        }
 
         // ── Tool call hint injection ──────────────────────────────────────
         // Override draft tokens with pre-known hint tokens for near-100%
@@ -169,7 +177,7 @@ bool run_dflash_spec_decode(
         int hint_filled = 0;
         if (hint_tokens && n_generated < (int)hint_tokens->size()) {
             const int hint_avail = (int)hint_tokens->size() - n_generated;
-            hint_filled = std::min(hint_avail, q_len - 1);
+            hint_filled = std::min(hint_avail, verify_width - 1);
             for (int i = 0; i < hint_filled; i++) {
                 draft_tok[1 + i] = (*hint_tokens)[n_generated + i];
             }
@@ -200,16 +208,18 @@ bool run_dflash_spec_decode(
 
         // Acceptance: longest matching prefix between draft and target argmax.
         int accept_n = 1;
-        for (int i = 0; i < q_len - 1; i++) {
+        for (int i = 0; i < verify_width - 1; i++) {
             if (draft_tok[i + 1] == target_tok[i]) accept_n++;
             else break;
         }
+        width_controller.observe(accept_n, verify_width);
+        n_offered_sum += verify_width;
         // Track hint acceptance telemetry.
         if (hint_filled > 0) {
             n_hint_proposed += hint_filled;
             n_hint_accepted += std::min(hint_filled, accept_n - 1);
         }
-        int bonus_tok = (accept_n < q_len) ? target_tok[accept_n - 1] : -1;
+        int bonus_tok = (accept_n < verify_width) ? target_tok[accept_n - 1] : -1;
         int commit_n  = accept_n + (bonus_tok >= 0 ? 1 : 0);
         if (commit_n > need_commit_budget) {
             commit_n = need_commit_budget;
@@ -302,7 +312,7 @@ bool run_dflash_spec_decode(
     if (!use_remote_draft && draft_backend) ggml_backend_synchronize(draft_backend);
     auto t_dec1 = std::chrono::steady_clock::now();
     const double decode_s = std::chrono::duration<double>(t_dec1 - t_dec0).count();
-    const int total_draft_pos = std::max(1, n_draft_steps * q_len);
+    const int total_draft_pos = std::max(1, n_offered_sum);
     const double accept_pct = 100.0 * (double)n_accept_sum / (double)total_draft_pos;
     if (accept_rate_out) {
         *accept_rate_out = total_draft_pos > 0

--- a/server/src/common/model_capabilities.h
+++ b/server/src/common/model_capabilities.h
@@ -77,7 +77,7 @@ inline constexpr ArchCapabilities kArchCapabilities[] = {
     {"laguna",     true,  false, false, true,    kMono, kMono, kMono,  kNever, kNever,kNever, kNever},
     {"qwen3",      false, false, true,  false,   kNever, kNever, kNever, kNever, kNever,kNever, kNever},
     {"gemma4",     true,  false, false, false,   kMono, kNever, kNever, kNever, kBoth,kNever, kNever},
-    {"deepseek4",  true,  false, false, false,   kNever, kNever, kNever, kNever, kNever,kNever, kNever},
+    {"deepseek4",  true,  false, true,  false,   kNever, kNever, kNever, kNever, kNever, kNever, kNever},
 };
 
 inline constexpr std::size_t kArchCount =

--- a/server/src/common/moe_hybrid_ffn_eval.cpp
+++ b/server/src/common/moe_hybrid_ffn_eval.cpp
@@ -2877,11 +2877,23 @@ static bool eval_moe_owner_expert_major_batched(
         ggml_tensor * down_e = apply_scale2(ctx,
             ggml_mul_mat_id(ctx, down_tensor, gu, local_ids_tensor), desc.ffn_down_exps_s);
 
-        ggml_tensor * weights_3d = ggml_reshape_3d(ctx, owner_weights_tensor, 1, n_used, n_tokens);
-        ggml_tensor * routed_out = ggml_mul(ctx, down_e, weights_3d);
-        routed_out = ggml_cont(ctx, ggml_permute(ctx, routed_out, 1, 0, 2, 3));
-        routed_out = ggml_sum_rows(ctx, routed_out);
-        routed_out = ggml_reshape_2d(ctx, routed_out, n_embd, n_tokens);
+        ggml_tensor * routed_out = nullptr;
+        if (moe_hybrid_graph_policy().fused_combine) {
+            // Keep the grouped-MMID result in route-major form and combine it
+            // directly. This replaces the materialized weight multiply,
+            // permutation/copy, and row reduction with one reusable kernel.
+            routed_out = ggml_laguna_moe_combine(
+                ctx, down_e, owner_weights_tensor);
+        } else {
+            ggml_tensor * weights_3d = ggml_reshape_3d(
+                ctx, owner_weights_tensor, 1, n_used, n_tokens);
+            routed_out = ggml_mul(ctx, down_e, weights_3d);
+            routed_out = ggml_cont(
+                ctx, ggml_permute(ctx, routed_out, 1, 0, 2, 3));
+            routed_out = ggml_sum_rows(ctx, routed_out);
+            routed_out = ggml_reshape_2d(
+                ctx, routed_out, n_embd, n_tokens);
+        }
 
         ggml_tensor * combined_out = routed_out;
         if (has_shared) {

--- a/server/src/deepseek4/deepseek4_backend.cpp
+++ b/server/src/deepseek4/deepseek4_backend.cpp
@@ -4,7 +4,9 @@
 #include "deepseek4_backend.h"
 #include "deepseek4_budget_hook.h"
 #include "deepseek4_internal.h"
+#include "dflash27b.h"
 #include "common/dynamic_backend.h"
+#include "common/io_utils.h"
 #include "common/peer_access.h"
 #include "common/platform_env.h"
 #include "common/sampler.h"
@@ -27,6 +29,7 @@
 #include <cinttypes>
 #include <limits>
 #include <new>
+#include <sstream>
 
 namespace dflash::common {
 
@@ -1683,6 +1686,11 @@ bool DeepSeek4Backend::park(ParkTarget target) {
         std::printf("[deepseek4] DSpark drafter parked (VRAM released)\n");
         std::fflush(stdout);
     }
+    if (want_draft && pflash_drafter_loaded_) {
+        release_pflash_drafter();
+        std::printf("[deepseek4] PFlash drafter parked (VRAM released)\n");
+        std::fflush(stdout);
+    }
     if (!want_target_model || parked_) return true;
 
     maybe_save_routing_stats();
@@ -2599,17 +2607,150 @@ GenerateResult DeepSeek4Backend::restore_and_generate_impl(
     return result;
 }
 
+ModelBackend::CompressResult DeepSeek4Backend::compress(
+        const CompressRequest & req) {
+    const auto results = compress_batch({req});
+    return results.empty() ? CompressResult{} : results.front();
+}
+
+std::vector<ModelBackend::CompressResult> DeepSeek4Backend::compress_batch(
+        const std::vector<CompressRequest> & requests) {
+    std::vector<CompressResult> results(requests.size());
+    if (requests.empty()) return results;
+
+    const CompressRequest * load_request = nullptr;
+    for (const CompressRequest & request : requests) {
+        if (request.input_ids.empty() || request.drafter_path.empty() ||
+            request.keep_ratio <= 0.0f || request.keep_ratio > 1.0f) {
+            continue;
+        }
+        if (load_request == nullptr) {
+            load_request = &request;
+        } else if (request.drafter_path != load_request->drafter_path ||
+                   request.drafter_gpu != load_request->drafter_gpu ||
+                   request.skip_park != load_request->skip_park ||
+                   request.residency_action != load_request->residency_action) {
+            // A residency window can host only one drafter configuration.
+            // Process heterogeneous batches as independent windows instead of
+            // calling the virtual base fallback, which would recurse through
+            // DeepSeek4Backend::compress().
+            std::vector<CompressResult> independent(requests.size());
+            for (size_t index = 0; index < requests.size(); ++index) {
+                const auto one = compress_batch({requests[index]});
+                if (!one.empty()) independent[index] = one.front();
+            }
+            return independent;
+        }
+    }
+    if (load_request == nullptr) return results;
+
+    const bool was_parked = parked_;
+    if (!load_request->skip_park && !parked_ &&
+        !park(ParkTarget::TargetModel)) {
+        return results;
+    }
+    if (backend_) ggml_backend_synchronize(backend_);
+    if (spec_backend_) ggml_backend_synchronize(spec_backend_);
+
+    if (pflash_drafter_loaded_ &&
+        (pflash_drafter_path_ != load_request->drafter_path ||
+         pflash_drafter_gpu_ != load_request->drafter_gpu)) {
+        release_pflash_drafter();
+    }
+    if (!pflash_drafter_loaded_) {
+        if (!load_drafter(load_request->drafter_path, 999,
+                          load_request->drafter_gpu,
+                          pflash_drafter_ctx_)) {
+            std::fprintf(stderr, "[deepseek4-pflash] load failed: %s\n",
+                         dflash27b_last_error());
+            if (!load_request->skip_park && !was_parked) {
+                unpark(ParkTarget::TargetModel);
+            }
+            return results;
+        }
+        pflash_drafter_loaded_ = true;
+        pflash_drafter_path_ = load_request->drafter_path;
+        pflash_drafter_gpu_ = load_request->drafter_gpu;
+    }
+
+    for (size_t index = 0; index < requests.size(); ++index) {
+        const CompressRequest & request = requests[index];
+        if (request.input_ids.empty() || request.drafter_path.empty() ||
+            request.keep_ratio <= 0.0f || request.keep_ratio > 1.0f) {
+            continue;
+        }
+        CompressResult & result = results[index];
+        result.compressed_ids = drafter_score_and_compress(
+            pflash_drafter_ctx_, request.input_ids, request.keep_ratio);
+        result.ok = !result.compressed_ids.empty();
+    }
+
+    if (load_request->residency_action ==
+        DraftResidencyAction::ReleaseAfterUse) {
+        release_pflash_drafter();
+    }
+    if (!load_request->skip_park && !was_parked &&
+        !unpark(ParkTarget::TargetModel)) {
+        std::fill(results.begin(), results.end(), CompressResult{});
+    }
+    return results;
+}
+
 bool DeepSeek4Backend::handle_compress(const std::string & line,
-                                        const DaemonIO & io) {
-    (void)line; (void)io;
-    std::fprintf(stderr, "[deepseek4] compress not yet supported\n");
-    return false;
+                                       const DaemonIO & io) {
+    std::istringstream iss(line.size() > 9 ? line.substr(9) : std::string{});
+    std::string prompt_path;
+    std::string drafter_path;
+    int keep_x1000 = 0;
+    if (!(iss >> prompt_path >> keep_x1000)) {
+        std::fprintf(stderr, "[deepseek4-pflash] bad compress arguments\n");
+        io.emit(-1);
+        return false;
+    }
+
+    std::getline(iss >> std::ws, drafter_path);
+    bool skip_park = false;
+    const std::string suffix = " nopark";
+    if (drafter_path.size() > suffix.size() &&
+        drafter_path.compare(drafter_path.size() - suffix.size(),
+                             suffix.size(), suffix) == 0) {
+        skip_park = true;
+        drafter_path.resize(drafter_path.size() - suffix.size());
+    }
+
+    CompressRequest req;
+    req.input_ids = read_int32_file(prompt_path);
+    req.keep_ratio = (float) keep_x1000 / 1000.0f;
+    req.drafter_path = std::move(drafter_path);
+    req.skip_park = skip_park;
+    CompressResult result = compress(req);
+    if (!result.ok) {
+        std::fprintf(stderr, "[deepseek4-pflash] compression failed\n");
+        io.emit(-1);
+        return false;
+    }
+
+    std::printf("[deepseek4-pflash] %zu -> %zu tokens\n",
+                req.input_ids.size(), result.compressed_ids.size());
+    std::fflush(stdout);
+    for (int32_t token : result.compressed_ids) io.emit(token);
+    io.emit(-1);
+    return true;
+}
+
+void DeepSeek4Backend::release_pflash_drafter() {
+    if (!pflash_drafter_loaded_) return;
+    dflash::common::free_drafter(pflash_drafter_ctx_);
+    pflash_drafter_loaded_ = false;
+    pflash_drafter_path_.clear();
+    pflash_drafter_gpu_ = -1;
 }
 
 void DeepSeek4Backend::free_drafter() {
     // Keep the configured path so request-scoped residency and an explicit
     // later `unpark draft` can restore the DSpark model.
     release_spec_drafter(/*mark_parked=*/true);
+    release_pflash_drafter();
 }
 
 void DeepSeek4Backend::maybe_save_routing_stats() {

--- a/server/src/deepseek4/deepseek4_backend.cpp
+++ b/server/src/deepseek4/deepseek4_backend.cpp
@@ -230,6 +230,32 @@ static bool configure_dspark_mmvq_defaults(int gpu) {
     return true;
 }
 
+static void configure_gfx1151_sparse_decode_default(int gpu) {
+#if defined(DFLASH27B_BACKEND_HIP) || defined(GGML_USE_HIP)
+    // Only the DSpark verifier configuration has completed model-level
+    // qualification. Preserve an explicit user choice, including the burn-in
+    // kill switch value 0.
+    if (!env_flag_enabled("DFLASH_DS4_SPEC") ||
+        std::getenv("DFLASH_DS4_SPARSE_DECODE_FLASH") != nullptr) {
+        return;
+    }
+
+    cudaDeviceProp prop{};
+    if (cudaGetDeviceProperties(&prop, gpu) != cudaSuccess ||
+        std::strncmp(prop.gcnArchName, "gfx1151", 7) != 0) {
+        return;
+    }
+
+    if (::setenv("DFLASH_DS4_SPARSE_DECODE_FLASH", "1", 0) == 0) {
+        std::fprintf(stderr,
+                     "[deepseek4] gfx1151 DSpark: defaulting adaptive sparse "
+                     "decode flash attention on\n");
+    }
+#else
+    (void) gpu;
+#endif
+}
+
 static void configure_gfx1201_hybrid_sub_batch_default(int gpu) {
 #if defined(DFLASH27B_BACKEND_HIP) || defined(GGML_USE_HIP)
     if (std::getenv("DFLASH_MMQ_SUB_BATCH") != nullptr) {
@@ -1037,6 +1063,7 @@ bool DeepSeek4Backend::init() {
     if (!configure_dspark_mmvq_defaults(cfg_.device.gpu)) {
         return false;
     }
+    configure_gfx1151_sparse_decode_default(cfg_.device.gpu);
     configure_gfx1201_hybrid_sub_batch_default(cfg_.device.gpu);
 
     backend_ = ggml_backend_cuda_init(cfg_.device.gpu);

--- a/server/src/deepseek4/deepseek4_backend.cpp
+++ b/server/src/deepseek4/deepseek4_backend.cpp
@@ -256,6 +256,35 @@ static void configure_gfx1151_sparse_decode_default(int gpu) {
 #endif
 }
 
+static bool configure_gfx1151_mix_mmq_prefill_default(
+        int gpu, PrefillAttentionMode mode) {
+#if defined(DFLASH27B_BACKEND_HIP) || defined(GGML_USE_HIP)
+    // Preserve explicit user policy, including the value 0 kill switch.
+    if (std::getenv("DFLASH_DS4_MIX_MMQ_PREFILL") != nullptr) {
+        return true;
+    }
+
+    cudaDeviceProp prop{};
+    if (cudaGetDeviceProperties(&prop, gpu) != cudaSuccess ||
+        !deepseek4_mix_mmq_prefill_default(mode, prop.gcnArchName)) {
+        return true;
+    }
+
+    if (::setenv("DFLASH_DS4_MIX_MMQ_PREFILL", "1", 0) != 0) {
+        std::fprintf(stderr,
+                     "[deepseek4] failed to enable mixed ROCmFP MMQ prefill\n");
+        return false;
+    }
+    std::fprintf(stderr,
+                 "[deepseek4] gfx1151 approximate prefill: defaulting mixed "
+                 "ROCmFP MMQ on\n");
+#else
+    (void) gpu;
+    (void) mode;
+#endif
+    return true;
+}
+
 static void configure_gfx1201_hybrid_sub_batch_default(int gpu) {
 #if defined(DFLASH27B_BACKEND_HIP) || defined(GGML_USE_HIP)
     if (std::getenv("DFLASH_MMQ_SUB_BATCH") != nullptr) {
@@ -769,6 +798,15 @@ static MoeLayerDesc make_ds4_expert_layer_desc(const DeepSeek4Layer & layer) {
 
 }  // namespace
 
+bool deepseek4_mix_mmq_prefill_default(
+        PrefillAttentionMode mode, const char * gcn_arch) {
+    if (!prefill_attention_mode_is_approximate(mode) || gcn_arch == nullptr ||
+        std::strncmp(gcn_arch, "gfx1151", 7) != 0) {
+        return false;
+    }
+    return gcn_arch[7] == '\0' || gcn_arch[7] == ':';
+}
+
 DeepSeek4Backend::DeepSeek4Backend(const DeepSeek4BackendConfig & cfg)
     : cfg_(cfg) {}
 
@@ -1064,6 +1102,10 @@ bool DeepSeek4Backend::init() {
         return false;
     }
     configure_gfx1151_sparse_decode_default(cfg_.device.gpu);
+    if (!configure_gfx1151_mix_mmq_prefill_default(
+            cfg_.device.gpu, cfg_.prefill_mode)) {
+        return false;
+    }
     configure_gfx1201_hybrid_sub_batch_default(cfg_.device.gpu);
 
     backend_ = ggml_backend_cuda_init(cfg_.device.gpu);

--- a/server/src/deepseek4/deepseek4_backend.h
+++ b/server/src/deepseek4/deepseek4_backend.h
@@ -15,6 +15,7 @@
 #include "../common/moe_hybrid_stream.h"
 #include "deepseek4_internal.h"
 #include "deepseek4_dspark.h"
+#include "qwen3/qwen3_drafter.h"
 
 #include "ggml.h"
 #include "ggml-backend.h"
@@ -70,6 +71,9 @@ public:
                                              const GenerateRequest & req,
                                              const DaemonIO & io) override;
 
+    CompressResult compress(const CompressRequest & req) override;
+    std::vector<CompressResult> compress_batch(
+        const std::vector<CompressRequest> & requests) override;
     bool handle_compress(const std::string & line,
                          const DaemonIO & io) override;
     void free_drafter() override;
@@ -114,12 +118,17 @@ private:
     ggml_backend_t                 spec_backend_ = nullptr;
     std::unique_ptr<DSparkDrafter> spec_drafter_;
     std::vector<float>             spec_feat_window_;
+    DrafterContext                 pflash_drafter_ctx_;
+    bool                           pflash_drafter_loaded_ = false;
+    std::string                    pflash_drafter_path_;
+    int                            pflash_drafter_gpu_ = -1;
     // Once a long prompt selects the fragmentation-safe prefill shape, retain
     // it for later requests so the HIP arenas never switch back under load.
     int                            hybrid_prefill_chunk_cap_ = 0;
 
     bool load_spec_drafter();
     void release_spec_drafter(bool mark_parked);
+    void release_pflash_drafter();
     void keep_spec_feature_tail(std::vector<float> & features,
                                 size_t max_rows) const;
     // True when a wide prefill path returns per-token DSpark features and the

--- a/server/src/deepseek4/deepseek4_backend.h
+++ b/server/src/deepseek4/deepseek4_backend.h
@@ -42,6 +42,15 @@ int deepseek4_hybrid_prefill_step_tokens(
     int configured_chunk,
     int position,
     int remaining_tokens);
+
+// Mixed ROCmFP MMQ changes the reduction/quantization topology, so only the
+// already-approximate prefill modes may select it automatically. The policy is
+// kept separate from the qtype kernels so future model backends can reuse the
+// same generic MMQ path after device-level qualification.
+bool deepseek4_mix_mmq_prefill_default(
+    PrefillAttentionMode mode,
+    const char * gcn_arch);
+
 class DeepSeek4Backend : public ModelBackend {
 public:
     explicit DeepSeek4Backend(const DeepSeek4BackendConfig & cfg);

--- a/server/src/deepseek4/deepseek4_dspark_spec.cpp
+++ b/server/src/deepseek4/deepseek4_dspark_spec.cpp
@@ -25,6 +25,7 @@
 #include "deepseek4_internal.h"
 #include "deepseek4_roctx.h"
 #include "internal.h"
+#include "common/adaptive_spec_width.h"
 #include "common/dspark_head.h"
 
 #include "ggml.h"
@@ -704,27 +705,19 @@ bool run_deepseek4_dspark_spec_decode(
             "[ds4-spec] draft overlap probe requested without an independent "
             "in-process backend; probe disabled\n");
     }
-    // Laguna-style adaptive verify width: EWMA of accepted candidates, width =
-    // ewma + 2 (avg_commit << block means the wide tail is usually wasted).
-    // Keep this process-local: a shared filesystem control would let an
-    // unrelated user or benchmark change live inference behavior.
-    bool adaptive_width = true;
+    // Shared adaptive verify width is opt-in. The DS4-specific setting wins
+    // over the global setting so one backend can be qualified in isolation.
+    bool adaptive_width = adaptive_spec_width_globally_enabled();
     if (const char * raw = std::getenv("DFLASH_DS4_ADAPTIVE_WIDTH")) {
         adaptive_width = raw[0] && std::strcmp(raw, "0") != 0;
     }
-    // The adaptive policy was calibrated only through q=4. Q5 is an explicit
-    // fixed-width mode and must not be silently narrowed.
-    if (q5_verify) {
-        adaptive_width = false;
-    }
+    // The confidence artifact was calibrated through q=4. Q5 still adapts,
+    // but uses target acceptance feedback rather than extrapolating that head.
     const bool use_confidence_width = adaptive_width && !seq_verify_mode &&
+        !q5_verify &&
         drafter.confidence_w != nullptr && drafter.confidence_b != nullptr &&
         (drafter.confidence_dim == n_embd ||
          drafter.confidence_dim == n_embd + drafter.markov_rank);
-    if (timing && use_confidence_width) {
-        std::fprintf(stderr, "[ds4-spec] adaptive width policy=confidence\n");
-    }
-    double ewma_accept = 1.5;
 
     // The conservative fast path remains capped at the compression ratio.
     // The explicit wide path handles a second ratio-4 boundary in-graph and
@@ -749,6 +742,14 @@ bool run_deepseek4_dspark_spec_decode(
                      DS4_CONSERVATIVE_VERIFY_MAX_TOKENS, q_cap,
                      DS4_CONSERVATIVE_VERIFY_MAX_TOKENS);
         q_cap = DS4_CONSERVATIVE_VERIFY_MAX_TOKENS;
+    }
+    AdaptiveSpecWidth width_controller(
+        q_cap, 2, adaptive_width && !seq_verify_mode);
+    if (timing && width_controller.enabled()) {
+        std::fprintf(stderr, "[ds4-spec] adaptive width policy=%s\n",
+                     use_confidence_width
+                         ? "confidence (acceptance fallback)"
+                         : "acceptance");
     }
 
     // Snapshot backend for the legacy full-snapshot rollback path.
@@ -883,9 +884,12 @@ bool run_deepseek4_dspark_spec_decode(
                        : std::min(
                              q_cap,
                              DS4_CONSERVATIVE_VERIFY_MAX_TOKENS - (pos & 3));
-        if (adaptive_width && !use_confidence_width && !seq_verify_mode) {
-            const int w_cap = (int) ewma_accept + 2;
-            if (w_cap < q_step_cap) q_step_cap = w_cap;
+        // A calibrated confidence head already predicts this individual
+        // step. Do not stack the slower acceptance-regime cap on top of it;
+        // acceptance feedback remains the fallback and drives q5/artifacts
+        // without confidence metadata.
+        if (!use_confidence_width) {
+            q_step_cap = width_controller.next_width(q_step_cap);
         }
         if (q_step_cap >= 2) {
             std::memcpy(padded_hidden.data() + n_embd, local_hidden.data(),
@@ -938,10 +942,10 @@ bool run_deepseek4_dspark_spec_decode(
             }
             if ((int) draft_tok.size() > selected_q) draft_tok.resize((size_t) selected_q);
         } else if (use_confidence_width && !seq_verify_mode) {
-            // The fused head should always return confidence for a compatible
-            // artifact. Preserve the old policy if a backend cannot do so.
-            const int selected_q = (int) ewma_accept + 2;
-            if ((int) draft_tok.size() > selected_q) draft_tok.resize((size_t) selected_q);
+            const int selected_q = width_controller.next_width((int)draft_tok.size());
+            if ((int)draft_tok.size() > selected_q) {
+                draft_tok.resize((size_t)selected_q);
+            }
         }
         if ((int) draft_tok.size() > q_step_cap) draft_tok.resize(q_step_cap);
         const int q = (int) draft_tok.size();   // seed + candidates
@@ -1129,7 +1133,7 @@ bool run_deepseek4_dspark_spec_decode(
         lt = bonus;                    // deferred bonus becomes next seed
         accept_sum += matched;
         offered_sum += q - 1;
-        ewma_accept = 0.7 * ewma_accept + 0.3 * (double) matched;
+        width_controller.observe(accept, q);
         steps++;
         if (timing && (steps <= 4 || (steps & 31) == 0)) {
             std::fprintf(stderr,

--- a/server/src/deepseek4/deepseek4_fused_verify.inc
+++ b/server/src/deepseek4/deepseek4_fused_verify.inc
@@ -1223,14 +1223,20 @@ static int ds4_try_fused_verify_step(
     ds4_fv_set(fg->i32_bundle, i32v.data(), sizeof(int32_t) * i32v.size());
     ds4_fv_set(fg->i64_bundle, i64v.data(), sizeof(int64_t) * i64v.size());
 
-    // causal mask values
+    // Causal mask values.  At long context this tensor is multi-megabyte,
+    // while only the ring slots overwritten by this q-wide batch and the
+    // padded compressed tail change between verifier steps.  Build those
+    // negative spans directly.  Large masks are zeroed on the GPU, then only
+    // those negative spans cross the host/backend boundary.
     {
+        using MaskRange = std::pair<size_t, size_t>; // [begin, end)
         const size_t mask_count = (size_t) ggml_nelements(fg->mask_bundle);
         std::vector<float> & maskv = ex->mask_values;
-        if (maskv.size() != mask_count) {
-            maskv.resize(mask_count);
-        }
-        std::fill(maskv.begin(), maskv.end(), 0.0f);
+        std::vector<MaskRange> next_negative;
+        next_negative.reserve((size_t) w.n_layer * (size_t) q * 4u);
+        const auto add_range = [&](size_t begin, size_t end) {
+            if (begin < end) next_negative.emplace_back(begin, end);
+        };
         size_t off = 0;
         for (int il = 0; il < w.n_layer; ++il) {
             const int ratio = (int) w.compress_ratios[il];
@@ -1249,34 +1255,97 @@ static int ds4_try_fused_verify_step(
             const size_t n_attn = (size_t) w.n_swa + padded +
                                   (lane_q > 1 ? (size_t) lane_q : 0u);
             for (int i = 0; i < lane_q; ++i) {
-                float * col = maskv.data() + off + (size_t) i * n_attn;
+                const size_t col = off + (size_t) i * n_attn;
                 const int pos_i = lane_kv_start + i;
-                for (int r = 0; r < w.n_swa; ++r) {
-                    // position held by slot r AFTER this batch's ring writes
-                    const int p_r = (e <= w.n_swa) ? (r < e ? r : -1)
-                                  : (e - 1) - ((e - 1 - r) % w.n_swa);
-                    if (p_r < 0 || p_r > pos_i) col[r] = -1.0e30f;
+
+                // Raw ring after this batch's writes.  Before the ring fills,
+                // every slot after pos_i is invalid or future.  Afterwards,
+                // only the q-1-i future writes are hidden; their ring slots
+                // form one range, or two when they wrap.
+                if (e <= w.n_swa) {
+                    add_range(col + (size_t) (pos_i + 1),
+                              col + (size_t) w.n_swa);
+                } else {
+                    const int future = e - 1 - pos_i;
+                    if (future > 0) {
+                        const int begin = (pos_i + 1) % w.n_swa;
+                        const int first = std::min(future, w.n_swa - begin);
+                        add_range(col + (size_t) begin,
+                                  col + (size_t) (begin + first));
+                        add_range(col,
+                                  col + (size_t) (future - first));
+                    }
                 }
+
                 const int vis = (ratio > 0 && lc.comp_kv)
                               ? ds4_comp_rows_used(lc.comp_kv, lc.n_comp, ratio, pos_i) : 0;
-                for (int c = 0; c < padded; ++c) {
-                    if (c >= vis) col[(size_t) w.n_swa + c] = -1.0e30f;
-                }
+                add_range(col + (size_t) w.n_swa + (size_t) vis,
+                          col + (size_t) w.n_swa + (size_t) padded);
+
                 if (lane_q > 1) {
-                    for (int j = 0; j < lane_q; ++j) {
-                        const bool visible =
-                            (j > i) &&
-                            (lane_kv_start + j >= w.n_swa);
-                        if (!visible) {
-                            col[(size_t) w.n_swa + padded + j] = -1.0e30f;
-                        }
-                    }
+                    const int first_visible = std::max(
+                        i + 1, w.n_swa - lane_kv_start);
+                    const int masked = std::clamp(first_visible, 0, lane_q);
+                    add_range(col + (size_t) w.n_swa + (size_t) padded,
+                              col + (size_t) w.n_swa + (size_t) padded +
+                                  (size_t) masked);
                 }
             }
             off += n_attn * lane_q;
         }
-        GGML_ASSERT(off == maskv.size());
-        ds4_fv_set(fg->mask_bundle, maskv.data(), sizeof(float) * maskv.size());
+        GGML_ASSERT(off == mask_count);
+
+        const auto normalize_ranges = [](std::vector<MaskRange> & ranges) {
+            std::sort(ranges.begin(), ranges.end());
+            size_t out = 0;
+            for (const MaskRange & range : ranges) {
+                if (out > 0 && range.first <= ranges[out - 1].second) {
+                    ranges[out - 1].second = std::max(
+                        ranges[out - 1].second, range.second);
+                } else {
+                    ranges[out++] = range;
+                }
+            }
+            ranges.resize(out);
+        };
+        normalize_ranges(next_negative);
+
+        static const bool sparse_mask_update = [] {
+            const char * value = std::getenv(
+                "DFLASH_DS4_INCREMENTAL_VERIFY_MASK");
+            return !value || std::atoi(value) != 0;
+        }();
+        static const size_t sparse_mask_min_bytes = [] {
+            constexpr size_t default_bytes = 4u * 1024u * 1024u;
+            const char * value = std::getenv(
+                "DFLASH_DS4_INCREMENTAL_VERIFY_MASK_MIN_BYTES");
+            if (!value || !*value) return default_bytes;
+            const unsigned long long parsed = std::strtoull(value, nullptr, 10);
+            return parsed > 0 ? (size_t) parsed : default_bytes;
+        }();
+        const bool use_sparse_mask_update = sparse_mask_update &&
+            mask_count * sizeof(float) >= sparse_mask_min_bytes;
+        if (!use_sparse_mask_update) {
+            maskv.assign(mask_count, 0.0f);
+            for (const MaskRange & range : next_negative) {
+                std::fill(maskv.begin() + range.first,
+                          maskv.begin() + range.second, -1.0e30f);
+            }
+            ds4_fv_set(fg->mask_bundle, maskv.data(),
+                       sizeof(float) * maskv.size());
+        } else {
+            if (maskv.size() != mask_count) maskv.resize(mask_count);
+            ggml_backend_tensor_memset(
+                fg->mask_bundle, 0, 0, mask_count * sizeof(float));
+            for (const MaskRange & range : next_negative) {
+                std::fill(maskv.begin() + range.first,
+                          maskv.begin() + range.second, -1.0e30f);
+                ggml_backend_tensor_set(
+                    fg->mask_bundle, maskv.data() + range.first,
+                    range.first * sizeof(float),
+                    (range.second - range.first) * sizeof(float));
+            }
+        }
     }
 
     if (token_ids) {

--- a/server/src/deepseek4/deepseek4_fused_verify.inc
+++ b/server/src/deepseek4/deepseek4_fused_verify.inc
@@ -534,13 +534,30 @@ static bool ds4_build_fused_verify_graph(
         std::vector<DeepSeek4I32InputBinding> i32b;
         std::vector<DeepSeek4I32ArrayBinding> i32ab;
         std::vector<DeepSeek4I64ArrayBinding> i64ab;
+        std::vector<DeepSeek4F32ArrayBinding> f32ab;
+        // Sparse attention pays a fixed indexer/compaction cost. Keep the
+        // established explicit kernel while history is small, then switch per
+        // layer once sparse work can remove at least half of the compressed
+        // rows. This also avoids a transient identity binding at the exact
+        // top-k boundary, preserving fused-graph replay.
+        const bool sparse_attention =
+            ds4_env_flag("DFLASH_DS4_SPARSE_DECODE_FLASH") && ratio > 0 &&
+            padded > 2 * w.n_indexer_top_k;
+        const DeepSeek4AttentionImpl attention_impl = sparse_attention
+            ? DeepSeek4AttentionImpl::SparseFlash
+            : DeepSeek4AttentionImpl::Explicit;
         ggml_tensor * normed = build_rms_norm(ctx, attn_in, L.attn_norm, w.rms_eps);
         ggml_tensor * attn_out = build_mla_attention(ctx, gf, normed, w, L, lc, il,
                                                      lane_kv_start, lane_q, &ain,
-                                                     i32b, i32ab, i64ab);
+                                                     i32b, i32ab, i64ab,
+                                                     &f32ab, attention_impl);
         if (!attn_out) return false;
-        if (!i32b.empty() || !i32ab.empty() || !i64ab.empty()) {
-            std::fprintf(stderr, "[ds4-fused-verify] layer %d dynamic bindings; cannot fuse\n", il);
+        if (!i32b.empty() || !i32ab.empty() || !i64ab.empty() ||
+            !f32ab.empty()) {
+            std::fprintf(stderr,
+                "[ds4-fused-verify] layer %d dynamic bindings "
+                "(%zu/%zu/%zu/%zu); cannot fuse\n",
+                il, i32b.size(), i32ab.size(), i64ab.size(), f32ab.size());
             return false;
         }
 

--- a/server/src/deepseek4/deepseek4_graph.cpp
+++ b/server/src/deepseek4/deepseek4_graph.cpp
@@ -2082,8 +2082,9 @@ static ggml_tensor * build_mla_attention(
             score_mask = ggml_reshape_2d(ctx, cmask, n_attn, n_tokens);
         }
     }
-    const bool direct_indexer_topk = indexer_topk &&
-        ds4_env_flag("DFLASH_DS4_DIRECT_INDEXER_TOPK");
+    // Long sparse prefill already has the authoritative selected rows. Pass
+    // them through directly instead of materializing and rescanning a mask.
+    const bool direct_indexer_topk = indexer_topk && n_tokens > w.n_swa;
     if (indexer_topk) {
         if (!score_mask) {
             score_mask = ggml_new_tensor_2d(

--- a/server/src/deepseek4/deepseek4_graph.cpp
+++ b/server/src/deepseek4/deepseek4_graph.cpp
@@ -1878,11 +1878,14 @@ static ggml_tensor * build_mla_attention(
             : n_index_comp_live;
         ggml_tensor * index_visibility_mask = nullptr;
         if (masked_kv && n_index_comp > 0) {
-            index_visibility_mask = ggml_view_2d(
+            // The fused verifier stores one full attention-mask column per
+            // proposed token. Extract the compressed section for every token,
+            // then compact the strided view for the indexer scorer.
+            index_visibility_mask = ggml_cont(ctx, ggml_view_2d(
                 ctx, cached_inputs->attn_row_mask,
-                n_index_comp, 1,
-                (size_t) n_index_comp * sizeof(float),
-                (size_t) w.n_swa * sizeof(float));
+                n_index_comp, n_tokens,
+                cached_inputs->attn_row_mask->nb[1],
+                (size_t) w.n_swa * sizeof(float)));
         }
         indexer_topk = build_indexer_topk(
             ctx, qr, cur, w, L, index_comp_kv_source,
@@ -1954,18 +1957,21 @@ static ggml_tensor * build_mla_attention(
     } else {
         kv_attn = raw_kv_view(0, n_raw);
     }
-    const bool fused_explicit_f16_kv = w.fused_verify_f16_kv &&
+    const bool fused_verify_f16_kv = w.fused_verify_f16_kv &&
         masked_kv && n_tokens > 1 &&
-        attention_impl == DeepSeek4AttentionImpl::Explicit &&
         kv_attn->type == GGML_TYPE_F32 &&
         raw_kv_source->type == GGML_TYPE_F16 &&
         (!comp_kv_source || comp_kv_source->type == GGML_TYPE_F16) &&
         (!old_rows_scratch_f16 ||
          old_rows_scratch_f16->type == GGML_TYPE_F16);
-    if (fused_explicit_f16_kv) {
+    const bool fused_explicit_f16_kv = fused_verify_f16_kv &&
+        attention_impl == DeepSeek4AttentionImpl::Explicit;
+    const bool fused_sparse_f16_kv = fused_verify_f16_kv &&
+        attention_impl == DeepSeek4AttentionImpl::SparseFlash;
+    if (fused_explicit_f16_kv || fused_sparse_f16_kv) {
         // DS4's persistent MLA caches are already F16. Feed those tensors
-        // directly to the established explicit attention matmuls instead of
-        // casting the entire long-context cache to F32 on every verifier step.
+        // directly to the attention implementation instead of casting the
+        // entire long-context cache to F32 on every verifier step.
         // Current writes are consumed through their set_rows results, while
         // preserved overwritten rows retain the same cached F16 values.
         kv_attn = ggml_view_2d(
@@ -1981,12 +1987,15 @@ static ggml_tensor * build_mla_attention(
                 ctx, kv_attn, old_rows_scratch_f16, 1);
         }
         static std::atomic<bool> explicit_f16_kv_logged{false};
-        if (!explicit_f16_kv_logged.exchange(true)) {
+        static std::atomic<bool> sparse_f16_kv_logged{false};
+        std::atomic<bool> & logged = fused_sparse_f16_kv
+            ? sparse_f16_kv_logged : explicit_f16_kv_logged;
+        if (!logged.exchange(true)) {
             std::fprintf(stderr,
-                "[deepseek4] fused explicit F16 K/V active: tokens=%d "
+                "[deepseek4] fused %s F16 K/V active: tokens=%d "
                 "compressed=%d\n",
+                fused_sparse_f16_kv ? "sparse" : "explicit",
                 n_tokens, n_comp_attn);
-            explicit_f16_kv_logged = true;
         }
     } else {
         if (n_comp_attn > 0 && comp_kv_source) {
@@ -2249,7 +2258,12 @@ static ggml_tensor * build_mla_attention(
             // The DS4 D=512 kernel consumes Q strides directly, avoiding a full
             // [D,H,T] -> [D,T,H] materialization for every layer.
             ggml_tensor * q_fa = ggml_permute(ctx, q, 0, 2, 1, 3);
-            ggml_tensor * kv_fa = ds4_cast_if_needed(ctx, kv_attn, GGML_TYPE_F32);
+            // The DS4 D=512 kernel has native F16 K/V specializations. Keep
+            // fused verifier caches in their persistent representation and
+            // avoid a full long-context F16 -> F32 conversion every step.
+            ggml_tensor * kv_fa = fused_sparse_f16_kv
+                ? kv_attn
+                : ds4_cast_if_needed(ctx, kv_attn, GGML_TYPE_F32);
             ggml_tensor * k_fa = ggml_reshape_3d(ctx, kv_fa, head_dim, n_attn, 1);
             ggml_tensor * v_fa = k_fa;
             ggml_tensor * mask_fa = score_mask

--- a/server/src/deepseek4/deepseek4_graph.cpp
+++ b/server/src/deepseek4/deepseek4_graph.cpp
@@ -2007,12 +2007,12 @@ static ggml_tensor * build_mla_attention(
     // [n_kv,n_query] F16; the explicit path broadcasts the same values over
     // heads in F32.
     ggml_tensor * score_mask = nullptr;
-    const bool exact_two_band =
+    const bool exact_numerical_bands =
         attention_impl == DeepSeek4AttentionImpl::DenseFlash &&
         causal_batch &&
         n_tokens > DS4_NUMERICAL_PREFILL_BAND &&
-        n_tokens <= 2 * DS4_NUMERICAL_PREFILL_BAND;
-    if (!exact_two_band) {
+        n_tokens <= DS4_MAX_LAYER_MAJOR_PREFILL_TOKENS;
+    if (!exact_numerical_bands) {
         if (masked_kv && n_tokens > 1) {
             score_mask = ggml_reshape_2d(ctx, cached_inputs->attn_row_mask,
                                          n_attn, n_tokens);
@@ -2107,21 +2107,12 @@ static ggml_tensor * build_mla_attention(
     const bool use_flash = attention_impl != DeepSeek4AttentionImpl::Explicit &&
                            (n_tokens > 1 || indexer_topk != nullptr);
     if (use_flash) {
-        if (exact_two_band) {
-            // A larger scheduling band must retain the numerical topology of
-            // two 2K requests. Prefix queries use the first band's F32 raw KV;
-            // suffix queries see its final SWA tail after the same F16 cache
-            // round-trip. HC, projections and MoE still run once over the full
-            // token batch, avoiding a second expert-weight sweep.
-            const int first_count = DS4_NUMERICAL_PREFILL_BAND;
-            const int second_count = n_tokens - first_count;
-            const int first_comp = ratio > 0
-                ? ds4_comp_rows_used(lc.comp_kv, lc.n_comp, ratio,
-                                     kv_start + first_count - 1)
-                : 0;
-            const int second_comp = n_comp_live;
-            const int second_prior_count = std::min(first_count, w.n_swa);
-
+        if (exact_numerical_bands) {
+            // A larger scheduling batch retains the numerical topology of
+            // sequential 2K requests. Each later band sees the previous
+            // band's final SWA tail after the same F16 cache round-trip. HC,
+            // projections and MoE still run once over the full token batch,
+            // avoiding another expert-weight sweep.
             auto view_kv = [&](int first, int count) {
                 return ggml_view_2d(
                     ctx, kv, head_dim, count, kv->nb[1],
@@ -2203,36 +2194,53 @@ static ggml_tensor * build_mla_attention(
                     (size_t) first * q_fa->nb[1]);
             };
 
-            ggml_tensor * first_raw = ds4_cast_if_needed(
-                ctx, view_kv(0, first_count), GGML_TYPE_F32);
-            if (prior_rows_scratch) {
-                first_raw = ggml_concat(
-                    ctx, prior_rows_scratch, first_raw, 1);
+            for (int band_start = 0; band_start < n_tokens;
+                 band_start += DS4_NUMERICAL_PREFILL_BAND) {
+                const int band_count = std::min(
+                    DS4_NUMERICAL_PREFILL_BAND, n_tokens - band_start);
+                const int band_pos = kv_start + band_start;
+                const int band_prior_count = band_start == 0
+                    ? n_prior_rows
+                    : std::min(band_start, w.n_swa);
+                const int band_comp_count = ratio > 0
+                    ? ds4_comp_rows_used(
+                          lc.comp_kv, lc.n_comp, ratio,
+                          band_pos + band_count - 1)
+                    : 0;
+
+                ggml_tensor * band_raw = nullptr;
+                if (band_start == 0) {
+                    band_raw = ds4_cast_if_needed(
+                        ctx, view_kv(0, band_count), GGML_TYPE_F32);
+                    if (prior_rows_scratch) {
+                        band_raw = ggml_concat(
+                            ctx, prior_rows_scratch, band_raw, 1);
+                    }
+                } else {
+                    ggml_tensor * rounded_prior = ggml_cast(
+                        ctx,
+                        view_kv(band_start - band_prior_count,
+                                band_prior_count),
+                        GGML_TYPE_F16);
+                    rounded_prior = ggml_cast(
+                        ctx, rounded_prior, GGML_TYPE_F32);
+                    band_raw = ggml_concat(
+                        ctx, rounded_prior,
+                        view_kv(band_start, band_count), 1);
+                }
+
+                ggml_tensor * band_kv = append_comp(
+                    band_raw, band_comp_count);
+                ggml_tensor * band_mask = make_band_mask(
+                    band_pos, band_count, band_prior_count,
+                    band_comp_count);
+                ggml_tensor * band_context = make_flash(
+                    view_q(band_start, band_count), band_kv, band_mask,
+                    band_prior_count + band_count, band_pos);
+                context = context
+                    ? ggml_concat(ctx, context, band_context, 2)
+                    : band_context;
             }
-            ggml_tensor * first_kv = append_comp(first_raw, first_comp);
-            ggml_tensor * first_mask = make_band_mask(
-                kv_start, first_count, n_prior_rows, first_comp);
-            ggml_tensor * first_context = make_flash(
-                view_q(0, first_count), first_kv, first_mask,
-                n_prior_rows + first_count, kv_start);
-
-            ggml_tensor * rounded_prior = ggml_cast(
-                ctx, view_kv(first_count - second_prior_count,
-                             second_prior_count),
-                GGML_TYPE_F16);
-            rounded_prior = ggml_cast(ctx, rounded_prior, GGML_TYPE_F32);
-            ggml_tensor * second_raw = ggml_concat(
-                ctx, rounded_prior, view_kv(first_count, second_count), 1);
-            ggml_tensor * second_kv = append_comp(second_raw, second_comp);
-            ggml_tensor * second_mask = make_band_mask(
-                kv_start + first_count, second_count,
-                second_prior_count, second_comp);
-            ggml_tensor * second_context = make_flash(
-                view_q(first_count, second_count), second_kv, second_mask,
-                second_prior_count + second_count,
-                kv_start + first_count);
-
-            context = ggml_concat(ctx, first_context, second_context, 2);
             inverse_rope_fused = true;
         } else {
             // ggml FA convention: Q[D,T,H], K/V[D,K,Hkv]. DS4 MLA has one shared

--- a/server/src/deepseek4/deepseek4_graph.cpp
+++ b/server/src/deepseek4/deepseek4_graph.cpp
@@ -39,6 +39,7 @@
 #include <mutex>
 #include <functional>
 #include <limits>
+#include <utility>
 #include <vector>
 
 #if (defined(__x86_64__) || defined(_M_X64)) && (defined(__GNUC__) || defined(__clang__))
@@ -4843,7 +4844,8 @@ struct Ds4FusedVerifyCache {
         ggml_tensor * capture = nullptr;  // f32 [n_embd*ncap,q], token-major
         ggml_tensor * argmax = nullptr;   // i32 [q], optional greedy output
         // Reused host staging for the context-sized additive attention mask.
-        // Keeping it per slot removes one allocation from every verify step.
+        // Keeping it per slot removes allocation churn in both full and
+        // sparse-range mask update modes.
         std::vector<float> mask_values;
         int q = 0;
 

--- a/server/src/deepseek4/deepseek4_internal.h
+++ b/server/src/deepseek4/deepseek4_internal.h
@@ -28,10 +28,10 @@
 
 namespace dflash::common {
 
-// Layer-major prefill may schedule two 2K numerical bands while preserving
+// Layer-major prefill may schedule four 2K numerical bands while preserving
 // the raw-cache rounding boundary between them.
 inline constexpr int DS4_NUMERICAL_PREFILL_BAND = 2048;
-inline constexpr int DS4_MAX_LAYER_MAJOR_PREFILL_TOKENS = 4096;
+inline constexpr int DS4_MAX_LAYER_MAJOR_PREFILL_TOKENS = 8192;
 // Normal verification stays within one ratio-4 compressor window. Q5 is an
 // explicit opt-in whose fused graph models a second boundary.
 inline constexpr int DS4_CONSERVATIVE_VERIFY_MAX_TOKENS = 4;

--- a/server/src/gemma4/gemma4_backend.cpp
+++ b/server/src/gemma4/gemma4_backend.cpp
@@ -11,6 +11,7 @@
 #include "common/io_utils.h"
 #include "common/dflash_feature_ring.h"
 #include "common/dflash_draft_graph.h"
+#include "common/adaptive_spec_width.h"
 #include "common/step_graph.h"
 
 #include "ggml-cuda.h"
@@ -485,6 +486,8 @@ bool Gemma4Backend::do_spec_decode(int committed, int n_gen,
 
     DFlashTarget * target = dflash_target_;
     const int q_len = dw_.block_size;
+    AdaptiveSpecWidth width_controller(
+        q_len, 2, adaptive_spec_width_globally_enabled());
 
     StepGraph draft_sg;
 
@@ -499,6 +502,7 @@ bool Gemma4Backend::do_spec_decode(int committed, int n_gen,
     int n_generated     = 0;
     int n_draft_steps   = 0;
     int n_accept_sum    = 0;
+    int n_offered_sum   = 0;
 
     auto t_dec0 = std::chrono::steady_clock::now();
 
@@ -545,7 +549,7 @@ bool Gemma4Backend::do_spec_decode(int committed, int n_gen,
                                     tail_hook, forced_close_out);
                 auto t_dec1 = std::chrono::steady_clock::now();
                 const double decode_s = std::chrono::duration<double>(t_dec1 - t_dec0).count();
-                const int total_draft_pos = std::max(1, n_draft_steps * q_len);
+                const int total_draft_pos = std::max(1, n_offered_sum);
                 const double accept_pct = 100.0 * (double)n_accept_sum / (double)total_draft_pos;
                 std::fprintf(stderr,
                     "[gemma4-spec] tail-off-stats tokens=%d time=%.3f s "
@@ -623,6 +627,10 @@ bool Gemma4Backend::do_spec_decode(int committed, int n_gen,
             return false;
         }
         draft_tok[0] = last_tok;
+        const int verify_width = width_controller.next_width(q_len);
+        if ((int)draft_tok.size() > verify_width) {
+            draft_tok.resize((size_t)verify_width);
+        }
 
         // 4. Verify: run target forward over all draft tokens.
         // Gemma4 is a pure transformer — after verify, KV entries at accepted
@@ -638,11 +646,13 @@ bool Gemma4Backend::do_spec_decode(int committed, int n_gen,
 
         // 5. Acceptance: longest matching prefix
         int accept_n = 1;
-        for (int i = 0; i < q_len - 1; i++) {
+        for (int i = 0; i < verify_width - 1; i++) {
             if (draft_tok[i + 1] == target_tok[i]) accept_n++;
             else break;
         }
-        int bonus_tok = (accept_n < q_len) ? target_tok[accept_n - 1] : -1;
+        width_controller.observe(accept_n, verify_width);
+        n_offered_sum += verify_width;
+        int bonus_tok = (accept_n < verify_width) ? target_tok[accept_n - 1] : -1;
         int commit_n  = accept_n + (bonus_tok >= 0 ? 1 : 0);
         if (commit_n > need_commit_budget) {
             commit_n = need_commit_budget;
@@ -700,7 +710,7 @@ bool Gemma4Backend::do_spec_decode(int committed, int n_gen,
 
     auto t_dec1 = std::chrono::steady_clock::now();
     const double decode_s = std::chrono::duration<double>(t_dec1 - t_dec0).count();
-    const int total_draft_pos = std::max(1, n_draft_steps * q_len);
+    const int total_draft_pos = std::max(1, n_offered_sum);
     const double accept_pct = 100.0 * (double)n_accept_sum / (double)total_draft_pos;
     std::fprintf(stderr, "[gemma4-spec] tokens=%d time=%.3f s speed=%.2f tok/s "
                  "steps=%d accepted=%d/%d (%.1f%%) avg_commit=%.2f\n",

--- a/server/src/laguna/laguna_backend.cpp
+++ b/server/src/laguna/laguna_backend.cpp
@@ -32,6 +32,7 @@
 #include "common/step_graph.h"
 
 #include "ggml-cuda.h"
+#include "../common/adaptive_spec_width.h"
 #include "../common/adaptive_verify_width.h"
 #include "ggml-alloc.h"
 #include "common/snapshot_backend.h"
@@ -512,9 +513,9 @@ bool LagunaBackend::do_spec_decode(int committed, int n_gen,
     // proposes block_size tokens but avg_commit is ~2.9, so verifying the whole
     // block is wasteful. Measured (laguna-xs2 Q4_K_M, RTX 3090): width 8 -> 110
     // tok/s, 4 -> 138, 3 -> 150 (== AR). We verify only the first q_len of the
-    // drafted block; the accept rule is unchanged, so this stays lossless. AUTO
-    // tracks an EWMA of the accepted length (held constant per request so the
-    // verify graph stays CUDA-graph-stable); --verify-width forces a fixed width.
+    // drafted block; the accept rule is unchanged, so this stays lossless.
+    // --verify-width forces a fixed width. AUTO preserves the existing EWMA
+    // policy unless the shared per-step controller is explicitly enabled.
     const bool sampled_verify = laguna_sampled_verify_enabled(sampler_, true);
     int verify_width = args_.verify_width;
     if (const char * e = std::getenv("DFLASH_LAGUNA_VERIFY_WIDTH")) {
@@ -535,17 +536,26 @@ bool LagunaBackend::do_spec_decode(int committed, int n_gen,
     // [TAG_ADAPTIVE_WIDTH] default width policy: with the per-step
     // drafter-confidence trim active (on by default for greedy chains), run
     // from a base of 8 rows and let the trim shrink each step. The legacy
-    // accept-EWMA AUTO remains the fallback when the trim is off (theta 0)
-    // and for sampled verify, which has no candidate probabilities.
+    // acceptance-feedback AUTO remains the fallback when the trim is off
+    // (theta 0) and for sampled verify, which has no candidate probabilities.
     const bool width_trim = adaptive_verify_width_theta() > 0.0f &&
                             !sampled_verify && !args_.ddtree_mode;
+    const bool shared_feedback_width =
+        adaptive_width && !args_.ddtree_mode &&
+        adaptive_spec_width_globally_enabled();
     int chain_w = adaptive_width
-        ? (width_trim ? 8 : std::min((int)(spec_ewma_accept_ + 0.5) + 1, auto_w_max))
+        ? (width_trim
+               ? 8
+               : shared_feedback_width
+                     ? auto_w_max
+                     : std::min((int)(spec_ewma_accept_ + 0.5) + 1, auto_w_max))
         : verify_width;
     if (chain_w < 2) chain_w = 2;
     if (chain_w > std::min(block_size, 8)) chain_w = std::min(block_size, 8);
     // DDTree sizes its batch via its budget; chain uses the width chosen above.
     const int base_q_len = args_.ddtree_mode ? block_size : chain_w;
+    AdaptiveSpecWidth width_controller(
+        base_q_len, 2, shared_feedback_width);
 
     const bool ignore_eos = (std::getenv("DFLASH_IGNORE_EOS") != nullptr);
     if (dflash_target_) {
@@ -1093,6 +1103,12 @@ bool LagunaBackend::do_spec_decode(int committed, int n_gen,
                 target_tok.resize((size_t)q_len);
             }
         }
+        const int feedback_width = width_controller.next_width(q_len);
+        if (feedback_width < q_len) {
+            q_len = feedback_width;
+            draft_tok.resize((size_t)q_len);
+            target_tok.resize((size_t)q_len);
+        }
 
         int verify_last_tok = -1;
         if (step_prof) prof_lap();
@@ -1134,6 +1150,7 @@ bool LagunaBackend::do_spec_decode(int committed, int n_gen,
             }
             bonus_tok = (accept_n < q_len) ? target_tok[(size_t)accept_n - 1] : -1;
         }
+        width_controller.observe(accept_n, q_len);
         int commit_n = accept_n + (bonus_tok >= 0 ? 1 : 0);
         if (commit_n > need_commit_budget) {
             commit_n = need_commit_budget;
@@ -1262,10 +1279,11 @@ bool LagunaBackend::do_spec_decode(int committed, int n_gen,
         *accept_rate_out = (float)(n_accept_sum / (double)total_draft_pos);
     }
 
-    // [TAG_LAGUNA_VERIFY_WIDTH] Update the persisted accepted-length EWMA so the
-    // AUTO width converges to the throughput optimum for the active draft (chain
-    // only; DDTree sizes via its budget and accounts accepts differently).
-    if (adaptive_width && !args_.ddtree_mode && n_draft_steps > 0) {
+    // Preserve the established request-to-request AUTO policy when the shared
+    // controller is disabled. DDTree sizes its own batch and accounts accepts
+    // differently, so it intentionally does not update this EWMA.
+    if (adaptive_width && !args_.ddtree_mode && !shared_feedback_width &&
+        n_draft_steps > 0) {
         const double mean_accept = (double)n_accept_sum / (double)n_draft_steps;
         spec_ewma_accept_ = 0.7 * spec_ewma_accept_ + 0.3 * mean_accept;
     }

--- a/server/src/laguna/laguna_backend.h
+++ b/server/src/laguna/laguna_backend.h
@@ -116,8 +116,8 @@ private:
     DraftKvState                                draft_kv_{};
     LagunaDFlashTarget *                        dflash_target_ = nullptr;
     bool                                        draft_parked_ = false;
-    // [TAG_LAGUNA_VERIFY_WIDTH] EWMA of the accepted block length, persisted
-    // across requests. Drives the AUTO chain verify width (seeded for width 3).
+    // [TAG_LAGUNA_VERIFY_WIDTH] Legacy accepted-length EWMA. Keep this as the
+    // default AUTO policy; the shared per-step controller is explicitly opt-in.
     double                                      spec_ewma_accept_ = 1.5;
 
     // PFlash drafter (lazy-loaded on first compress command).

--- a/server/src/qwen35/qwen35_backend.cpp
+++ b/server/src/qwen35/qwen35_backend.cpp
@@ -1,6 +1,7 @@
 #include "qwen35_backend.h"
 #include "concurrency/qwen35_seq_engine.h"
 #include "common/chain_rollback_policy.h"
+#include "common/adaptive_spec_width.h"
 #include "common/draft_block_size.h"
 #include "common/draft_swa.h"
 #include "placement/skip_park_guard.h"
@@ -2770,12 +2771,14 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
     // visible to the rows we keep, and would break the fixed block_size
     // contract the IPC drafter validates against.
     // Clamped to q_len: a checkpoint whose published block is below the
-    // narrowing floor never widens past its own block, and the accept-rate
-    // denominator (n_spec_steps * verify_cap) stays equal to the positions
-    // actually drafted.
+    // narrowing floor never widens past its own block. The legacy accept-rate
+    // denominator is preserved unless shared adaptive width is enabled.
     const int verify_cap = committed >= kLongCtxNarrowTokens
                                ? std::min(q_len, std::max(kLongCtxMinVerify, q_len / 2))
                                : q_len;
+    const bool shared_feedback_width =
+        !cfg_.ddtree_mode && adaptive_spec_width_globally_enabled();
+    AdaptiveSpecWidth width_controller(q_len, 2, shared_feedback_width);
     if (verify_cap != q_len) {
         static std::atomic<bool> s_narrowed_logged{false};
         if (!s_narrowed_logged.exchange(true)) {
@@ -2815,6 +2818,8 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
     int n_generated     = 0;
     int n_draft_steps   = 0;
     int n_accept_sum    = 0;
+    int n_spec_offered_sum = 0;
+    int n_spec_steps       = 0;
     int n_hint_proposed = 0;
     int n_hint_accepted = 0;
     int target_forwards = 0;
@@ -2875,7 +2880,6 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
     float accepted_ema = 2.0f * adaptive.accept_threshold();
     int   ar_burst_left = 0;
     int   n_ar_burst_steps = 0;
-    int   n_spec_steps = 0;      // steps that actually proposed q_len drafts
     bool  probe_step = false;   // first spec step after a burst
     // Live step-time EMAs (seconds) for the break-even ratio; 0 = not yet measured.
     double t_spec_step_ema = 0.0;
@@ -3647,6 +3651,13 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
                 draft_tok.resize((size_t)verify_cap);
             }
         }
+        if (!ar_step) {
+            const int feedback_width = width_controller.next_width(v_len);
+            if (feedback_width < v_len) {
+                v_len = feedback_width;
+                draft_tok.resize((size_t)v_len);
+            }
+        }
 
         // 3b. Tool call hint injection: override draft tokens with pre-known
         // structural tokens for near-100% acceptance.
@@ -3764,6 +3775,10 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
                 else break;
             }
             bonus_tok = (accept_n < v_len) ? target_tok[accept_n - 1] : -1;
+        }
+        if (!ar_step) {
+            width_controller.observe(accept_n, v_len);
+            n_spec_offered_sum += v_len;
         }
         // Track hint acceptance telemetry.
         if (hint_fill > 0) {
@@ -4050,7 +4065,9 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
         if (floor_to_ar) {
             step_graph_destroy(draft_sg);
             cache_.last_tok = out_tokens.empty() ? last_tok : out_tokens.back();
-            const int total_draft_pos = std::max(1, n_spec_steps * verify_cap);
+            const int total_draft_pos = shared_feedback_width
+                ? std::max(1, n_spec_offered_sum)
+                : std::max(1, n_spec_steps * verify_cap);
             out_accept_rate =
                 (float)((double)n_accept_sum / (double)total_draft_pos);
             const int ar_n_gen = n_gen - n_generated;
@@ -4095,7 +4112,9 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
             cache_.cur_pos = committed;
             step_graph_destroy(draft_sg);
             cache_.last_tok = out_tokens.empty() ? last_tok : out_tokens.back();
-            const int total_draft_pos = std::max(1, n_spec_steps * verify_cap);
+            const int total_draft_pos = shared_feedback_width
+                ? std::max(1, n_spec_offered_sum)
+                : std::max(1, n_spec_steps * verify_cap);
             out_accept_rate =
                 (float)((double)n_accept_sum / (double)total_draft_pos);
             const int ar_n_gen = n_gen - n_generated;
@@ -4126,7 +4145,9 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
 
     auto t_dec1 = std::chrono::steady_clock::now();
     const double decode_s = std::chrono::duration<double>(t_dec1 - t_dec0).count();
-    const int total_draft_pos = std::max(1, n_spec_steps * verify_cap);
+    const int total_draft_pos = shared_feedback_width
+        ? std::max(1, n_spec_offered_sum)
+        : std::max(1, n_spec_steps * verify_cap);
     const double accept_pct = 100.0 * (double)n_accept_sum / (double)total_draft_pos;
     out_accept_rate = (float)((double)n_accept_sum / (double)total_draft_pos);
     std::fprintf(stderr, "[spec-decode] tokens=%d time=%.3f s speed=%.2f tok/s "

--- a/server/src/qwen35moe/qwen35moe_backend.cpp
+++ b/server/src/qwen35moe/qwen35moe_backend.cpp
@@ -7,6 +7,7 @@
 #include "../common/kvflash_placement.h"
 #include "common/ggml_graph_precision.h"
 #include "common/sampler.h"
+#include "common/adaptive_spec_width.h"
 #include "common/dflash_spec_decode.h"
 #include "dflash_draft_graph.h"
 #include "dflash_feature_ring.h"
@@ -1995,6 +1996,10 @@ bool Qwen35MoeBackend::do_hybrid_spec_decode(int committed, int n_gen,
         const char * e = std::getenv("DFLASH_VERIFY_WIDTH");
         return e ? std::max(1, std::min(q_len, std::atoi(e))) : 0;
     }();
+    const bool shared_feedback_width =
+        forced_verify_width == 0 && adaptive_spec_width_globally_enabled();
+    AdaptiveSpecWidth width_controller(
+        q_len, std::min(6, q_len), shared_feedback_width);
     int observed_max_accept = 1;
 
     int32_t last_tok = target_cache().last_tok;
@@ -2012,6 +2017,7 @@ bool Qwen35MoeBackend::do_hybrid_spec_decode(int committed, int n_gen,
     int n_generated = 0;
     int n_draft_steps = 0;
     int n_accept_sum = 0;
+    int n_offered_sum = 0;
 
     // Allocate DeltaNet rollback snapshot tensors (no-op if already present).
     // Without these, snapshot_ssm_state/restore_ssm_state silently do nothing
@@ -2028,7 +2034,9 @@ bool Qwen35MoeBackend::do_hybrid_spec_decode(int committed, int n_gen,
         const int need_commit_budget = n_gen - n_generated;
         const int verify_width = forced_verify_width > 0
             ? forced_verify_width
-            : std::min(q_len, std::max(6, observed_max_accept + 2));
+            : shared_feedback_width
+                  ? width_controller.next_width(q_len)
+                  : std::min(q_len, std::max(6, observed_max_accept + 2));
 
         // 1. Build noise input for draft
         noise_ids[0] = last_tok;
@@ -2137,8 +2145,13 @@ bool Qwen35MoeBackend::do_hybrid_spec_decode(int committed, int n_gen,
             if (draft_tok[i + 1] == target_tok[i]) accept_n++;
             else break;
         }
+        if (shared_feedback_width) {
+            width_controller.observe(accept_n, verify_width);
+        } else {
+            observed_max_accept = std::max(observed_max_accept, accept_n);
+        }
+        n_offered_sum += verify_width;
         int bonus_tok = (accept_n < verify_width) ? target_tok[accept_n - 1] : -1;
-        observed_max_accept = std::max(observed_max_accept, accept_n);
         int commit_n = accept_n + (bonus_tok >= 0 ? 1 : 0);
         if (commit_n > need_commit_budget) {
             commit_n = need_commit_budget;
@@ -2199,7 +2212,9 @@ bool Qwen35MoeBackend::do_hybrid_spec_decode(int committed, int n_gen,
         const int fallback_steps = hybrid_spec_min_steps_before_ar();
         if (!io.is_cancelled() && !hit_eos && fallback_steps > 0 &&
             n_draft_steps >= fallback_steps && n_generated < n_gen) {
-            const int total_draft_pos_so_far = std::max(1, n_draft_steps * q_len);
+            const int total_draft_pos_so_far = shared_feedback_width
+                ? std::max(1, n_offered_sum)
+                : std::max(1, n_draft_steps * q_len);
             const float accept_rate_value =
                 (float)((double)n_accept_sum / (double)total_draft_pos_so_far);
             const float min_accept = hybrid_spec_min_accept_rate();
@@ -2225,7 +2240,9 @@ bool Qwen35MoeBackend::do_hybrid_spec_decode(int committed, int n_gen,
 
     auto t_dec1 = std::chrono::steady_clock::now();
     const double decode_s = std::chrono::duration<double>(t_dec1 - t_dec0).count();
-    const int total_draft_pos = std::max(1, n_draft_steps * q_len);
+    const int total_draft_pos = shared_feedback_width
+        ? std::max(1, n_offered_sum)
+        : std::max(1, n_draft_steps * q_len);
     const double accept_pct = 100.0 * (double)n_accept_sum / (double)total_draft_pos;
     if (accept_rate_out) {
         *accept_rate_out = total_draft_pos > 0

--- a/server/test/bench_ds4_topk.cpp
+++ b/server/test/bench_ds4_topk.cpp
@@ -1,0 +1,184 @@
+#include "ggml-backend.h"
+#include "ggml-cuda.h"
+#include "ggml.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+namespace {
+
+struct RunResult {
+    std::vector<int32_t> indices;
+    double milliseconds = 0.0;
+};
+
+std::vector<float> make_scores(int ncols, int nrows) {
+    std::vector<float> scores((size_t) ncols * nrows);
+    for (int row = 0; row < nrows; ++row) {
+        for (int col = 0; col < ncols; ++col) {
+            // An odd multiplier is a permutation modulo 2^24, so every score
+            // in a row is distinct and exactly representable as float.
+            const uint32_t value =
+                ((uint32_t) col * 2654435761u + (uint32_t) row * 2246822519u) &
+                0x00ffffffu;
+            scores[(size_t) row * ncols + col] =
+                (float) ((int32_t) value - 0x00800000);
+        }
+    }
+    return scores;
+}
+
+bool compute_topk(
+        ggml_backend_t backend,
+        int ncols,
+        int nrows,
+        int k,
+        bool block_radix,
+        int warmup,
+        int iterations,
+        RunResult & result) {
+    ggml_init_params params{};
+    params.mem_size = 4 * 1024 * 1024;
+    params.no_alloc = true;
+    ggml_context * ctx = ggml_init(params);
+    if (!ctx) {
+        std::fprintf(stderr, "ggml_init failed\n");
+        return false;
+    }
+
+    ggml_tensor * scores =
+        ggml_new_tensor_2d(ctx, GGML_TYPE_F32, ncols, nrows);
+    ggml_tensor * selected = ggml_top_k(ctx, scores, k);
+    ggml_set_input(scores);
+    ggml_set_output(selected);
+    ggml_cgraph * graph = ggml_new_graph(ctx);
+    ggml_build_forward_expand(graph, selected);
+
+    ggml_backend_buffer_t buffer = ggml_backend_alloc_ctx_tensors(ctx, backend);
+    if (!buffer) {
+        std::fprintf(stderr, "backend tensor allocation failed\n");
+        ggml_free(ctx);
+        return false;
+    }
+
+    const std::vector<float> host_scores = make_scores(ncols, nrows);
+    ggml_backend_tensor_set(
+        scores, host_scores.data(), 0, host_scores.size() * sizeof(float));
+    setenv("GGML_DS4_TOPK_BLOCK_RADIX", block_radix ? "1" : "0", 1);
+
+    bool ok = true;
+    for (int i = 0; i < warmup; ++i) {
+        ok = ggml_backend_graph_compute(backend, graph) == GGML_STATUS_SUCCESS;
+        if (!ok) {
+            break;
+        }
+    }
+    ggml_backend_synchronize(backend);
+
+    const auto begin = std::chrono::steady_clock::now();
+    for (int i = 0; ok && i < iterations; ++i) {
+        ok = ggml_backend_graph_compute(backend, graph) == GGML_STATUS_SUCCESS;
+    }
+    ggml_backend_synchronize(backend);
+    const auto end = std::chrono::steady_clock::now();
+    result.milliseconds =
+        std::chrono::duration<double, std::milli>(end - begin).count() /
+        iterations;
+
+    if (ok) {
+        result.indices.resize((size_t) nrows * k);
+        ggml_backend_tensor_get(
+            selected,
+            result.indices.data(),
+            0,
+            result.indices.size() * sizeof(int32_t));
+    }
+
+    ggml_backend_buffer_free(buffer);
+    ggml_free(ctx);
+    return ok;
+}
+
+bool same_selected_set(
+        const std::vector<int32_t> & reference,
+        const std::vector<int32_t> & candidate,
+        int ncols,
+        int nrows,
+        int k) {
+    if (reference.size() != candidate.size()) {
+        return false;
+    }
+    for (int row = 0; row < nrows; ++row) {
+        const auto begin = (size_t) row * k;
+        std::vector<int32_t> expected(
+            reference.begin() + begin, reference.begin() + begin + k);
+        std::vector<int32_t> actual(
+            candidate.begin() + begin, candidate.begin() + begin + k);
+        if (std::any_of(actual.begin(), actual.end(), [ncols](int32_t index) {
+                return index < 0 || index >= ncols;
+            })) {
+            return false;
+        }
+        std::sort(expected.begin(), expected.end());
+        std::sort(actual.begin(), actual.end());
+        if (expected != actual) {
+            return false;
+        }
+    }
+    return true;
+}
+
+}  // namespace
+
+int main() {
+    ggml_backend_t backend = ggml_backend_cuda_init(0);
+    if (!backend) {
+        std::fprintf(stderr, "ggml_backend_cuda_init failed\n");
+        return 1;
+    }
+
+    const bool previous_graphs_disabled =
+        ggml_backend_cuda_set_graphs_disabled_override(true);
+    constexpr int k = 512;
+    constexpr int nrows = 4;
+    const int shapes[] = {
+        5121, 8192, 8193, 12288, 12289, 16384, 28673, 30720, 32768
+    };
+    bool all_ok = true;
+
+    for (const int ncols : shapes) {
+        RunResult full_sort;
+        RunResult hierarchical;
+        const int iterations = ncols == 30720 ? 100 : 5;
+        const bool ran =
+            compute_topk(
+                backend, ncols, nrows, k, false, 2, iterations, full_sort) &&
+            compute_topk(
+                backend, ncols, nrows, k, true, 2, iterations, hierarchical);
+        const bool exact = ran && same_selected_set(
+            full_sort.indices, hierarchical.indices, ncols, nrows, k);
+        const double speedup = hierarchical.milliseconds > 0.0
+            ? full_sort.milliseconds / hierarchical.milliseconds
+            : 0.0;
+        std::printf(
+            "ncols=%d rows=%d k=%d full_sort=%.3f ms hierarchical=%.3f ms "
+            "speedup=%.2fx exact_set=%s\n",
+            ncols,
+            nrows,
+            k,
+            full_sort.milliseconds,
+            hierarchical.milliseconds,
+            speedup,
+            exact ? "yes" : "NO");
+        all_ok = all_ok && exact;
+    }
+
+    unsetenv("GGML_DS4_TOPK_BLOCK_RADIX");
+    ggml_backend_cuda_set_graphs_disabled_override(previous_graphs_disabled);
+    ggml_backend_free(backend);
+    return all_ok ? 0 : 1;
+}

--- a/server/test/bench_rocmfp_mix_gateup_glu.cpp
+++ b/server/test/bench_rocmfp_mix_gateup_glu.cpp
@@ -1,4 +1,4 @@
-// Microbenchmark: ONE fused gate/up+SwiGLU launch vs TWO unfused matvec launches.
+// Microbenchmark: the dynamic fused gate/up+SwiGLU path vs TWO plain matvec launches.
 //
 // Tests the claim the whole fusion rests on. Profiling attributed ~102% of the measured 4.6%
 // adaptive decode penalty to LAUNCH COUNT (30100 vs qtype 107's 15050) rather than to decode
@@ -11,9 +11,11 @@
 // shape actually costs. The fused arm therefore looks *worse* than reality -- a conservative
 // comparison, which is the direction to err in.
 //
-// Reports per-iteration wall time over many iterations on one stream, after a warmup, plus the
-// relative delta. Single stream and back-to-back launches on purpose: that is the decode
-// dependency chain, where launch overhead cannot be hidden.
+// The fused wrapper uses one dual-projection launch through q=2 and two
+// lower-register launches (with SwiGLU folded into the second) for wider verification. Reports
+// per-iteration wall time over many iterations on one stream, after a warmup,
+// plus the relative delta. Single stream and back-to-back launches on purpose:
+// that is the decode dependency chain, where launch overhead cannot be hidden.
 
 #include "ggml-cuda.h"
 
@@ -21,6 +23,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -39,9 +42,20 @@ bool ggml_cuda_rocmfp2_mix_mul_mat_id_glu(
     int64_t ids_s0, int64_t ids_s1, int64_t src1_s1, int64_t src1_s2,
     int64_t dst_s1, int64_t dst_s2, float glu_limit, hipStream_t stream);
 
+bool ggml_cuda_rocmfp3_mix_mul_mat_id(
+    const void * vx, const float * src1, const int32_t * ids, float * dst,
+    int in, int out, int n_expert_used, int n_tokens, int ne11,
+    int64_t ids_s0, int64_t ids_s1, int64_t src1_s1, int64_t src1_s2,
+    int64_t dst_s1, int64_t dst_s2, hipStream_t stream);
+
+bool ggml_cuda_rocmfp3_mix_mul_mat_id_glu(
+    const void * vx_up, const void * vx_gate,
+    const float * src1, const int32_t * ids, float * dst,
+    int in, int out, int n_expert_used, int n_tokens, int ne11,
+    int64_t ids_s0, int64_t ids_s1, int64_t src1_s1, int64_t src1_s2,
+    int64_t dst_s1, int64_t dst_s2, float glu_limit, hipStream_t stream);
+
 static constexpr int QK = 32;
-static constexpr int BLOCK_BYTES = 10;
-static constexpr int K = 4;
 
 static uint32_t xs = 0x1234567u;
 static uint32_t rnd() { xs ^= xs << 13; xs ^= xs >> 17; xs ^= xs << 5; return xs; }
@@ -58,28 +72,49 @@ static double median(std::vector<double> v) {
     return v[v.size() / 2];
 }
 
-int main() {
+static uint64_t fnv1a64(const std::vector<float> & values) {
+    uint64_t hash = 1469598103934665603ull;
+    const uint8_t * bytes = reinterpret_cast<const uint8_t *>(values.data());
+    for (size_t i = 0; i < sizeof(float) * values.size(); ++i) {
+        hash = (hash ^ bytes[i]) * 1099511628211ull;
+    }
+    return hash;
+}
+
+int main(int argc, char ** argv) {
     int ndev = 0;
     if (hipGetDeviceCount(&ndev) != hipSuccess || ndev == 0) {
         std::fprintf(stderr, "SKIP: no HIP device\n");
         return 0;
     }
 
-    // DeepSeek-V4-Flash decode geometry: hidden 7168, n_ff_exp 2048, top-k 4 (--ds4-expert-top-k 4
-    // is what the measured runs used), one token per step.
-    const int in = 7168, out = 2048, n_experts = 8, n_used = 4, ntok = 1;
+    // DeepSeek-V4-Flash verifier geometry: hidden 4096, n_ff_exp 2048,
+    // model-default top-k 6. The optional first argument selects the verifier
+    // width so q=1 and q=4 can be compared without rebuilding.
+    const int in = 4096, out = 2048, n_experts = 8, n_used = 6;
+    const int ntok = argc > 1 ? std::atoi(argv[1]) : 4;
+    const bool fp3 = argc > 2 && std::strcmp(argv[2], "q3") == 0;
+    const bool fixed_levels = argc > 3 && std::strcmp(argv[3], "fixed") == 0;
+    if (ntok <= 0 || ntok > 16 ||
+        (argc > 2 && !fp3 && std::strcmp(argv[2], "q2") != 0) ||
+        (argc > 3 && !fixed_levels && std::strcmp(argv[3], "learned") != 0)) {
+        std::fprintf(stderr, "usage: %s [tokens:1..16] [q2|q3] [learned|fixed]\n", argv[0]);
+        return 2;
+    }
+    const int block_bytes = fp3 ? 14 : 10;
+    const int levels = fp3 ? 8 : 4;
     const int nb = in / QK;
-    const size_t rows_bytes = (size_t) out * nb * BLOCK_BYTES;
+    const size_t rows_bytes = (size_t) out * nb * block_bytes;
 
     std::vector<uint8_t> w(rows_bytes * n_experts);
     for (auto & b : w) b = (uint8_t) rnd();
-    for (size_t blk = 0; blk < w.size() / BLOCK_BYTES; ++blk) {
-        w[blk * BLOCK_BYTES + 8] = 0x30;
-        w[blk * BLOCK_BYTES + 9] = 0x30;
+    for (size_t blk = 0; blk < w.size() / block_bytes; ++blk) {
+        w[blk * block_bytes + block_bytes - 2] = 0x30;
+        w[blk * block_bytes + block_bytes - 1] = 0x30;
     }
-    std::vector<uint16_t> books((size_t) n_experts * 2 * K);
+    std::vector<uint16_t> books((size_t) n_experts * 2 * levels);
     for (size_t i = 0; i < books.size(); ++i) books[i] = f32_to_bf16(-0.5f + 0.2f * (float) (i % 5));
-    std::vector<uint8_t> modes(n_experts, 1);
+    std::vector<uint8_t> modes(n_experts, fixed_levels ? 0 : 1);
 
     void * d_up = nullptr, * d_gate = nullptr;
     float * d_x = nullptr, * d_a = nullptr, * d_b = nullptr;
@@ -100,16 +135,25 @@ int main() {
     for (int i = 0; i < n_used * ntok; ++i) idsh[i] = i % n_experts;
     HIP_OK(hipMemcpy(d_ids, idsh.data(), sizeof(int32_t) * idsh.size(), hipMemcpyHostToDevice));
 
-    if (!ggml_cuda_rocmfp2_mix_register_host(
+    const auto register_mix = fp3 ? ggml_cuda_rocmfp3_mix_register_host
+                                  : ggml_cuda_rocmfp2_mix_register_host;
+    const auto unregister_mix = fp3 ? ggml_cuda_rocmfp3_mix_unregister
+                                    : ggml_cuda_rocmfp2_mix_unregister;
+    const auto mul_mat_id = fp3 ? ggml_cuda_rocmfp3_mix_mul_mat_id
+                                : ggml_cuda_rocmfp2_mix_mul_mat_id;
+    const auto mul_mat_id_glu = fp3 ? ggml_cuda_rocmfp3_mix_mul_mat_id_glu
+                                    : ggml_cuda_rocmfp2_mix_mul_mat_id_glu;
+
+    if (!register_mix(
             d_up, rows_bytes, n_experts, out, in,
             books.data(), modes.data())) {
         std::fprintf(stderr, "FAIL: mixed-tensor registration failed\n");
         return 1;
     }
-    if (!ggml_cuda_rocmfp2_mix_register_host(
+    if (!register_mix(
             d_gate, rows_bytes, n_experts, out, in,
             books.data(), modes.data())) {
-        ggml_cuda_rocmfp2_mix_unregister(d_up);
+        unregister_mix(d_up);
         std::fprintf(stderr, "FAIL: mixed-tensor registration failed\n");
         return 1;
     }
@@ -126,17 +170,17 @@ int main() {
     auto time_unfused = [&]() {
         hipEvent_t a, b; hipEventCreate(&a); hipEventCreate(&b);
         for (int i = 0; i < WARM; ++i) {
-            ggml_cuda_rocmfp2_mix_mul_mat_id(d_up, d_x, d_ids, d_a, in, out, n_used, ntok, 1,
+            mul_mat_id(d_up, d_x, d_ids, d_a, in, out, n_used, ntok, 1,
                 ids_s0, ids_s1, src1_s1, src1_s2, dst_s1, dst_s2, stream);
-            ggml_cuda_rocmfp2_mix_mul_mat_id(d_gate, d_x, d_ids, d_b, in, out, n_used, ntok, 1,
+            mul_mat_id(d_gate, d_x, d_ids, d_b, in, out, n_used, ntok, 1,
                 ids_s0, ids_s1, src1_s1, src1_s2, dst_s1, dst_s2, stream);
         }
         hipStreamSynchronize(stream);
         hipEventRecord(a, stream);
         for (int i = 0; i < ITERS; ++i) {
-            ggml_cuda_rocmfp2_mix_mul_mat_id(d_up, d_x, d_ids, d_a, in, out, n_used, ntok, 1,
+            mul_mat_id(d_up, d_x, d_ids, d_a, in, out, n_used, ntok, 1,
                 ids_s0, ids_s1, src1_s1, src1_s2, dst_s1, dst_s2, stream);
-            ggml_cuda_rocmfp2_mix_mul_mat_id(d_gate, d_x, d_ids, d_b, in, out, n_used, ntok, 1,
+            mul_mat_id(d_gate, d_x, d_ids, d_b, in, out, n_used, ntok, 1,
                 ids_s0, ids_s1, src1_s1, src1_s2, dst_s1, dst_s2, stream);
         }
         hipEventRecord(b, stream);
@@ -148,13 +192,13 @@ int main() {
     auto time_fused = [&]() {
         hipEvent_t a, b; hipEventCreate(&a); hipEventCreate(&b);
         for (int i = 0; i < WARM; ++i) {
-            ggml_cuda_rocmfp2_mix_mul_mat_id_glu(d_up, d_gate, d_x, d_ids, d_a, in, out, n_used,
+            mul_mat_id_glu(d_up, d_gate, d_x, d_ids, d_a, in, out, n_used,
                 ntok, 1, ids_s0, ids_s1, src1_s1, src1_s2, dst_s1, dst_s2, 7.0f, stream);
         }
         hipStreamSynchronize(stream);
         hipEventRecord(a, stream);
         for (int i = 0; i < ITERS; ++i) {
-            ggml_cuda_rocmfp2_mix_mul_mat_id_glu(d_up, d_gate, d_x, d_ids, d_a, in, out, n_used,
+            mul_mat_id_glu(d_up, d_gate, d_x, d_ids, d_a, in, out, n_used,
                 ntok, 1, ids_s0, ids_s1, src1_s1, src1_s2, dst_s1, dst_s2, 7.0f, stream);
         }
         hipEventRecord(b, stream);
@@ -170,20 +214,51 @@ int main() {
     for (int r = 0; r < REPS; ++r) { u.push_back(time_unfused()); f.push_back(time_fused()); }
 
     const double mu = median(u), mf = median(f);
-    std::fprintf(stderr, "geometry: in=%d out=%d top_k=%d ntok=%d  (%d iters x %d interleaved reps)\n",
+    std::fprintf(stderr, "geometry: qtype=%s levels=%s in=%d out=%d top_k=%d ntok=%d  "
+                         "(%d iters x %d interleaved reps)\n",
+                 fp3 ? "q3-mix" : "q2-mix", fixed_levels ? "fixed" : "learned",
                  in, out, n_used, ntok, ITERS, REPS);
     std::fprintf(stderr, "  unfused (2 launches, swiglu NOT counted): %8.4f ms/step  [",
                  mu);
     for (double v : u) std::fprintf(stderr, " %.4f", v);
-    std::fprintf(stderr, " ]\n  fused   (1 launch,  swiglu included ): %8.4f ms/step  [", mf);
+    const int fused_launches = fp3 || ntok <= 2 ? 1 : 2;
+    std::fprintf(stderr, " ]\n  fused   (%d launch%s, swiglu included): %8.4f ms/step  [",
+                 fused_launches, fused_launches == 1 ? " " : "es", mf);
     for (double v : f) std::fprintf(stderr, " %.4f", v);
     std::fprintf(stderr, " ]\n");
     std::fprintf(stderr, "  fused is %+.2f%% vs unfused (negative = faster)\n", 100.0 * (mf / mu - 1.0));
     std::fprintf(stderr, "  per-layer saving %.4f ms -> over 43 layers %.3f ms/step\n",
                  mu - mf, (mu - mf) * 43.0);
 
-    ggml_cuda_rocmfp2_mix_unregister(d_gate);
-    ggml_cuda_rocmfp2_mix_unregister(d_up);
+    // Hash both raw projections and the fused output after timing. This catches
+    // mode-specific numerical drift even when the generated-token hash happens
+    // to remain unchanged.
+    if (!mul_mat_id(d_up, d_x, d_ids, d_a, in, out, n_used, ntok, 1,
+            ids_s0, ids_s1, src1_s1, src1_s2, dst_s1, dst_s2, stream) ||
+        !mul_mat_id(d_gate, d_x, d_ids, d_b, in, out, n_used, ntok, 1,
+            ids_s0, ids_s1, src1_s1, src1_s2, dst_s1, dst_s2, stream)) {
+        std::fprintf(stderr, "FAIL: raw projection dispatch rejected\n");
+        return 1;
+    }
+    HIP_OK(hipStreamSynchronize(stream));
+    std::vector<float> up_result(yn), gate_result(yn), fused_result(yn);
+    HIP_OK(hipMemcpy(up_result.data(), d_a, sizeof(float) * yn, hipMemcpyDeviceToHost));
+    HIP_OK(hipMemcpy(gate_result.data(), d_b, sizeof(float) * yn, hipMemcpyDeviceToHost));
+    if (!mul_mat_id_glu(d_up, d_gate, d_x, d_ids, d_a, in, out, n_used,
+            ntok, 1, ids_s0, ids_s1, src1_s1, src1_s2, dst_s1, dst_s2, 7.0f, stream)) {
+        std::fprintf(stderr, "FAIL: fused projection dispatch rejected\n");
+        return 1;
+    }
+    HIP_OK(hipStreamSynchronize(stream));
+    HIP_OK(hipMemcpy(fused_result.data(), d_a, sizeof(float) * yn, hipMemcpyDeviceToHost));
+    std::fprintf(stderr, "  raw up/gate fnv1a64: %016llx %016llx\n",
+                 (unsigned long long) fnv1a64(up_result),
+                 (unsigned long long) fnv1a64(gate_result));
+    std::fprintf(stderr, "  result fnv1a64: %016llx\n",
+                 (unsigned long long) fnv1a64(fused_result));
+
+    unregister_mix(d_gate);
+    unregister_mix(d_up);
     hipStreamDestroy(stream);
     HIP_OK(hipFree(d_up)); HIP_OK(hipFree(d_gate)); HIP_OK(hipFree(d_x));
     HIP_OK(hipFree(d_a));  HIP_OK(hipFree(d_b));    HIP_OK(hipFree(d_ids));

--- a/server/test/test_adaptive_spec_width.cpp
+++ b/server/test/test_adaptive_spec_width.cpp
@@ -1,0 +1,73 @@
+#include "CppUnitTestFramework.hpp"
+#include "common/adaptive_spec_width.h"
+
+#include <cmath>
+
+using namespace dflash::common;
+
+namespace {
+struct AdaptiveSpecWidthFixture {};
+
+bool near(float lhs, float rhs, float tolerance = 1e-6f) {
+    return std::fabs(lhs - rhs) <= tolerance;
+}
+} // namespace
+
+TEST_CASE(AdaptiveSpecWidthFixture, starts_with_two_candidates) {
+    AdaptiveSpecWidth width(16);
+    CHECK(width.next_width() == 3);
+}
+
+TEST_CASE(AdaptiveSpecWidthFixture, clean_drafts_probe_upward) {
+    AdaptiveSpecWidth width(8);
+    CHECK(width.next_width() == 3);
+    width.observe(3, 3);
+    CHECK(width.next_width() == 4);
+    width.observe(4, 4);
+    CHECK(width.next_width() == 5);
+}
+
+TEST_CASE(AdaptiveSpecWidthFixture, censored_sample_is_not_averaged_down) {
+    AdaptiveSpecWidth width(8, 2, true, 5.0f);
+    width.observe(3, 3);
+    CHECK(near(width.accepted_candidates_ema(), 6.0f));
+    CHECK(width.next_width() == 7);
+}
+
+TEST_CASE(AdaptiveSpecWidthFixture, rejection_backs_off_gently) {
+    AdaptiveSpecWidth width(8, 2, true, 4.0f);
+    width.observe(2, 6); // one accepted candidate, then a rejection
+    CHECK(near(width.accepted_candidates_ema(), 3.25f));
+    CHECK(width.next_width() == 4);
+}
+
+TEST_CASE(AdaptiveSpecWidthFixture, respects_model_and_feedback_caps) {
+    AdaptiveSpecWidth width(8, 2, true, 5.0f);
+    CHECK(width.next_width(4) == 4);
+    CHECK(width.next_width(99) == 6);
+    CHECK(width.next_width(1) == 1);
+}
+
+TEST_CASE(AdaptiveSpecWidthFixture, respects_minimum_width) {
+    AdaptiveSpecWidth width(16, 6, true, 0.0f);
+    CHECK(width.next_width() == 6);
+    width.observe(1, 6);
+    CHECK(width.next_width() == 6);
+}
+
+TEST_CASE(AdaptiveSpecWidthFixture, disabled_controller_preserves_proposal) {
+    AdaptiveSpecWidth width(16, 2, false);
+    CHECK(width.next_width() == 16);
+    CHECK(width.next_width(7) == 7);
+    width.observe(1, 16);
+    CHECK(width.next_width() == 16);
+}
+
+TEST_CASE(AdaptiveSpecWidthFixture, reset_restores_initial_estimate) {
+    AdaptiveSpecWidth width(8);
+    width.observe(1, 3);
+    CHECK(!near(width.accepted_candidates_ema(), 2.0f));
+    width.reset();
+    CHECK(near(width.accepted_candidates_ema(), 2.0f));
+    CHECK(width.next_width() == 3);
+}

--- a/server/test/test_deepseek4_mmid_grouped_cuda.cpp
+++ b/server/test/test_deepseek4_mmid_grouped_cuda.cpp
@@ -247,11 +247,13 @@ static int run_child(const char * mode, const char * output_path) {
         GGML_TYPE_Q5_K, GGML_TYPE_Q2_0_ROCMFP2, GGML_TYPE_Q3_0_ROCMFPX,
         GGML_TYPE_Q4_0_ROCMFP4_FAST,
     };
-    const int widths[] = {2, 4, 8, 9, 16, 32, 48, 64};
     int width_filter = 0;
     if (const char * raw = std::getenv("DFLASH_MMID_TEST_WIDTH")) {
         width_filter = std::max(0, std::atoi(raw));
     }
+    const std::vector<int> widths = width_filter > 0
+        ? std::vector<int>{width_filter}
+        : std::vector<int>{2, 4, 8, 9, 16, 32, 48, 64};
     bool ok = output.good();
     for (ggml_type type : types) {
         if (type == GGML_TYPE_Q4_0_ROCMFP4_FAST && width_filter == 0) {

--- a/server/test/test_deepseek4_mmid_grouped_cuda.cpp
+++ b/server/test/test_deepseek4_mmid_grouped_cuda.cpp
@@ -7,6 +7,7 @@
 #include <cuda_runtime.h>
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <cstddef>
 #include <cstdio>
@@ -31,10 +32,25 @@ static bool run_case(
         bool fused_ds4,
         bool write_output,
         std::ofstream & output) {
-    constexpr int k_dim = 256;
-    constexpr int n_rows = 128;
-    constexpr int n_experts = 32;
-    constexpr int top_k = 8;
+    int k_dim = 256;
+    int n_rows = 128;
+    int n_experts = 32;
+    int top_k = 8;
+    const auto env_positive = [](const char * name, int fallback) {
+        const char * raw = std::getenv(name);
+        const int parsed = raw ? std::atoi(raw) : 0;
+        return parsed > 0 ? parsed : fallback;
+    };
+    if (std::getenv("DFLASH_MMID_BENCH_ITERS")) {
+        k_dim = env_positive("DFLASH_MMID_BENCH_K", k_dim);
+        n_rows = env_positive("DFLASH_MMID_BENCH_ROWS", n_rows);
+        n_experts = env_positive("DFLASH_MMID_BENCH_EXPERTS", n_experts);
+        top_k = env_positive("DFLASH_MMID_BENCH_TOP_K", top_k);
+    }
+    if (top_k > n_experts) {
+        std::fprintf(stderr, "top_k=%d exceeds n_experts=%d\n", top_k, n_experts);
+        return false;
+    }
 
     ggml_init_params params = {16 * 1024 * 1024, nullptr, true};
     ggml_context * ctx = ggml_init(params);
@@ -70,9 +86,13 @@ static bool run_case(
         return false;
     }
 
+    const bool benchmark = std::getenv("DFLASH_MMID_BENCH_ITERS") != nullptr;
     std::mt19937 rng(20260713u + (unsigned) type * 97u + (unsigned) width);
     std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
-    std::vector<float> weights_f((size_t) k_dim * n_rows * n_experts);
+    std::vector<float> weights_f;
+    if (!benchmark) {
+        weights_f.resize((size_t) k_dim * n_rows * n_experts);
+    }
     std::vector<float> input_f((size_t) k_dim * width);
     for (float & value : weights_f) {
         value = dist(rng);
@@ -82,7 +102,11 @@ static bool run_case(
     }
 
     std::vector<uint8_t> weights_q(ggml_nbytes(weights));
-    const size_t quantized =
+    // A zero-filled quantized tensor is valid and exercises the identical GPU
+    // load/dequantize path without constructing multi-gigabyte F32 weights for
+    // realistic expert-count benchmarks. Correctness runs still use quantized
+    // randomized weights.
+    const size_t quantized = benchmark ? weights_q.size() :
         type == GGML_TYPE_Q2_0_ROCMFP2
             ? rocmfpx_quantize_fp2(
                   weights_f.data(), weights_q.data(), n_rows * n_experts,
@@ -126,7 +150,27 @@ static bool run_case(
     ggml_backend_tensor_set(ids, ids_h.data(), 0, ids_h.size() * sizeof(int32_t));
     ggml_backend_synchronize(backend);
 
-    const ggml_status status = ggml_backend_graph_compute(backend, graph);
+    ggml_status status = ggml_backend_graph_compute(backend, graph);
+    int benchmark_iterations = 0;
+    if (const char * raw = std::getenv("DFLASH_MMID_BENCH_ITERS")) {
+        benchmark_iterations = std::max(0, std::atoi(raw));
+    }
+    if (status == GGML_STATUS_SUCCESS && benchmark_iterations > 0) {
+        ggml_backend_synchronize(backend);
+        const auto start = std::chrono::steady_clock::now();
+        for (int i = 0; i < benchmark_iterations && status == GGML_STATUS_SUCCESS; ++i) {
+            status = ggml_backend_graph_compute(backend, graph);
+        }
+        ggml_backend_synchronize(backend);
+        const auto end = std::chrono::steady_clock::now();
+        const double average_us = std::chrono::duration<double, std::micro>(
+            end - start).count() / benchmark_iterations;
+        std::printf(
+            "[mmid-grouped-test] benchmark type=%s width=%d experts=%d top_k=%d "
+            "k=%d rows=%d iterations=%d average_us=%.3f\n",
+            ggml_type_name(type), width, n_experts, top_k, k_dim, n_rows,
+            benchmark_iterations, average_us);
+    }
     std::vector<float> result_h(ggml_nelements(result));
     if (status == GGML_STATUS_SUCCESS) {
         ggml_backend_synchronize(backend);
@@ -201,18 +245,28 @@ static int run_child(const char * mode, const char * output_path) {
     const ggml_type types[] = {
         GGML_TYPE_Q4_K, GGML_TYPE_Q6_K, GGML_TYPE_Q4_0, GGML_TYPE_Q8_0,
         GGML_TYPE_Q5_K, GGML_TYPE_Q2_0_ROCMFP2, GGML_TYPE_Q3_0_ROCMFPX,
+        GGML_TYPE_Q4_0_ROCMFP4_FAST,
     };
-    const int widths[] = {2, 4, 8, 9, 16, 32};
+    const int widths[] = {2, 4, 8, 9, 16, 32, 48, 64};
+    int width_filter = 0;
+    if (const char * raw = std::getenv("DFLASH_MMID_TEST_WIDTH")) {
+        width_filter = std::max(0, std::atoi(raw));
+    }
     bool ok = output.good();
     for (ggml_type type : types) {
+        if (type == GGML_TYPE_Q4_0_ROCMFP4_FAST && width_filter == 0) {
+            continue;
+        }
         for (int width : widths) {
-            if (width == 32 &&
+            if ((width_filter > 0 && width != width_filter) ||
+                (width >= 32 &&
                 type != GGML_TYPE_Q2_0_ROCMFP2 &&
-                type != GGML_TYPE_Q3_0_ROCMFPX) {
+                type != GGML_TYPE_Q3_0_ROCMFPX &&
+                type != GGML_TYPE_Q4_0_ROCMFP4_FAST)) {
                 continue;
             }
             ok = run_case(backend, type, width, false, true, output) && ok;
-            if (width < 32) {
+            if (width < 32 && width_filter == 0) {
                 ok = run_case(backend, type, width, true, true, output) && ok;
             }
         }
@@ -320,6 +374,196 @@ static bool grouped_supported_device() {
 #endif
 }
 
+struct CombineRun {
+    std::vector<float> output;
+    double average_us = 0.0;
+    bool ok = false;
+};
+
+static CombineRun run_combine_graph(
+        ggml_backend_t backend,
+        bool fused,
+        int n_embd,
+        int n_used,
+        int n_tokens,
+        const std::vector<float> & experts_h,
+        const std::vector<float> & weights_h,
+        int iterations) {
+    CombineRun run;
+    ggml_init_params params = {16 * 1024 * 1024, nullptr, true};
+    ggml_context * ctx = ggml_init(params);
+    if (ctx == nullptr) {
+        return run;
+    }
+
+    ggml_tensor * experts = ggml_new_tensor_3d(
+        ctx, GGML_TYPE_F32, n_embd, n_used, n_tokens);
+    ggml_tensor * weights = ggml_new_tensor_2d(
+        ctx, GGML_TYPE_F32, n_used, n_tokens);
+    ggml_set_input(experts);
+    ggml_set_input(weights);
+
+    ggml_tensor * result = nullptr;
+    if (fused) {
+        result = ggml_laguna_moe_combine(ctx, experts, weights);
+    } else {
+        ggml_tensor * weights_3d = ggml_reshape_3d(
+            ctx, weights, 1, n_used, n_tokens);
+        result = ggml_mul(ctx, experts, weights_3d);
+        result = ggml_cont(ctx, ggml_permute(ctx, result, 1, 0, 2, 3));
+        result = ggml_sum_rows(ctx, result);
+        result = ggml_reshape_2d(ctx, result, n_embd, n_tokens);
+    }
+    ggml_set_output(result);
+    ggml_cgraph * graph = ggml_new_graph(ctx);
+    ggml_build_forward_expand(graph, result);
+
+    ggml_gallocr_t alloc = ggml_gallocr_new(
+        ggml_backend_get_default_buffer_type(backend));
+    if (!alloc || !ggml_gallocr_alloc_graph(alloc, graph)) {
+        if (alloc) ggml_gallocr_free(alloc);
+        ggml_free(ctx);
+        return run;
+    }
+
+    ggml_backend_tensor_set(
+        experts, experts_h.data(), 0, experts_h.size() * sizeof(float));
+    ggml_backend_tensor_set(
+        weights, weights_h.data(), 0, weights_h.size() * sizeof(float));
+    ggml_status status = ggml_backend_graph_compute(backend, graph);
+    ggml_backend_synchronize(backend);
+
+    const auto start = std::chrono::steady_clock::now();
+    for (int i = 0; i < iterations && status == GGML_STATUS_SUCCESS; ++i) {
+        status = ggml_backend_graph_compute(backend, graph);
+    }
+    ggml_backend_synchronize(backend);
+    const auto end = std::chrono::steady_clock::now();
+
+    run.output.resize((size_t)n_embd * n_tokens);
+    if (status == GGML_STATUS_SUCCESS) {
+        ggml_backend_tensor_get(
+            result, run.output.data(), 0, run.output.size() * sizeof(float));
+        run.average_us = std::chrono::duration<double, std::micro>(
+            end - start).count() / std::max(iterations, 1);
+        run.ok = true;
+    }
+
+    ggml_gallocr_free(alloc);
+    ggml_free(ctx);
+    return run;
+}
+
+static bool run_combine_parity_and_benchmark(ggml_backend_t backend) {
+    const char * bench_raw = std::getenv("DFLASH_MOE_COMBINE_BENCH");
+    const bool benchmark = bench_raw && *bench_raw && std::strcmp(bench_raw, "0") != 0;
+    const int n_embd = benchmark ? 4096 : 260;
+    const int n_used = 6;
+    int n_tokens = benchmark ? 3072 : 33;
+    if (const char * raw = std::getenv("DFLASH_MOE_COMBINE_BENCH_TOKENS")) {
+        const int requested = std::atoi(raw);
+        if (requested > 0) n_tokens = requested;
+    }
+    const int iterations = benchmark ? 20 : 2;
+
+    std::vector<float> experts((size_t)n_embd * n_used * n_tokens);
+    std::vector<float> weights((size_t)n_used * n_tokens);
+    for (size_t i = 0; i < experts.size(); ++i) {
+        experts[i] = ((int)(i % 251) - 125) * (1.0f / 127.0f);
+    }
+    for (int t = 0; t < n_tokens; ++t) {
+        float total = 0.0f;
+        for (int e = 0; e < n_used; ++e) {
+            float value = (float)(e + 1 + t % 7);
+            if ((t + e) % 11 == 0) value = 0.0f;
+            weights[(size_t)t * n_used + e] = value;
+            total += value;
+        }
+        for (int e = 0; e < n_used; ++e) {
+            weights[(size_t)t * n_used + e] /= total;
+        }
+    }
+
+    std::vector<float> expected((size_t)n_embd * n_tokens);
+    for (int t = 0; t < n_tokens; ++t) {
+        for (int h = 0; h < n_embd; ++h) {
+            float sum = 0.0f;
+            for (int e = 0; e < n_used; ++e) {
+                const float weight = weights[(size_t)t * n_used + e];
+                if (weight == 0.0f) {
+                    if (e == 0) sum = 0.0f;
+                    continue;
+                }
+                const float product =
+                    experts[((size_t)t * n_used + e) * n_embd + h] * weight;
+                sum = e == 0 ? product : sum + product;
+            }
+            expected[(size_t)t * n_embd + h] = sum;
+        }
+    }
+
+    CombineRun legacy;
+    if (benchmark) {
+        legacy = run_combine_graph(
+            backend, false, n_embd, n_used, n_tokens,
+            experts, weights, iterations);
+    }
+    const CombineRun fused = run_combine_graph(
+        backend, true, n_embd, n_used, n_tokens,
+        experts, weights, iterations);
+    if (!fused.ok || fused.output.size() != expected.size() ||
+        (benchmark && (!legacy.ok || legacy.output.size() != expected.size()))) {
+        return false;
+    }
+
+    double fused_squared_error = 0.0;
+    double legacy_squared_error = 0.0;
+    double reference_power = 0.0;
+    float fused_max_abs_error = 0.0f;
+    size_t fused_exact = 0;
+    for (size_t i = 0; i < expected.size(); ++i) {
+        if (std::memcmp(&expected[i], &fused.output[i], sizeof(float)) == 0) {
+            ++fused_exact;
+        }
+        const float fused_error = fused.output[i] - expected[i];
+        fused_max_abs_error = std::max(
+            fused_max_abs_error, std::fabs(fused_error));
+        fused_squared_error += (double)fused_error * fused_error;
+        if (benchmark) {
+            const float legacy_error = legacy.output[i] - expected[i];
+            legacy_squared_error += (double)legacy_error * legacy_error;
+        }
+        reference_power += (double)expected[i] * expected[i];
+    }
+    const double fused_nmse =
+        fused_squared_error / std::max(reference_power, 1e-30);
+    const double legacy_nmse = benchmark
+        ? legacy_squared_error / std::max(reference_power, 1e-30) : 0.0;
+    const double speedup = benchmark && fused.average_us > 0.0
+        ? legacy.average_us / fused.average_us : 0.0;
+    if (!std::isfinite(fused_nmse) || fused_nmse > 1e-12) {
+        for (size_t i = 0; i < std::min<size_t>(expected.size(), 8); ++i) {
+            std::fprintf(stderr,
+                "combine mismatch[%zu] expected=%g fused=%g\n",
+                i, expected[i], fused.output[i]);
+        }
+    }
+    if (benchmark) {
+        std::printf(
+            "[mmid-grouped-test] combine n_embd=%d n_used=%d n_tokens=%d "
+            "legacy_us=%.3f fused_us=%.3f speedup=%.3fx "
+            "fused_max_abs=%g fused_nmse=%g legacy_nmse=%g\n",
+            n_embd, n_used, n_tokens, legacy.average_us, fused.average_us,
+            speedup, fused_max_abs_error, fused_nmse, legacy_nmse);
+    } else {
+        std::printf(
+            "[mmid-grouped-test] combine-vec4 exact=%zu/%zu "
+            "max_abs=%g nmse=%g\n",
+            fused_exact, expected.size(), fused_max_abs_error, fused_nmse);
+    }
+    return std::isfinite(fused_nmse) && fused_nmse <= 1e-12;
+}
+
 static std::string shell_quote(const std::string & value) {
 #if defined(_WIN32)
     std::string quoted = "\"";
@@ -370,9 +614,11 @@ int main(int argc, char ** argv) {
     if (argc == 4 && std::strcmp(argv[1], "--child") == 0) {
         return run_child(argv[2], argv[3]);
     }
-    if (argc != 1) {
+    const bool combine_only =
+        argc == 2 && std::strcmp(argv[1], "--combine-only") == 0;
+    if (argc != 1 && !combine_only) {
         std::fprintf(stderr,
-                     "usage: %s [--child legacy|grouped|masked-fused OUTPUT]\n",
+                     "usage: %s [--combine-only|--child legacy|grouped|masked-fused OUTPUT]\n",
                      argv[0]);
         return 2;
     }
@@ -380,6 +626,29 @@ int main(int argc, char ** argv) {
     if (!grouped_supported_device()) {
         std::printf("[mmid-grouped-test] SKIP: grouped MMID requires NVIDIA Turing+ or AMD RDNA3/RDNA4\n");
         return 77;
+    }
+
+#if defined(_WIN32)
+    if (!std::getenv("DFLASH_MOE_COMBINE_VEC4")) {
+        _putenv_s("DFLASH_MOE_COMBINE_VEC4", "1");
+    }
+#else
+    setenv("DFLASH_MOE_COMBINE_VEC4", "1", 0);
+#endif
+
+    ggml_backend_t combine_backend = ggml_backend_cuda_init(0);
+    if (combine_backend == nullptr) {
+        std::fprintf(stderr, "GPU backend unavailable for combine parity\n");
+        return 1;
+    }
+    const bool combine_parity = run_combine_parity_and_benchmark(combine_backend);
+    ggml_backend_free(combine_backend);
+    if (!combine_parity) {
+        std::fprintf(stderr, "grouped MoE fused-combine parity failed\n");
+        return 1;
+    }
+    if (combine_only) {
+        return 0;
     }
 
 #if defined(_WIN32)
@@ -417,7 +686,7 @@ int main(int argc, char ** argv) {
         GGML_TYPE_Q4_K, GGML_TYPE_Q6_K, GGML_TYPE_Q4_0, GGML_TYPE_Q8_0,
         GGML_TYPE_Q5_K, GGML_TYPE_Q2_0_ROCMFP2, GGML_TYPE_Q3_0_ROCMFPX,
     };
-    const int widths[] = {2, 4, 8, 9, 16, 32};
+    const int widths[] = {2, 4, 8, 9, 16, 32, 48, 64};
     size_t offset = 0;
     size_t compared_bytes = 0;
     int compared_cases = 0;
@@ -427,14 +696,14 @@ int main(int argc, char ** argv) {
     bool grouped_dispatch = true;
     for (ggml_type type : types) {
         for (int width : widths) {
-            if (width == 32 &&
+            if (width >= 32 &&
                 type != GGML_TYPE_Q2_0_ROCMFP2 &&
                 type != GGML_TYPE_Q3_0_ROCMFPX) {
                 continue;
             }
             const bool legacy_mmvq = has_mmvq_record(legacy_log, type, width);
             for (bool fused_ds4 : {false, true}) {
-                if (width == 32 && fused_ds4) {
+                if (width >= 32 && fused_ds4) {
                     continue;
                 }
                 const size_t case_bytes = (size_t) 128 * 8 * width * sizeof(float);
@@ -461,7 +730,7 @@ int main(int argc, char ** argv) {
             }
         }
     }
-    output_parity = output_parity && offset == legacy.size() && compared_cases == 72;
+    output_parity = output_parity && offset == legacy.size() && compared_cases == 76;
     const size_t masked_case_bytes = (size_t) 128 * 8 * 32 * sizeof(float);
     const bool masked_fused_zero = masked_fused.size() == masked_case_bytes;
     const bool pass = legacy_status == 0 && grouped_status == 0 &&

--- a/server/test/test_feature_gate.cpp
+++ b/server/test/test_feature_gate.cpp
@@ -698,6 +698,7 @@ void test_model_capability_tables() {
     CHECK(!arch_has_expert_offload("qwen35"));
     // deepseek4 is mixture-of-experts but has no hot/cold offload path.
     CHECK(!arch_has_expert_offload("deepseek4"));
+    CHECK(arch_supports_pflash_compression("deepseek4"));
 
     // Every capability predicate must be false for an architecture the
     // factory cannot build, so no rule can admit an unbuildable model.

--- a/server/test/test_rocmfp_mix_gateup_glu.cpp
+++ b/server/test/test_rocmfp_mix_gateup_glu.cpp
@@ -122,7 +122,9 @@ TEST_CASE(RocmfpMixGateupGluFixture, fused_gateup_glu) {
 
     // in must be a multiple of 128: the wide block load reads 128 weights at a time and would
     // read past the tensor on the final block (register_host enforces this).
-    const int in = 256, out = 64, n_experts = 6, n_used = 3, ntok = 2;
+    // Three tokens exercises the low-register two-pass GLU finalizer. q <= 2
+    // uses the one-pass kernel and is checked separately below.
+    const int in = 256, out = 64, n_experts = 6, n_used = 3, ntok = 3;
     const int nb = in / QK;
     const size_t rows_bytes = (size_t) out * nb * BLOCK_BYTES;
 
@@ -223,6 +225,41 @@ TEST_CASE(RocmfpMixGateupGluFixture, fused_gateup_glu) {
     }
     std::fprintf(stderr, "worst relative deviation from the host reference: %.3e\n", worst);
     CHECK(worst < 1e-5);
+
+    // q <= 2 selects the one-pass dual-projection kernel. Exercise that branch
+    // separately while the main ntok=3 case above covers the two-pass finalizer.
+    {
+        const int one_tok = 1;
+        const size_t one_yn = (size_t) out * n_used;
+        CHECK(ggml_cuda_rocmfp2_mix_mul_mat_id(d_up, d_x, d_ids, d_up_out,
+                                               in, out, n_used, one_tok, 1,
+                                               ids_s0, ids_s1, src1_s1, src1_s2,
+                                               dst_s1, dst_s2, nullptr));
+        CHECK(ggml_cuda_rocmfp2_mix_mul_mat_id(d_gate, d_x, d_ids, d_gate_out,
+                                               in, out, n_used, one_tok, 1,
+                                               ids_s0, ids_s1, src1_s1, src1_s2,
+                                               dst_s1, dst_s2, nullptr));
+        CHECK(ggml_cuda_rocmfp2_mix_mul_mat_id_glu(d_up, d_gate, d_x, d_ids, d_fused,
+                                                   in, out, n_used, one_tok, 1,
+                                                   ids_s0, ids_s1, src1_s1, src1_s2,
+                                                   dst_s1, dst_s2, limit, nullptr));
+        HIP_OK(cudaDeviceSynchronize());
+        std::vector<float> one_u(one_yn), one_g(one_yn), one_f(one_yn);
+        HIP_OK(cudaMemcpy(one_u.data(), d_up_out, sizeof(float) * one_yn,
+                          cudaMemcpyDeviceToHost));
+        HIP_OK(cudaMemcpy(one_g.data(), d_gate_out, sizeof(float) * one_yn,
+                          cudaMemcpyDeviceToHost));
+        HIP_OK(cudaMemcpy(one_f.data(), d_fused, sizeof(float) * one_yn,
+                          cudaMemcpyDeviceToHost));
+        double one_worst = 0.0;
+        for (size_t i = 0; i < one_yn; ++i) {
+            const float ref = host_swiglu_ds4(one_g[i], one_u[i], limit);
+            const double denom = std::fmax(1e-6, std::fabs((double) ref));
+            one_worst = std::fmax(one_worst,
+                std::fabs((double) one_f[i] - (double) ref) / denom);
+        }
+        CHECK(one_worst < 1e-5);
+    }
 
     // ---- operand ORDER: swiglu_ds4 applies silu to GATE, so the two are not symmetric ----
     float * d_swapped = nullptr;

--- a/server/tests/test_deepseek4_unit.cpp
+++ b/server/tests/test_deepseek4_unit.cpp
@@ -1726,18 +1726,43 @@ static void test_dspark_park_all_releases_drafter() {
     backend.spec_draft_path_ = "/tmp/ds4-dspark-fixture.gguf";
     backend.spec_drafter_ = std::make_unique<DSparkDrafter>();
     backend.spec_enabled_ = true;
+    backend.pflash_drafter_loaded_ = true;
+    backend.pflash_drafter_path_ = "/tmp/ds4-pflash-fixture.gguf";
+    backend.pflash_drafter_gpu_ = 1;
 
     TEST_ASSERT(backend.park(ParkTarget::All));
     TEST_ASSERT(backend.parked_);
     TEST_ASSERT(backend.spec_drafter_ == nullptr);
     TEST_ASSERT(!backend.spec_enabled_);
     TEST_ASSERT(backend.spec_drafter_parked_);
+    TEST_ASSERT(!backend.pflash_drafter_loaded_);
+    TEST_ASSERT(backend.pflash_drafter_path_.empty());
+    TEST_ASSERT(backend.pflash_drafter_gpu_ == -1);
 
     backend.free_drafter();
     TEST_ASSERT(backend.spec_drafter_ == nullptr);
     TEST_ASSERT(!backend.spec_enabled_);
     TEST_ASSERT(backend.spec_drafter_parked_);
     TEST_ASSERT(backend.spec_draft_path_ == "/tmp/ds4-dspark-fixture.gguf");
+    std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
+}
+
+static void test_pflash_rejects_invalid_requests() {
+    std::fprintf(stderr, "  test_pflash_rejects_invalid_requests ...");
+    DeepSeek4BackendConfig cfg;
+    DeepSeek4Backend backend(cfg);
+
+    ModelBackend::CompressRequest empty;
+    TEST_ASSERT(!backend.compress(empty).ok);
+
+    ModelBackend::CompressRequest invalid_ratio;
+    invalid_ratio.input_ids = {1, 2, 3};
+    invalid_ratio.keep_ratio = 0.0f;
+    invalid_ratio.drafter_path = "/nonexistent/drafter.gguf";
+    const auto results = backend.compress_batch({empty, invalid_ratio});
+    TEST_ASSERT(results.size() == 2);
+    TEST_ASSERT(!results[0].ok);
+    TEST_ASSERT(!results[1].ok);
     std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
 }
 
@@ -2831,28 +2856,16 @@ static void test_ds4_flash_attention_parallel_index_scan_gpu() {
     std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
 }
 
-static void test_ds4_indexer_score_packed_q4_gpu() {
-    std::fprintf(stderr, "  test_ds4_indexer_score_packed_q4_gpu ...");
-#if !defined(GGML_USE_HIP)
-    std::fprintf(stderr, " skipped (HIP-only candidate)\n");
-    return;
-#endif
-    ggml_backend_t backend = ggml_backend_cuda_init(0);
-    if (!backend) {
-        std::fprintf(stderr, " skipped (no GPU backend)\n");
-        return;
-    }
-
+static void run_ds4_indexer_score_packed_small_case(
+        ggml_backend_t backend, int n_tokens) {
     constexpr int dim = 128;
     constexpr int n_heads = 64;
-    constexpr int n_tokens = 4;
     constexpr int n_comp = 4160;
     constexpr int kv_start = 16384;
     constexpr int ratio = 4;
     ggml_context * ctx = make_test_context(4u << 20);
     TEST_ASSERT_MSG(ctx != nullptr, "ggml_init failed");
     if (!ctx) {
-        ggml_backend_free(backend);
         std::fprintf(stderr, " FAIL\n");
         return;
     }
@@ -2867,14 +2880,14 @@ static void test_ds4_indexer_score_packed_q4_gpu() {
         ctx, q, weights, comp, kv_start, ratio);
     ggml_set_output(scores);
     TEST_ASSERT_MSG(ggml_backend_supports_op(backend, scores),
-                    "GPU rejected packed-q4 indexer fixture");
+                    "GPU rejected packed-small indexer fixture");
 
     ggml_cgraph * graph = ggml_new_graph_custom(ctx, 16, false);
     ggml_build_forward_expand(graph, scores);
     ggml_gallocr_t alloc = ggml_gallocr_new(
         ggml_backend_get_default_buffer_type(backend));
     const bool allocated = ggml_gallocr_alloc_graph(alloc, graph);
-    TEST_ASSERT_MSG(allocated, "packed-q4 indexer graph allocation failed");
+    TEST_ASSERT_MSG(allocated, "packed-small indexer graph allocation failed");
     if (allocated) {
         std::vector<float> q_data((size_t) dim * n_heads * n_tokens);
         std::vector<float> weight_data((size_t) n_heads * n_tokens);
@@ -2896,37 +2909,35 @@ static void test_ds4_indexer_score_packed_q4_gpu() {
         ggml_backend_tensor_set(comp, comp_data.data(), 0,
                                 comp_data.size() * sizeof(ggml_fp16_t));
 
-        const char * previous = std::getenv("GGML_DS4_INDEXER_PACK_Q4");
-        const std::string previous_value = previous ? previous : "";
         std::vector<float> reference((size_t) n_comp * n_tokens);
         std::vector<float> candidate(reference.size());
         ScopedCudaGraphOverrides eager(
             /*disable_graphs=*/true,
             /*mmvq_max_ncols=*/0,
             /*skip_property_check=*/false);
-        unsetenv("GGML_DS4_INDEXER_PACK_Q4");
+        setenv("GGML_DS4_INDEXER_PACK_SMALL", "0", 1);
         TEST_ASSERT_MSG(
             ggml_backend_graph_compute(backend, graph) == GGML_STATUS_SUCCESS,
-            "reference q4 indexer score failed");
+            "reference small-CM indexer score failed");
         ggml_backend_tensor_get(scores, reference.data(), 0,
                                 reference.size() * sizeof(float));
 
-        setenv("GGML_DS4_INDEXER_PACK_Q4", "1", 1);
+        setenv("GGML_DS4_INDEXER_PACK_SMALL", "1", 1);
         TEST_ASSERT_MSG(
             ggml_backend_graph_compute(backend, graph) == GGML_STATUS_SUCCESS,
-            "packed q4 indexer score failed");
+            "packed small-CM indexer score failed");
         ggml_backend_tensor_get(scores, candidate.data(), 0,
                                 candidate.size() * sizeof(float));
         TEST_ASSERT_MSG(
             std::memcmp(reference.data(), candidate.data(),
                         reference.size() * sizeof(float)) == 0,
-            "packed q4 indexer changed score bits");
+            "packed small-CM indexer changed score bits");
 
         auto measure_us = [&](bool packed) {
             if (packed) {
-                setenv("GGML_DS4_INDEXER_PACK_Q4", "1", 1);
+                setenv("GGML_DS4_INDEXER_PACK_SMALL", "1", 1);
             } else {
-                unsetenv("GGML_DS4_INDEXER_PACK_Q4");
+                setenv("GGML_DS4_INDEXER_PACK_SMALL", "0", 1);
             }
             constexpr int warmups = 3;
             constexpr int iterations = 30;
@@ -2945,18 +2956,29 @@ static void test_ds4_indexer_score_packed_q4_gpu() {
         };
         const double reference_us = measure_us(false);
         const double packed_us = measure_us(true);
-        std::fprintf(stderr, " reference=%.1fus packed=%.1fus",
+        std::fprintf(stderr, " q%d=%.1f->%.1fus", n_tokens,
                      reference_us, packed_us);
-
-        if (previous) {
-            setenv("GGML_DS4_INDEXER_PACK_Q4", previous_value.c_str(), 1);
-        } else {
-            unsetenv("GGML_DS4_INDEXER_PACK_Q4");
-        }
     }
 
     ggml_gallocr_free(alloc);
     ggml_free(ctx);
+}
+
+static void test_ds4_indexer_score_packed_small_gpu() {
+    std::fprintf(stderr, "  test_ds4_indexer_score_packed_small_gpu ...");
+#if !defined(GGML_USE_HIP)
+    std::fprintf(stderr, " skipped (HIP-only candidate)\n");
+    return;
+#endif
+    ggml_backend_t backend = ggml_backend_cuda_init(0);
+    if (!backend) {
+        std::fprintf(stderr, " skipped (no GPU backend)\n");
+        return;
+    }
+    ScopedEnvVar packed_small_guard("GGML_DS4_INDEXER_PACK_SMALL");
+    for (int n_tokens = 2; n_tokens <= 5; ++n_tokens) {
+        run_ds4_indexer_score_packed_small_case(backend, n_tokens);
+    }
     ggml_backend_free(backend);
     std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
 }
@@ -4153,6 +4175,7 @@ int main() {
     test_safe_compressor_batch_tokens();
     test_hybrid_prefill_chunk_tokens();
     test_dspark_park_all_releases_drafter();
+    test_pflash_rejects_invalid_requests();
     test_dspark_raw_ring_rollback_after_wrap(backend);
     test_snapshot_save_restore();
     test_monolithic_snapshot_preserves_decode_state();
@@ -4168,7 +4191,7 @@ int main() {
 #if defined(GGML_USE_CUDA) || defined(GGML_USE_HIP)
     test_ds4_flash_attention_keep_cap_gpu();
     test_ds4_flash_attention_parallel_index_scan_gpu();
-    test_ds4_indexer_score_packed_q4_gpu();
+    test_ds4_indexer_score_packed_small_gpu();
     test_ds4_topk_block_radix_gpu();
     test_ds4_flash_attention_inverse_rope_fallback_gpu();
     test_hc_post_strided_split_gpu();

--- a/server/tests/test_deepseek4_unit.cpp
+++ b/server/tests/test_deepseek4_unit.cpp
@@ -2966,12 +2966,14 @@ static void test_ds4_flash_attention_streaming_topk_gpu() {
                                 topk_data.size() * sizeof(int32_t));
 
         ScopedEnvVar streaming_guard("GGML_CUDA_MLA_STREAM_TOPK");
+        ScopedEnvVar f32_stage_guard("GGML_CUDA_MLA_STREAM_F32_STAGE");
         ScopedCudaGraphOverrides eager(
             /*disable_graphs=*/true,
             /*mmvq_max_ncols=*/0,
             /*skip_property_check=*/false);
         std::vector<float> reference((size_t) ggml_nelements(output));
-        std::vector<float> candidate(reference.size());
+        std::vector<float> candidate_f16_stage(reference.size());
+        std::vector<float> candidate_f32_stage(reference.size());
         setenv("GGML_CUDA_MLA_STREAM_TOPK", "0", 1);
         TEST_ASSERT_MSG(
             ggml_backend_graph_compute(backend, graph) == GGML_STATUS_SUCCESS,
@@ -2980,23 +2982,36 @@ static void test_ds4_flash_attention_streaming_topk_gpu() {
                                 reference.size() * sizeof(float));
 
         setenv("GGML_CUDA_MLA_STREAM_TOPK", "1", 1);
+        setenv("GGML_CUDA_MLA_STREAM_F32_STAGE", "0", 1);
         TEST_ASSERT_MSG(
             ggml_backend_graph_compute(backend, graph) == GGML_STATUS_SUCCESS,
-            "streaming top-k attention failed");
-        ggml_backend_tensor_get(output, candidate.data(), 0,
-                                candidate.size() * sizeof(float));
+            "F16-staged streaming top-k attention failed");
+        ggml_backend_tensor_get(output, candidate_f16_stage.data(), 0,
+                                candidate_f16_stage.size() * sizeof(float));
+
+        setenv("GGML_CUDA_MLA_STREAM_F32_STAGE", "1", 1);
+        TEST_ASSERT_MSG(
+            ggml_backend_graph_compute(backend, graph) == GGML_STATUS_SUCCESS,
+            "F32-staged streaming top-k attention failed");
+        ggml_backend_tensor_get(output, candidate_f32_stage.data(), 0,
+                                candidate_f32_stage.size() * sizeof(float));
 
         for (size_t i = 0; i < reference.size(); ++i) {
             TEST_ASSERT_MSG(
-                std::isfinite(candidate[i]),
+                std::isfinite(candidate_f32_stage[i]),
                 "streaming top-k attention output must be finite");
             TEST_ASSERT_MSG(
-                nearly_equal(reference[i], candidate[i], 5.0e-4f, 5.0e-4f),
+                nearly_equal(reference[i], candidate_f32_stage[i],
+                             5.0e-4f, 5.0e-4f),
                 "streaming top-k attention exceeded numeric tolerance");
+            TEST_ASSERT_MSG(
+                candidate_f16_stage[i] == candidate_f32_stage[i],
+                "F32 staging changed streaming top-k attention output");
         }
 
-        auto measure_us = [&](bool streaming) {
+        auto measure_us = [&](bool streaming, bool f32_stage) {
             setenv("GGML_CUDA_MLA_STREAM_TOPK", streaming ? "1" : "0", 1);
+            setenv("GGML_CUDA_MLA_STREAM_F32_STAGE", f32_stage ? "1" : "0", 1);
             constexpr int warmups = 3;
             constexpr int iterations = 20;
             for (int i = 0; i < warmups; ++i) {
@@ -3012,10 +3027,26 @@ static void test_ds4_flash_attention_streaming_topk_gpu() {
             return std::chrono::duration<double, std::micro>(end - begin).count() /
                 iterations;
         };
-        const double grouped_us = measure_us(false);
-        const double streaming_us = measure_us(true);
-        std::fprintf(stderr, " grouped=%.1fus streaming=%.1fus speedup=%.2fx",
-                     grouped_us, streaming_us, grouped_us / streaming_us);
+        const double grouped_us = measure_us(false, false);
+        constexpr int timing_rounds = 4;
+        double streaming_f16_us = 0.0;
+        double streaming_f32_us = 0.0;
+        for (int round = 0; round < timing_rounds; ++round) {
+            if ((round & 1) == 0) {
+                streaming_f16_us += measure_us(true, false);
+                streaming_f32_us += measure_us(true, true);
+            } else {
+                streaming_f32_us += measure_us(true, true);
+                streaming_f16_us += measure_us(true, false);
+            }
+        }
+        streaming_f16_us /= timing_rounds;
+        streaming_f32_us /= timing_rounds;
+        std::fprintf(stderr,
+                     " grouped=%.1fus streaming_f16=%.1fus"
+                     " streaming_f32=%.1fus speedup=%.2fx",
+                     grouped_us, streaming_f16_us, streaming_f32_us,
+                     grouped_us / streaming_f32_us);
     }
 
     ggml_gallocr_free(alloc);

--- a/server/tests/test_deepseek4_unit.cpp
+++ b/server/tests/test_deepseek4_unit.cpp
@@ -2936,11 +2936,11 @@ static void test_ds4_flash_attention_streaming_topk_gpu() {
         std::vector<int32_t> topk_data(
             (size_t) selected_rows * n_tokens);
         for (size_t i = 0; i < q_data.size(); ++i) {
-            q_data[i] = ((int) (i % 43) - 21) * 0.001f;
+            q_data[i] = ((int) (i % 43) - 21) * 0.05f;
         }
         for (size_t i = 0; i < kv_data.size(); ++i) {
             kv_data[i] = ggml_fp32_to_fp16(
-                ((int) (i % 47) - 23) * 0.001f);
+                ((int) (i % 47) - 23) * 0.05f);
         }
         for (int token = 0; token < n_tokens; ++token) {
             ggml_fp16_t * token_mask =
@@ -2967,6 +2967,7 @@ static void test_ds4_flash_attention_streaming_topk_gpu() {
 
         ScopedEnvVar streaming_guard("GGML_CUDA_MLA_STREAM_TOPK");
         ScopedEnvVar f32_stage_guard("GGML_CUDA_MLA_STREAM_F32_STAGE");
+        ScopedEnvVar fast_exp_guard("GGML_CUDA_MLA_STREAM_FAST_EXP");
         ScopedCudaGraphOverrides eager(
             /*disable_graphs=*/true,
             /*mmvq_max_ncols=*/0,
@@ -2974,7 +2975,9 @@ static void test_ds4_flash_attention_streaming_topk_gpu() {
         std::vector<float> reference((size_t) ggml_nelements(output));
         std::vector<float> candidate_f16_stage(reference.size());
         std::vector<float> candidate_f32_stage(reference.size());
+        std::vector<float> candidate_fast_exp(reference.size());
         setenv("GGML_CUDA_MLA_STREAM_TOPK", "0", 1);
+        setenv("GGML_CUDA_MLA_STREAM_FAST_EXP", "0", 1);
         TEST_ASSERT_MSG(
             ggml_backend_graph_compute(backend, graph) == GGML_STATUS_SUCCESS,
             "grouped compact attention reference failed");
@@ -2996,6 +2999,16 @@ static void test_ds4_flash_attention_streaming_topk_gpu() {
         ggml_backend_tensor_get(output, candidate_f32_stage.data(), 0,
                                 candidate_f32_stage.size() * sizeof(float));
 
+        setenv("GGML_CUDA_MLA_STREAM_FAST_EXP", "1", 1);
+        TEST_ASSERT_MSG(
+            ggml_backend_graph_compute(backend, graph) == GGML_STATUS_SUCCESS,
+            "fast-exp streaming top-k attention failed");
+        ggml_backend_tensor_get(output, candidate_fast_exp.data(), 0,
+                                candidate_fast_exp.size() * sizeof(float));
+
+        double fast_exp_squared_error = 0.0;
+        double f32_stage_power = 0.0;
+        float fast_exp_max_abs = 0.0f;
         for (size_t i = 0; i < reference.size(); ++i) {
             TEST_ASSERT_MSG(
                 std::isfinite(candidate_f32_stage[i]),
@@ -3007,11 +3020,29 @@ static void test_ds4_flash_attention_streaming_topk_gpu() {
             TEST_ASSERT_MSG(
                 candidate_f16_stage[i] == candidate_f32_stage[i],
                 "F32 staging changed streaming top-k attention output");
+            TEST_ASSERT_MSG(
+                std::isfinite(candidate_fast_exp[i]),
+                "fast-exp streaming output must be finite");
+            TEST_ASSERT_MSG(
+                nearly_equal(reference[i], candidate_fast_exp[i],
+                             5.0e-4f, 5.0e-4f),
+                "fast-exp streaming attention exceeded numeric tolerance");
+            const double fast_exp_error =
+                (double) candidate_fast_exp[i] - candidate_f32_stage[i];
+            fast_exp_squared_error += fast_exp_error * fast_exp_error;
+            f32_stage_power +=
+                (double) candidate_f32_stage[i] * candidate_f32_stage[i];
+            fast_exp_max_abs = std::max(
+                fast_exp_max_abs,
+                std::fabs(candidate_fast_exp[i] - candidate_f32_stage[i]));
         }
+        const double fast_exp_nmse = fast_exp_squared_error /
+            std::max(f32_stage_power, 1.0e-30);
 
-        auto measure_us = [&](bool streaming, bool f32_stage) {
+        auto measure_us = [&](bool streaming, bool f32_stage, bool fast_exp) {
             setenv("GGML_CUDA_MLA_STREAM_TOPK", streaming ? "1" : "0", 1);
             setenv("GGML_CUDA_MLA_STREAM_F32_STAGE", f32_stage ? "1" : "0", 1);
+            setenv("GGML_CUDA_MLA_STREAM_FAST_EXP", fast_exp ? "1" : "0", 1);
             constexpr int warmups = 3;
             constexpr int iterations = 20;
             for (int i = 0; i < warmups; ++i) {
@@ -3027,26 +3058,32 @@ static void test_ds4_flash_attention_streaming_topk_gpu() {
             return std::chrono::duration<double, std::micro>(end - begin).count() /
                 iterations;
         };
-        const double grouped_us = measure_us(false, false);
+        const double grouped_us = measure_us(false, false, false);
         constexpr int timing_rounds = 4;
         double streaming_f16_us = 0.0;
         double streaming_f32_us = 0.0;
+        double fast_exp_us = 0.0;
         for (int round = 0; round < timing_rounds; ++round) {
             if ((round & 1) == 0) {
-                streaming_f16_us += measure_us(true, false);
-                streaming_f32_us += measure_us(true, true);
+                streaming_f16_us += measure_us(true, false, false);
+                streaming_f32_us += measure_us(true, true, false);
+                fast_exp_us += measure_us(true, true, true);
             } else {
-                streaming_f32_us += measure_us(true, true);
-                streaming_f16_us += measure_us(true, false);
+                fast_exp_us += measure_us(true, true, true);
+                streaming_f32_us += measure_us(true, true, false);
+                streaming_f16_us += measure_us(true, false, false);
             }
         }
         streaming_f16_us /= timing_rounds;
         streaming_f32_us /= timing_rounds;
+        fast_exp_us /= timing_rounds;
         std::fprintf(stderr,
                      " grouped=%.1fus streaming_f16=%.1fus"
-                     " streaming_f32=%.1fus speedup=%.2fx",
+                     " streaming_f32=%.1fus fast_exp=%.1fus speedup=%.2fx"
+                     " fast_nmse=%.3g fast_max_abs=%.3g",
                      grouped_us, streaming_f16_us, streaming_f32_us,
-                     grouped_us / streaming_f32_us);
+                     fast_exp_us, grouped_us / fast_exp_us,
+                     fast_exp_nmse, fast_exp_max_abs);
     }
 
     ggml_gallocr_free(alloc);

--- a/server/tests/test_deepseek4_unit.cpp
+++ b/server/tests/test_deepseek4_unit.cpp
@@ -1718,6 +1718,23 @@ static void test_hybrid_prefill_chunk_tokens() {
                     2048, 32768, 0) == 0);
     std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
 }
+
+static void test_mix_mmq_prefill_default() {
+    std::fprintf(stderr, "  test_mix_mmq_prefill_default ...");
+    TEST_ASSERT(!deepseek4_mix_mmq_prefill_default(
+        PrefillAttentionMode::Exact, "gfx1151"));
+    TEST_ASSERT(deepseek4_mix_mmq_prefill_default(
+        PrefillAttentionMode::Dense, "gfx1151"));
+    TEST_ASSERT(deepseek4_mix_mmq_prefill_default(
+        PrefillAttentionMode::Sparse, "gfx1151:sramecc+:xnack-"));
+    TEST_ASSERT(!deepseek4_mix_mmq_prefill_default(
+        PrefillAttentionMode::Sparse, "gfx1201"));
+    TEST_ASSERT(!deepseek4_mix_mmq_prefill_default(
+        PrefillAttentionMode::Sparse, "gfx11510"));
+    TEST_ASSERT(!deepseek4_mix_mmq_prefill_default(
+        PrefillAttentionMode::Sparse, nullptr));
+    std::fprintf(stderr, " OK\n");
+}
 static void test_dspark_park_all_releases_drafter() {
     std::fprintf(stderr, "  test_dspark_park_all_releases_drafter ...");
 
@@ -4174,6 +4191,7 @@ int main() {
     test_dspark_confidence_uses_separate_hidden(backend);
     test_safe_compressor_batch_tokens();
     test_hybrid_prefill_chunk_tokens();
+    test_mix_mmq_prefill_default();
     test_dspark_park_all_releases_drafter();
     test_pflash_rejects_invalid_requests();
     test_dspark_raw_ring_rollback_after_wrap(backend);

--- a/server/tests/test_deepseek4_unit.cpp
+++ b/server/tests/test_deepseek4_unit.cpp
@@ -2873,6 +2873,157 @@ static void test_ds4_flash_attention_parallel_index_scan_gpu() {
     std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
 }
 
+static void test_ds4_flash_attention_streaming_topk_gpu() {
+    std::fprintf(stderr,
+                 "  test_ds4_flash_attention_streaming_topk_gpu ...");
+#if !defined(GGML_USE_HIP)
+    std::fprintf(stderr, " skipped (HIP-only candidate)\n");
+    return;
+#endif
+    ggml_backend_t backend = ggml_backend_cuda_init(0);
+    if (!backend) {
+        std::fprintf(stderr, " skipped (no GPU backend)\n");
+        return;
+    }
+
+    constexpr int head_dim = 512;
+    constexpr int n_heads = 64;
+    constexpr int n_tokens = 64;
+    constexpr int raw_rows = 128;
+    constexpr int raw_window = 128;
+    constexpr int selected_rows = 512;
+    constexpr int n_comp_rows = 1920;
+    constexpr int n_kv = raw_rows + n_comp_rows;
+
+    ggml_context * ctx = make_test_context(4u << 20);
+    TEST_ASSERT_MSG(ctx != nullptr, "ggml_init failed");
+    if (!ctx) {
+        ggml_backend_free(backend);
+        std::fprintf(stderr, " FAIL\n");
+        return;
+    }
+
+    ggml_tensor * q = ggml_new_tensor_3d(
+        ctx, GGML_TYPE_F32, head_dim, n_tokens, n_heads);
+    ggml_tensor * kv = ggml_new_tensor_3d(
+        ctx, GGML_TYPE_F16, head_dim, n_kv, 1);
+    ggml_tensor * mask = ggml_new_tensor_2d(
+        ctx, GGML_TYPE_F16, n_kv, n_tokens);
+    ggml_tensor * topk = ggml_new_tensor_2d(
+        ctx, GGML_TYPE_I32, selected_rows, n_tokens);
+    ggml_tensor * output = ggml_flash_attn_ext(
+        ctx, q, kv, kv, mask, 1.0f / std::sqrt((float) head_dim),
+        0.0f, 0.0f);
+    ggml_flash_attn_ext_set_ds4_sparse(
+        output, raw_rows, raw_window, -selected_rows, 1);
+    ggml_flash_attn_ext_set_ds4_indexer_topk(output, topk);
+    ggml_set_output(output);
+    TEST_ASSERT_MSG(ggml_backend_supports_op(backend, output),
+                    "GPU rejected streaming top-k attention fixture");
+
+    ggml_cgraph * graph = ggml_new_graph_custom(ctx, 32, false);
+    ggml_build_forward_expand(graph, output);
+    ggml_gallocr_t alloc = ggml_gallocr_new(
+        ggml_backend_get_default_buffer_type(backend));
+    const bool allocated = ggml_gallocr_alloc_graph(alloc, graph);
+    TEST_ASSERT_MSG(allocated, "streaming top-k graph allocation failed");
+    if (allocated) {
+        std::vector<float> q_data(
+            (size_t) head_dim * n_tokens * n_heads);
+        std::vector<ggml_fp16_t> kv_data((size_t) head_dim * n_kv);
+        std::vector<ggml_fp16_t> mask_data(
+            (size_t) n_kv * n_tokens, ggml_fp32_to_fp16(-1.0e30f));
+        std::vector<int32_t> topk_data(
+            (size_t) selected_rows * n_tokens);
+        for (size_t i = 0; i < q_data.size(); ++i) {
+            q_data[i] = ((int) (i % 43) - 21) * 0.001f;
+        }
+        for (size_t i = 0; i < kv_data.size(); ++i) {
+            kv_data[i] = ggml_fp32_to_fp16(
+                ((int) (i % 47) - 23) * 0.001f);
+        }
+        for (int token = 0; token < n_tokens; ++token) {
+            ggml_fp16_t * token_mask =
+                mask_data.data() + (size_t) token * n_kv;
+            for (int row = 0; row < raw_rows; ++row) {
+                token_mask[row] = ggml_fp32_to_fp16(0.0f);
+            }
+            for (int row = 0; row < n_comp_rows; ++row) {
+                token_mask[raw_rows + row] = ggml_fp32_to_fp16(0.0f);
+            }
+            for (int rank = 0; rank < selected_rows; ++rank) {
+                topk_data[(size_t) token * selected_rows + rank] =
+                    (token * 17 + selected_rows - 1 - rank) % n_comp_rows;
+            }
+        }
+        ggml_backend_tensor_set(q, q_data.data(), 0,
+                                q_data.size() * sizeof(float));
+        ggml_backend_tensor_set(kv, kv_data.data(), 0,
+                                kv_data.size() * sizeof(ggml_fp16_t));
+        ggml_backend_tensor_set(mask, mask_data.data(), 0,
+                                mask_data.size() * sizeof(ggml_fp16_t));
+        ggml_backend_tensor_set(topk, topk_data.data(), 0,
+                                topk_data.size() * sizeof(int32_t));
+
+        ScopedEnvVar streaming_guard("GGML_CUDA_MLA_STREAM_TOPK");
+        ScopedCudaGraphOverrides eager(
+            /*disable_graphs=*/true,
+            /*mmvq_max_ncols=*/0,
+            /*skip_property_check=*/false);
+        std::vector<float> reference((size_t) ggml_nelements(output));
+        std::vector<float> candidate(reference.size());
+        setenv("GGML_CUDA_MLA_STREAM_TOPK", "0", 1);
+        TEST_ASSERT_MSG(
+            ggml_backend_graph_compute(backend, graph) == GGML_STATUS_SUCCESS,
+            "grouped compact attention reference failed");
+        ggml_backend_tensor_get(output, reference.data(), 0,
+                                reference.size() * sizeof(float));
+
+        setenv("GGML_CUDA_MLA_STREAM_TOPK", "1", 1);
+        TEST_ASSERT_MSG(
+            ggml_backend_graph_compute(backend, graph) == GGML_STATUS_SUCCESS,
+            "streaming top-k attention failed");
+        ggml_backend_tensor_get(output, candidate.data(), 0,
+                                candidate.size() * sizeof(float));
+
+        for (size_t i = 0; i < reference.size(); ++i) {
+            TEST_ASSERT_MSG(
+                std::isfinite(candidate[i]),
+                "streaming top-k attention output must be finite");
+            TEST_ASSERT_MSG(
+                nearly_equal(reference[i], candidate[i], 5.0e-4f, 5.0e-4f),
+                "streaming top-k attention exceeded numeric tolerance");
+        }
+
+        auto measure_us = [&](bool streaming) {
+            setenv("GGML_CUDA_MLA_STREAM_TOPK", streaming ? "1" : "0", 1);
+            constexpr int warmups = 3;
+            constexpr int iterations = 20;
+            for (int i = 0; i < warmups; ++i) {
+                ggml_backend_graph_compute(backend, graph);
+            }
+            ggml_backend_synchronize(backend);
+            const auto begin = std::chrono::steady_clock::now();
+            for (int i = 0; i < iterations; ++i) {
+                ggml_backend_graph_compute(backend, graph);
+            }
+            ggml_backend_synchronize(backend);
+            const auto end = std::chrono::steady_clock::now();
+            return std::chrono::duration<double, std::micro>(end - begin).count() /
+                iterations;
+        };
+        const double grouped_us = measure_us(false);
+        const double streaming_us = measure_us(true);
+        std::fprintf(stderr, " grouped=%.1fus streaming=%.1fus speedup=%.2fx",
+                     grouped_us, streaming_us, grouped_us / streaming_us);
+    }
+
+    ggml_gallocr_free(alloc);
+    ggml_free(ctx);
+    ggml_backend_free(backend);
+    std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
+}
+
 static void run_ds4_indexer_score_packed_small_case(
         ggml_backend_t backend, int n_tokens) {
     constexpr int dim = 128;
@@ -4209,6 +4360,7 @@ int main() {
 #if defined(GGML_USE_CUDA) || defined(GGML_USE_HIP)
     test_ds4_flash_attention_keep_cap_gpu();
     test_ds4_flash_attention_parallel_index_scan_gpu();
+    test_ds4_flash_attention_streaming_topk_gpu();
     test_ds4_indexer_score_packed_small_gpu();
     test_ds4_topk_block_radix_gpu();
     test_ds4_flash_attention_inverse_rope_fallback_gpu();

--- a/server/tests/test_deepseek4_unit.cpp
+++ b/server/tests/test_deepseek4_unit.cpp
@@ -3041,7 +3041,7 @@ static void test_ds4_topk_block_radix_gpu() {
             /*disable_graphs=*/true,
             /*mmvq_max_ncols=*/0,
             /*skip_property_check=*/false);
-        unsetenv("GGML_DS4_TOPK_BLOCK_RADIX");
+        setenv("GGML_DS4_TOPK_BLOCK_RADIX", "0", 1);
         TEST_ASSERT_MSG(
             ggml_backend_graph_compute(backend, graph) == GGML_STATUS_SUCCESS,
             "reference long-context top-k failed");
@@ -3095,7 +3095,7 @@ static void test_ds4_topk_block_radix_gpu() {
             if (block_radix) {
                 setenv("GGML_DS4_TOPK_BLOCK_RADIX", "1", 1);
             } else {
-                unsetenv("GGML_DS4_TOPK_BLOCK_RADIX");
+                setenv("GGML_DS4_TOPK_BLOCK_RADIX", "0", 1);
             }
             constexpr int warmups = 5;
             constexpr int iterations = 100;


### PR DESCRIPTION
## Status

Draft integration branch. Do not merge until a matched 8K/32K/128K qualification runs on the 128 GiB Strix Halo target.

## Composition

- current `main`, including merged #673 sparse gate/up MMQ prefill;
- #684's 8K layer-major sparse scheduling and direct long-prefill top-k handoff;
- #667's already-qualified adaptive/fused gfx1151 verification stack;
- #683's mixed ROCmFP MMQ policy, streaming MLA attention, vectorized staging, ROCmFP2/3 loads, adaptive sparse-MoE tiles, persistent compact work queue, and fast softmax.

The commits are replayed rather than percentage-stacked. Existing measurements from divergent branches are not added together.

## Validation completed

Physical gfx1151 / ROCm HIP build on Lucebox Cina:

- `dflash_server` builds;
- `test_deepseek4_unit`: pass;
- `test_deepseek4_mmid_grouped_cuda`: 76/76 parity cases pass;
- `test_server_unit`: 455/455 pass;
- `test_feature_gate`: 1/1 pass.

The composed streaming-attention microbenchmark measured 2613.4 us for the grouped path and 2079.0 us for FP32-staged streaming MLA with fast exp: 1.26x kernel speedup, NMSE 1.97e-14 and max absolute error 4.1e-8 versus the precise path.

## Existing full-model evidence, not a unified result

- #684 reported 254.921 tok/s at 7680 tokens versus a cited Vulkan 254.07 tok/s. The prompt/model artifact was not proven identical, so this is directional short-context parity, not a strict cross-engine result.
- #667's independent 122879-token result was 142.82 tok/s versus cited Vulkan 226.82 tok/s. This remains the last matched long-context baseline; no unified long-context number is claimed yet.

## Qualification switches

The first matched run should preserve the deployed release settings and additionally test:

- `DFLASH_DS4_DIRECT_INDEXER_TOPK=1`
- `GGML_CUDA_MLA_STREAM_TOPK=1`
- `GGML_CUDA_MLA_STREAM_F32_STAGE=1`
- `GGML_CUDA_MLA_STREAM_FAST_EXP=1`
- `GGML_CUDA_MMQ_MOE_ADAPTIVE_X=1`
- `GGML_CUDA_MMQ_MOE_PERSISTENT=1`
- `DFLASH_DS4_LONG_CONTEXT_CHUNK=8192`

Each switch remains independently killable until the full-model matrix is complete.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

