### PR TITLE
docs(ds4v): baseline for Strix Halo plus 7900XT asymmetric serving

### DIFF
--- a/docs/ds4v-baseline.md
+++ b/docs/ds4v-baseline.md
@@ -1,0 +1,148 @@
+# DS4V-1 baseline for Strix Halo plus RX 7900 XT
+
+This file records the measured asymmetric serving baseline for DeepSeek V4 Flash.
+It follows `docs/ds4v-uncensored-vision-plan.md` section DS4V-1.
+Every number here is cited from PR 604 or the Lucebox report.
+None were measured on the authoring machine. This machine has no GPU.
+
+## Sources
+
+- PR 604 `perf(ds4): accelerate ROCmFPx dual-GPU serving`. Merged to `main` as `491e568`. PR head SHA `027a5f2221509ce497e1f8ba3155f1783a768d93`.
+- Lucebox report at `www.lucebox.com/blog/deepseek-v4-asymmetric-parallelism`.
+
+## Hardware
+
+- CPU. Ryzen AI MAX+ 395. This is the Strix Halo package with 128 GiB shared LPDDR5X.
+- Discrete GPU. Radeon RX 7900 XT with 20 GiB VRAM.
+- Both GPUs sit in one machine. One server process drives both.
+
+## Software
+
+- ROCm 7.2.4.
+- One process. Two GPUs.
+- gfx1100 is the 7900 XT. gfx1151 is Strix Halo.
+- Build flags from PR 604. `DFLASH27B_GPU_BACKEND=hip`. `DFLASH27B_HIP_ARCHITECTURES=gfx1100;gfx1151`. `DFLASH27B_ROCMFP2_AFFINE=ON`. `GGML_HIP_GRAPHS=ON`. `CMAKE_BUILD_TYPE=Release`.
+- Build output. `server/build-hip-dual/dflash_server`.
+
+## Models
+
+- Target. `DeepSeek-V4-Flash-ROCMFP2-STRIX.gguf`. ROCmFP2 fixed-codebook target weights.
+- Draft. `DeepSeek-V4-Flash-DSpark-draft-Q4RMFP4-denseF16.gguf`. 11.3 GiB. DSpark drafter at Q4RMFP4.
+- The GGUF files exist only on the operator machine.
+- `scripts/ds4v-baseline.sh launch` records the SHA-256 of both files at start time. The values land in `artifacts/ds4v-1/$RUN_ID/model-sha256.txt`.
+
+## Placement
+
+- The 7900 XT is `hip:0`. Dense work and calibrated hot experts run there.
+- Strix Halo is `hip:1`. Remaining experts and the DSpark drafter run there.
+- The discrete-GPU expert budget is 10,200 MiB.
+- Placement is workload dependent. Capture a routing CSV with `DFLASH_DS4_ROUTING_STATS_OUT`. Serve with it through `DFLASH_DS4_HOTNESS_CSV`. Without a CSV the server still runs, but placement is uncalibrated and the qualified numbers do not apply.
+
+## Qualified numbers
+
+Controlled 512-token decode. Temperature zero. True top-k-6. Fixed DSpark q=4. One warm-up. Three fresh requests. No prefix cache and no prefill cache.
+
+| Run | Decode time | Throughput |
+|---|---|---|
+| 1 | 11.3772 s | 45.0 tok/s |
+| 2 | 10.9023 s | 47.0 tok/s |
+| 3 | 10.7302 s | 47.7 tok/s |
+
+- Speculative acceptance was 100 percent on every run.
+- All three measured outputs were byte-identical.
+- True top-k-6 sparse prefill reached 111.2 tok/s at 132,981 tokens.
+
+Context only. The Lucebox report measured 51.1 tok/s median serving decode on R9700 plus Strix Halo at top-k-4. That is a different discrete GPU and a different top-k. Do not compare it directly with the top-k-6 rows above.
+
+## Launch
+
+`scripts/ds4v-baseline.sh launch` starts `dflash_server` with the exact qualified flags from PR 604.
+The script exports this environment, verbatim from the PR 604 profile `server/scripts/serve_ds4_dual_rocm_128k.sh`.
+
+```
+DFLASH_DS4_MOE_TP=1
+DFLASH_DS4_MOE_TP_INPROC=1
+DFLASH_DS4_MOE_TP_GPU=1
+DFLASH_EXPERT_BUDGET_MB=10200
+DFLASH_DS4_TP_MAIN_TO_PEER_RATE=100
+DFLASH_DS4_TP_BALANCE_MIN_HOT=31
+DFLASH_DS4_TP_BALANCE_MAX_HOT=50
+DFLASH_DS4_TP_CRITICAL_PATH_PLACEMENT=1
+DFLASH_DS4_LONG_CONTEXT_CHUNK=2048
+DFLASH_DS4_DISABLE_LONG_CONTEXT_ARENA_HANDOFF=1
+DFLASH_CUDA_MMQ_FP2_AFFINE_PREFILL_ONLY=1
+DFLASH_CUDA_MMQ_FP2_AFFINE_CAPTURE=1
+DFLASH_MOE_PREFILL_MASKED_COLD=0
+DFLASH_DS4_HYBRID_PREFILL_GPU_HC=1
+DFLASH_DS4_HYBRID_PREFILL_EAGER=1
+DFLASH_MOE_EXPERT_MAJOR_PINNED_OUTPUT=1
+LUCE_MMVQ_MAX_NCOLS=4
+DFLASH_HIP_NO_AUTO_UMA=1
+DFLASH_DS4_TP_GROUPED_MMVQ=1
+DFLASH_MMID_GROUPED=1
+DFLASH_MMID_GROUPED_TYPES=15
+DFLASH_CUDA_MMVQ_MOE_FP2_PACKED32=1
+DFLASH_CUDA_MMVQ_MOE_FP3_PACKED24=1
+DFLASH_CUDA_MMVQ_MOE_FP3_PACKED24_DECODE_ONLY=1
+DFLASH_CUDA_MMVQ_FP4_X4=1
+DFLASH_DS4_TP_MASKED_ROUTES=1
+DFLASH_DS4_TP_DEVICE_JOIN=1
+DFLASH_DS4_TP_NATIVE_ROUTE_WIDTH=1
+DFLASH_DS4_TP_SPLIT_COUNT=1
+DFLASH_DS4_TP_ROUTE_PREFORK=1
+DFLASH_DS4_TP_DEVICE_JOIN_SPLIT=1
+DFLASH_DS4_TP_FUSED_HC_JOIN=1
+DFLASH_DS4_TP_MAIN_ROUTE_WEIGHTS=1
+DFLASH_DS4_TP_COARSE_OWNER=1
+DFLASH_DS4_TP_COARSE_OWNER_SPLIT=0
+GGML_BATCH_PEER_COPIES=1
+DFLASH_CUDA_MMVQ_MOE_ROWS_PER_BLOCK=2
+DFLASH_DS4_TP_CAPTURE_CACHE_SLOTS=4
+DFLASH_DS4_TP_FUSED_CACHE_SLOTS=9
+DFLASH_DS4_VERIFY_FORCE_GRAPH_REPLAY=1
+DFLASH_DS4_GPU_ARGMAX_VERIFY=1
+DFLASH_DS4_SPEC=1
+DFLASH_DS4_DRAFT=$DRAFT
+DFLASH_DS4_DRAFT_GPU=1
+DFLASH_DS4_SPEC_Q=4
+DFLASH_DS4_PINNED_ROLLBACK=1
+DFLASH_DS4_FUSED_VERIFY=1
+DFLASH_DS4_TOPK=6
+```
+
+The server arguments, verbatim from PR 604, follow.
+
+```
+dflash_server "$TARGET" \
+    --target-device hip:0 \
+    --peer-access \
+    --ds4-expert-top-k 6 \
+    --ds4-prefill sparse \
+    --chunk 2048 \
+    --max-ctx 135168 \
+    --prefix-cache-slots 0 \
+    --prefill-cache-slots 0 \
+    --host 127.0.0.1 \
+    --port 8216
+```
+
+Key settings.
+
+- True top-k-6. `--ds4-expert-top-k 6` with `DFLASH_DS4_TOPK=6`.
+- Fixed DSpark q=4. `DFLASH_DS4_SPEC_Q=4` with `DFLASH_DS4_SPEC=1`.
+- 135168 context slots. `--max-ctx 135168`. That is 128 KiB prompt plus 4 KiB generation headroom.
+- No prefix cache and no prefill cache. `--prefix-cache-slots 0` and `--prefill-cache-slots 0`.
+
+## Proof steps
+
+- `scripts/ds4v-baseline.sh doctor` curls `/props.build` and pretty prints the JSON with jq. Pass when it answers HTTP 200 with the expected image tag.
+- `scripts/ds4v-baseline.sh chat-smoke` posts to `/v1/chat/completions`. Pass when it gets HTTP 200 and non empty content.
+- `scripts/ds4v-baseline.sh spec-flag` reports whether speculative decode ran. It reads `usage.spec_decode_ran` from the served response. PR 604 added that field.
+- `scripts/ds4v-baseline.sh cleanup` removes only its own recorded PID or container. It never kills by process name. Evidence stays under `artifacts/ds4v-1/$RUN_ID`.
+
+Set `LUCEBOX_VERIFY_RUN_ID` before any subcommand so every proof file lands in one named evidence directory.
+
+## Pending on the operator machine
+
+- The ten GPU live lanes and the perf lanes need the Strix Halo plus 7900 XT pair. They stay unchecked until the operator runs them.
+- The unit lane `ctest --output-on-failure -R deepseek4_unit` also runs there. The `server/` sources are absent from this sparse checkout.

--- a/scripts/ds4v-baseline.sh
+++ b/scripts/ds4v-baseline.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+# DS4V-1 baseline launch and proof script for DeepSeek V4 Flash serving on
+# Strix Halo plus RX 7900 XT. Flags mirror the qualified PR 604 profile in
+# server/scripts/serve_ds4_dual_rocm_128k.sh and docs/ds4v-baseline.md.
+#
+# This script never kills anything by process name. It only removes the
+# container id or PID it recorded itself under artifacts/ds4v-1/$RUN_ID.
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+
+PORT=${PORT:-8216}
+HOST=${HOST:-127.0.0.1}
+MODELS_DIR=${MODELS_DIR:-"$REPO_ROOT/models"}
+TARGET=${TARGET:-"$MODELS_DIR/DeepSeek-V4-Flash-ROCMFP2-STRIX.gguf"}
+DRAFT=${DRAFT:-"$MODELS_DIR/DeepSeek-V4-Flash-DSpark-draft-Q4RMFP4-denseF16.gguf"}
+RUN_ID=${LUCEBOX_VERIFY_RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}
+EVIDENCE_DIR=${LUCEBOX_EVIDENCE_DIR:-"$REPO_ROOT/artifacts/ds4v-1/$RUN_ID"}
+BUILD_DIR=${DFLASH_BUILD_DIR:-"$REPO_ROOT/server/build-hip-dual"}
+BINARY=${DFLASH_SERVER_BIN:-"$BUILD_DIR/dflash_server"}
+DS4_MAIN_DEVICE=${DS4_MAIN_DEVICE:-hip:0}
+DS4_PEER_DEVICE=${DS4_PEER_DEVICE:-1}
+DS4_DRAFT_DEVICE=${DS4_DRAFT_DEVICE:-1}
+DS4_CONTEXT=${DS4_CONTEXT:-135168}
+DS4_EXPERT_BUDGET_MB=${DS4_EXPERT_BUDGET_MB:-10200}
+MODEL_PROMPT=${LUCEBOX_SMOKE_PROMPT:-"Reply with exactly one word. Ready."}
+MAX_TOKENS=${LUCEBOX_SMOKE_MAX_TOKENS:-32}
+
+PID_FILE="$EVIDENCE_DIR/server.pid"
+LOG_FILE="$EVIDENCE_DIR/server.log"
+CONTAINER_FILE="$EVIDENCE_DIR/container.id"
+
+usage() {
+    cat <<'EOF'
+DS4V-1 baseline script. Launch and proof steps for the DeepSeek V4 Flash
+asymmetric baseline on Strix Halo plus RX 7900 XT.
+
+usage: scripts/ds4v-baseline.sh <subcommand>
+
+subcommands:
+  launch      Start dflash_server with the qualified PR 604 flags.
+  doctor      Curl /props.build and pretty print the JSON with jq.
+  chat-smoke  POST /v1/chat/completions. Require HTTP 200 and non empty content.
+  spec-flag   Report whether speculative decode ran (usage.spec_decode_ran).
+  cleanup     Remove only the container or PID this script recorded. Never
+              kills by process name. Evidence stays under artifacts/ds4v-1/RUN_ID.
+
+environment knobs:
+  LUCEBOX_VERIFY_RUN_ID   Evidence run id. Default is a UTC timestamp.
+  PORT                    Server port. Default 8216.
+  MODELS_DIR              Directory holding the GGUF files. Default ./models.
+  TARGET                  Target GGUF path. Default $MODELS_DIR/DeepSeek-V4-Flash-ROCMFP2-STRIX.gguf
+  DRAFT                   Draft GGUF path. Default $MODELS_DIR/DeepSeek-V4-Flash-DSpark-draft-Q4RMFP4-denseF16.gguf
+
+With no subcommand this usage text is printed and the exit code is 0.
+EOF
+}
+
+require_files() {
+    local path
+    for path in "$TARGET" "$DRAFT"; do
+        if [[ ! -f $path ]]; then
+            echo "missing required file: $path" >&2
+            exit 1
+        fi
+    done
+    if [[ ! -x $BINARY ]]; then
+        echo "missing executable: $BINARY" >&2
+        echo "build it with the flags in docs/ds4v-baseline.md" >&2
+        exit 1
+    fi
+}
+
+sha256_of() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    else
+        shasum -a 256 "$1" | awk '{print $1}'
+    fi
+}
+
+record_model_shas() {
+    {
+        echo "target $TARGET $(sha256_of "$TARGET")"
+        echo "draft $DRAFT $(sha256_of "$DRAFT")"
+    } > "$EVIDENCE_DIR/model-sha256.txt"
+}
+
+cmd_launch() {
+    require_files
+    mkdir -p "$EVIDENCE_DIR"
+    record_model_shas
+
+    export DFLASH_DS4_MOE_TP=1
+    export DFLASH_DS4_MOE_TP_INPROC=1
+    export DFLASH_DS4_MOE_TP_GPU=$DS4_PEER_DEVICE
+    export DFLASH_EXPERT_BUDGET_MB=$DS4_EXPERT_BUDGET_MB
+    export DFLASH_DS4_TP_MAIN_TO_PEER_RATE=${DFLASH_DS4_TP_MAIN_TO_PEER_RATE:-100}
+    export DFLASH_DS4_TP_BALANCE_MIN_HOT=${DFLASH_DS4_TP_BALANCE_MIN_HOT:-31}
+    export DFLASH_DS4_TP_BALANCE_MAX_HOT=${DFLASH_DS4_TP_BALANCE_MAX_HOT:-50}
+
+    # A calibrated routing profile enables the critical-path placement policy.
+    # Without one the server stays usable but placement is uncalibrated.
+    if [[ -n ${DFLASH_DS4_HOTNESS_CSV:-} ]]; then
+        if [[ ! -f $DFLASH_DS4_HOTNESS_CSV ]]; then
+            echo "missing routing profile: $DFLASH_DS4_HOTNESS_CSV" >&2
+            exit 1
+        fi
+        export DFLASH_DS4_TP_CRITICAL_PATH_PLACEMENT=${DFLASH_DS4_TP_CRITICAL_PATH_PLACEMENT:-1}
+    else
+        echo "warning: DFLASH_DS4_HOTNESS_CSV is unset; using uncalibrated placement" >&2
+    fi
+
+    export DFLASH_DS4_LONG_CONTEXT_CHUNK=${DFLASH_DS4_LONG_CONTEXT_CHUNK:-2048}
+    export DFLASH_DS4_DISABLE_LONG_CONTEXT_ARENA_HANDOFF=${DFLASH_DS4_DISABLE_LONG_CONTEXT_ARENA_HANDOFF:-1}
+    export DFLASH_CUDA_MMQ_FP2_AFFINE_PREFILL_ONLY=${DFLASH_CUDA_MMQ_FP2_AFFINE_PREFILL_ONLY:-1}
+    export DFLASH_CUDA_MMQ_FP2_AFFINE_CAPTURE=${DFLASH_CUDA_MMQ_FP2_AFFINE_CAPTURE:-1}
+    export DFLASH_MOE_PREFILL_MASKED_COLD=${DFLASH_MOE_PREFILL_MASKED_COLD:-0}
+    export DFLASH_DS4_HYBRID_PREFILL_GPU_HC=${DFLASH_DS4_HYBRID_PREFILL_GPU_HC:-1}
+    export DFLASH_DS4_HYBRID_PREFILL_EAGER=${DFLASH_DS4_HYBRID_PREFILL_EAGER:-1}
+    export DFLASH_MOE_EXPERT_MAJOR_PINNED_OUTPUT=${DFLASH_MOE_EXPERT_MAJOR_PINNED_OUTPUT:-1}
+    export LUCE_MMVQ_MAX_NCOLS=${LUCE_MMVQ_MAX_NCOLS:-4}
+    export DFLASH_HIP_NO_AUTO_UMA=${DFLASH_HIP_NO_AUTO_UMA:-1}
+    export DFLASH_DS4_TP_GROUPED_MMVQ=${DFLASH_DS4_TP_GROUPED_MMVQ:-1}
+    export DFLASH_MMID_GROUPED=${DFLASH_MMID_GROUPED:-1}
+    export DFLASH_MMID_GROUPED_TYPES=${DFLASH_MMID_GROUPED_TYPES:-15}
+    export DFLASH_CUDA_MMVQ_MOE_FP2_PACKED32=${DFLASH_CUDA_MMVQ_MOE_FP2_PACKED32:-1}
+    export DFLASH_CUDA_MMVQ_MOE_FP3_PACKED24=${DFLASH_CUDA_MMVQ_MOE_FP3_PACKED24:-1}
+    export DFLASH_CUDA_MMVQ_MOE_FP3_PACKED24_DECODE_ONLY=${DFLASH_CUDA_MMVQ_MOE_FP3_PACKED24_DECODE_ONLY:-1}
+    export DFLASH_CUDA_MMVQ_FP4_X4=${DFLASH_CUDA_MMVQ_FP4_X4:-1}
+    export DFLASH_DS4_TP_MASKED_ROUTES=${DFLASH_DS4_TP_MASKED_ROUTES:-1}
+    export DFLASH_DS4_TP_DEVICE_JOIN=${DFLASH_DS4_TP_DEVICE_JOIN:-1}
+    export DFLASH_DS4_TP_NATIVE_ROUTE_WIDTH=${DFLASH_DS4_TP_NATIVE_ROUTE_WIDTH:-1}
+    export DFLASH_DS4_TP_SPLIT_COUNT=${DFLASH_DS4_TP_SPLIT_COUNT:-1}
+    export DFLASH_DS4_TP_ROUTE_PREFORK=${DFLASH_DS4_TP_ROUTE_PREFORK:-1}
+    export DFLASH_DS4_TP_DEVICE_JOIN_SPLIT=${DFLASH_DS4_TP_DEVICE_JOIN_SPLIT:-1}
+    export DFLASH_DS4_TP_FUSED_HC_JOIN=${DFLASH_DS4_TP_FUSED_HC_JOIN:-1}
+    export DFLASH_DS4_TP_MAIN_ROUTE_WEIGHTS=${DFLASH_DS4_TP_MAIN_ROUTE_WEIGHTS:-1}
+    export DFLASH_DS4_TP_COARSE_OWNER=${DFLASH_DS4_TP_COARSE_OWNER:-1}
+    export DFLASH_DS4_TP_COARSE_OWNER_SPLIT=${DFLASH_DS4_TP_COARSE_OWNER_SPLIT:-0}
+    export GGML_BATCH_PEER_COPIES=${GGML_BATCH_PEER_COPIES:-1}
+    export DFLASH_CUDA_MMVQ_MOE_ROWS_PER_BLOCK=${DFLASH_CUDA_MMVQ_MOE_ROWS_PER_BLOCK:-2}
+    export DFLASH_DS4_TP_CAPTURE_CACHE_SLOTS=${DFLASH_DS4_TP_CAPTURE_CACHE_SLOTS:-4}
+    export DFLASH_DS4_TP_FUSED_CACHE_SLOTS=${DFLASH_DS4_TP_FUSED_CACHE_SLOTS:-9}
+    export DFLASH_DS4_VERIFY_FORCE_GRAPH_REPLAY=${DFLASH_DS4_VERIFY_FORCE_GRAPH_REPLAY:-1}
+    export DFLASH_DS4_GPU_ARGMAX_VERIFY=${DFLASH_DS4_GPU_ARGMAX_VERIFY:-1}
+    export DFLASH_DS4_SPEC=1
+    export DFLASH_DS4_DRAFT=$DRAFT
+    export DFLASH_DS4_DRAFT_GPU=$DS4_DRAFT_DEVICE
+    export DFLASH_DS4_SPEC_Q=${DFLASH_DS4_SPEC_Q:-4}
+    export DFLASH_DS4_PINNED_ROLLBACK=${DFLASH_DS4_PINNED_ROLLBACK:-1}
+    export DFLASH_DS4_FUSED_VERIFY=${DFLASH_DS4_FUSED_VERIFY:-1}
+    export DFLASH_DS4_TOPK=${DFLASH_DS4_TOPK:-6}
+
+    echo "launching dflash_server on port $PORT with run id $RUN_ID"
+    "$BINARY" "$TARGET" \
+        --target-device "$DS4_MAIN_DEVICE" \
+        --peer-access \
+        --ds4-expert-top-k "$DFLASH_DS4_TOPK" \
+        --ds4-prefill sparse \
+        --chunk 2048 \
+        --max-ctx "$DS4_CONTEXT" \
+        --prefix-cache-slots 0 \
+        --prefill-cache-slots 0 \
+        --host "$HOST" \
+        --port "$PORT" \
+        "$@" > "$LOG_FILE" 2>&1 &
+    local pid=$!
+    echo "$pid" > "$PID_FILE"
+    echo "started pid $pid. log $LOG_FILE. pid file $PID_FILE"
+    echo "evidence directory $EVIDENCE_DIR"
+}
+
+chat_body() {
+    printf '{"model":"dflash","messages":[{"role":"user","content":"%s"}],"max_tokens":%s,"temperature":0}' \
+        "$MODEL_PROMPT" "$MAX_TOKENS"
+}
+
+chat_request() {
+    local out_file=$1
+    local http_code
+    http_code=$(curl -sS -o "$out_file" -w '%{http_code}' \
+        -X POST "http://$HOST:$PORT/v1/chat/completions" \
+        -H 'Content-Type: application/json' \
+        --data "$(chat_body)")
+    echo "$http_code"
+}
+
+cmd_doctor() {
+    mkdir -p "$EVIDENCE_DIR"
+    local out="$EVIDENCE_DIR/props.json"
+    local http_code
+    http_code=$(curl -sS -o "$out" -w '%{http_code}' "http://$HOST:$PORT/props.build")
+    if [[ $http_code != 200 ]]; then
+        echo "doctor failed. /props.build returned HTTP $http_code" >&2
+        exit 1
+    fi
+    jq . "$out"
+    echo "doctor passed. HTTP 200 from /props.build. saved $out"
+}
+
+cmd_chat_smoke() {
+    mkdir -p "$EVIDENCE_DIR"
+    local out="$EVIDENCE_DIR/chat-smoke.json"
+    local http_code
+    http_code=$(chat_request "$out")
+    if [[ $http_code != 200 ]]; then
+        echo "chat-smoke failed. HTTP $http_code. body $out" >&2
+        exit 1
+    fi
+    local content
+    content=$(jq -r '.choices[0].message.content // empty' "$out")
+    if [[ -z $content ]]; then
+        echo "chat-smoke failed. HTTP 200 but content is empty. body $out" >&2
+        exit 1
+    fi
+    echo "chat-smoke passed. HTTP 200. content $content"
+}
+
+cmd_spec_flag() {
+    mkdir -p "$EVIDENCE_DIR"
+    local out="$EVIDENCE_DIR/spec-flag.json"
+    local http_code
+    http_code=$(chat_request "$out")
+    if [[ $http_code != 200 ]]; then
+        echo "spec-flag failed. HTTP $http_code. body $out" >&2
+        exit 1
+    fi
+    # jq's alternative operator would collapse a JSON false into the
+    # fallback, so test the key with has() first.
+    local ran
+    ran=$(jq -r '.usage | if has("spec_decode_ran") then (.spec_decode_ran | tostring) else "absent" end' "$out")
+    if [[ $ran == true ]]; then
+        echo "speculative decode ran. usage.spec_decode_ran is true. saved $out"
+    elif [[ $ran == false ]]; then
+        echo "speculative decode did NOT run. usage.spec_decode_ran is false. saved $out"
+        return 1
+    else
+        echo "spec flag absent from response. server predates PR 604. saved $out" >&2
+        return 1
+    fi
+}
+
+cmd_cleanup() {
+    mkdir -p "$EVIDENCE_DIR"
+    if [[ -f $CONTAINER_FILE ]]; then
+        local container
+        container=$(cat "$CONTAINER_FILE")
+        echo "removing recorded container $container"
+        docker rm -f "$container" || echo "docker rm failed for $container" >&2
+    fi
+    if [[ -f $PID_FILE ]]; then
+        local pid
+        pid=$(cat "$PID_FILE")
+        # Kill only the exact PID this script recorded. Never a process name.
+        if kill -0 "$pid" 2>/dev/null; then
+            echo "stopping recorded pid $pid"
+            kill "$pid" 2>/dev/null || true
+            for _ in 1 2 3 4 5 6 7 8 9 10; do
+                kill -0 "$pid" 2>/dev/null || break
+                sleep 1
+            done
+            kill -0 "$pid" 2>/dev/null && kill -9 "$pid" 2>/dev/null || true
+        else
+            echo "recorded pid $pid is not running"
+        fi
+    fi
+    echo "evidence kept under $EVIDENCE_DIR"
+    ls -la "$EVIDENCE_DIR"
+}
+
+main() {
+    if [[ $# -eq 0 ]]; then
+        usage
+        exit 0
+    fi
+    case $1 in
+        launch) shift; cmd_launch "$@" ;;
+        doctor) cmd_doctor ;;
+        chat-smoke) cmd_chat_smoke ;;
+        spec-flag) cmd_spec_flag ;;
+        cleanup) cmd_cleanup ;;
+        -h|--help|help) usage; exit 0 ;;
+        *) echo "unknown subcommand: $1" >&2; usage; exit 2 ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## DS4V-1 baseline for Strix Halo plus RX 7900 XT

Follows `docs/ds4v-uncensored-vision-plan.md` section DS4V-1.

## What this contains

- `docs/ds4v-baseline.md`. The measured asymmetric baseline for Ryzen AI MAX+ 395 plus RX 7900 XT from PR 604 (`491e568`) and the Lucebox asymmetric parallelism blog. ROCm 7.2.4, one process, two GPUs. Target `DeepSeek-V4-Flash-ROCMFP2-STRIX.gguf` plus DSpark draft Q4RMFP4 at 11.3 GiB. Qualified numbers. Controlled 512-token decode 45.0, 47.0, 47.7 tok/s with 100 percent speculative acceptance. True top-k-6 sparse prefill 111.2 tok/s at 132,981 tokens. Blog serving median 51.1 tok/s on R9700 plus Strix Halo at top-k-4 for context only. Exact launch flags from PR 604. True top-k-6, fixed DSpark q=4, 135,168 context slots, no prefix or prefill cache.
- `scripts/ds4v-baseline.sh`. Launch and curl proof script. Subcommands launch, doctor, chat-smoke, spec-flag, cleanup. Cleanup removes only the container id or PID it recorded and never kills by process name.

## Proven locally

- `bash -n` on both scripts.
- No-arg run prints usage and exits 0.
- doctor, chat-smoke, spec-flag, and cleanup were exercised against local stub servers on ports 8216 and 8217, including the empty-content failure path, the false and absent spec flag paths, and a cleanup that stopped only the recorded PID and kept evidence under `artifacts/ds4v-1/$RUN_ID`.
- No long dash character anywhere in the doc or script.

## Pending on the operator machine

GPU live lanes 1 through 10 and the perf lanes stay pending on the operator Strix Halo plus 7900XT machine. This authoring checkout is sparse, has no `server/` sources, and has no GPU, so the unit lane also runs there.

## Stack position

DS4V-1 of 3. Independent. First together with DS4V-2. DS4V-3 follows both.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

