### PR TITLE
feat(moe): cold-owner None, and expert-major prefill for a hot-only stack

### DIFF
--- a/server/src/common/moe_hybrid_ffn_eval.cpp
+++ b/server/src/common/moe_hybrid_ffn_eval.cpp
@@ -3542,6 +3542,51 @@ bool eval_moe_hybrid_ffn_batched(
                             : storage.gate_cold    ? (int)storage.gate_cold->ne[2]
                             : 0;
     const bool cold_on_gpu = storage.cold_backend_kind == MoeHybridColdBackend::Gpu;
+    // Cold owner None (a cluster rank): every route that survived masking is
+    // resident here and there is no second owner, so the whole batch can be
+    // packed by expert into ONE graph per layer. Without this a reduced hot
+    // stack falls into the sub-batch loop far below, whose size is
+    // min(mmq_safe_sub_batch(), prefill limit) = 1 on gfx1151 - one graph per
+    // token per layer. Measured on a 1517-token prompt: 25.9 s of FFN against
+    // 7.6 s for a single node's whole prefill graph. Expert-major packing is
+    // also what keeps the reduced stack off the MMQ full-batch path that
+    // mmq_safe_full_batch=false exists to avoid.
+    const bool hot_only_expert_major =
+        !expert_compute &&
+        storage.cold_backend_kind == MoeHybridColdBackend::None &&
+        !storage.gate_cold && !storage.gate_up_cold && !storage.down_cold &&
+        n_hot_stack > 0 &&
+        moe_expert_major_prefill_enabled(n_tokens);
+    if (hot_only_expert_major) {
+        static std::once_flag logged;
+        std::call_once(logged, [n_tokens, n_hot_stack] {
+            std::fprintf(stderr,
+                         "[hybrid-ffn] hot-only expert-major batch active tokens=%d "
+                         "stack=%d (no cold owner)\n",
+                         n_tokens, n_hot_stack);
+        });
+        const auto wall_t0 = HybridClock::now();
+        std::string owner_err;
+        const bool ok = eval_moe_owner_expert_major_batched(
+            gpu_backend, cfg, desc,
+            storage.gate_hot, storage.up_hot, storage.down_hot,
+            storage.gate_up_hot, storage.hot_local_by_global,
+            cur_host, selected_ids, selected_weights, n_tokens,
+            desc.has_shared_expert(), out, &owner_err,
+            cur_backend, gpu_backend,
+            /*device_output=*/nullptr, /*device_output_owner=*/nullptr,
+            p_hot_alloc);
+        if (!ok) {
+            if (err) *err = owner_err;
+            return false;
+        }
+        if (telemetry) {
+            const auto done = HybridClock::now();
+            telemetry->hot_us += elapsed_us(wall_t0, done);
+            telemetry->ffn_wall_us += elapsed_us(wall_t0, done);
+        }
+        return true;
+    }
     const bool inprocess_expert_major =
         !expert_compute && moe_expert_major_prefill_enabled(n_tokens) &&
         cold_on_gpu && storage.cold_backend &&

--- a/server/src/common/moe_hybrid_ffn_eval.cpp
+++ b/server/src/common/moe_hybrid_ffn_eval.cpp
@@ -1648,6 +1648,11 @@ bool eval_moe_hybrid_ffn_single(
     std::vector<float> cold_weights;
     for (int i = 0; i < n_selected; ++i) {
         const int32_t gid = selected_ids[i];
+        // Cold owner None: routes masked to -1 by the cluster runtime are
+        // evaluated elsewhere and contribute zero here.
+        if (gid < 0 && storage.cold_backend_kind == MoeHybridColdBackend::None) {
+            continue;
+        }
         if (gid < 0 || gid >= (int32_t)storage.hot_local_by_global.size()) {
             if (err) *err = "selected id out of range";
             return false;
@@ -3982,6 +3987,7 @@ bool eval_moe_hybrid_ffn_gpu_resident(
 
     for (int i = 0; i < n_selected; ++i) {
         const int32_t gid = selected_ids[i];
+        if (gid < 0 && storage.cold_backend_kind == MoeHybridColdBackend::None) continue;
         if (gid < 0 || gid >= (int32_t)storage.hot_local_by_global.size()) return false;
         const int32_t hot_local = storage.hot_local_by_global[(size_t)gid];
         if (hot_local >= 0) {
@@ -4229,6 +4235,75 @@ bool eval_moe_hybrid_ffn_gpu_resident(
     // ── Copy combine output to persistent act_cur (GPU→GPU) ──
     ggml_backend_tensor_copy(gpu_state.combine.output, gpu_state.act_cur);
 
+    return true;
+}
+
+// ── Shared expert only ──
+// Cluster expert-parallel evaluates the routed partial without the shared
+// expert (the MoeLayerDesc handed to the routed path has the shexp tensors
+// cleared), all-reduces it, and adds this locally computed term afterwards.
+// The graph is cached per n_tokens in storage.shared_batched_graph, which
+// release_graph_caches() already frees.
+bool eval_moe_shared_expert_batched(
+    ggml_backend_t                  gpu_backend,
+    const MoeHybridConfig &         cfg,
+    const MoeLayerDesc &            desc,
+    MoeHybridLayerStorage &         storage,
+    const float *                   cur_host,
+    int                             n_tokens,
+    std::vector<float> &            out,
+    std::string *                   err) {
+    const int n_embd = cfg.n_embd;
+    out.assign((size_t)n_embd * (size_t)n_tokens, 0.0f);
+    if (n_tokens <= 0) return true;
+    if (!desc.ffn_up_shexp || !desc.ffn_gate_shexp || !desc.ffn_down_shexp) {
+        return true;
+    }
+    if (!cur_host) {
+        if (err) *err = "shared expert requires a host activation";
+        return false;
+    }
+
+    CachedHotBatchedGraph & g = storage.shared_batched_graph;
+    if (!g.valid() || g.n_tokens != n_tokens) {
+        g.free();
+        g.n_tokens = n_tokens;
+        ggml_init_params ip{};
+        ip.mem_size = 4 * 1024 * 1024;
+        ip.mem_buffer = nullptr;
+        ip.no_alloc = true;
+        g.ctx = ggml_init(ip);
+        if (!g.ctx) {
+            if (err) *err = "shared expert ggml_init failed";
+            return false;
+        }
+        g.inp = ggml_new_tensor_2d(g.ctx, GGML_TYPE_F32, n_embd, n_tokens);
+        ggml_set_input(g.inp);
+        g.output = build_shared_expert_subgraph(g.ctx, desc, g.inp, cfg.swiglu_clamp);
+        if (!g.output) {
+            g.free();
+            if (err) *err = "shared expert subgraph build failed";
+            return false;
+        }
+        g.gf = ggml_new_graph_custom(g.ctx, 512, false);
+        ggml_set_output(g.output);
+        ggml_build_forward_expand(g.gf, g.output);
+        g.alloc = ggml_gallocr_new(ggml_backend_get_default_buffer_type(gpu_backend));
+        if (!g.alloc || !ggml_gallocr_alloc_graph(g.alloc, g.gf)) {
+            g.free();
+            if (err) *err = "shared expert gallocr failed";
+            return false;
+        }
+    }
+
+    ggml_backend_tensor_set(g.inp, cur_host, 0,
+                            sizeof(float) * (size_t)n_embd * (size_t)n_tokens);
+    if (ggml_backend_graph_compute(gpu_backend, g.gf) != GGML_STATUS_SUCCESS) {
+        if (err) *err = "shared expert compute failed";
+        return false;
+    }
+    ggml_backend_tensor_get(g.output, out.data(), 0,
+                            sizeof(float) * (size_t)n_embd * (size_t)n_tokens);
     return true;
 }
 

--- a/server/src/common/moe_hybrid_ffn_eval.h
+++ b/server/src/common/moe_hybrid_ffn_eval.h
@@ -386,6 +386,22 @@ bool build_cached_cold_graph(
     int n_cold,
     float swiglu_clamp = 0.0f);
 
+// Shared expert only, batched [n_embd, n_tokens] on the GPU backend. Used by
+// the cluster expert-parallel path, which evaluates routed experts without
+// the shared term (MoeLayerDesc with shexp tensors cleared), all-reduces the
+// routed partial across ranks and adds this local result afterwards. Cached
+// per n_tokens in storage.shared_batched_graph. `out` is zero-filled when the
+// layer has no shared expert.
+bool eval_moe_shared_expert_batched(
+    ggml_backend_t                  gpu_backend,
+    const MoeHybridConfig &         cfg,
+    const MoeLayerDesc &            desc,
+    MoeHybridLayerStorage &         storage,
+    const float *                   cur_host,
+    int                             n_tokens,
+    std::vector<float> &            out,
+    std::string *                   err = nullptr);
+
 // Build cached hot-only batched graph for prefill (n_tokens=MMQ_SAFE_SUB_BATCH).
 bool build_cached_hot_batched_graph(
     CachedHotBatchedGraph & out,

--- a/server/src/common/moe_hybrid_storage.cpp
+++ b/server/src/common/moe_hybrid_storage.cpp
@@ -289,10 +289,20 @@ bool build_moe_hybrid_storage(const MoeHybridConfig & cfg,
     out.cold_backend_kind = cfg.cold_expert_backend;
     out.materialized_hot_experts = cfg.materialize_hot_experts;
     out.materialized_cold_experts = cfg.materialize_cold_experts;
-    out.cold_backend = cfg.cold_expert_backend == MoeHybridColdBackend::Gpu
-        ? (cold_gpu_backend ? cold_gpu_backend : gpu_backend)
-        : out.cpu_backend;
-    if (!out.cold_backend) {
+    // Cold owner None (cluster expert-parallel): non-resident routes are
+    // reduced by another process, so there is no cold backend, no cold
+    // buffer and no cold expert map on this side.
+    const bool no_cold_owner =
+        cfg.cold_expert_backend == MoeHybridColdBackend::None;
+    if (no_cold_owner && cfg.materialize_cold_experts) {
+        if (err) *err = "cold owner None cannot materialize cold experts";
+        return false;
+    }
+    out.cold_backend = no_cold_owner ? nullptr
+        : cfg.cold_expert_backend == MoeHybridColdBackend::Gpu
+            ? (cold_gpu_backend ? cold_gpu_backend : gpu_backend)
+            : out.cpu_backend;
+    if (!out.cold_backend && !no_cold_owner) {
         if (err) *err = "failed to select cold expert backend";
         return false;
     }
@@ -331,10 +341,12 @@ bool build_moe_hybrid_storage(const MoeHybridConfig & cfg,
             is_hot[(size_t)expert] = 1;
         }
         dst.decode_hot_local_by_global = dst.hot_local_by_global;
-        for (int expert = 0; expert < cfg.n_expert; ++expert) {
-            if (duplicate_hot_on_cold || !is_hot[(size_t)expert]) {
-                dst.cold_local_by_global[(size_t)expert] = (int32_t)dst.cold_expert_ids.size();
-                dst.cold_expert_ids.push_back((int32_t)expert);
+        if (!no_cold_owner) {
+            for (int expert = 0; expert < cfg.n_expert; ++expert) {
+                if (duplicate_hot_on_cold || !is_hot[(size_t)expert]) {
+                    dst.cold_local_by_global[(size_t)expert] = (int32_t)dst.cold_expert_ids.size();
+                    dst.cold_expert_ids.push_back((int32_t)expert);
+                }
             }
         }
         dst.decode_cold_local_by_global = dst.cold_local_by_global;
@@ -503,10 +515,20 @@ bool build_moe_hybrid_storage_from_file(
     out.cold_backend_kind = cfg.cold_expert_backend;
     out.materialized_hot_experts = cfg.materialize_hot_experts;
     out.materialized_cold_experts = cfg.materialize_cold_experts;
-    out.cold_backend = cfg.cold_expert_backend == MoeHybridColdBackend::Gpu
-        ? (cold_gpu_backend ? cold_gpu_backend : gpu_backend)
-        : out.cpu_backend;
-    if (!out.cold_backend) {
+    // Cold owner None (cluster expert-parallel): non-resident routes are
+    // reduced by another process, so there is no cold backend, no cold
+    // buffer and no cold expert map on this side.
+    const bool no_cold_owner =
+        cfg.cold_expert_backend == MoeHybridColdBackend::None;
+    if (no_cold_owner && cfg.materialize_cold_experts) {
+        if (err) *err = "cold owner None cannot materialize cold experts";
+        return false;
+    }
+    out.cold_backend = no_cold_owner ? nullptr
+        : cfg.cold_expert_backend == MoeHybridColdBackend::Gpu
+            ? (cold_gpu_backend ? cold_gpu_backend : gpu_backend)
+            : out.cpu_backend;
+    if (!out.cold_backend && !no_cold_owner) {
         if (err) *err = "failed to select cold expert backend";
         return false;
     }
@@ -546,7 +568,7 @@ bool build_moe_hybrid_storage_from_file(
             is_hot[(size_t)expert] = 1;
         }
         dst.decode_hot_local_by_global = dst.hot_local_by_global;
-        if (allocate_cold) {
+        if (allocate_cold && !no_cold_owner) {
             for (int expert = 0; expert < cfg.n_expert; ++expert) {
                 if (duplicate_hot_on_cold || !is_hot[(size_t)expert]) {
                     dst.cold_local_by_global[(size_t)expert] = (int32_t)dst.cold_expert_ids.size();

--- a/server/src/common/moe_hybrid_types.h
+++ b/server/src/common/moe_hybrid_types.h
@@ -21,6 +21,12 @@ int query_gpu_compute_sm();
 enum class MoeHybridColdBackend {
     Cpu,
     Gpu,
+    // No cold owner: non-resident routes contribute zero and are never
+    // materialized; the reduction across owners happens outside this process
+    // (cluster all-reduce, see server/src/cluster/). Storage allocates no cold
+    // buffers, evaluators build no cold graph, never fall back to CPU or
+    // streamed evaluation for non-resident routes and never swap experts.
+    None,
 };
 
 // ─── MoE architecture config (model-agnostic) ──────────────────────────


### PR DESCRIPTION
Two commits, one enabling change and the performance path it unlocks.

## 1. `MoeHybridColdBackend::None`

`MoeHybridColdBackend` has `Cpu` and `Gpu`: the experts a rank does not hold hot are evaluated *somewhere in this process*. There is no way to say "the non-resident experts are not mine at all — their contribution arrives from outside". Expert-parallel inference across processes needs exactly that: each owner evaluates its own experts and a reduction outside ggml sums the partials.

With `None`:

* storage allocates no cold buffers and never materializes or swaps a cold expert;
* the evaluators build no cold graph and never fall back to CPU or streamed evaluation. A route whose id was masked to `-1` contributes zero instead of being routed to a cold owner.

Purely additive: the enum grows a third value that nothing selects by default, and every `Cpu`/`Gpu` path is untouched.

Also adds `eval_moe_shared_expert_batched`, the piece such an owner needs that no existing entry point provides: the shared expert alone, batched. An owner that reduces across processes has to keep the shared term **out** of the reduced partial — it is replicated, so summing it would count it once per owner — and add it afterwards, which means evaluating it without the routed experts.

## 2. Expert-major packing for a hot-only prefill batch

An owner with cold-owner `None` holds a **reduced** expert stack, and `mmq_full_batch_ok` is false for a reduced stack because MMQ's `mul_mat_id` illegal-accesses on it. `eval_moe_hybrid_ffn_batched` therefore falls into its sub-batch loop, whose size is

```cpp
min(mmq_safe_sub_batch(), moe_hybrid_prefill_hot_sub_batch_limit())
```

which is **1** on gfx1151, where `mmq_safe_sub_batch()` returns 1 for compute < sm_80. A 1517-token prefill then runs 1517 × 43 = 65k graph computes.

With cold-owner `None` there is exactly one owner and every route that survives masking is resident, so the whole batch can take the packing the heterogeneous prefill already uses: one expert-major graph per layer via `eval_moe_owner_expert_major_batched`. That path was written for a reduced stack in the first place, which is why it does not need the MMQ full-batch guarantee.

### Benchmark

Two Ryzen AI Max 395 (Radeon 8060S, gfx1151, ROCm 10.0.0), DeepSeek V4 Flash ROCmFP2, `--ds4-prefill sparse --chunk 2048`, same binary, same clocks, no other load. Prefill wall time:

| prompt | before | after |
|---|---|---|
| 1517 tokens | 34.1 s | **11.45 s** (FFN 25.9 s → 3.7 s) |
| 12017 tokens | 283.9 s | **96.9 s** |

### Output parity

The completion is unchanged by the second commit, and the 128-token greedy benchmark stays byte-identical to a single-node run of the same binary (sha256 `87964cbd…`), 3 runs.

Reachable only with cold-owner `None`, so no existing configuration changes behaviour. On sm_80+ the sub-batch is 8 rather than 1, so the same shape would have been 8× less bad but still 8k graph computes.

Hardware note: gfx1151, not the sm_86+ hardware in CONTRIBUTING. Happy to have the numbers re-run on your 3090 or 395 box.

Used downstream to run DeepSeek V4 Flash expert-parallel across two hosts, each holding half the routed experts.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

