### PR TITLE
feat(ds4v): vision GGUF quant recipe for Strix Halo plus 7900XT

### DIFF
--- a/docs/ds4v-quant.md
+++ b/docs/ds4v-quant.md
@@ -1,0 +1,77 @@
+# DS4V-3 vision GGUF quant for Strix Halo plus 7900 XT
+
+This file defines the quant recipe and the budget math for the DS4V vision GGUF.
+It follows `docs/ds4v-uncensored-vision-plan.md` section DS4V-3.
+The source weights are the OrcaRouter abliterated parent locked in `docs/ds4v-source.md`.
+The rung sizes come from the prometheusAIR rung table for DeepSeek V4 Flash Vision.
+This authoring machine has no GPU and holds no weights. The quant run stays pending on the operator machine.
+
+## Rung table
+
+prometheusAIR sizes for the vision parent. The mmproj at F16 adds 0.9 GiB on top of every rung.
+
+| Rung | Weights GiB | Full load GiB |
+|---|---|---|
+| IQ1_M | 66.9 | 92.1 |
+| IQ2_XXS | 78.8 | 104.0 |
+| IQ2_S | 95.8 | 121.0 |
+| IQ3_XXS | 108.7 | 133.9 |
+
+Full load equals weights plus 0.9 mmproj plus 13 KV at 1M context plus 11.3 draft.
+The total hardware budget is 152 GiB. That is 128 GiB Strix Halo plus 24 GiB discrete.
+
+## Default rung
+
+The default rung is IQ2_XXS.
+
+Reason. Weights plus mmproj plus KV at full 1M context sit at 92.7 GiB. That fits one 96 GiB card with the full 1M context loaded. On the operator pair it leaves 48.0 GiB of headroom for the draft model plus KV plus serving overhead. Quality holds above IQ1_M on the abliterated source. IQ2_S also fits with 31.0 GiB left. IQ3_XXS fits with 18.1 GiB left but the margin gets thin under vision activations.
+
+## Recipe
+
+Run it with `scripts/ds4v-quant.sh`. The `plan` subcommand prints the exact commands. The `run` subcommand executes them. The `verify` subcommand checks the output.
+
+1. Dequant. The FP8 source shards are dequantized to BF16 first. The abliteration is baked into the FP4 and FP8 expert shards and survives the dequant.
+2. Convert. `convert_hf_to_gguf.py` emits the BF16 gguf. It also emits the mmproj at F16. That mmproj is the 0.9 GiB file.
+3. Imatrix. Build the importance matrix from the abliterated source. Use text plus image calibration prompts. `llama-imatrix -m bf16.gguf --mmproj mmproj.gguf -f calibration.txt -o imatrix.gguf`.
+4. Quantize. One `llama-quantize` pass per rung with `--imatrix`.
+
+The type map inside the quantize pass.
+
+- `token_embd` and `output` at Q8_0.
+- Attention tensors and shared expert tensors at Q6_K.
+- Router tensors `ffn_gate_inp` and `exp_probs_b` at BF16.
+- `bias_vl` router bias at BF16. It stays on all 43 layers. The DS4V-2 manifest counted 43 of them.
+- Routed expert tensors at the rung type from the table.
+- The mmproj ships at F16. It is never quantized down.
+
+The llama.cpp build is pinned at master `9400c894` or later with both vision PRs merged. Release `b10763` is refused. The script checks the version output and the git ancestry before it runs anything.
+
+The script never deletes the source weights. The FP8 shards and the BF16 gguf both stay in place after the run.
+
+## Budget math
+
+Against the 152 GiB pair.
+
+| Rung | Full load GiB | Margin GiB |
+|---|---|---|
+| IQ1_M | 92.1 | 59.9 |
+| IQ2_XXS | 104.0 | 48.0 |
+| IQ2_S | 121.0 | 31.0 |
+| IQ3_XXS | 133.9 | 18.1 |
+
+The placement follows PR 604 asymmetric expert parallelism. Dense work and hot experts run on the discrete GPU. Tail experts run on Strix Halo. The device join happens on the discrete GPU. The draft runs on Strix Halo. The card in `share/model_cards/ds4v-vision.json` records the per device budgets as 122880 MiB for Strix Halo and 24576 MiB for the discrete GPU.
+
+The headline serving profile uses top_k 4 with the DSpark drafter at Q4RMFP4. Top_k 6 stays as the reference profile from `docs/ds4v-baseline.md`. Context is 135168 slots, same as the baseline. The KV figure above assumes full 1M context. The 135168 slot profile uses less.
+
+## Verify
+
+- The GGUF keeps `bias_vl` on all 43 layers. The script greps the gguf dump for `bias_vl` and counts 43.
+- The mmproj loads. The script runs a one token generation through the mtmd path with the mmproj attached.
+- Both checks need the weights. They run on the operator machine. No weights are needed for the script help and plan paths.
+
+## Pending on the operator machine
+
+- The weight download from `scripts/ds4v-fetch-source.sh`.
+- The dequant, convert, imatrix and quant run. Record the GGUF SHA-256 values here once they exist.
+- The unit verify box. Bias_vl on 43 layers and mmproj load.
+- The ten live lanes and the perf lanes from the plan.

--- a/scripts/ds4v-quant.sh
+++ b/scripts/ds4v-quant.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# DS4V-3 vision GGUF quant recipe for Strix Halo plus 7900 XT.
+# Follows docs/ds4v-uncensored-vision-plan.md section DS4V-3.
+# See docs/ds4v-quant.md for the rung table and the budget math.
+#
+# Usage:
+#   scripts/ds4v-quant.sh plan               print the exact quantize commands for the chosen rung
+#   scripts/ds4v-quant.sh run                execute the recipe (needs weights, imatrix and a pinned llama.cpp)
+#   scripts/ds4v-quant.sh verify SRC MMPROJ  assert bias_vl on 43 layers and that the mmproj loads
+#   scripts/ds4v-quant.sh help               this text, exit 0
+#
+# Env knobs.
+#   MODEL_DIR     source model directory      (default models/DeepSeek-V4-Flash-Vision-Uncensored)
+#   IMATRIX       importance matrix gguf      (default $OUT_DIR/imatrix.gguf)
+#   RUNG          IQ1_M, IQ2_XXS, IQ2_S, IQ3_XXS  (default IQ2_XXS)
+#   OUT_DIR       output directory            (default models/ds4v-vision-quant)
+#   LLAMA_CPP_DIR llama.cpp checkout          (default llama.cpp)
+
+set -euo pipefail
+
+MODEL_DIR="${MODEL_DIR:-models/DeepSeek-V4-Flash-Vision-Uncensored}"
+OUT_DIR="${OUT_DIR:-models/ds4v-vision-quant}"
+RUNG="${RUNG:-IQ2_XXS}"
+LLAMA_CPP_DIR="${LLAMA_CPP_DIR:-llama.cpp}"
+IMATRIX="${IMATRIX:-$OUT_DIR/imatrix.gguf}"
+
+# llama.cpp master pin. The quant needs both vision PRs from 9400c894 or later.
+# Release b10763 predates them and is refused.
+PIN_COMMIT="9400c894"
+REFUSED_BUILD="b10763"
+
+runge_ftype() {
+    case "$RUNG" in
+        IQ1_M)   echo "iq1_m" ;;
+        IQ2_XXS) echo "iq2_xxs" ;;
+        IQ2_S)   echo "iq2_s" ;;
+        IQ3_XXS) echo "iq3_xxs" ;;
+        *) echo "unknown rung $RUNG. Use IQ1_M, IQ2_XXS, IQ2_S or IQ3_XXS" >&2; return 1 ;;
+    esac
+}
+
+usage() {
+    cat <<'EOF'
+DS4V-3 vision GGUF quant recipe.
+
+Usage:
+  scripts/ds4v-quant.sh plan               print the exact quantize commands for the chosen rung
+  scripts/ds4v-quant.sh run                execute the recipe (needs weights, imatrix and a pinned llama.cpp)
+  scripts/ds4v-quant.sh verify SRC MMPROJ  assert bias_vl on 43 layers and that the mmproj loads
+  scripts/ds4v-quant.sh help               this text, exit 0
+
+Env knobs.
+  MODEL_DIR     source model directory      (default models/DeepSeek-V4-Flash-Vision-Uncensored)
+  IMATRIX       importance matrix gguf      (default $OUT_DIR/imatrix.gguf)
+  RUNG          IQ1_M, IQ2_XXS, IQ2_S, IQ3_XXS  (default IQ2_XXS)
+  OUT_DIR       output directory            (default models/ds4v-vision-quant)
+  LLAMA_CPP_DIR llama.cpp checkout          (default llama.cpp)
+
+The recipe pins llama.cpp master 9400c894 or later with both vision PRs.
+Release b10763 is refused.
+EOF
+}
+
+die() {
+    echo "error. $1" >&2
+    exit 1
+}
+
+quantize_bin() {
+    for c in "$LLAMA_CPP_DIR/build/bin/llama-quantize" "$LLAMA_CPP_DIR/llama-quantize"; do
+        if [ -x "$c" ]; then
+            echo "$c"
+            return 0
+        fi
+    done
+    if command -v llama-quantize >/dev/null 2>&1; then
+        command -v llama-quantize
+        return 0
+    fi
+    die "llama-quantize not found under LLAMA_CPP_DIR=$LLAMA_CPP_DIR"
+}
+
+check_pin() {
+    local bin ver hash
+    bin="$(quantize_bin)"
+    ver="$("$bin" --version 2>&1 | head -n 1)" || die "cannot read version from $bin"
+    echo "$ver"
+    if printf '%s' "$ver" | grep -q "$REFUSED_BUILD"; then
+        die "refusing llama.cpp release $REFUSED_BUILD. It lacks the vision PRs. Use master at or after $PIN_COMMIT"
+    fi
+    if printf '%s' "$ver" | grep -q "$PIN_COMMIT"; then
+        return 0
+    fi
+    hash="$(printf '%s' "$ver" | sed -n 's/.*(\([0-9a-f]\{7,\}\)).*/\1/p')"
+    if [ -n "$hash" ] && [ -d "$LLAMA_CPP_DIR/.git" ]; then
+        if git -C "$LLAMA_CPP_DIR" merge-base --is-ancestor "$PIN_COMMIT" HEAD 2>/dev/null; then
+            return 0
+        fi
+    fi
+    die "llama.cpp build $ver is not master at or after $PIN_COMMIT with the vision PRs"
+}
+
+# One llama-quantize pass. Routed experts take the rung type as the main type.
+# Attention plus shared experts get Q6_K. token_embd plus output get Q8_0.
+# Routers and bias_vl stay at BF16. The mmproj ships at F16 and is never requantized.
+quantize_command() {
+    local src="$1" out="$2" ftype
+    ftype="$(runge_ftype)"
+    echo "$LLAMA_CPP_DIR/build/bin/llama-quantize \\"
+    echo "  --imatrix \"$IMATRIX\" \\"
+    echo "  --token-embedding-type q8_0 \\"
+    echo "  --output-tensor-type q8_0 \\"
+    echo "  --tensor-type 'blk\\.[0-9]+\\.attn_.*=q6_k' \\"
+    echo "  --tensor-type 'blk\\.[0-9]+\\.ffn_(gate|up|down)_shexp=q6_k' \\"
+    echo "  --tensor-type 'blk\\.[0-9]+\\.ffn_gate_inp=bf16' \\"
+    echo "  --tensor-type 'blk\\.[0-9]+\\.exp_probs_b=bf16' \\"
+    echo "  --tensor-type 'blk\\.[0-9]+\\.bias_vl=bf16' \\"
+    echo "  \"$src\" \"$out\" $ftype"
+}
+
+cmd_plan() {
+    local ftype src out
+    ftype="$(runge_ftype)"
+    src="$MODEL_DIR/DeepSeek-V4-Flash-Vision-Uncensored-BF16.gguf"
+    mkdir -p "$OUT_DIR"
+    out="$OUT_DIR/DeepSeek-V4-Flash-Vision-Uncensored-$RUNG.gguf"
+    echo "# llama.cpp pin $PIN_COMMIT or later with both vision PRs. $REFUSED_BUILD is refused."
+    echo "# rung $RUNG, expert ftype $ftype"
+    echo "# step 1, imatrix from the abliterated source"
+    echo "$LLAMA_CPP_DIR/build/bin/llama-imatrix -m \"$src\" --mmproj \"$MODEL_DIR/mmproj-DeepSeek-V4-Flash-Vision-Uncensored-f16.gguf\" -f \"$MODEL_DIR/calibration.txt\" -o \"$IMATRIX\""
+    echo "# step 2, quantize. bias_vl stays on all 43 layers. mmproj ships at F16."
+    quantize_command "$src" "$out"
+    echo "# source weights are never deleted. FP8 shards and BF16 gguf stay in $MODEL_DIR"
+}
+
+cmd_run() {
+    local bin src out mmproj
+    mkdir -p "$OUT_DIR"
+    bin="$(quantize_bin)"
+    [ -d "$MODEL_DIR" ] || die "MODEL_DIR=$MODEL_DIR does not exist. Run scripts/ds4v-fetch-source.sh first"
+    src="$MODEL_DIR/DeepSeek-V4-Flash-Vision-Uncensored-BF16.gguf"
+    [ -f "$src" ] || die "missing $src. Dequantize the FP8 shards to BF16 and convert with convert_hf_to_gguf.py first. See docs/ds4v-quant.md"
+    [ -f "$IMATRIX" ] || die "missing imatrix $IMATRIX. Run the llama-imatrix step printed by plan first"
+    check_pin
+    out="$OUT_DIR/DeepSeek-V4-Flash-Vision-Uncensored-$RUNG.gguf"
+    echo "run. quantize $src to rung $RUNG into $out"
+    bash -c "$(quantize_command "$src" "$out")"
+    mmproj="$MODEL_DIR/mmproj-DeepSeek-V4-Flash-Vision-Uncensored-f16.gguf"
+    [ -f "$mmproj" ] || echo "warning. mmproj $mmproj not found. Vision needs it at F16"
+    echo "done. source weights in $MODEL_DIR were not touched"
+    echo "verify with. scripts/ds4v-quant.sh verify \"$out\" \"$mmproj\""
+}
+
+gguf_dump_cmd() {
+    local f="$1"
+    if [ -n "${LLAMA_CPP_DIR:-}" ] && [ -f "$LLAMA_CPP_DIR/gguf-py/gguf/scripts/gguf_dump.py" ]; then
+        echo "python3 $LLAMA_CPP_DIR/gguf-py/gguf/scripts/gguf_dump.py"
+        return 0
+    fi
+    echo "python3 -m gguf.scripts.gguf_dump"
+}
+
+cmd_verify() {
+    local src="$1" mmproj="$2" dump n
+    [ -f "$src" ] || die "missing gguf $src"
+    dump="$(gguf_dump_cmd "$src")"
+    n="$($dump "$src" 2>/dev/null | grep -o 'bias_vl' | wc -l | tr -d ' ')"
+    if [ "$n" -eq 43 ]; then
+        echo "pass. bias_vl present on 43 layers"
+    else
+        die "bias_vl count is $n, expected 43. The vision PRs or the quant type map dropped it"
+    fi
+    [ -f "$mmproj" ] || die "missing mmproj $mmproj"
+    echo "mmproj load check. one token through the mtmd path with the mmproj attached"
+    "$LLAMA_CPP_DIR/build/bin/llama-mtmd-cli" \
+        --model "$src" \
+        --mmproj "$mmproj" \
+        -p "load check" \
+        -n 1 \
+        --temp 0
+    echo "pass. mmproj loaded and generated one token"
+}
+
+case "${1:-help}" in
+    plan)
+        cmd_plan
+        ;;
+    run)
+        cmd_run
+        ;;
+    verify)
+        if [ "${2:-}" = "--help" ] || [ "${2:-}" = "-h" ] || [ $# -lt 3 ]; then
+            usage
+            echo ""
+            echo "verify needs the quantized gguf and the mmproj path. Both checks need the weights. Run it on the operator machine."
+            if [ "${2:-}" = "--help" ] || [ "${2:-}" = "-h" ]; then
+                exit 0
+            fi
+            exit 1
+        fi
+        cmd_verify "$2" "$3"
+        ;;
+    help|-h|--help)
+        usage
+        exit 0
+        ;;
+    *)
+        usage
+        echo ""
+        echo "unknown subcommand $1" >&2
+        exit 1
+        ;;
+esac

--- a/share/model_cards/ds4v-vision.json
+++ b/share/model_cards/ds4v-vision.json
@@ -1,0 +1,36 @@
+{
+  "model": "DeepSeek-V4-Flash-Vision-Uncensored-GGUF",
+  "base_model": "deepseek-ai/DeepSeek-V4-Flash-Vision-Exp",
+  "source_repo": "orcarouter/DeepSeek-V4-Flash-Vision-Uncensored",
+  "rung": {
+    "default": "IQ2_XXS",
+    "options": ["IQ1_M", "IQ2_XXS", "IQ2_S", "IQ3_XXS"],
+    "source": "prometheusAIR rung table, see docs/ds4v-quant.md"
+  },
+  "budget_per_device_mib": {
+    "strix_halo_mib": 122880,
+    "discrete_mib": 24576
+  },
+  "placement": {
+    "scheme": "asymmetric expert parallel per PR 604",
+    "discrete": ["dense", "hot experts"],
+    "strix_halo": ["tail experts"],
+    "join": "discrete"
+  },
+  "draft": {
+    "model": "DeepSeek-V4-Flash-DSpark-draft-Q4RMFP4-denseF16.gguf",
+    "gib": 11.3,
+    "top_k": 4,
+    "top_k_reference": 6,
+    "note": "headline profile is top_k 4. top_k 6 is the reference profile from docs/ds4v-baseline.md"
+  },
+  "context_slots": 135168,
+  "vision": {
+    "mmproj_required": true,
+    "mmproj_type": "F16",
+    "mmproj_gib": 0.9,
+    "bias_vl_layers": 43
+  },
+  "uncensored": true,
+  "warning": "Uncensored model. Local only. Do not expose it to the network."
+}


### PR DESCRIPTION
Follows docs/ds4v-uncensored-vision-plan.md DS4V-3.

## What is in this PR

- `scripts/ds4v-quant.sh`. Bash with `set -euo pipefail`. Subcommands `plan`, `run`, `verify`, `help`. Env knobs `MODEL_DIR`, `IMATRIX`, `RUNG` (default `IQ2_XXS`), `OUT_DIR`, `LLAMA_CPP_DIR`. The recipe pins llama.cpp master `9400c894` or later with both vision PRs and refuses release `b10763`. Source weights are never deleted.
- `docs/ds4v-quant.md`. The prometheusAIR rung table (IQ1_M 66.9 GiB, IQ2_XXS 78.8 GiB, IQ2_S 95.8 GiB, IQ3_XXS 108.7 GiB, plus mmproj F16 0.9 GiB) and the budget math against the 128 GiB Strix Halo plus 24 GiB discrete pair.
- `share/model_cards/ds4v-vision.json`. Model card with the PR 604 asymmetric expert parallel placement, per device budgets (strix_halo_mib 122880, discrete_mib 24576), DSpark Q4RMFP4 draft, top_k 4 headline with top_k 6 as reference, 135168 context slots, mmproj required, uncensored with a local only warning.

## Proof on this authoring machine

Authorable boxes are done and proven locally. Budget math recomputed with python3. Rung plus 0.9 mmproj plus 13 KV at 1M context plus 11.3 draft against 152 GiB total. IQ2_XXS lands at 104.0 GiB with 48.0 GiB margin, and weights plus mmproj plus KV fit one 96 GiB card at full 1M context at 92.7 GiB. `bash -n` clean. `help` and `plan` exit 0 and print the pinned commit `9400c894`. `jq empty` clean on the card. Stub llama.cpp builds prove the `b10763` refusal, the exact quantize command execution, and the verify bias_vl 43 layer check. All three files grep clean for long dash characters.

## Pending on the operator machine

The real quant run plus the image lanes plus perf stay pending on the operator Strix Halo plus 7900XT pair. No weights or GPU exist on this machine. The GGUF SHA-256 records land in docs/ds4v-quant.md after the run.

## Stack position

DS4V-3 of 3, after DS4V-1 and DS4V-2.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

