### PR TITLE
feat(ggml): in-graph collective node via a caller-registered callback

### DIFF
--- a/server/deps/llama.cpp/ggml/include/ggml.h
+++ b/server/deps/llama.cpp/ggml/include/ggml.h
@@ -2568,7 +2568,23 @@ extern "C" {
         GGML_MOE_FUSED_OWNER_SPLIT        = -4,
         GGML_MOE_FUSED_ALIGN_IDS          = -5,
         GGML_MOE_FUSED_BALANCED_OWNER_IDS = -6,
+        GGML_MOE_FUSED_CLUSTER_ALLREDUCE  = -7,
     };
+
+    // Word offsets in ggml_tensor::op_params for the in-graph collective.
+    // Both pointers start at naturally aligned 64-bit boundaries.
+    enum ggml_moe_fused_cluster_allreduce_param {
+        GGML_MOE_FUSED_CLUSTER_ALLREDUCE_FN_WORD   = 2,
+        GGML_MOE_FUSED_CLUSTER_ALLREDUCE_USER_WORD = 4,
+    };
+
+    // Sums `n` float elements at `data` element-wise across the caller's
+    // process group, in place, enqueued on `stream` (cudaStream_t /
+    // hipStream_t as an opaque pointer). ggml deliberately does not know how
+    // the sum is produced: the caller registers this callback, so no
+    // collective library becomes a ggml dependency.
+    typedef void (*ggml_cluster_allreduce_fn)(void * user, void * data,
+                                              size_t n, void * stream);
 
     // Word offsets in ggml_tensor::op_params for the deferred peer-copy op.
     // Both pointers start at naturally aligned 64-bit boundaries.
@@ -2593,6 +2609,18 @@ extern "C" {
             int64_t               n_embd,
             int64_t               ff_dim,
             int64_t               n_expert_used);
+
+    // In-graph collective: `a` is summed element-wise across the process
+    // group and the sum becomes this node's value. The collective is enqueued
+    // on the executing backend's own stream, so it is ordered after the
+    // kernels that produced `a` and before the kernels that consume the
+    // result, without a host synchronization. GPU backends only; `a` must be
+    // contiguous F32.
+    GGML_API struct ggml_tensor * ggml_cluster_allreduce(
+            struct ggml_context     * ctx,
+            struct ggml_tensor      * a,
+            ggml_cluster_allreduce_fn fn,
+            void                    * user);
 
     GGML_API struct ggml_tensor * ggml_laguna_moe_combine(
             struct ggml_context * ctx,

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -3888,6 +3888,18 @@ static void ggml_backend_cuda_synchronize(ggml_backend_t backend) {
 }
 
 #ifdef USE_CUDA_GRAPH
+
+// GGML_CUDA_COLLECTIVE_GRAPH_CAPTURE=1: allow graph capture of a graph that
+// contains a GGML_MOE_FUSED_CLUSTER_ALLREDUCE node. Off by default; see the
+// note at the call site for why.
+static bool ggml_cuda_cluster_capture_allowed() {
+    static const bool allowed = [] {
+        const char * v = getenv("GGML_CUDA_COLLECTIVE_GRAPH_CAPTURE");
+        return v && v[0] && strcmp(v, "0") != 0;
+    }();
+    return allowed;
+}
+
 static bool ggml_cuda_graph_check_compability(ggml_cgraph * cgraph) {
 
     bool use_cuda_graph = true;
@@ -3908,6 +3920,22 @@ static bool ggml_cuda_graph_check_compability(ggml_cgraph * cgraph) {
             use_cuda_graph = false; // Split buffers are not supported by CUDA graph capture
 #ifndef NDEBUG
             GGML_LOG_DEBUG("%s: disabling CUDA graphs due to split buffer\n", __func__);
+#endif
+        }
+
+        // A collective node calls into a library on this stream. Whether such
+        // a collective may be captured and replayed is runtime- and
+        // library-specific, so a graph containing one is executed eagerly.
+        // Measured on gfx1151 with RCCL 2.30.4: capture IS bit-exact there,
+        // and replaying a 5.4k-node graph that holds 43 collectives is 11 %
+        // SLOWER than launching it eagerly, so allowing capture is opt-in.
+        // This costs nothing where no such node exists.
+        if (node->op == GGML_OP_MOE_FUSED &&
+            ggml_get_op_params_i32(node, 0) == GGML_MOE_FUSED_CLUSTER_ALLREDUCE &&
+            !ggml_cuda_cluster_capture_allowed()) {
+            use_cuda_graph = false;
+#ifndef NDEBUG
+            GGML_LOG_DEBUG("%s: disabling CUDA graphs due to a collective node\n", __func__);
 #endif
         }
 

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/moe-fused.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/moe-fused.cu
@@ -710,6 +710,33 @@ void ggml_cuda_op_moe_fused(ggml_backend_cuda_context & ctx, ggml_tensor * dst) 
             (int) (dst->nb[1] / sizeof(int32_t)));
         return;
     }
+    if (mode == GGML_MOE_FUSED_CLUSTER_ALLREDUCE) {
+        // The collective runs as an ordinary graph node on this backend's
+        // stream, so partial sums are combined between the kernels that
+        // produce and consume them without a host round trip. ggml stays free
+        // of any collective library: the caller registered a callback.
+        const ggml_tensor * src = dst->src[0];
+        GGML_ASSERT(src && src->type == GGML_TYPE_F32);
+        GGML_ASSERT(dst->type == GGML_TYPE_F32);
+        GGML_ASSERT(ggml_is_contiguous(src) && ggml_is_contiguous(dst));
+        GGML_ASSERT(ggml_nelements(src) == ggml_nelements(dst));
+
+        ggml_cluster_allreduce_fn fn = nullptr;
+        memcpy(&fn, &dst->op_params[GGML_MOE_FUSED_CLUSTER_ALLREDUCE_FN_WORD],
+               sizeof(fn));
+        GGML_ASSERT(fn);
+        void * user = nullptr;
+        memcpy(&user, &dst->op_params[GGML_MOE_FUSED_CLUSTER_ALLREDUCE_USER_WORD],
+               sizeof(user));
+
+        const size_t n = (size_t) ggml_nelements(dst);
+        if (dst->data != src->data) {
+            CUDA_CHECK(cudaMemcpyAsync(dst->data, src->data, n * sizeof(float),
+                                       cudaMemcpyDeviceToDevice, ctx.stream()));
+        }
+        fn(user, dst->data, n, (void *) ctx.stream());
+        return;
+    }
     if (mode == GGML_MOE_FUSED_DEFERRED_PEER_COPY) {
         GGML_ASSERT(ggml_is_contiguous(dst));
 

--- a/server/deps/llama.cpp/ggml/src/ggml.c
+++ b/server/deps/llama.cpp/ggml/src/ggml.c
@@ -8941,6 +8941,28 @@ struct ggml_tensor * ggml_ds4_deferred_peer_copy(
     return result;
 }
 
+struct ggml_tensor * ggml_cluster_allreduce(
+        struct ggml_context     * ctx,
+        struct ggml_tensor      * a,
+        ggml_cluster_allreduce_fn fn,
+        void                    * user) {
+    GGML_ASSERT(a->type == GGML_TYPE_F32);
+    GGML_ASSERT(ggml_is_contiguous(a));
+    GGML_ASSERT(fn != NULL);
+
+    struct ggml_tensor * result = ggml_dup_tensor(ctx, a);
+    result->op = GGML_OP_MOE_FUSED;
+    result->src[0] = a;
+
+    ggml_set_op_params_i32(result, 0, GGML_MOE_FUSED_CLUSTER_ALLREDUCE);
+    memcpy(&result->op_params[GGML_MOE_FUSED_CLUSTER_ALLREDUCE_FN_WORD],
+           &fn, sizeof(fn));
+    memcpy(&result->op_params[GGML_MOE_FUSED_CLUSTER_ALLREDUCE_USER_WORD],
+           &user, sizeof(user));
+
+    return result;
+}
+
 struct ggml_tensor * ggml_ds4_hc_pre(
         struct ggml_context * ctx,
         struct ggml_tensor  * mix,


### PR DESCRIPTION
Multi-device inference that partitions work across *processes* has to combine partial sums between the kernels that produce them and the kernels that consume them. Doing that outside the graph means a host round trip per combination: download, reduce, upload, synchronize. For a 43-layer MoE model that is 43 round trips per forward.

`ggml_cluster_allreduce(ctx, a, fn, user)` adds a node whose value is `a` summed element-wise across the caller's process group. The CUDA/HIP backend runs it on the same stream as the surrounding kernels, so it is ordered after the producers and before the consumers with no host synchronization.

### ggml gains no dependency

The node carries a callback and a user pointer in `op_params`; the caller decides how the sum is produced (NCCL, RCCL, MPI, a test double):

```c
typedef void (*ggml_cluster_allreduce_fn)(void * user, void * data, size_t n, void * stream);
```

No new library, no new build option, no new backend entry point. It is a sub-op of the existing `GGML_OP_MOE_FUSED` family, so `supports_op` needs no change.

### Graph capture

A graph containing such a node is not captured by default, and the reason is measured rather than assumed.

On gfx1151 with RCCL 2.30.4, capture **is** bit-exact — a 128-token greedy completion stays byte-identical — and replaying a 5445-node graph that holds 43 collectives is **slower** than launching it eagerly:

| | eager | captured |
|---|---|---|
| autoregressive decode | 21.5 tok/s | 19.15 tok/s |
| speculative decode (q=4) | 29.45 tok/s | 26.65 tok/s |

Two nodes over RoCE v2, DeepSeek V4 Flash, medians of 3 runs, same binary and clocks, `GGML_CUDA_GRAPH_STATS=1` confirming 23 replays per 25 forwards (so this is not capture churn). `GGML_CUDA_COLLECTIVE_GRAPH_CAPTURE=1` allows it for anyone whose runtime behaves differently.

### What the node itself is worth

Measured by returning early from the callback — wrong output, exact timing — the whole 43-collective budget is **2.7 ms of a 48 ms decode step** on that hardware. The node's value is not the collective's speed but that it removes the per-layer host round trip and lets a rank keep using the fused whole-model graph; without it the same model falls back to 43 host-driven per-layer graphs.

Hardware note: all numbers are gfx1151 (Radeon 8060S, Ryzen AI Max 395, ROCm 10), not the sm_86+ hardware in CONTRIBUTING. Happy to have them re-run on a 3090 or the 395 box if that is useful.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

