### PR TITLE
feat(test): add kernel qualification coverage for GDN, MoE, and DeepSeek4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,13 +84,14 @@ jobs:
             test_dflash test_generate test_flash_attn_sparse test_server_unit \
             test_deepseek4_unit test_feature_gate test_seq_slot_manager \
             test_seq_engine_contract test_seq_batch_plan test_client_send_buffer \
-            test_model_smoke test_batched_gdn test_concat_transpose -j$(nproc)
+            test_model_smoke test_batched_gdn test_concat_transpose \
+            test_kernel_qualification_core test_kernel_qualification_gdn -j$(nproc)
 
       - name: Run C++ server unit tests
         run: |
           cd server/build
           ctest --output-on-failure \
-            -R "server_unit|deepseek4_unit|feature_gate|seq_slot_manager|seq_engine_contract|seq_batch_plan|client_send_buffer|batched_gdn_cpu" \
+            -R "server_unit|deepseek4_unit|feature_gate|seq_slot_manager|seq_engine_contract|seq_batch_plan|client_send_buffer|batched_gdn_cpu|test_kernel_qualification_core" \
             --no-tests=error
 
       - name: Populate venv with cu128 torch + setuptools
@@ -215,6 +216,8 @@ jobs:
             test_model_smoke
             test_batched_gdn
             test_gdn_replay_log
+            test_kernel_qualification_core
+            test_kernel_qualification_gdn
             test_concat_transpose
           )
           if [[ "$RUN_SPARSE_ATTENTION_TEST" == "true" ]]; then
@@ -235,7 +238,7 @@ jobs:
       - name: Run concurrent-serving kernel tests
         run: |
           ctest --test-dir server/build --output-on-failure \
-            -R '^(test_model_smoke\.PagedAttention\.|batched_gdn$|gdn_replay_log_preflight$|concat_transpose$)' --no-tests=error
+            -R '^(test_model_smoke\.PagedAttention\.|batched_gdn$|gdn_replay_log_preflight$|test_kernel_qualification_core$|kernel_qualification_gdn$|concat_transpose$)' --no-tests=error
 
       # Optional model-backed end-to-end smoke (real spec-decode on the 3090),
       # disabled by default because it builds dflash_server and lazy-loads the
@@ -353,11 +356,12 @@ jobs:
               test_recurrent_snapshot test_server_unit test_rocmfp3_mix_registry \
               test_rocmfp_mix_slice_matvec test_rocmfp_mix_gateup_glu \
               test_ds4_mix_registry_teardown test_model_smoke test_batched_gdn \
+              test_kernel_qualification_core test_kernel_qualification_gdn \
               test_concat_transpose test_cuda_pool_shutdown \
             --parallel 8
           ctest --test-dir "$RUNNER_TEMP/rocmfp-build" \
             --output-on-failure \
-            -R 'cuda_pool_shutdown|rocmfp4_reference|rocmfpx_reference|rocmfp4_hip_tail|rocmfpx_mmq|deepseek4_mmid_grouped_cuda|deepseek4_unit|recurrent_snapshot|ChainRollbackPolicy|rocmfp3_mix_registry|rocmfp_mix_slice_matvec|rocmfp_mix_gateup_glu|ds4_mix_registry_teardown|test_model_smoke\.PagedAttention\.|batched_gdn$|concat_transpose$'
+            -R 'cuda_pool_shutdown|rocmfp4_reference|rocmfpx_reference|rocmfp4_hip_tail|rocmfpx_mmq|deepseek4_mmid_grouped_cuda|deepseek4_unit|recurrent_snapshot|ChainRollbackPolicy|rocmfp3_mix_registry|rocmfp_mix_slice_matvec|rocmfp_mix_gateup_glu|ds4_mix_registry_teardown|test_model_smoke\.PagedAttention\.|batched_gdn$|test_kernel_qualification_core$|kernel_qualification_gdn$|concat_transpose$'
 
       - name: Build + test affine ROCmFP2 GPU paths
         # Keep the default wire-format build above and compile the affine layout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,8 @@ jobs:
             test_deepseek4_unit test_feature_gate test_seq_slot_manager \
             test_seq_engine_contract test_seq_batch_plan test_client_send_buffer \
             test_model_smoke test_batched_gdn test_concat_transpose \
-            test_kernel_qualification_core test_kernel_qualification_gdn -j$(nproc)
+            test_kernel_qualification_core test_kernel_qualification_gdn \
+            test_kernel_qualification_moe_ds4 -j$(nproc)
 
       - name: Run C++ server unit tests
         run: |
@@ -218,6 +219,7 @@ jobs:
             test_gdn_replay_log
             test_kernel_qualification_core
             test_kernel_qualification_gdn
+            test_kernel_qualification_moe_ds4
             test_concat_transpose
           )
           if [[ "$RUN_SPARSE_ATTENTION_TEST" == "true" ]]; then
@@ -238,7 +240,7 @@ jobs:
       - name: Run concurrent-serving kernel tests
         run: |
           ctest --test-dir server/build --output-on-failure \
-            -R '^(test_model_smoke\.PagedAttention\.|batched_gdn$|gdn_replay_log_preflight$|test_kernel_qualification_core$|kernel_qualification_gdn$|concat_transpose$)' --no-tests=error
+            -R '^(test_model_smoke\.PagedAttention\.|batched_gdn$|gdn_replay_log_preflight$|test_kernel_qualification_core\.|kernel_qualification_gdn$|kernel_qualification_moe_ds4$|concat_transpose$)' --no-tests=error
 
       # Optional model-backed end-to-end smoke (real spec-decode on the 3090),
       # disabled by default because it builds dflash_server and lazy-loads the
@@ -357,11 +359,12 @@ jobs:
               test_rocmfp_mix_slice_matvec test_rocmfp_mix_gateup_glu \
               test_ds4_mix_registry_teardown test_model_smoke test_batched_gdn \
               test_kernel_qualification_core test_kernel_qualification_gdn \
+              test_kernel_qualification_moe_ds4 \
               test_concat_transpose test_cuda_pool_shutdown \
             --parallel 8
           ctest --test-dir "$RUNNER_TEMP/rocmfp-build" \
             --output-on-failure \
-            -R 'cuda_pool_shutdown|rocmfp4_reference|rocmfpx_reference|rocmfp4_hip_tail|rocmfpx_mmq|deepseek4_mmid_grouped_cuda|deepseek4_unit|recurrent_snapshot|ChainRollbackPolicy|rocmfp3_mix_registry|rocmfp_mix_slice_matvec|rocmfp_mix_gateup_glu|ds4_mix_registry_teardown|test_model_smoke\.PagedAttention\.|batched_gdn$|test_kernel_qualification_core$|kernel_qualification_gdn$|concat_transpose$'
+            -R 'cuda_pool_shutdown|rocmfp4_reference|rocmfpx_reference|rocmfp4_hip_tail|rocmfpx_mmq|deepseek4_mmid_grouped_cuda|deepseek4_unit|recurrent_snapshot|ChainRollbackPolicy|rocmfp3_mix_registry|rocmfp_mix_slice_matvec|rocmfp_mix_gateup_glu|ds4_mix_registry_teardown|test_model_smoke\.PagedAttention\.|batched_gdn$|test_kernel_qualification_core\.|kernel_qualification_gdn$|kernel_qualification_moe_ds4$|concat_transpose$'
 
       - name: Build + test affine ROCmFP2 GPU paths
         # Keep the default wire-format build above and compile the affine layout

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -894,7 +894,6 @@ if(DFLASH27B_TESTS)
     target_include_directories(
         test_kernel_qualification_core PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/test)
-    list(APPEND _raw_unit_test_targets test_kernel_qualification_core)
 
     # Header-only platform shims must remain independently buildable and
     # runnable on hosted Windows workers without a GPU.
@@ -1880,6 +1879,7 @@ if(DFLASH27B_TESTS)
         test_server_unit
         test_model_smoke)
     set(_new_cppunit_test_targets
+        test_kernel_qualification_core
         test_platform_compat
         test_draft_swa
         test_feature_gate
@@ -2134,6 +2134,52 @@ if(DFLASH27B_TESTS)
             kernel_qualification_gdn PROPERTIES SKIP_RETURN_CODE 77)
         if(TARGET check)
             add_dependencies(check test_kernel_qualification_gdn)
+        endif()
+    endif()
+
+    if((DFLASH27B_GPU_BACKEND STREQUAL "cuda" OR
+        DFLASH27B_GPU_BACKEND STREQUAL "hip")
+       AND EXISTS
+           "${CMAKE_CURRENT_SOURCE_DIR}/test/test_kernel_qualification_moe_ds4.cpp")
+        add_executable(
+            test_kernel_qualification_moe_ds4
+            test/test_kernel_qualification_moe_ds4.cpp)
+        if(DFLASH27B_GPU_BACKEND STREQUAL "hip")
+            set_source_files_properties(
+                test/test_kernel_qualification_moe_ds4.cpp PROPERTIES LANGUAGE HIP)
+            set_target_properties(
+                test_kernel_qualification_moe_ds4 PROPERTIES
+                HIP_ARCHITECTURES "${_dflash_archs}")
+            target_compile_definitions(
+                test_kernel_qualification_moe_ds4 PRIVATE GGML_USE_HIP)
+            target_link_libraries(
+                test_kernel_qualification_moe_ds4 PRIVATE hip::host)
+        else()
+            set_source_files_properties(
+                test/test_kernel_qualification_moe_ds4.cpp PROPERTIES LANGUAGE CUDA)
+            set_target_properties(
+                test_kernel_qualification_moe_ds4 PROPERTIES
+                CUDA_ARCHITECTURES "${_dflash_archs}")
+            target_link_libraries(
+                test_kernel_qualification_moe_ds4 PRIVATE CUDA::cudart)
+        endif()
+        target_include_directories(
+            test_kernel_qualification_moe_ds4 PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/test
+            ${CMAKE_CURRENT_SOURCE_DIR}/deps/llama.cpp/ggml/include
+            ${CMAKE_CURRENT_SOURCE_DIR}/deps/llama.cpp/ggml/src
+            ${CMAKE_CURRENT_SOURCE_DIR}/deps/llama.cpp/ggml/src/ggml-cuda
+            ${CMAKE_CURRENT_SOURCE_DIR}/deps/llama.cpp/ggml/rocmfpx)
+        target_link_libraries(
+            test_kernel_qualification_moe_ds4 PRIVATE
+            ggml ggml-base ${DFLASH27B_GGML_BACKEND_TARGET})
+        add_test(
+            NAME kernel_qualification_moe_ds4
+            COMMAND test_kernel_qualification_moe_ds4)
+        set_tests_properties(
+            kernel_qualification_moe_ds4 PROPERTIES SKIP_RETURN_CODE 77)
+        if(TARGET check)
+            add_dependencies(check test_kernel_qualification_moe_ds4)
         endif()
     endif()
 

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -888,6 +888,14 @@ if(DFLASH27B_TESTS)
     set(_raw_unit_test_targets)
     enable_testing()
 
+    add_executable(
+        test_kernel_qualification_core
+        test/test_kernel_qualification_core.cpp)
+    target_include_directories(
+        test_kernel_qualification_core PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/test)
+    list(APPEND _raw_unit_test_targets test_kernel_qualification_core)
+
     # Header-only platform shims must remain independently buildable and
     # runnable on hosted Windows workers without a GPU.
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_platform_compat.cpp")
@@ -2108,6 +2116,26 @@ if(DFLASH27B_TESTS)
             ${CMAKE_CURRENT_SOURCE_DIR}/deps/llama.cpp/ggml/include
             ${CMAKE_CURRENT_SOURCE_DIR}/deps/llama.cpp/ggml/src)
     endfunction()
+
+    if((DFLASH27B_GPU_BACKEND STREQUAL "cuda" OR
+        DFLASH27B_GPU_BACKEND STREQUAL "hip")
+       AND EXISTS
+           "${CMAKE_CURRENT_SOURCE_DIR}/test/test_kernel_qualification_gdn.cpp")
+        dflash_add_ggml_gpu_executable(
+            test_kernel_qualification_gdn
+            test/test_kernel_qualification_gdn.cpp)
+        target_include_directories(
+            test_kernel_qualification_gdn PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/test)
+        add_test(
+            NAME kernel_qualification_gdn
+            COMMAND test_kernel_qualification_gdn)
+        set_tests_properties(
+            kernel_qualification_gdn PROPERTIES SKIP_RETURN_CODE 77)
+        if(TARGET check)
+            add_dependencies(check test_kernel_qualification_gdn)
+        endif()
+    endif()
 
     if((DFLASH27B_GPU_BACKEND STREQUAL "cuda" OR
         DFLASH27B_GPU_BACKEND STREQUAL "hip")

--- a/server/deps/llama.cpp/ggml/include/ggml-cuda.h
+++ b/server/deps/llama.cpp/ggml/include/ggml-cuda.h
@@ -74,6 +74,11 @@ GGML_BACKEND_API size_t ggml_backend_cuda_get_concat_transpose_f32_count(void);
 GGML_BACKEND_API size_t ggml_backend_cuda_get_mmvq_launch_count(void);
 GGML_BACKEND_API size_t ggml_backend_cuda_get_mmq_launch_count(void);
 
+// Calling-thread launch counters for the scalar and grouped-column GDN
+// kernels. Focused qualification tests use these to reject silent fallback.
+GGML_BACKEND_API size_t ggml_backend_cuda_get_gdn_scalar_launch_count(void);
+GGML_BACKEND_API size_t ggml_backend_cuda_get_gdn_grouped_cols_launch_count(void);
+
 // device buffer
 GGML_BACKEND_API ggml_backend_buffer_type_t ggml_backend_cuda_buffer_type(int device);
 

--- a/server/deps/llama.cpp/ggml/include/ggml-cuda.h
+++ b/server/deps/llama.cpp/ggml/include/ggml-cuda.h
@@ -68,16 +68,19 @@ GGML_BACKEND_API bool ggml_backend_cuda_set_graphs_disabled_override(bool disabl
 // Intended for focused correctness tests of the dispatch guard.
 GGML_BACKEND_API size_t ggml_backend_cuda_get_concat_transpose_f32_count(void);
 
-// Calling-thread launch counters for quantized matrix-vector (MMVQ) and
-// matrix-matrix (MMQ) kernels. Intended for focused tests that must prove
-// which dispatch path executed rather than only checking numerical output.
+// Calling-thread launch counters for quantized matrix-vector (MMVQ), its
+// grouped-expert MMID specialization, and matrix-matrix (MMQ) kernels.
+// Intended for focused tests that must prove which dispatch path executed
+// rather than only checking numerical output.
 GGML_BACKEND_API size_t ggml_backend_cuda_get_mmvq_launch_count(void);
 GGML_BACKEND_API size_t ggml_backend_cuda_get_mmq_launch_count(void);
+GGML_BACKEND_API size_t ggml_backend_cuda_get_mmvq_mmid_grouped_launch_count(void);
 
 // Calling-thread launch counters for the scalar and grouped-column GDN
 // kernels. Focused qualification tests use these to reject silent fallback.
 GGML_BACKEND_API size_t ggml_backend_cuda_get_gdn_scalar_launch_count(void);
 GGML_BACKEND_API size_t ggml_backend_cuda_get_gdn_grouped_cols_launch_count(void);
+GGML_BACKEND_API bool ggml_backend_cuda_supports_gdn_grouped_cols(int device);
 
 // device buffer
 GGML_BACKEND_API ggml_backend_buffer_type_t ggml_backend_cuda_buffer_type(int device);

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/gated_delta_net.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/gated_delta_net.cu
@@ -16,6 +16,22 @@ extern "C" size_t ggml_backend_cuda_get_gdn_grouped_cols_launch_count(void) {
     return g_gdn_grouped_cols_launch_count;
 }
 
+static bool gdn_grouped_cols_supported(int device) {
+    const ggml_cuda_device_info & info = ggml_cuda_info();
+    if (device < 0 || device >= info.device_count) {
+        return false;
+    }
+    const int cc = info.devices[device].cc;
+    const int warp_size = info.devices[device].warp_size;
+    return ((GGML_CUDA_CC_IS_NVIDIA(cc) && cc >= GGML_CUDA_CC_AMPERE) ||
+            GGML_CUDA_CC_IS_AMD(cc)) &&
+        (warp_size == 32 || warp_size == 64);
+}
+
+extern "C" bool ggml_backend_cuda_supports_gdn_grouped_cols(int device) {
+    return gdn_grouped_cols_supported(device);
+}
+
 // Tree-mode parent index sentinel: a node whose parent is the pre-block state
 // (i.e. a "root" node in the DFS-flattened tree) uses this value in
 // parent_ids[]. Any value < 0 triggers a reload from curr_state.
@@ -634,9 +650,7 @@ static void launch_gated_delta_net(
     const bool use_grouped_cols = force_grouped_cols ||
         (!disable_grouped_cols && !ampere_nvidia);
     const bool take_grouped_cols = S_v == 128 && !KDA && use_grouped_cols &&
-        ((GGML_CUDA_CC_IS_NVIDIA(cc) && cc >= GGML_CUDA_CC_AMPERE) ||
-         GGML_CUDA_CC_IS_AMD(cc)) &&
-        (warp_size == 32 || warp_size == 64);
+        gdn_grouped_cols_supported(ggml_cuda_get_device());
     if (take_grouped_cols) {
         ++g_gdn_grouped_cols_launch_count;
     } else {

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/gated_delta_net.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/gated_delta_net.cu
@@ -5,6 +5,17 @@
 #include <cstdlib>
 #include <type_traits>
 
+static thread_local size_t g_gdn_scalar_launch_count = 0;
+static thread_local size_t g_gdn_grouped_cols_launch_count = 0;
+
+extern "C" size_t ggml_backend_cuda_get_gdn_scalar_launch_count(void) {
+    return g_gdn_scalar_launch_count;
+}
+
+extern "C" size_t ggml_backend_cuda_get_gdn_grouped_cols_launch_count(void) {
+    return g_gdn_grouped_cols_launch_count;
+}
+
 // Tree-mode parent index sentinel: a node whose parent is the pre-block state
 // (i.e. a "root" node in the DFS-flattened tree) uses this value in
 // parent_ids[]. Any value < 0 triggers a reload from curr_state.
@@ -622,6 +633,15 @@ static void launch_gated_delta_net(
     const bool disable_grouped_cols = getenv("DFLASH_GDN_NO_GROUPED_COLS") != nullptr;
     const bool use_grouped_cols = force_grouped_cols ||
         (!disable_grouped_cols && !ampere_nvidia);
+    const bool take_grouped_cols = S_v == 128 && !KDA && use_grouped_cols &&
+        ((GGML_CUDA_CC_IS_NVIDIA(cc) && cc >= GGML_CUDA_CC_AMPERE) ||
+         GGML_CUDA_CC_IS_AMD(cc)) &&
+        (warp_size == 32 || warp_size == 64);
+    if (take_grouped_cols) {
+        ++g_gdn_grouped_cols_launch_count;
+    } else {
+        ++g_gdn_scalar_launch_count;
+    }
 
     switch (S_v) {
         case 16:
@@ -645,9 +665,7 @@ static void launch_gated_delta_net(
         }
         case 128: {
             if constexpr (!KDA) {
-                if (use_grouped_cols &&
-                    ((GGML_CUDA_CC_IS_NVIDIA(cc) && cc >= GGML_CUDA_CC_AMPERE) ||
-                     GGML_CUDA_CC_IS_AMD(cc))) {
+                if (take_grouped_cols) {
                     constexpr int cols = 4;
                     constexpr int width = 16;
                     constexpr int column_groups_per_block = 8;
@@ -665,11 +683,6 @@ static void launch_gated_delta_net(
                         dim3 grouped_grid_dims(H, n_seqs, (groups + column_groups_per_block * groups_per_warp - 1) / (column_groups_per_block * groups_per_warp));
                         dim3 grouped_block_dims(64, column_groups_per_block, 1);
                         gated_delta_net_cuda_grouped_cols<128, cols, width, 64, TREE_MODE, WRITE_INTER, InterT><<<grouped_grid_dims, grouped_block_dims, 0, stream>>>(
-                            q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, replay_log_d, H,
-                            n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,
-                            sb1, sb2, sb3, neqk1_magic, rq3_magic, scale, gate_bias, gate_A);
-                    } else {
-                        gated_delta_net_cuda<128, KDA, TREE_MODE, WRITE_INTER, InterT><<<grid_dims, block_dims, 0, stream>>>(
                             q_d, k_d, v_d, g_d, b_d, s_d, active_slot_ids_d, dst_d, state_out_d, parent_ids_d, persist_inter_d, replay_log_d, H,
                             n_tokens, n_seqs, n_state_slots, sq1, sq2, sq3, sv1, sv2, sv3,
                             sb1, sb2, sb3, neqk1_magic, rq3_magic, scale, gate_bias, gate_A);

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/mmvq.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/mmvq.cu
@@ -9,9 +9,14 @@
 #include <cstring>
 
 static thread_local size_t g_mmvq_launch_count = 0;
+static thread_local size_t g_mmvq_mmid_grouped_launch_count = 0;
 
 extern "C" size_t ggml_backend_cuda_get_mmvq_launch_count(void) {
     return g_mmvq_launch_count;
+}
+
+extern "C" size_t ggml_backend_cuda_get_mmvq_mmid_grouped_launch_count(void) {
+    return g_mmvq_mmid_grouped_launch_count;
 }
 
 typedef float (*vec_dot_q_cuda_t)(const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs);
@@ -2820,6 +2825,7 @@ void ggml_cuda_mul_mat_vec_q(
                 (int) s01, (int) stride_col_y, (int) stride_col_dst,
                 (int) s02, (int) stride_channel_y, (int) stride_channel_dst,
                 np, stream)) {
+            ++g_mmvq_mmid_grouped_launch_count;
             if (mmid_telemetry) {
                 std::fprintf(stderr,
                     "[dflash-mmid] event=mmvq type=%s width=%lld pairs=%d variant=grouped\n",

--- a/server/test/kernel_qualification.h
+++ b/server/test/kernel_qualification.h
@@ -21,8 +21,9 @@ enum class Status {
 
 struct Metric {
     std::string name;
+    std::string error_measure = "max_abs";
     double tolerance = 0.0;
-    double max_abs_error = 0.0;
+    double observed_error = 0.0;
     size_t worst_index = 0;
     bool finite = true;
     bool passed = false;
@@ -52,39 +53,85 @@ inline const char * status_name(Status status) {
     return "fail";
 }
 
-inline Metric compare_f32(
+inline Metric compare_f32_impl(
         std::string name,
         const std::vector<float> & candidate,
         const std::vector<float> & reference,
-        double tolerance) {
+        double tolerance,
+        bool normalized_mse) {
     Metric result;
     result.name = std::move(name);
+    result.error_measure = normalized_mse ? "normalized_mse" : "max_abs";
     result.tolerance = tolerance;
+    if (!std::isfinite(tolerance)) {
+        result.reason = "non-finite tolerance";
+        return result;
+    }
+    if (tolerance < 0.0) {
+        result.reason = "negative tolerance";
+        return result;
+    }
     if (candidate.size() != reference.size()) {
-        result.max_abs_error = std::numeric_limits<double>::infinity();
+        result.observed_error = std::numeric_limits<double>::infinity();
         result.finite = false;
         result.reason = "size mismatch";
         return result;
     }
+    if (candidate.empty()) {
+        result.reason = "no samples";
+        return result;
+    }
 
+    double squared_error = 0.0;
+    double reference_power = 0.0;
+    double worst_error = 0.0;
     for (size_t i = 0; i < candidate.size(); ++i) {
         if (!std::isfinite(candidate[i]) || !std::isfinite(reference[i])) {
-            result.max_abs_error = std::numeric_limits<double>::infinity();
+            result.observed_error = std::numeric_limits<double>::infinity();
             result.worst_index = i;
             result.finite = false;
             result.reason = "non-finite value";
             return result;
         }
-        const double error = std::fabs(
-            static_cast<double>(candidate[i]) - reference[i]);
-        if (error > result.max_abs_error) {
-            result.max_abs_error = error;
+        const double error = static_cast<double>(candidate[i]) - reference[i];
+        const double absolute_error = std::fabs(error);
+        if (absolute_error > worst_error) {
+            worst_error = absolute_error;
             result.worst_index = i;
         }
+        if (normalized_mse) {
+            squared_error += error*error;
+            reference_power +=
+                static_cast<double>(reference[i])*reference[i];
+        } else {
+            result.observed_error = worst_error;
+        }
     }
-    result.passed = result.max_abs_error <= tolerance;
+    if (normalized_mse) {
+        result.observed_error =
+            squared_error/std::max(reference_power, 1.0e-30);
+    }
+    result.passed = result.observed_error <= tolerance;
     if (!result.passed) result.reason = "tolerance exceeded";
     return result;
+}
+
+inline Metric compare_f32(
+        std::string name,
+        const std::vector<float> & candidate,
+        const std::vector<float> & reference,
+        double tolerance) {
+    return compare_f32_impl(
+        std::move(name), candidate, reference, tolerance, false);
+}
+
+inline Metric compare_f32_nmse(
+        std::string name,
+        const std::vector<float> & candidate,
+        const std::vector<float> & reference,
+        double tolerance) {
+    return compare_f32_impl(
+        std::move(name), candidate, reference, tolerance, true);
 }
 
 inline CaseResult evaluate(
@@ -95,9 +142,15 @@ inline CaseResult evaluate(
     result.name = std::move(name);
     result.metrics = std::move(metrics);
     result.route = std::move(route);
+    if (result.metrics.empty()) {
+        result.reason = "no metrics";
+        return result;
+    }
     result.status = result.route.matched &&
             std::all_of(result.metrics.begin(), result.metrics.end(),
-                        [](const Metric & metric) { return metric.passed; })
+                        [](const Metric & metric) {
+                            return metric.finite && metric.passed;
+                        })
         ? Status::pass
         : Status::fail;
     if (!result.route.matched) {
@@ -105,8 +158,14 @@ inline CaseResult evaluate(
     } else {
         const auto failed = std::find_if(
             result.metrics.begin(), result.metrics.end(),
-            [](const Metric & metric) { return !metric.passed; });
-        if (failed != result.metrics.end()) result.reason = failed->reason;
+            [](const Metric & metric) {
+                return !metric.finite || !metric.passed;
+            });
+        if (failed != result.metrics.end()) {
+            result.reason = failed->reason.empty() && !failed->finite
+                ? "non-finite metric"
+                : failed->reason;
+        }
     }
     return result;
 }
@@ -120,6 +179,7 @@ inline CaseResult unsupported(std::string name, std::string reason) {
 }
 
 inline Status aggregate_status(const std::vector<CaseResult> & cases) {
+    if (cases.empty()) return Status::fail;
     if (std::any_of(cases.begin(), cases.end(), [](const CaseResult & result) {
             return result.status == Status::fail;
         })) {
@@ -172,7 +232,8 @@ inline void write_json(
         std::ostream & out,
         const std::string & backend,
         const std::vector<CaseResult> & cases) {
-    out << "{\"schema\":\"lucebox.kernel_qualification.v1\""
+    out << std::setprecision(std::numeric_limits<double>::max_digits10)
+        << "{\"schema\":\"lucebox.kernel_qualification.v1\""
         << ",\"backend\":" << json_string(backend)
         << ",\"status\":" << json_string(status_name(aggregate_status(cases)))
         << ",\"cases\":[";
@@ -192,10 +253,17 @@ inline void write_json(
             const Metric & metric = result.metrics[metric_index];
             if (metric_index != 0) out << ',';
             out << "{\"name\":" << json_string(metric.name)
-                << ",\"tolerance\":" << metric.tolerance
-                << ",\"max_abs_error\":";
-            if (std::isfinite(metric.max_abs_error)) {
-                out << metric.max_abs_error;
+                << ",\"error_measure\":"
+                << json_string(metric.error_measure)
+                << ",\"tolerance\":";
+            if (std::isfinite(metric.tolerance)) {
+                out << metric.tolerance;
+            } else {
+                out << "null";
+            }
+            out << ",\"observed_error\":";
+            if (std::isfinite(metric.observed_error)) {
+                out << metric.observed_error;
             } else {
                 out << "null";
             }

--- a/server/test/kernel_qualification.h
+++ b/server/test/kernel_qualification.h
@@ -1,0 +1,212 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <iomanip>
+#include <limits>
+#include <ostream>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace lucebox::kernel_qualification {
+
+enum class Status {
+    pass,
+    fail,
+    unsupported,
+};
+
+struct Metric {
+    std::string name;
+    double tolerance = 0.0;
+    double max_abs_error = 0.0;
+    size_t worst_index = 0;
+    bool finite = true;
+    bool passed = false;
+    std::string reason;
+};
+
+struct Route {
+    std::string expected;
+    std::string observed;
+    bool matched = false;
+};
+
+struct CaseResult {
+    std::string name;
+    Status status = Status::fail;
+    std::string reason;
+    Route route;
+    std::vector<Metric> metrics;
+};
+
+inline const char * status_name(Status status) {
+    switch (status) {
+        case Status::pass: return "pass";
+        case Status::fail: return "fail";
+        case Status::unsupported: return "unsupported";
+    }
+    return "fail";
+}
+
+inline Metric compare_f32(
+        std::string name,
+        const std::vector<float> & candidate,
+        const std::vector<float> & reference,
+        double tolerance) {
+    Metric result;
+    result.name = std::move(name);
+    result.tolerance = tolerance;
+    if (candidate.size() != reference.size()) {
+        result.max_abs_error = std::numeric_limits<double>::infinity();
+        result.finite = false;
+        result.reason = "size mismatch";
+        return result;
+    }
+
+    for (size_t i = 0; i < candidate.size(); ++i) {
+        if (!std::isfinite(candidate[i]) || !std::isfinite(reference[i])) {
+            result.max_abs_error = std::numeric_limits<double>::infinity();
+            result.worst_index = i;
+            result.finite = false;
+            result.reason = "non-finite value";
+            return result;
+        }
+        const double error = std::fabs(
+            static_cast<double>(candidate[i]) - reference[i]);
+        if (error > result.max_abs_error) {
+            result.max_abs_error = error;
+            result.worst_index = i;
+        }
+    }
+    result.passed = result.max_abs_error <= tolerance;
+    if (!result.passed) result.reason = "tolerance exceeded";
+    return result;
+}
+
+inline CaseResult evaluate(
+        std::string name,
+        std::vector<Metric> metrics,
+        Route route) {
+    CaseResult result;
+    result.name = std::move(name);
+    result.metrics = std::move(metrics);
+    result.route = std::move(route);
+    result.status = result.route.matched &&
+            std::all_of(result.metrics.begin(), result.metrics.end(),
+                        [](const Metric & metric) { return metric.passed; })
+        ? Status::pass
+        : Status::fail;
+    if (!result.route.matched) {
+        result.reason = "candidate route was not observed";
+    } else {
+        const auto failed = std::find_if(
+            result.metrics.begin(), result.metrics.end(),
+            [](const Metric & metric) { return !metric.passed; });
+        if (failed != result.metrics.end()) result.reason = failed->reason;
+    }
+    return result;
+}
+
+inline CaseResult unsupported(std::string name, std::string reason) {
+    CaseResult result;
+    result.name = std::move(name);
+    result.status = Status::unsupported;
+    result.reason = std::move(reason);
+    return result;
+}
+
+inline Status aggregate_status(const std::vector<CaseResult> & cases) {
+    if (std::any_of(cases.begin(), cases.end(), [](const CaseResult & result) {
+            return result.status == Status::fail;
+        })) {
+        return Status::fail;
+    }
+    if (std::any_of(cases.begin(), cases.end(), [](const CaseResult & result) {
+            return result.status == Status::pass;
+        })) {
+        return Status::pass;
+    }
+    return Status::unsupported;
+}
+
+inline int exit_code(const std::vector<CaseResult> & cases) {
+    switch (aggregate_status(cases)) {
+        case Status::pass: return 0;
+        case Status::fail: return 1;
+        case Status::unsupported: return 77;
+    }
+    return 1;
+}
+
+inline std::string json_string(const std::string & value) {
+    std::ostringstream out;
+    out << '"';
+    for (unsigned char ch : value) {
+        switch (ch) {
+            case '"': out << "\\\""; break;
+            case '\\': out << "\\\\"; break;
+            case '\b': out << "\\b"; break;
+            case '\f': out << "\\f"; break;
+            case '\n': out << "\\n"; break;
+            case '\r': out << "\\r"; break;
+            case '\t': out << "\\t"; break;
+            default:
+                if (ch < 0x20) {
+                    out << "\\u" << std::hex << std::setw(4)
+                        << std::setfill('0') << static_cast<int>(ch)
+                        << std::dec << std::setfill(' ');
+                } else {
+                    out << static_cast<char>(ch);
+                }
+        }
+    }
+    out << '"';
+    return out.str();
+}
+
+inline void write_json(
+        std::ostream & out,
+        const std::string & backend,
+        const std::vector<CaseResult> & cases) {
+    out << "{\"schema\":\"lucebox.kernel_qualification.v1\""
+        << ",\"backend\":" << json_string(backend)
+        << ",\"status\":" << json_string(status_name(aggregate_status(cases)))
+        << ",\"cases\":[";
+    for (size_t case_index = 0; case_index < cases.size(); ++case_index) {
+        const CaseResult & result = cases[case_index];
+        if (case_index != 0) out << ',';
+        out << "{\"name\":" << json_string(result.name)
+            << ",\"status\":" << json_string(status_name(result.status))
+            << ",\"reason\":" << json_string(result.reason)
+            << ",\"route\":{\"expected\":"
+            << json_string(result.route.expected)
+            << ",\"observed\":" << json_string(result.route.observed)
+            << ",\"matched\":" << (result.route.matched ? "true" : "false")
+            << "},\"metrics\":[";
+        for (size_t metric_index = 0;
+             metric_index < result.metrics.size(); ++metric_index) {
+            const Metric & metric = result.metrics[metric_index];
+            if (metric_index != 0) out << ',';
+            out << "{\"name\":" << json_string(metric.name)
+                << ",\"tolerance\":" << metric.tolerance
+                << ",\"max_abs_error\":";
+            if (std::isfinite(metric.max_abs_error)) {
+                out << metric.max_abs_error;
+            } else {
+                out << "null";
+            }
+            out << ",\"worst_index\":" << metric.worst_index
+                << ",\"finite\":" << (metric.finite ? "true" : "false")
+                << ",\"passed\":" << (metric.passed ? "true" : "false")
+                << ",\"reason\":" << json_string(metric.reason) << '}';
+        }
+        out << "]}";
+    }
+    out << "]}\n";
+}
+
+}  // namespace lucebox::kernel_qualification

--- a/server/test/test_kernel_qualification_core.cpp
+++ b/server/test/test_kernel_qualification_core.cpp
@@ -1,65 +1,136 @@
 #include "kernel_qualification.h"
+#include "CppUnitTestFramework.hpp"
 
 #include <cmath>
-#include <iostream>
 #include <limits>
 #include <sstream>
 #include <string>
 #include <vector>
 
 namespace kq = lucebox::kernel_qualification;
+using CppUnitTestFramework::CommonFixture;
 
 namespace {
 
-bool require(bool condition, const char * message) {
-    if (!condition) std::cerr << message << '\n';
-    return condition;
-}
+struct KernelQualificationFixture : CommonFixture {
+    using CommonFixture::CommonFixture;
+};
 
 }  // namespace
 
-int main() {
-    bool ok = true;
-
+TEST_CASE(KernelQualificationFixture, comparisons) {
     const kq::Metric within = kq::compare_f32(
         "output", {1.0f, 2.0f}, {1.0f, 2.00001f}, 2.0e-5);
-    ok = require(within.passed && within.finite,
-                 "comparison inside tolerance must pass") && ok;
+    REQUIRE_TRUE(within.passed && within.finite);
 
     const kq::Metric outside = kq::compare_f32(
         "state", {1.0f, 2.1f}, {1.0f, 2.0f}, 1.0e-3);
-    ok = require(!outside.passed && outside.reason == "tolerance exceeded",
-                 "comparison outside tolerance must fail") && ok;
+    REQUIRE_TRUE(!outside.passed && outside.reason == "tolerance exceeded");
 
     const kq::Metric nonfinite = kq::compare_f32(
         "nonfinite", {std::numeric_limits<float>::quiet_NaN()}, {0.0f}, 1.0);
-    ok = require(!nonfinite.passed && !nonfinite.finite,
-                 "non-finite values must fail") && ok;
+    REQUIRE_TRUE(!nonfinite.passed && !nonfinite.finite);
 
+    const kq::Metric infinite_tolerance = kq::compare_f32(
+        "infinite_tolerance", {1.0f}, {1.0f},
+        std::numeric_limits<double>::infinity());
+    const kq::Metric nan_tolerance = kq::compare_f32_nmse(
+        "nan_tolerance", {1.0f}, {1.0f},
+        std::numeric_limits<double>::quiet_NaN());
+    REQUIRE_TRUE(
+        !infinite_tolerance.passed && infinite_tolerance.finite &&
+        infinite_tolerance.reason == "non-finite tolerance");
+    REQUIRE_TRUE(
+        !nan_tolerance.passed && nan_tolerance.finite &&
+        nan_tolerance.reason == "non-finite tolerance");
+
+    const kq::Metric negative_tolerance = kq::compare_f32(
+        "negative_tolerance", {1.0f}, {1.0f}, -1.0);
+    const kq::Metric negative_nmse_tolerance = kq::compare_f32_nmse(
+        "negative_nmse_tolerance", {1.0f}, {1.0f}, -1.0);
+    REQUIRE_TRUE(
+        !negative_tolerance.passed && negative_tolerance.finite &&
+        negative_tolerance.reason == "negative tolerance");
+    REQUIRE_TRUE(
+        !negative_nmse_tolerance.passed &&
+        negative_nmse_tolerance.finite &&
+        negative_nmse_tolerance.reason == "negative tolerance");
+
+    const kq::Metric empty = kq::compare_f32("empty", {}, {}, 0.0);
+    const kq::Metric empty_nmse =
+        kq::compare_f32_nmse("empty_nmse", {}, {}, 0.0);
+    REQUIRE_TRUE(!empty.passed && empty.reason == "no samples");
+    REQUIRE_TRUE(
+        !empty_nmse.passed && empty_nmse.reason == "no samples");
+
+    const kq::Metric nmse = kq::compare_f32_nmse(
+        "output", {1.0f, 2.001f}, {1.0f, 2.0f}, 1.0e-6);
+    REQUIRE_TRUE(nmse.passed && nmse.error_measure == "normalized_mse");
+}
+
+TEST_CASE(KernelQualificationFixture, statuses) {
+    const kq::Metric within = kq::compare_f32(
+        "output", {1.0f, 2.0f}, {1.0f, 2.00001f}, 2.0e-5);
     const kq::CaseResult passed = kq::evaluate(
         "gdn", {within}, {"gdn.grouped_cols", "gdn.grouped_cols", true});
     const kq::CaseResult wrong_route = kq::evaluate(
         "gdn", {within}, {"gdn.grouped_cols", "gdn.scalar", false});
+    const kq::CaseResult empty = kq::evaluate(
+        "gdn", {}, {"gdn.grouped_cols", "gdn.grouped_cols", true});
     const kq::CaseResult skipped = kq::unsupported(
         "gdn", "GPU backend unavailable");
-    ok = require(passed.status == kq::Status::pass,
-                 "matching numerics and route must pass") && ok;
-    ok = require(wrong_route.status == kq::Status::fail,
-                 "a route mismatch must fail") && ok;
-    ok = require(skipped.status == kq::Status::unsupported,
-                 "unsupported must not be reported as pass") && ok;
-    ok = require(kq::exit_code({skipped}) == 77,
-                 "unsupported-only reports must use the CTest skip code") && ok;
+    kq::Metric contradictory = within;
+    contradictory.finite = false;
+    contradictory.passed = true;
+    const kq::CaseResult nonfinite = kq::evaluate(
+        "gdn", {contradictory},
+        {"gdn.grouped_cols", "gdn.grouped_cols", true});
+    REQUIRE_TRUE(passed.status == kq::Status::pass);
+    REQUIRE_TRUE(wrong_route.status == kq::Status::fail);
+    REQUIRE_TRUE(skipped.status == kq::Status::unsupported);
+    REQUIRE_TRUE(empty.status == kq::Status::fail && empty.reason == "no metrics");
+    REQUIRE_TRUE(
+        nonfinite.status == kq::Status::fail &&
+        nonfinite.reason == "non-finite metric");
+    REQUIRE_TRUE(kq::exit_code({skipped}) == 77);
+    REQUIRE_TRUE(kq::aggregate_status({}) == kq::Status::fail);
+    REQUIRE_TRUE(kq::exit_code({}) == 1);
+}
 
+TEST_CASE(KernelQualificationFixture, report_preserves_double_precision) {
+    kq::Metric precise;
+    precise.name = "precise";
+    precise.tolerance = 1.2345678901234567e-12;
+    precise.observed_error = 9.8765432109876543e-13;
+    precise.finite = true;
+    precise.passed = true;
+    const kq::CaseResult passed = kq::evaluate(
+        "report", {precise}, {"route", "route", true});
     std::ostringstream report;
     kq::write_json(report, "self-test", {passed});
     const std::string json = report.str();
-    ok = require(
+    REQUIRE_TRUE(
         json.find("\"schema\":\"lucebox.kernel_qualification.v1\"") !=
             std::string::npos &&
-        json.find("\"status\":\"pass\"") != std::string::npos,
-        "report must include the stable schema and aggregate status") && ok;
+        json.find("\"status\":\"pass\"") != std::string::npos);
+    REQUIRE_TRUE(
+        json.find("1.2345678901234567e-12") != std::string::npos);
+    REQUIRE_TRUE(
+        json.find("9.8765432109876542e-13") != std::string::npos);
+}
 
-    if (ok) std::cout << json;
-    return ok ? 0 : 1;
+TEST_CASE(KernelQualificationFixture, report_rejects_nonfinite_numbers) {
+    kq::Metric invalid;
+    invalid.name = "invalid";
+    invalid.tolerance = std::numeric_limits<double>::infinity();
+    invalid.observed_error = std::numeric_limits<double>::quiet_NaN();
+    invalid.finite = false;
+    const kq::CaseResult failed = kq::evaluate(
+        "report", {invalid}, {"route", "route", true});
+    std::ostringstream report;
+    kq::write_json(report, "self-test", {failed});
+    const std::string json = report.str();
+    REQUIRE_TRUE(json.find("\"tolerance\":null") != std::string::npos);
+    REQUIRE_TRUE(
+        json.find("\"observed_error\":null") != std::string::npos);
 }

--- a/server/test/test_kernel_qualification_core.cpp
+++ b/server/test/test_kernel_qualification_core.cpp
@@ -1,0 +1,65 @@
+#include "kernel_qualification.h"
+
+#include <cmath>
+#include <iostream>
+#include <limits>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace kq = lucebox::kernel_qualification;
+
+namespace {
+
+bool require(bool condition, const char * message) {
+    if (!condition) std::cerr << message << '\n';
+    return condition;
+}
+
+}  // namespace
+
+int main() {
+    bool ok = true;
+
+    const kq::Metric within = kq::compare_f32(
+        "output", {1.0f, 2.0f}, {1.0f, 2.00001f}, 2.0e-5);
+    ok = require(within.passed && within.finite,
+                 "comparison inside tolerance must pass") && ok;
+
+    const kq::Metric outside = kq::compare_f32(
+        "state", {1.0f, 2.1f}, {1.0f, 2.0f}, 1.0e-3);
+    ok = require(!outside.passed && outside.reason == "tolerance exceeded",
+                 "comparison outside tolerance must fail") && ok;
+
+    const kq::Metric nonfinite = kq::compare_f32(
+        "nonfinite", {std::numeric_limits<float>::quiet_NaN()}, {0.0f}, 1.0);
+    ok = require(!nonfinite.passed && !nonfinite.finite,
+                 "non-finite values must fail") && ok;
+
+    const kq::CaseResult passed = kq::evaluate(
+        "gdn", {within}, {"gdn.grouped_cols", "gdn.grouped_cols", true});
+    const kq::CaseResult wrong_route = kq::evaluate(
+        "gdn", {within}, {"gdn.grouped_cols", "gdn.scalar", false});
+    const kq::CaseResult skipped = kq::unsupported(
+        "gdn", "GPU backend unavailable");
+    ok = require(passed.status == kq::Status::pass,
+                 "matching numerics and route must pass") && ok;
+    ok = require(wrong_route.status == kq::Status::fail,
+                 "a route mismatch must fail") && ok;
+    ok = require(skipped.status == kq::Status::unsupported,
+                 "unsupported must not be reported as pass") && ok;
+    ok = require(kq::exit_code({skipped}) == 77,
+                 "unsupported-only reports must use the CTest skip code") && ok;
+
+    std::ostringstream report;
+    kq::write_json(report, "self-test", {passed});
+    const std::string json = report.str();
+    ok = require(
+        json.find("\"schema\":\"lucebox.kernel_qualification.v1\"") !=
+            std::string::npos &&
+        json.find("\"status\":\"pass\"") != std::string::npos,
+        "report must include the stable schema and aggregate status") && ok;
+
+    if (ok) std::cout << json;
+    return ok ? 0 : 1;
+}

--- a/server/test/test_kernel_qualification_gdn.cpp
+++ b/server/test/test_kernel_qualification_gdn.cpp
@@ -1,0 +1,364 @@
+#include "kernel_qualification.h"
+
+#include "ggml-backend.h"
+#include "ggml-cuda.h"
+#include "ggml.h"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace kq = lucebox::kernel_qualification;
+
+namespace {
+
+constexpr int S_V = 128;
+constexpr int N_HEAD = 4;
+constexpr int N_SEQS = 2;
+constexpr int N_STATE_SLOTS = 2;
+constexpr int N_STEPS = 3;
+constexpr double OUTPUT_TOLERANCE = 5.0e-5;
+constexpr double STATE_TOLERANCE = 2.0e-4;
+constexpr size_t QKV_ELEMENTS = (size_t) S_V*N_HEAD*N_SEQS;
+constexpr size_t GATE_ELEMENTS = (size_t) N_HEAD*N_SEQS;
+constexpr size_t STATE_ELEMENTS =
+    (size_t) S_V*S_V*N_HEAD*N_STATE_SLOTS;
+constexpr size_t GUARD_ELEMENTS = 64;
+
+bool set_environment(const char * name, const char * value) {
+#ifdef _WIN32
+    return _putenv_s(name, value ? value : "") == 0;
+#else
+    return value ? setenv(name, value, 1) == 0 : unsetenv(name) == 0;
+#endif
+}
+
+class EnvironmentValue {
+public:
+    EnvironmentValue(const char * name, const char * value) : name_(name) {
+        const char * previous = std::getenv(name);
+        if (previous) {
+            had_previous_ = true;
+            previous_ = previous;
+        }
+        valid_ = set_environment(name, value);
+    }
+
+    ~EnvironmentValue() {
+        set_environment(name_.c_str(),
+                        had_previous_ ? previous_.c_str() : nullptr);
+    }
+
+    bool valid() const { return valid_; }
+
+    EnvironmentValue(const EnvironmentValue &) = delete;
+    EnvironmentValue & operator=(const EnvironmentValue &) = delete;
+
+private:
+    std::string name_;
+    std::string previous_;
+    bool had_previous_ = false;
+    bool valid_ = false;
+};
+
+struct StepInput {
+    std::vector<float> q = std::vector<float>(QKV_ELEMENTS);
+    std::vector<float> k = std::vector<float>(QKV_ELEMENTS);
+    std::vector<float> v = std::vector<float>(QKV_ELEMENTS);
+    std::vector<float> g = std::vector<float>(GATE_ELEMENTS);
+    std::vector<float> beta = std::vector<float>(GATE_ELEMENTS);
+};
+
+struct StepOutput {
+    bool computed = false;
+    std::vector<float> output = std::vector<float>(QKV_ELEMENTS);
+    std::vector<float> state = std::vector<float>(STATE_ELEMENTS);
+    std::vector<float> guard_before = std::vector<float>(GUARD_ELEMENTS);
+    std::vector<float> guard_after = std::vector<float>(GUARD_ELEMENTS);
+};
+
+struct PathRun {
+    bool computed = false;
+    std::string reason;
+    size_t scalar_launches = 0;
+    size_t grouped_launches = 0;
+    std::vector<StepOutput> steps;
+};
+
+void fill_uniform(
+        std::mt19937 & rng,
+        float low,
+        float high,
+        std::vector<float> & values) {
+    std::uniform_real_distribution<float> distribution(low, high);
+    for (float & value : values) value = distribution(rng);
+}
+
+std::vector<StepInput> make_inputs() {
+    std::mt19937 rng(20260901);
+    std::vector<StepInput> steps(N_STEPS);
+    for (StepInput & step : steps) {
+        fill_uniform(rng, -0.25f, 0.25f, step.q);
+        fill_uniform(rng, -0.25f, 0.25f, step.k);
+        fill_uniform(rng, -0.25f, 0.25f, step.v);
+        fill_uniform(rng, -1.0f, -0.02f, step.g);
+        fill_uniform(rng, 0.05f, 0.95f, step.beta);
+
+        for (int sequence = 0; sequence < N_SEQS; ++sequence) {
+            for (int head = 0; head < N_HEAD; ++head) {
+                const size_t base =
+                    ((size_t) sequence*N_HEAD + head)*S_V;
+                for (std::vector<float> * values : {&step.q, &step.k}) {
+                    float norm2 = 0.0f;
+                    for (int i = 0; i < S_V; ++i) {
+                        const float value = (*values)[base + i];
+                        norm2 += value*value;
+                    }
+                    const float inverse_norm = 1.0f/std::sqrt(norm2);
+                    for (int i = 0; i < S_V; ++i) {
+                        (*values)[base + i] *= inverse_norm;
+                    }
+                }
+            }
+        }
+    }
+    return steps;
+}
+
+std::vector<float> make_initial_state() {
+    std::mt19937 rng(20260902);
+    std::vector<float> state(STATE_ELEMENTS);
+    fill_uniform(rng, -0.06f, 0.06f, state);
+    return state;
+}
+
+std::vector<float> make_guard(float offset) {
+    std::vector<float> guard(GUARD_ELEMENTS);
+    for (size_t i = 0; i < guard.size(); ++i) {
+        guard[i] = offset + static_cast<float>(i)*0.125f;
+    }
+    return guard;
+}
+
+StepOutput run_step(
+        ggml_backend_t backend,
+        const StepInput & input,
+        const std::vector<float> & state_input) {
+    StepOutput result;
+    ggml_init_params params{};
+    params.mem_size = 4*1024*1024;
+    params.no_alloc = true;
+    ggml_context * context = ggml_init(params);
+    if (!context) return result;
+
+    ggml_tensor * guard_before =
+        ggml_new_tensor_1d(context, GGML_TYPE_F32, GUARD_ELEMENTS);
+    ggml_tensor * q = ggml_new_tensor_4d(
+        context, GGML_TYPE_F32, S_V, N_HEAD, 1, N_SEQS);
+    ggml_tensor * k = ggml_dup_tensor(context, q);
+    ggml_tensor * v = ggml_dup_tensor(context, q);
+    ggml_tensor * g = ggml_new_tensor_4d(
+        context, GGML_TYPE_F32, 1, N_HEAD, 1, N_SEQS);
+    ggml_tensor * beta = ggml_dup_tensor(context, g);
+    ggml_tensor * state = ggml_new_tensor_4d(
+        context, GGML_TYPE_F32, S_V, S_V, N_HEAD, N_STATE_SLOTS);
+    ggml_tensor * active_slots =
+        ggml_new_tensor_1d(context, GGML_TYPE_I32, N_SEQS);
+    for (ggml_tensor * tensor :
+         {guard_before, q, k, v, g, beta, state, active_slots}) {
+        ggml_set_input(tensor);
+    }
+
+    ggml_tensor * output = ggml_gated_delta_net_active_inplace(
+        context, q, k, v, g, beta, state, active_slots);
+    ggml_gated_delta_net_set_skip_intermediate(output, true);
+    ggml_set_output(output);
+    ggml_tensor * guard_after =
+        ggml_new_tensor_1d(context, GGML_TYPE_F32, GUARD_ELEMENTS);
+    ggml_set_input(guard_after);
+
+    ggml_cgraph * graph = ggml_new_graph(context);
+    ggml_build_forward_expand(graph, output);
+    ggml_backend_buffer_t buffer =
+        ggml_backend_alloc_ctx_tensors(context, backend);
+    if (!buffer) {
+        ggml_free(context);
+        return result;
+    }
+
+    const std::vector<float> expected_guard_before = make_guard(1000.0f);
+    const std::vector<float> expected_guard_after = make_guard(-1000.0f);
+    const std::array<int32_t, N_SEQS> slot_ids{1, 0};
+    ggml_backend_tensor_set(
+        guard_before, expected_guard_before.data(), 0,
+        expected_guard_before.size()*sizeof(float));
+    ggml_backend_tensor_set(q, input.q.data(), 0, input.q.size()*sizeof(float));
+    ggml_backend_tensor_set(k, input.k.data(), 0, input.k.size()*sizeof(float));
+    ggml_backend_tensor_set(v, input.v.data(), 0, input.v.size()*sizeof(float));
+    ggml_backend_tensor_set(g, input.g.data(), 0, input.g.size()*sizeof(float));
+    ggml_backend_tensor_set(
+        beta, input.beta.data(), 0, input.beta.size()*sizeof(float));
+    ggml_backend_tensor_set(
+        state, state_input.data(), 0, state_input.size()*sizeof(float));
+    ggml_backend_tensor_set(
+        active_slots, slot_ids.data(), 0, slot_ids.size()*sizeof(int32_t));
+    ggml_backend_tensor_set(
+        guard_after, expected_guard_after.data(), 0,
+        expected_guard_after.size()*sizeof(float));
+
+    result.computed =
+        ggml_backend_graph_compute(backend, graph) == GGML_STATUS_SUCCESS;
+    if (result.computed) {
+        ggml_backend_tensor_get(
+            output, result.output.data(), 0, result.output.size()*sizeof(float));
+        ggml_backend_tensor_get(
+            state, result.state.data(), 0, result.state.size()*sizeof(float));
+        ggml_backend_tensor_get(
+            guard_before, result.guard_before.data(), 0,
+            result.guard_before.size()*sizeof(float));
+        ggml_backend_tensor_get(
+            guard_after, result.guard_after.data(), 0,
+            result.guard_after.size()*sizeof(float));
+    }
+
+    ggml_backend_buffer_free(buffer);
+    ggml_free(context);
+    return result;
+}
+
+PathRun run_path(
+        ggml_backend_t backend,
+        const std::vector<StepInput> & inputs,
+        const std::vector<float> & initial_state,
+        bool grouped) {
+    PathRun result;
+    EnvironmentValue force_grouped(
+        "DFLASH_GDN_FORCE_GROUPED_COLS", grouped ? "1" : nullptr);
+    EnvironmentValue disable_grouped(
+        "DFLASH_GDN_NO_GROUPED_COLS", grouped ? nullptr : "1");
+    if (!force_grouped.valid() || !disable_grouped.valid()) {
+        result.reason = "failed to select GDN route";
+        return result;
+    }
+
+    const size_t scalar_before =
+        ggml_backend_cuda_get_gdn_scalar_launch_count();
+    const size_t grouped_before =
+        ggml_backend_cuda_get_gdn_grouped_cols_launch_count();
+    std::vector<float> state = initial_state;
+    for (const StepInput & input : inputs) {
+        StepOutput step = run_step(backend, input, state);
+        if (!step.computed) {
+            result.reason = "backend graph compute failed";
+            return result;
+        }
+        state = step.state;
+        result.steps.push_back(std::move(step));
+    }
+    result.scalar_launches =
+        ggml_backend_cuda_get_gdn_scalar_launch_count() - scalar_before;
+    result.grouped_launches =
+        ggml_backend_cuda_get_gdn_grouped_cols_launch_count() - grouped_before;
+    result.computed = true;
+    return result;
+}
+
+kq::Metric failed_metric(const std::string & reason) {
+    kq::Metric metric;
+    metric.name = "compute";
+    metric.finite = false;
+    metric.reason = reason;
+    return metric;
+}
+
+kq::CaseResult qualify_gdn(ggml_backend_t backend) {
+    const std::vector<StepInput> inputs = make_inputs();
+    const std::vector<float> initial_state = make_initial_state();
+    const bool previous_graphs_disabled =
+        ggml_backend_cuda_set_graphs_disabled_override(true);
+    const PathRun reference = run_path(backend, inputs, initial_state, false);
+    const PathRun candidate = run_path(backend, inputs, initial_state, true);
+    ggml_backend_cuda_set_graphs_disabled_override(previous_graphs_disabled);
+
+    const bool route_matched = reference.computed && candidate.computed &&
+        reference.scalar_launches == N_STEPS &&
+        reference.grouped_launches == 0 &&
+        candidate.scalar_launches == 0 &&
+        candidate.grouped_launches == N_STEPS;
+    const std::string observed =
+        "reference.scalar=" + std::to_string(reference.scalar_launches) +
+        ",reference.grouped_cols=" +
+        std::to_string(reference.grouped_launches) +
+        ",candidate.scalar=" + std::to_string(candidate.scalar_launches) +
+        ",candidate.grouped_cols=" +
+        std::to_string(candidate.grouped_launches);
+    kq::Route route{
+        "reference.scalar=" + std::to_string(N_STEPS) +
+            ",candidate.grouped_cols=" + std::to_string(N_STEPS),
+        observed, route_matched};
+
+    if (!reference.computed || !candidate.computed) {
+        const std::string reason = !reference.computed
+            ? "reference: " + reference.reason
+            : "candidate: " + candidate.reason;
+        return kq::evaluate(
+            "gdn.active_inplace.eager.grouped_cols_vs_scalar",
+            {failed_metric(reason)}, std::move(route));
+    }
+
+    std::vector<kq::Metric> metrics;
+    const std::vector<float> expected_guard_before = make_guard(1000.0f);
+    const std::vector<float> expected_guard_after = make_guard(-1000.0f);
+    for (size_t step = 0; step < inputs.size(); ++step) {
+        const std::string prefix = "step" + std::to_string(step) + ".";
+        metrics.push_back(kq::compare_f32(
+            prefix + "output", candidate.steps[step].output,
+            reference.steps[step].output, OUTPUT_TOLERANCE));
+        metrics.push_back(kq::compare_f32(
+            prefix + "state", candidate.steps[step].state,
+            reference.steps[step].state, STATE_TOLERANCE));
+        metrics.push_back(kq::compare_f32(
+            prefix + "reference.guard_before",
+            reference.steps[step].guard_before, expected_guard_before, 0.0));
+        metrics.push_back(kq::compare_f32(
+            prefix + "reference.guard_after",
+            reference.steps[step].guard_after, expected_guard_after, 0.0));
+        metrics.push_back(kq::compare_f32(
+            prefix + "candidate.guard_before",
+            candidate.steps[step].guard_before, expected_guard_before, 0.0));
+        metrics.push_back(kq::compare_f32(
+            prefix + "candidate.guard_after",
+            candidate.steps[step].guard_after, expected_guard_after, 0.0));
+    }
+    return kq::evaluate(
+        "gdn.active_inplace.eager.grouped_cols_vs_scalar",
+        std::move(metrics), std::move(route));
+}
+
+}  // namespace
+
+int main() {
+    ggml_backend_t backend = ggml_backend_cuda_init(0);
+    if (!backend) {
+        const std::vector<kq::CaseResult> cases{kq::unsupported(
+            "gdn.active_inplace.eager.grouped_cols_vs_scalar",
+            "CUDA/HIP backend unavailable")};
+        kq::write_json(std::cout, "unavailable", cases);
+        return kq::exit_code(cases);
+    }
+
+    char description[256] = {};
+    ggml_backend_cuda_get_device_description(
+        0, description, sizeof(description));
+    const std::vector<kq::CaseResult> cases{qualify_gdn(backend)};
+    kq::write_json(std::cout, description, cases);
+    ggml_backend_free(backend);
+    return kq::exit_code(cases);
+}

--- a/server/test/test_kernel_qualification_gdn.cpp
+++ b/server/test/test_kernel_qualification_gdn.cpp
@@ -1,6 +1,7 @@
 #include "kernel_qualification.h"
 
 #include "ggml-backend.h"
+#include "ggml-cpu.h"
 #include "ggml-cuda.h"
 #include "ggml.h"
 
@@ -78,10 +79,13 @@ struct StepInput {
 
 struct StepOutput {
     bool computed = false;
+    std::string reason;
     std::vector<float> output = std::vector<float>(QKV_ELEMENTS);
     std::vector<float> state = std::vector<float>(STATE_ELEMENTS);
-    std::vector<float> guard_before = std::vector<float>(GUARD_ELEMENTS);
-    std::vector<float> guard_after = std::vector<float>(GUARD_ELEMENTS);
+    std::vector<float> state_guard_before = std::vector<float>(GUARD_ELEMENTS);
+    std::vector<float> state_guard_after = std::vector<float>(GUARD_ELEMENTS);
+    std::vector<float> output_guard_before = std::vector<float>(GUARD_ELEMENTS);
+    std::vector<float> output_guard_after = std::vector<float>(GUARD_ELEMENTS);
 };
 
 struct PathRun {
@@ -147,6 +151,34 @@ std::vector<float> make_guard(float offset) {
     return guard;
 }
 
+size_t padded_allocation_size(const ggml_tensor * tensor) {
+    const size_t alignment =
+        ggml_backend_buffer_get_alignment(tensor->buffer);
+    const size_t size =
+        ggml_backend_buffer_get_alloc_size(tensor->buffer, tensor);
+    return (size + alignment - 1) & ~(alignment - 1);
+}
+
+bool guards_are_adjacent(
+        const ggml_tensor * before,
+        const ggml_tensor * guarded,
+        const ggml_tensor * after) {
+    if (!before->buffer || before->buffer != guarded->buffer ||
+        guarded->buffer != after->buffer ||
+        !before->data || !guarded->data || !after->data) {
+        return false;
+    }
+    const uintptr_t before_address =
+        reinterpret_cast<uintptr_t>(before->data);
+    const uintptr_t guarded_address =
+        reinterpret_cast<uintptr_t>(guarded->data);
+    const uintptr_t after_address =
+        reinterpret_cast<uintptr_t>(after->data);
+    return before_address + padded_allocation_size(before) ==
+            guarded_address &&
+        guarded_address + padded_allocation_size(guarded) == after_address;
+}
+
 StepOutput run_step(
         ggml_backend_t backend,
         const StepInput & input,
@@ -158,8 +190,6 @@ StepOutput run_step(
     ggml_context * context = ggml_init(params);
     if (!context) return result;
 
-    ggml_tensor * guard_before =
-        ggml_new_tensor_1d(context, GGML_TYPE_F32, GUARD_ELEMENTS);
     ggml_tensor * q = ggml_new_tensor_4d(
         context, GGML_TYPE_F32, S_V, N_HEAD, 1, N_SEQS);
     ggml_tensor * k = ggml_dup_tensor(context, q);
@@ -167,12 +197,19 @@ StepOutput run_step(
     ggml_tensor * g = ggml_new_tensor_4d(
         context, GGML_TYPE_F32, 1, N_HEAD, 1, N_SEQS);
     ggml_tensor * beta = ggml_dup_tensor(context, g);
+    ggml_tensor * state_guard_before =
+        ggml_new_tensor_1d(context, GGML_TYPE_F32, GUARD_ELEMENTS);
     ggml_tensor * state = ggml_new_tensor_4d(
         context, GGML_TYPE_F32, S_V, S_V, N_HEAD, N_STATE_SLOTS);
+    ggml_tensor * state_guard_after =
+        ggml_new_tensor_1d(context, GGML_TYPE_F32, GUARD_ELEMENTS);
     ggml_tensor * active_slots =
         ggml_new_tensor_1d(context, GGML_TYPE_I32, N_SEQS);
+    ggml_tensor * output_guard_before =
+        ggml_new_tensor_1d(context, GGML_TYPE_F32, GUARD_ELEMENTS);
     for (ggml_tensor * tensor :
-         {guard_before, q, k, v, g, beta, state, active_slots}) {
+         {q, k, v, g, beta, state_guard_before, state,
+          state_guard_after, active_slots, output_guard_before}) {
         ggml_set_input(tensor);
     }
 
@@ -180,9 +217,9 @@ StepOutput run_step(
         context, q, k, v, g, beta, state, active_slots);
     ggml_gated_delta_net_set_skip_intermediate(output, true);
     ggml_set_output(output);
-    ggml_tensor * guard_after =
+    ggml_tensor * output_guard_after =
         ggml_new_tensor_1d(context, GGML_TYPE_F32, GUARD_ELEMENTS);
-    ggml_set_input(guard_after);
+    ggml_set_input(output_guard_after);
 
     ggml_cgraph * graph = ggml_new_graph(context);
     ggml_build_forward_expand(graph, output);
@@ -192,13 +229,25 @@ StepOutput run_step(
         ggml_free(context);
         return result;
     }
+    if (!guards_are_adjacent(
+            state_guard_before, state, state_guard_after) ||
+        !guards_are_adjacent(
+            output_guard_before, output, output_guard_after)) {
+        result.reason =
+            "allocation guards are not adjacent to state/output";
+        ggml_backend_buffer_free(buffer);
+        ggml_free(context);
+        return result;
+    }
 
-    const std::vector<float> expected_guard_before = make_guard(1000.0f);
-    const std::vector<float> expected_guard_after = make_guard(-1000.0f);
+    const std::vector<float> expected_state_guard_before = make_guard(1000.0f);
+    const std::vector<float> expected_state_guard_after = make_guard(-1000.0f);
+    const std::vector<float> expected_output_guard_before = make_guard(2000.0f);
+    const std::vector<float> expected_output_guard_after = make_guard(-2000.0f);
     const std::array<int32_t, N_SEQS> slot_ids{1, 0};
     ggml_backend_tensor_set(
-        guard_before, expected_guard_before.data(), 0,
-        expected_guard_before.size()*sizeof(float));
+        state_guard_before, expected_state_guard_before.data(), 0,
+        expected_state_guard_before.size()*sizeof(float));
     ggml_backend_tensor_set(q, input.q.data(), 0, input.q.size()*sizeof(float));
     ggml_backend_tensor_set(k, input.k.data(), 0, input.k.size()*sizeof(float));
     ggml_backend_tensor_set(v, input.v.data(), 0, input.v.size()*sizeof(float));
@@ -208,10 +257,16 @@ StepOutput run_step(
     ggml_backend_tensor_set(
         state, state_input.data(), 0, state_input.size()*sizeof(float));
     ggml_backend_tensor_set(
+        state_guard_after, expected_state_guard_after.data(), 0,
+        expected_state_guard_after.size()*sizeof(float));
+    ggml_backend_tensor_set(
         active_slots, slot_ids.data(), 0, slot_ids.size()*sizeof(int32_t));
     ggml_backend_tensor_set(
-        guard_after, expected_guard_after.data(), 0,
-        expected_guard_after.size()*sizeof(float));
+        output_guard_before, expected_output_guard_before.data(), 0,
+        expected_output_guard_before.size()*sizeof(float));
+    ggml_backend_tensor_set(
+        output_guard_after, expected_output_guard_after.data(), 0,
+        expected_output_guard_after.size()*sizeof(float));
 
     result.computed =
         ggml_backend_graph_compute(backend, graph) == GGML_STATUS_SUCCESS;
@@ -221,15 +276,42 @@ StepOutput run_step(
         ggml_backend_tensor_get(
             state, result.state.data(), 0, result.state.size()*sizeof(float));
         ggml_backend_tensor_get(
-            guard_before, result.guard_before.data(), 0,
-            result.guard_before.size()*sizeof(float));
+            state_guard_before, result.state_guard_before.data(), 0,
+            result.state_guard_before.size()*sizeof(float));
         ggml_backend_tensor_get(
-            guard_after, result.guard_after.data(), 0,
-            result.guard_after.size()*sizeof(float));
+            state_guard_after, result.state_guard_after.data(), 0,
+            result.state_guard_after.size()*sizeof(float));
+        ggml_backend_tensor_get(
+            output_guard_before, result.output_guard_before.data(), 0,
+            result.output_guard_before.size()*sizeof(float));
+        ggml_backend_tensor_get(
+            output_guard_after, result.output_guard_after.data(), 0,
+            result.output_guard_after.size()*sizeof(float));
     }
 
     ggml_backend_buffer_free(buffer);
     ggml_free(context);
+    return result;
+}
+
+PathRun run_steps(
+        ggml_backend_t backend,
+        const std::vector<StepInput> & inputs,
+        const std::vector<float> & initial_state) {
+    PathRun result;
+    std::vector<float> state = initial_state;
+    for (const StepInput & input : inputs) {
+        StepOutput step = run_step(backend, input, state);
+        if (!step.computed) {
+            result.reason = step.reason.empty()
+                ? "backend graph compute failed"
+                : step.reason;
+            return result;
+        }
+        state = step.state;
+        result.steps.push_back(std::move(step));
+    }
+    result.computed = true;
     return result;
 }
 
@@ -238,12 +320,12 @@ PathRun run_path(
         const std::vector<StepInput> & inputs,
         const std::vector<float> & initial_state,
         bool grouped) {
-    PathRun result;
     EnvironmentValue force_grouped(
         "DFLASH_GDN_FORCE_GROUPED_COLS", grouped ? "1" : nullptr);
     EnvironmentValue disable_grouped(
         "DFLASH_GDN_NO_GROUPED_COLS", grouped ? nullptr : "1");
     if (!force_grouped.valid() || !disable_grouped.valid()) {
+        PathRun result;
         result.reason = "failed to select GDN route";
         return result;
     }
@@ -252,21 +334,11 @@ PathRun run_path(
         ggml_backend_cuda_get_gdn_scalar_launch_count();
     const size_t grouped_before =
         ggml_backend_cuda_get_gdn_grouped_cols_launch_count();
-    std::vector<float> state = initial_state;
-    for (const StepInput & input : inputs) {
-        StepOutput step = run_step(backend, input, state);
-        if (!step.computed) {
-            result.reason = "backend graph compute failed";
-            return result;
-        }
-        state = step.state;
-        result.steps.push_back(std::move(step));
-    }
+    PathRun result = run_steps(backend, inputs, initial_state);
     result.scalar_launches =
         ggml_backend_cuda_get_gdn_scalar_launch_count() - scalar_before;
     result.grouped_launches =
         ggml_backend_cuda_get_gdn_grouped_cols_launch_count() - grouped_before;
-    result.computed = true;
     return result;
 }
 
@@ -281,6 +353,14 @@ kq::Metric failed_metric(const std::string & reason) {
 kq::CaseResult qualify_gdn(ggml_backend_t backend) {
     const std::vector<StepInput> inputs = make_inputs();
     const std::vector<float> initial_state = make_initial_state();
+    ggml_backend_t cpu_backend = ggml_backend_cpu_init();
+    PathRun oracle;
+    if (cpu_backend) {
+        oracle = run_steps(cpu_backend, inputs, initial_state);
+    } else {
+        oracle.reason = "backend unavailable";
+    }
+    if (cpu_backend) ggml_backend_free(cpu_backend);
     const bool previous_graphs_disabled =
         ggml_backend_cuda_set_graphs_disabled_override(true);
     const PathRun reference = run_path(backend, inputs, initial_state, false);
@@ -304,41 +384,71 @@ kq::CaseResult qualify_gdn(ggml_backend_t backend) {
             ",candidate.grouped_cols=" + std::to_string(N_STEPS),
         observed, route_matched};
 
-    if (!reference.computed || !candidate.computed) {
-        const std::string reason = !reference.computed
+    if (!oracle.computed || !reference.computed || !candidate.computed) {
+        const std::string reason = !oracle.computed
+            ? "CPU oracle: " + oracle.reason
+            : !reference.computed
             ? "reference: " + reference.reason
             : "candidate: " + candidate.reason;
         return kq::evaluate(
-            "gdn.active_inplace.eager.grouped_cols_vs_scalar",
+            "gdn.active_inplace.eager.gpu_routes_vs_cpu",
             {failed_metric(reason)}, std::move(route));
     }
 
     std::vector<kq::Metric> metrics;
-    const std::vector<float> expected_guard_before = make_guard(1000.0f);
-    const std::vector<float> expected_guard_after = make_guard(-1000.0f);
+    const std::vector<float> expected_state_guard_before = make_guard(1000.0f);
+    const std::vector<float> expected_state_guard_after = make_guard(-1000.0f);
+    const std::vector<float> expected_output_guard_before = make_guard(2000.0f);
+    const std::vector<float> expected_output_guard_after = make_guard(-2000.0f);
     for (size_t step = 0; step < inputs.size(); ++step) {
         const std::string prefix = "step" + std::to_string(step) + ".";
         metrics.push_back(kq::compare_f32(
-            prefix + "output", candidate.steps[step].output,
-            reference.steps[step].output, OUTPUT_TOLERANCE));
+            prefix + "scalar.output", reference.steps[step].output,
+            oracle.steps[step].output, OUTPUT_TOLERANCE));
         metrics.push_back(kq::compare_f32(
-            prefix + "state", candidate.steps[step].state,
-            reference.steps[step].state, STATE_TOLERANCE));
+            prefix + "scalar.state", reference.steps[step].state,
+            oracle.steps[step].state, STATE_TOLERANCE));
         metrics.push_back(kq::compare_f32(
-            prefix + "reference.guard_before",
-            reference.steps[step].guard_before, expected_guard_before, 0.0));
+            prefix + "grouped.output", candidate.steps[step].output,
+            oracle.steps[step].output, OUTPUT_TOLERANCE));
         metrics.push_back(kq::compare_f32(
-            prefix + "reference.guard_after",
-            reference.steps[step].guard_after, expected_guard_after, 0.0));
+            prefix + "grouped.state", candidate.steps[step].state,
+            oracle.steps[step].state, STATE_TOLERANCE));
         metrics.push_back(kq::compare_f32(
-            prefix + "candidate.guard_before",
-            candidate.steps[step].guard_before, expected_guard_before, 0.0));
+            prefix + "reference.state_guard_before",
+            reference.steps[step].state_guard_before,
+            expected_state_guard_before, 0.0));
         metrics.push_back(kq::compare_f32(
-            prefix + "candidate.guard_after",
-            candidate.steps[step].guard_after, expected_guard_after, 0.0));
+            prefix + "reference.state_guard_after",
+            reference.steps[step].state_guard_after,
+            expected_state_guard_after, 0.0));
+        metrics.push_back(kq::compare_f32(
+            prefix + "reference.output_guard_before",
+            reference.steps[step].output_guard_before,
+            expected_output_guard_before, 0.0));
+        metrics.push_back(kq::compare_f32(
+            prefix + "reference.output_guard_after",
+            reference.steps[step].output_guard_after,
+            expected_output_guard_after, 0.0));
+        metrics.push_back(kq::compare_f32(
+            prefix + "candidate.state_guard_before",
+            candidate.steps[step].state_guard_before,
+            expected_state_guard_before, 0.0));
+        metrics.push_back(kq::compare_f32(
+            prefix + "candidate.state_guard_after",
+            candidate.steps[step].state_guard_after,
+            expected_state_guard_after, 0.0));
+        metrics.push_back(kq::compare_f32(
+            prefix + "candidate.output_guard_before",
+            candidate.steps[step].output_guard_before,
+            expected_output_guard_before, 0.0));
+        metrics.push_back(kq::compare_f32(
+            prefix + "candidate.output_guard_after",
+            candidate.steps[step].output_guard_after,
+            expected_output_guard_after, 0.0));
     }
     return kq::evaluate(
-        "gdn.active_inplace.eager.grouped_cols_vs_scalar",
+        "gdn.active_inplace.eager.gpu_routes_vs_cpu",
         std::move(metrics), std::move(route));
 }
 
@@ -348,7 +458,7 @@ int main() {
     ggml_backend_t backend = ggml_backend_cuda_init(0);
     if (!backend) {
         const std::vector<kq::CaseResult> cases{kq::unsupported(
-            "gdn.active_inplace.eager.grouped_cols_vs_scalar",
+            "gdn.active_inplace.eager.gpu_routes_vs_cpu",
             "CUDA/HIP backend unavailable")};
         kq::write_json(std::cout, "unavailable", cases);
         return kq::exit_code(cases);
@@ -357,6 +467,15 @@ int main() {
     char description[256] = {};
     ggml_backend_cuda_get_device_description(
         0, description, sizeof(description));
+    if (!ggml_backend_cuda_supports_gdn_grouped_cols(0)) {
+        const std::vector<kq::CaseResult> cases{kq::unsupported(
+            "gdn.active_inplace.eager.gpu_routes_vs_cpu",
+            "grouped-column GDN route unsupported on this device")};
+        kq::write_json(std::cout, description, cases);
+        ggml_backend_free(backend);
+        return kq::exit_code(cases);
+    }
+
     const std::vector<kq::CaseResult> cases{qualify_gdn(backend)};
     kq::write_json(std::cout, description, cases);
     ggml_backend_free(backend);

--- a/server/test/test_kernel_qualification_moe_ds4.cpp
+++ b/server/test/test_kernel_qualification_moe_ds4.cpp
@@ -1,0 +1,655 @@
+#include "kernel_qualification.h"
+
+#include "ds4_test_gpu_runtime.h"
+#include "ggml-alloc.h"
+#include "ggml-backend.h"
+#include "ggml-cuda.h"
+#include "ggml.h"
+#include "rocmfpx.h"
+
+// Keep this representative rather than reproducing the large standalone test
+// matrices. The MoE case qualifies one fused mixed-expert gate/up launch with
+// invalid route sentinels and allocation guards. The DeepSeek4 case qualifies
+// one speculative-width grouped MMID launch against the disabled-grouped path.
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <random>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <process.h>
+#else
+#include <cerrno>
+#include <csignal>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+bool ggml_cuda_rocmfp2_mix_mul_mat_id(
+    const void * vx, const float * src1, const int32_t * ids, float * dst,
+    int in, int out, int n_expert_used, int n_tokens, int ne11,
+    int64_t ids_s0, int64_t ids_s1,
+    int64_t src1_s1, int64_t src1_s2,
+    int64_t dst_s1, int64_t dst_s2, cudaStream_t stream);
+
+bool ggml_cuda_rocmfp2_mix_mul_mat_id_glu(
+    const void * vx_up, const void * vx_gate,
+    const float * src1, const int32_t * ids, float * dst,
+    int in, int out, int n_expert_used, int n_tokens, int ne11,
+    int64_t ids_s0, int64_t ids_s1,
+    int64_t src1_s1, int64_t src1_s2,
+    int64_t dst_s1, int64_t dst_s2,
+    float glu_limit, cudaStream_t stream);
+
+namespace kq = lucebox::kernel_qualification;
+
+namespace {
+
+constexpr const char * MOE_CASE = "moe.rocmfp2_mix.gate_up_glu";
+constexpr const char * DS4_CASE = "deepseek4.grouped_mmid.rocmfp2";
+
+kq::Metric failed_metric(const std::string & reason) {
+    kq::Metric metric;
+    metric.name = "compute";
+    metric.finite = false;
+    metric.reason = reason;
+    return metric;
+}
+
+kq::CaseResult failed_case(
+        const char * name,
+        const std::string & reason,
+        kq::Route route) {
+    return kq::evaluate(name, {failed_metric(reason)}, std::move(route));
+}
+
+template <typename T>
+class DeviceBuffer {
+public:
+    DeviceBuffer() = default;
+    explicit DeviceBuffer(size_t count) { allocate(count); }
+
+    ~DeviceBuffer() {
+        if (data_) cudaFree(data_);
+    }
+
+    bool allocate(size_t count) {
+        if (data_) return false;
+        count_ = count;
+        return cudaMalloc(reinterpret_cast<void **>(&data_),
+                          count*sizeof(T)) == cudaSuccess;
+    }
+
+    bool copy_from(const std::vector<T> & values) {
+        return values.size() <= count_ &&
+            cudaMemcpy(data_, values.data(), values.size()*sizeof(T),
+                       cudaMemcpyHostToDevice) == cudaSuccess;
+    }
+
+    bool copy_to(std::vector<T> & values) const {
+        return values.size() <= count_ &&
+            cudaMemcpy(values.data(), data_, values.size()*sizeof(T),
+                       cudaMemcpyDeviceToHost) == cudaSuccess;
+    }
+
+    T * data() { return data_; }
+    const T * data() const { return data_; }
+
+    DeviceBuffer(const DeviceBuffer &) = delete;
+    DeviceBuffer & operator=(const DeviceBuffer &) = delete;
+
+private:
+    T * data_ = nullptr;
+    size_t count_ = 0;
+};
+
+class MixRegistration {
+public:
+    MixRegistration() = default;
+    ~MixRegistration() {
+        if (base_) ggml_cuda_rocmfp2_mix_unregister(base_);
+    }
+
+    bool register_host(
+            const void * base,
+            size_t expert_stride,
+            int n_experts,
+            int out,
+            int in,
+            const std::vector<uint16_t> & codebooks,
+            const std::vector<uint8_t> & modes) {
+        if (!ggml_cuda_rocmfp2_mix_register_host(
+                base, expert_stride, n_experts, out, in,
+                codebooks.data(), modes.data())) {
+            return false;
+        }
+        base_ = base;
+        return true;
+    }
+
+    MixRegistration(const MixRegistration &) = delete;
+    MixRegistration & operator=(const MixRegistration &) = delete;
+
+private:
+    const void * base_ = nullptr;
+};
+
+uint16_t f32_to_bf16(float value) {
+    uint32_t bits;
+    std::memcpy(&bits, &value, sizeof(bits));
+    const uint32_t rounding = ((bits >> 16) & 1U) + 0x7FFFU;
+    return static_cast<uint16_t>((bits + rounding) >> 16);
+}
+
+float host_swiglu_ds4(float gate, float up, float limit) {
+    gate = std::fmin(gate, limit);
+    up = std::fmax(std::fmin(up, limit), -limit);
+    return gate/(1.0f + std::exp(-gate))*up;
+}
+
+std::vector<float> make_guard(float offset, size_t count) {
+    std::vector<float> guard(count);
+    for (size_t i = 0; i < count; ++i) {
+        guard[i] = offset + static_cast<float>(i)*0.125f;
+    }
+    return guard;
+}
+
+kq::CaseResult qualify_moe_gate_up_glu() {
+    constexpr int qk = 32;
+    constexpr int block_bytes = 10;
+    constexpr int levels = 4;
+    constexpr int in = 256;
+    constexpr int out = 64;
+    constexpr int n_experts = 6;
+    constexpr int n_used = 3;
+    constexpr int n_tokens = 2;
+    constexpr size_t guard_elements = 32;
+    constexpr float limit = 7.0f;
+    const size_t row_bytes = static_cast<size_t>(in/qk)*block_bytes;
+    const size_t expert_bytes = static_cast<size_t>(out)*row_bytes;
+    const size_t weight_bytes = expert_bytes*n_experts;
+    const size_t input_elements = static_cast<size_t>(in)*n_tokens;
+    const size_t output_elements = static_cast<size_t>(out)*n_used*n_tokens;
+
+    std::mt19937 rng(20260903);
+    std::uniform_int_distribution<int> byte_distribution(0, 255);
+    std::vector<uint8_t> weights_up(weight_bytes);
+    std::vector<uint8_t> weights_gate(weight_bytes);
+    for (uint8_t & value : weights_up) {
+        value = static_cast<uint8_t>(byte_distribution(rng));
+    }
+    for (uint8_t & value : weights_gate) {
+        value = static_cast<uint8_t>(byte_distribution(rng));
+    }
+    for (size_t block = 0; block < weight_bytes/block_bytes; ++block) {
+        for (std::vector<uint8_t> * weights : {&weights_up, &weights_gate}) {
+            (*weights)[block*block_bytes + 8] = static_cast<uint8_t>(
+                0x30U | ((*weights)[block*block_bytes + 8] & 0x80U));
+            (*weights)[block*block_bytes + 9] = static_cast<uint8_t>(
+                0x30U | ((*weights)[block*block_bytes + 9] & 0x80U));
+        }
+    }
+
+    std::vector<uint16_t> books_up(n_experts*2*levels);
+    std::vector<uint16_t> books_gate(n_experts*2*levels);
+    for (size_t i = 0; i < books_up.size(); ++i) {
+        books_up[i] = f32_to_bf16(-1.0f + 0.37f*static_cast<float>(i % 7));
+        books_gate[i] = f32_to_bf16(0.5f - 0.21f*static_cast<float>(i % 5));
+    }
+    const std::vector<uint8_t> modes(n_experts, 1);
+
+    std::vector<float> input(input_elements);
+    for (size_t i = 0; i < input.size(); ++i) {
+        input[i] = -0.75f + 0.03f*static_cast<float>(i % 51);
+    }
+    const std::vector<int32_t> ids{-1, 1, 3, n_experts, 5, 2};
+    const std::vector<float> guard_before = make_guard(1000.0f, guard_elements);
+    const std::vector<float> guard_after = make_guard(-1000.0f, guard_elements);
+    std::vector<float> guarded_output(
+        guard_elements + output_elements + guard_elements);
+    std::copy(guard_before.begin(), guard_before.end(), guarded_output.begin());
+    std::copy(guard_after.begin(), guard_after.end(),
+              guarded_output.begin() + guard_elements + output_elements);
+
+    DeviceBuffer<uint8_t> device_up(weight_bytes);
+    DeviceBuffer<uint8_t> device_gate(weight_bytes);
+    DeviceBuffer<float> device_input(input_elements);
+    DeviceBuffer<int32_t> device_ids(ids.size());
+    DeviceBuffer<float> device_up_output(output_elements);
+    DeviceBuffer<float> device_gate_output(output_elements);
+    DeviceBuffer<float> device_guarded_output(guarded_output.size());
+    const bool allocated = device_up.data() && device_gate.data() &&
+        device_input.data() && device_ids.data() && device_up_output.data() &&
+        device_gate_output.data() && device_guarded_output.data();
+    const bool copied = allocated && device_up.copy_from(weights_up) &&
+        device_gate.copy_from(weights_gate) && device_input.copy_from(input) &&
+        device_ids.copy_from(ids) && device_guarded_output.copy_from(guarded_output);
+    if (!copied) {
+        return failed_case(
+            MOE_CASE, "device allocation or copy failed",
+            {"unfused.up=1,unfused.gate=1,fused=1", "setup_failed", false});
+    }
+
+    MixRegistration up_registration;
+    MixRegistration gate_registration;
+    if (!up_registration.register_host(
+            device_up.data(), expert_bytes, n_experts, out, in,
+            books_up, modes) ||
+        !gate_registration.register_host(
+            device_gate.data(), expert_bytes, n_experts, out, in,
+            books_gate, modes)) {
+        return failed_case(
+            MOE_CASE, "mixed expert registration failed",
+            {"unfused.up=1,unfused.gate=1,fused=1", "registration_failed", false});
+    }
+
+    constexpr int64_t ids_s0 = 1;
+    constexpr int64_t ids_s1 = n_used;
+    constexpr int64_t input_s1 = 0;
+    constexpr int64_t input_s2 = in;
+    constexpr int64_t output_s1 = out;
+    constexpr int64_t output_s2 = static_cast<int64_t>(out)*n_used;
+    const bool up_launched = ggml_cuda_rocmfp2_mix_mul_mat_id(
+        device_up.data(), device_input.data(), device_ids.data(),
+        device_up_output.data(), in, out, n_used, n_tokens, 1,
+        ids_s0, ids_s1, input_s1, input_s2, output_s1, output_s2, nullptr);
+    const bool gate_launched = ggml_cuda_rocmfp2_mix_mul_mat_id(
+        device_gate.data(), device_input.data(), device_ids.data(),
+        device_gate_output.data(), in, out, n_used, n_tokens, 1,
+        ids_s0, ids_s1, input_s1, input_s2, output_s1, output_s2, nullptr);
+    float * candidate = device_guarded_output.data() + guard_elements;
+    const bool fused_launched = ggml_cuda_rocmfp2_mix_mul_mat_id_glu(
+        device_up.data(), device_gate.data(), device_input.data(),
+        device_ids.data(), candidate, in, out, n_used, n_tokens, 1,
+        ids_s0, ids_s1, input_s1, input_s2, output_s1, output_s2,
+        limit, nullptr);
+    const bool synchronized = cudaDeviceSynchronize() == cudaSuccess;
+    const bool route_matched =
+        up_launched && gate_launched && fused_launched && synchronized;
+    const std::string observed =
+        "unfused.up=" + std::to_string(up_launched ? 1 : 0) +
+        ",unfused.gate=" + std::to_string(gate_launched ? 1 : 0) +
+        ",fused=" + std::to_string(fused_launched ? 1 : 0) +
+        ",sync=" + std::to_string(synchronized ? 1 : 0);
+    kq::Route route{
+        "unfused.up=1,unfused.gate=1,fused=1,sync=1",
+        observed, route_matched};
+    if (!route_matched) {
+        return failed_case(MOE_CASE, "kernel launch failed", std::move(route));
+    }
+
+    std::vector<float> up_output(output_elements);
+    std::vector<float> gate_output(output_elements);
+    if (!device_up_output.copy_to(up_output) ||
+        !device_gate_output.copy_to(gate_output) ||
+        !device_guarded_output.copy_to(guarded_output)) {
+        return failed_case(MOE_CASE, "device result copy failed", std::move(route));
+    }
+    std::vector<float> fused_output(
+        guarded_output.begin() + guard_elements,
+        guarded_output.begin() + guard_elements + output_elements);
+    std::vector<float> reference(output_elements);
+    for (size_t i = 0; i < reference.size(); ++i) {
+        reference[i] = host_swiglu_ds4(gate_output[i], up_output[i], limit);
+    }
+    std::vector<float> actual_guard_before(
+        guarded_output.begin(), guarded_output.begin() + guard_elements);
+    std::vector<float> actual_guard_after(
+        guarded_output.begin() + guard_elements + output_elements,
+        guarded_output.end());
+    std::vector<float> sentinel_output;
+    for (size_t route = 0; route < ids.size(); ++route) {
+        if (ids[route] >= 0 && ids[route] < n_experts) continue;
+        const size_t offset = route*static_cast<size_t>(out);
+        sentinel_output.insert(
+            sentinel_output.end(),
+            fused_output.begin() + offset,
+            fused_output.begin() + offset + out);
+    }
+    const std::vector<float> sentinel_reference(sentinel_output.size(), 0.0f);
+
+    return kq::evaluate(
+        MOE_CASE,
+        {
+            kq::compare_f32("output", fused_output, reference, 1.0e-4),
+            kq::compare_f32(
+                "invalid_route_zero", sentinel_output, sentinel_reference, 0.0),
+            kq::compare_f32(
+                "guard_before", actual_guard_before, guard_before, 0.0),
+            kq::compare_f32(
+                "guard_after", actual_guard_after, guard_after, 0.0),
+        },
+        std::move(route));
+}
+
+struct GraphRun {
+    bool computed = false;
+    size_t grouped_launches = 0;
+    std::vector<float> output;
+};
+
+GraphRun run_grouped_mmid_graph(ggml_backend_t backend) {
+    constexpr int k_dim = 256;
+    constexpr int n_rows = 128;
+    constexpr int n_experts = 32;
+    constexpr int top_k = 8;
+    constexpr int width = 8;
+    GraphRun run;
+
+    ggml_init_params params{16*1024*1024, nullptr, true};
+    ggml_context * context = ggml_init(params);
+    if (!context) return run;
+    ggml_tensor * weights = ggml_new_tensor_3d(
+        context, GGML_TYPE_Q2_0_ROCMFP2, k_dim, n_rows, n_experts);
+    ggml_tensor * input = ggml_new_tensor_3d(
+        context, GGML_TYPE_F32, k_dim, 1, width);
+    ggml_tensor * ids = ggml_new_tensor_2d(
+        context, GGML_TYPE_I32, top_k, width);
+    for (ggml_tensor * tensor : {weights, input, ids}) ggml_set_input(tensor);
+    ggml_tensor * result = ggml_mul_mat_id(context, weights, input, ids);
+    ggml_set_output(result);
+    ggml_cgraph * graph = ggml_new_graph(context);
+    ggml_build_forward_expand(graph, result);
+
+    ggml_gallocr_t allocator = ggml_gallocr_new(
+        ggml_backend_get_default_buffer_type(backend));
+    if (!ggml_gallocr_alloc_graph(allocator, graph)) {
+        ggml_gallocr_free(allocator);
+        ggml_free(context);
+        return run;
+    }
+
+    std::mt19937 rng(20260904);
+    std::uniform_real_distribution<float> distribution(-1.0f, 1.0f);
+    std::vector<float> weights_f(
+        static_cast<size_t>(k_dim)*n_rows*n_experts);
+    std::vector<float> input_f(static_cast<size_t>(k_dim)*width);
+    for (float & value : weights_f) value = distribution(rng);
+    for (float & value : input_f) value = distribution(rng);
+    std::vector<uint8_t> weights_q(ggml_nbytes(weights));
+    const size_t quantized = rocmfpx_quantize_fp2(
+        weights_f.data(), weights_q.data(), n_rows*n_experts, k_dim, nullptr);
+    std::vector<int32_t> ids_f(static_cast<size_t>(top_k)*width);
+    for (int token = 0; token < width; ++token) {
+        for (int slot = 0; slot < top_k; ++slot) {
+            ids_f[static_cast<size_t>(token)*top_k + slot] =
+                (token*3 + slot*5) % n_experts;
+        }
+    }
+
+    if (quantized == weights_q.size()) {
+        ggml_backend_tensor_set(weights, weights_q.data(), 0, weights_q.size());
+        ggml_backend_tensor_set(
+            input, input_f.data(), 0, input_f.size()*sizeof(float));
+        ggml_backend_tensor_set(
+            ids, ids_f.data(), 0, ids_f.size()*sizeof(int32_t));
+        const size_t grouped_before =
+            ggml_backend_cuda_get_mmvq_mmid_grouped_launch_count();
+        const bool graphs_were_disabled =
+            ggml_backend_cuda_set_graphs_disabled_override(true);
+        run.computed =
+            ggml_backend_graph_compute(backend, graph) == GGML_STATUS_SUCCESS;
+        ggml_backend_cuda_set_graphs_disabled_override(graphs_were_disabled);
+        run.grouped_launches =
+            ggml_backend_cuda_get_mmvq_mmid_grouped_launch_count() -
+            grouped_before;
+        if (run.computed) {
+            run.output.resize(ggml_nelements(result));
+            ggml_backend_tensor_get(
+                result, run.output.data(), 0, run.output.size()*sizeof(float));
+        }
+    }
+
+    ggml_gallocr_free(allocator);
+    ggml_free(context);
+    return run;
+}
+
+bool write_binary(const std::string & path, const std::vector<float> & values) {
+    std::ofstream output(path, std::ios::binary | std::ios::trunc);
+    output.write(reinterpret_cast<const char *>(values.data()),
+                 static_cast<std::streamsize>(values.size()*sizeof(float)));
+    return output.good();
+}
+
+bool write_count(const std::string & path, size_t count) {
+    std::ofstream output(path, std::ios::trunc);
+    output << count << '\n';
+    return output.good();
+}
+
+std::vector<float> read_binary(const std::string & path) {
+    std::ifstream input(path, std::ios::binary | std::ios::ate);
+    if (!input) return {};
+    const std::streamsize bytes = input.tellg();
+    if (bytes <= 0 || bytes % static_cast<std::streamsize>(sizeof(float)) != 0) {
+        return {};
+    }
+    input.seekg(0);
+    std::vector<float> values(static_cast<size_t>(bytes)/sizeof(float));
+    input.read(reinterpret_cast<char *>(values.data()), bytes);
+    return input ? values : std::vector<float>{};
+}
+
+size_t read_count(const std::string & path) {
+    std::ifstream input(path);
+    size_t count = 0;
+    return input >> count ? count : static_cast<size_t>(-1);
+}
+
+std::string shell_quote(const std::string & value) {
+#if defined(_WIN32)
+    std::string quoted = "\"";
+    for (char ch : value) {
+        if (ch == '"') quoted += '\\';
+        quoted += ch;
+    }
+    return quoted + "\"";
+#else
+    std::string quoted = "'";
+    for (char ch : value) {
+        if (ch == '\'') quoted += "'\\''";
+        else quoted += ch;
+    }
+    return quoted + "'";
+#endif
+}
+
+std::string child_command(
+        const std::string & executable,
+        bool grouped,
+        const std::string & output_path,
+        const std::string & count_path) {
+#if defined(_WIN32)
+    return "set \"DFLASH_MMID_GROUPED_TYPES=15\" && set \"DFLASH_MMID_GROUPED=" +
+        std::string(grouped ? "1" : "0") + "\" && " + shell_quote(executable) +
+        " --child " + shell_quote(output_path) + " " + shell_quote(count_path);
+#else
+    return "DFLASH_MMID_GROUPED_TYPES=15 DFLASH_MMID_GROUPED=" +
+        std::string(grouped ? "1" : "0") + " " + shell_quote(executable) +
+        " --child " + shell_quote(output_path) + " " + shell_quote(count_path);
+#endif
+}
+
+int run_command_with_timeout(
+        const std::string & command,
+        std::chrono::seconds timeout) {
+#if defined(_WIN32)
+    std::string command_line = "cmd.exe /S /C " + command;
+    STARTUPINFOA startup{};
+    startup.cb = sizeof(startup);
+    PROCESS_INFORMATION process{};
+    if (!CreateProcessA(
+            nullptr, command_line.data(), nullptr, nullptr, FALSE,
+            CREATE_NO_WINDOW, nullptr, nullptr, &startup, &process)) {
+        return 1;
+    }
+    const DWORD wait_status = WaitForSingleObject(
+        process.hProcess, static_cast<DWORD>(timeout.count()*1000));
+    int status = 1;
+    if (wait_status == WAIT_TIMEOUT) {
+        TerminateProcess(process.hProcess, 124);
+        WaitForSingleObject(process.hProcess, 5000);
+        status = 124;
+    } else if (wait_status == WAIT_OBJECT_0) {
+        DWORD exit_code = 1;
+        if (GetExitCodeProcess(process.hProcess, &exit_code)) {
+            status = static_cast<int>(exit_code);
+        }
+    }
+    CloseHandle(process.hThread);
+    CloseHandle(process.hProcess);
+    return status;
+#else
+    const pid_t child = fork();
+    if (child < 0) return 1;
+    if (child == 0) {
+        execl("/bin/sh", "sh", "-c", command.c_str(), nullptr);
+        _exit(127);
+    }
+
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    int wait_status = 0;
+    while (std::chrono::steady_clock::now() < deadline) {
+        const pid_t waited = waitpid(child, &wait_status, WNOHANG);
+        if (waited == child) {
+            return WIFEXITED(wait_status) ? WEXITSTATUS(wait_status) : 1;
+        }
+        if (waited < 0 && errno != EINTR) return 1;
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    kill(child, SIGKILL);
+    while (waitpid(child, &wait_status, 0) < 0 && errno == EINTR) {}
+    return 124;
+#endif
+}
+
+class TemporaryFiles {
+public:
+    explicit TemporaryFiles(std::string prefix) : prefix_(std::move(prefix)) {}
+    ~TemporaryFiles() {
+        for (const std::string & suffix : {
+                 "_reference.bin", "_reference.count",
+                 "_candidate.bin", "_candidate.count"}) {
+            std::remove((prefix_ + suffix).c_str());
+        }
+    }
+
+    std::string path(const char * suffix) const { return prefix_ + suffix; }
+
+private:
+    std::string prefix_;
+};
+
+bool grouped_supported_device() {
+    cudaDeviceProp properties{};
+    if (cudaGetDeviceProperties(&properties, 0) != cudaSuccess) return false;
+#if defined(__HIP_PLATFORM_AMD__)
+    const std::string arch = properties.gcnArchName;
+    return arch.rfind("gfx11", 0) == 0 || arch.rfind("gfx12", 0) == 0;
+#else
+    return properties.major*10 + properties.minor >= 75;
+#endif
+}
+
+kq::CaseResult qualify_deepseek4_grouped_mmid(const std::string & executable) {
+    if (!grouped_supported_device()) {
+        return kq::unsupported(
+            DS4_CASE, "grouped MMID requires NVIDIA Turing+ or AMD RDNA3/RDNA4");
+    }
+#if defined(_WIN32)
+    const long long pid = static_cast<long long>(_getpid());
+#else
+    const long long pid = static_cast<long long>(getpid());
+#endif
+    TemporaryFiles files("kernel_qualification_ds4_" + std::to_string(pid));
+    const std::string reference_output = files.path("_reference.bin");
+    const std::string reference_count = files.path("_reference.count");
+    const std::string candidate_output = files.path("_candidate.bin");
+    const std::string candidate_count = files.path("_candidate.count");
+    constexpr std::chrono::seconds child_timeout(120);
+    const int reference_status = run_command_with_timeout(
+        child_command(executable, false, reference_output, reference_count),
+        child_timeout);
+    const int candidate_status = run_command_with_timeout(
+        child_command(executable, true, candidate_output, candidate_count),
+        child_timeout);
+    const std::vector<float> reference = read_binary(reference_output);
+    const std::vector<float> candidate = read_binary(candidate_output);
+    const size_t reference_grouped = read_count(reference_count);
+    const size_t candidate_grouped = read_count(candidate_count);
+    const bool route_matched = reference_status == 0 && candidate_status == 0 &&
+        reference_grouped == 0 && candidate_grouped == 1;
+    const std::string observed =
+        "reference.grouped=" + std::to_string(reference_grouped) +
+        ",candidate.grouped=" + std::to_string(candidate_grouped) +
+        ",reference.status=" + std::to_string(reference_status) +
+        ",candidate.status=" + std::to_string(candidate_status);
+    kq::Route route{
+        "reference.grouped=0,candidate.grouped=1,status=0",
+        observed, route_matched};
+    if (!route_matched || reference.empty() || candidate.empty()) {
+        return failed_case(
+            DS4_CASE, "reference or grouped child failed", std::move(route));
+    }
+    return kq::evaluate(
+        DS4_CASE,
+        {kq::compare_f32_nmse("output", candidate, reference, 5.0e-4)},
+        std::move(route));
+}
+
+int run_child(const char * output_path, const char * count_path) {
+    ggml_backend_t backend = ggml_backend_cuda_init(0);
+    if (!backend) return 1;
+    const GraphRun run = run_grouped_mmid_graph(backend);
+    const bool wrote = run.computed && write_binary(output_path, run.output) &&
+        write_count(count_path, run.grouped_launches);
+    ggml_backend_free(backend);
+    return wrote ? 0 : 1;
+}
+
+}  // namespace
+
+int main(int argc, char ** argv) {
+    if (argc == 4 && std::strcmp(argv[1], "--child") == 0) {
+        return run_child(argv[2], argv[3]);
+    }
+    if (argc != 1) {
+        std::cerr << "usage: " << argv[0] << " [--child OUTPUT COUNT]\n";
+        return 2;
+    }
+
+    int device_count = 0;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+        const std::vector<kq::CaseResult> cases{
+            kq::unsupported(MOE_CASE, "CUDA/HIP backend unavailable"),
+            kq::unsupported(DS4_CASE, "CUDA/HIP backend unavailable"),
+        };
+        kq::write_json(std::cout, "unavailable", cases);
+        return kq::exit_code(cases);
+    }
+
+    char description[256] = {};
+    ggml_backend_cuda_get_device_description(0, description, sizeof(description));
+    const std::vector<kq::CaseResult> cases{
+        qualify_moe_gate_up_glu(),
+        qualify_deepseek4_grouped_mmid(argv[0]),
+    };
+    kq::write_json(std::cout, description, cases);
+    return kq::exit_code(cases);
+}


### PR DESCRIPTION
## What this adds

- A reusable kernel qualification result core with finite checks, maximum absolute error and normalized MSE metrics, explicit `pass`, `fail`, and `unsupported` states, CTest-compatible exit codes, and a stable `lucebox.kernel_qualification.v1` JSON report.
- A stateful GDN active-inplace contract. It runs three deterministic steps through the scalar reference and the grouped-column candidate. Each path carries its own state. The contract compares output and mutated state, checks allocation guards, and proves both dispatch routes with launch counters.
- A fused MoE gate/up GLU contract for the ROCmFP2 mixed-expert path. It compares the fused launch with two unfused launches plus a host SwiGLU reference. The inputs include invalid expert IDs. Allocation guards catch writes outside the output.
- A compact DeepSeek4 grouped-MMID contract at speculative-verification width. Separate child processes run the disabled-grouped reference and the grouped candidate because the dispatch flags are process-cached. The contract compares their outputs at the repository's MMQ tolerance and requires exactly one grouped-MMID launch.
- A grouped-MMID launch counter for route proof.
- Build and test coverage in the existing NVIDIA and ROCm jobs. This PR does not add a workflow or service.

## Scope

This draft covers ggml-level kernel correctness and dispatch proof. It is separate from #636, which owns model and release qualification through profiles, baselines, evidence, reports, and dashboards.

The runner follows the useful shape of llama.cpp's [`tests/test-backend-ops.cpp`](https://github.com/ggml-org/llama.cpp/blob/master/tests/test-backend-ops.cpp): deterministic inputs, reference and candidate execution, non-finite rejection, and explicit tolerances. Lucebox also checks state changes, allocation guards, route counters, and unsupported hardware.

The current contracts are representative, not a model-by-model test matrix. GDN covers the recurrent kernel used by the Qwen and speculative paths. The MoE and DeepSeek4 contracts cover one focused optimized route each.

## What remains

- Run the CUDA and HIP builds and all three GPU contracts on the RTX 3090, GB10, R9700, and Strix runners. This host has no CUDA or HIP toolkit and no GPU.
- Add a FlashPrefill contract after the backend exposes a reliable route witness. Numerical comparison without dispatch proof would allow a silent fallback to pass.
- Qualify full speculative decoding in a separate runtime-level change. That work must cover draft generation, acceptance, KV rollback, sampling, cache state, and multi-step commit behavior. These checks do not belong in a single-kernel contract.
- Add LuceForge orchestration after the GPU contracts pass. Forge can consume the JSON report and combine it with the model profiles and release evidence from #636.
- Keep Qwen model profiles in #636. Current `main` has Qwen 3.5 and Qwen 3.6 paths, but no Qwen 3.8 backend. This PR does not claim Qwen 3.8 model coverage.

## Local validation

Passed on the CPU-only macOS host:

- The core qualification self-test under AddressSanitizer and UndefinedBehaviorSanitizer.
- JSON parsing plus schema, status, and metric assertions.
- Strict C++17 syntax and warning checks for the GDN and MoE/DeepSeek4 qualification sources. The latter used the real project headers and minimal declarations for the unavailable CUDA runtime.
- Workflow YAML parsing.
- `git diff --check`.

Not run here:

- CUDA or HIP compilation of the modified backend translation units.
- GDN, fused MoE gate/up GLU, or grouped DeepSeek4 MMID execution on a GPU.

The draft stays open until the remote GPU runners are available and these checks pass.
