### PR TITLE
feat(ggml-cuda): env override for the AMD F16 mul_mat_vec ceiling

### DIFF
--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/mmvf.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/mmvf.cu
@@ -786,6 +786,26 @@ void ggml_cuda_op_mul_mat_vec_f(
     GGML_UNUSED_VARS(ctx, src1, dst, src1_ddq_i, src1_ncols, src1_padded_row_size);
 }
 
+// LUCE_MMVF_MAX_NCOLS_F16: ceiling on ne11 at or below which an F16 mul_mat
+// prefers this file's mul_mat_vec kernel over rocBLAS on AMD. Unset (or 0)
+// keeps the per-architecture values chosen below, so this changes nothing on
+// its own.
+//
+// The knob exists because crossing that ceiling is a cliff, not a slope. For a
+// tall-skinny F16 weight rocBLAS can pick a macro tile that covers the whole
+// output in a SINGLE workgroup and performs the entire K reduction inside it,
+// which uses a small fraction of the GPU however wide the GPU is. gfx1151
+// (RDNA 3.5, Strix Halo) currently inherits the RDNA3 ceiling of 3, a value
+// measured on discrete RX 7000 cards; on unified memory a verify width of 4
+// lands one column past it. See the pull request for the measurement.
+static int luce_mmvf_f16_max_ncols() {
+    static const int value = []() {
+        const char * e = getenv("LUCE_MMVF_MAX_NCOLS_F16");
+        return e ? atoi(e) : 0;
+    }();
+    return value;
+}
+
 bool ggml_cuda_should_use_mmvf(enum ggml_type type, int cc, const int64_t * src0_ne, const size_t * src0_nb, int64_t ne11) {
     if (src0_ne[0] % 2 != 0) {
         return false;
@@ -835,6 +855,10 @@ bool ggml_cuda_should_use_mmvf(enum ggml_type type, int cc, const int64_t * src0
                 return ne11 <= 8;
             } else if (GGML_CUDA_CC_IS_AMD(cc)) {
                 if (fp16_mma_hardware_available(cc)) {
+                    const int ceiling = luce_mmvf_f16_max_ncols();
+                    if (ceiling > 0) {
+                        return ne11 <= ceiling;
+                    }
                     if (GGML_CUDA_CC_IS_RDNA3(cc)) {
                         return ne11 <= 3;
                     }


### PR DESCRIPTION
`ggml_cuda_should_use_mmvf` picks a per-architecture ceiling on `ne11` below which an F16 `mul_mat` takes the `mul_mat_vec` kernel instead of rocBLAS. gfx1151 (RDNA 3.5, Strix Halo) falls under `GGML_CUDA_CC_IS_RDNA3` and therefore inherits that family's ceiling of 3 — a value measured on discrete RX 7000 cards rather than on unified memory.

## Why the ceiling matters more than it looks

Crossing it is a cliff, not a slope. For a tall-skinny F16 weight, rocBLAS can select a macro tile that covers the whole output in a **single workgroup** and performs the entire K reduction inside it, using a small fraction of the GPU however wide the GPU is. I saw this as `Cijk_Alik_Bljk_HB_MT128x128x32` dispatched with `grid=128, workgroup=128` — one workgroup, 375 µs per call.

A speculative verify of width 4 lands exactly one column past the RDNA3 ceiling. DeepSeek V4's per-layer router gate `ffn_gate_inp` is `[4096, 256]` F16 and runs in all 43 layers, so each verify step paid that cliff 43 times.

## Measurement

Radeon 8060S (gfx1151, 128 GB unified), ROCm 10, DeepSeek V4 Flash, DSpark q=4, 128 tokens at temperature 0, median of 3. The completion is byte-identical in every case.

| `LUCE_MMVF_MAX_NCOLS_F16` | decode |
|---|---|
| unset (ceiling 3) | 27.9 tok/s |
| 4 | 34.5 tok/s |
| 8 | 34.7 tok/s |

A `rocprofv3` kernel trace confirms the mechanism: with the ceiling raised, the Tensile kernel disappears from the profile entirely and total GPU kernel time drops from 17.14 s to 14.54 s over the same benchmark.

## Scope

Unset, or `0`, keeps every architecture's current ceiling, so **this commit changes no behaviour on its own**.

I am proposing the knob rather than a new RDNA 3.5 default deliberately: the measurement is one model on one board, and choosing the right default needs more weight shapes than I can cover. The mechanism, though, applies to any tall-skinny F16 weight, and without a knob there is no way for someone on this hardware to discover that they are on the wrong side of the cliff. If you would prefer a separate `GGML_CUDA_CC_IS_RDNA3_5` default instead of (or alongside) the environment variable, I am happy to change it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

