### PR TITLE
feat(ggml-cuda): public accessors for a backend's stream and device

### DIFF
--- a/server/deps/llama.cpp/ggml/include/ggml-cuda.h
+++ b/server/deps/llama.cpp/ggml/include/ggml-cuda.h
@@ -90,6 +90,16 @@ GGML_BACKEND_API int  ggml_backend_cuda_get_device_count(void);
 GGML_BACKEND_API void ggml_backend_cuda_get_device_description(int device, char * description, size_t description_size);
 GGML_BACKEND_API void ggml_backend_cuda_get_device_memory(int device, size_t * free, size_t * total);
 
+// Current compute stream of a CUDA/HIP backend (cudaStream_t / hipStream_t
+// returned as an opaque pointer), so work submitted outside ggml can be
+// enqueued stream-ordered with the kernels of the same backend instead of
+// synchronizing the host. The stream is created lazily on first use.
+// Returns NULL for non-CUDA/HIP backends.
+GGML_BACKEND_API void * ggml_backend_cuda_get_stream(ggml_backend_t backend);
+
+// Device ordinal the backend was created for, or -1 for non-CUDA/HIP backends.
+GGML_BACKEND_API int ggml_backend_cuda_get_device_id(ggml_backend_t backend);
+
 // Override the plain quantized MUL_MAT MMVQ column ceiling on the calling
 // thread. Pass zero to restore LUCE_MMVQ_MAX_NCOLS. This is intentionally
 // thread-local so one graph builder can select a safe topology without

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -5759,6 +5759,22 @@ void ggml_backend_cuda_get_device_memory(int device, size_t * free, size_t * tot
     CUDA_CHECK(cudaMemGetInfo(free, total));
 }
 
+void * ggml_backend_cuda_get_stream(ggml_backend_t backend) {
+    if (!ggml_backend_is_cuda(backend)) {
+        return nullptr;
+    }
+    ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *) backend->context;
+    return (void *) cuda_ctx->stream();
+}
+
+int ggml_backend_cuda_get_device_id(ggml_backend_t backend) {
+    if (!ggml_backend_is_cuda(backend)) {
+        return -1;
+    }
+    ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *) backend->context;
+    return cuda_ctx->device;
+}
+
 bool ggml_backend_cuda_register_host_buffer(void * buffer, size_t size) {
     if (getenv("GGML_CUDA_REGISTER_HOST") == nullptr) {
         return false;


### PR DESCRIPTION
Work submitted outside ggml — a collective, a peer copy, a profiling marker — has to land on the same stream as the backend's kernels to be ordered against them. Today the only alternatives are to synchronize the host between the two, or to reach into `ggml_backend_cuda_context`, which is not a public type.

Adds two accessors next to the existing `ggml_backend_cuda_get_device_*` functions:

```c
GGML_BACKEND_API void * ggml_backend_cuda_get_stream(ggml_backend_t backend);
GGML_BACKEND_API int    ggml_backend_cuda_get_device_id(ggml_backend_t backend);
```

The stream is returned as an opaque pointer so the header stays free of CUDA/HIP types, matching how the rest of `ggml-cuda.h` is written. Both return the "not a CUDA/HIP backend" value (`NULL` / `-1`) rather than asserting, so a caller can probe a backend it did not create.

### Correctness

Purely additive: nothing inside ggml calls either function, so no existing path changes. Compile-verified against `main` on a HIP build (gfx1151, ROCm 10).

### Why

Used downstream to enqueue an RCCL all-reduce stream-ordered with the kernels that produce and consume its input, which removes one host round trip per layer — 43 of them per forward for DeepSeek V4 Flash. There is no `tok/s` delta to report for this patch alone; it is the accessor the measured change depends on.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

