### PR TITLE
fix(deepseek4): fill the verifier's all-logits hook on the cached q=1 path

### DIFF
--- a/server/src/deepseek4/deepseek4_graph.cpp
+++ b/server/src/deepseek4/deepseek4_graph.cpp
@@ -8354,6 +8354,17 @@ bool deepseek4_step_layer_range(
             out_logits->resize((size_t)w.n_vocab);
             ggml_backend_tensor_get(cached_decode_output_graph.sg.logits,
                                     out_logits->data(), 0, sizeof(float) * (size_t)w.n_vocab);
+            if (verify_hooks && verify_hooks->all_logits_out) {
+                // reuse_decode_graphs implies n_tokens == 1, so this single
+                // row IS the whole verify batch of this call. Leaving the
+                // hook empty is invisible until a caller concatenates it:
+                // the compressor-boundary splitter above runs a q-token
+                // verify as q single-token chunks and joins their hook
+                // vectors, so an empty chunk silently drops the logits of
+                // the entire verify batch and the verify fails with
+                // "all_logits too small".
+                *verify_hooks->all_logits_out = *out_logits;
+            }
         } else {
             const size_t ctx_size = 16 * 1024 * 1024;
             ggml_init_params params{};


### PR DESCRIPTION
`deepseek4_step_layer_range` has two output paths. The dynamic one honours `Ds4VerifyHooks::all_logits_out`; the cached single-token decode graph (`reuse_decode_graphs`, i.e. `n_tokens == 1`) writes `out_logits` and returns without touching the hook.

That is invisible until a caller concatenates the hook across calls, and one caller does — the compressor-boundary splitter in the same function runs a q-token verify as q single-token chunks and joins their hook vectors:

```cpp
chunk_hooks.all_logits_out = verify_hooks->all_logits_out ? &chunk_logits : nullptr;
...
logits_all.insert(logits_all.end(), chunk_logits.begin(), chunk_logits.end());
```

Every chunk contributes nothing, so the whole verify batch's logits come back empty and `deepseek4_dspark_verify_forward` fails with `all_logits too small: got=0 need=<q*n_vocab>`, failing the speculative decode.

### Reproducing

Any DSpark verify whose batch starts off a learned-compressor boundary while the fused verifier is not in use — `DFLASH_DS4_FUSED_VERIFY=0`, or a placement the fused path declines. With ratios 4 and 128, a q=2 batch at an odd position splits 1+1 and fails immediately.

### The fix

On the cached path, copy the row into the hook. `reuse_decode_graphs` implies `n_tokens == 1`, so that single row *is* the whole verify batch of this call and the two vectors hold the same data.

### Correctness

No behaviour change for callers that pass no hook, which is every non-verifier caller.

Verified on gfx1151 (Radeon 8060S, ROCm 10.0.0, Ryzen AI Max 395): before this patch the speculative decode aborted at the first split batch; after it, a 128-token greedy completion is byte-identical to the same prompt decoded autoregressively (sha256 `87964cbd…`), over 3 runs at the same clocks. No `tok/s` claim is attached — this is a correctness fix on a path that previously could not complete.

Found while running DeepSeek V4 Flash expert-parallel across two hosts, where the fused verifier is unavailable and every verify takes the split path.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

