### PR TITLE
docs(deepseek4): the compressor padding stride does change generated text

### DIFF
--- a/server/src/deepseek4/deepseek4_graph.cpp
+++ b/server/src/deepseek4/deepseek4_graph.cpp
@@ -1476,10 +1476,29 @@ static int ds4_comp_rows_used(const ggml_tensor * comp_cache, int n_cached, int 
 }
 
 // Round the live compressed-row count up to a fixed stride so the fused decode
-// graph topology repeats across steps (enabling CUDA/HIP graph replay). The
-// rows in [n_comp, padded) are masked to -1e30 in the score matrix, which
-// underflows to exactly 0 in softmax, so a padded read is bit-identical to an
-// unpadded read of the first n_comp rows.
+// graph topology repeats across steps (enabling CUDA/HIP graph replay).
+//
+// The rows in [n_comp, padded) are masked to -1e30 in the score matrix and
+// underflow to exactly 0 in softmax, so they contribute no value. They do
+// change the arithmetic: the reduction they join is longer, and a longer
+// parallel reduction sums in a different order, so the surviving terms round
+// differently. Two strides therefore do not agree token-for-token on a
+// generation long enough to cross a boundary where their padding differs.
+//
+// Measured on a Radeon 8060S (gfx1151) with DeepSeek V4 Flash, DSpark q=4,
+// temperature 0, a free-form prompt and 200 generated tokens, each stride
+// deterministic across its own runs:
+//
+//   stride 16   326182af...  (repeated, identical)
+//   stride 128  973cc7a4...
+//
+// A 128-token benchmark prompt stays identical between the two, which is how
+// this went unnoticed: it never crosses a differing boundary. Quality is not
+// affected either way (60/60 on the exact-copy fidelity check in DS4.md), and
+// the coarser stride is much faster because the padded row count is part of
+// the fused verify graph's shape key -- see the pull request. But it is a
+// speed/exactness trade, not a free one, so treat a change of stride the way
+// you would treat --ds4-prefill sparse.
 static int ds4_comp_pad_stride() {
     static const int stride = [] {
         constexpr int default_stride = 16;


### PR DESCRIPTION
The comment above `ds4_comp_pad_stride` says:

> the rows in `[n_comp, padded)` are masked to `-1e30` in the score matrix, which underflows to exactly 0 in softmax, so a padded read is **bit-identical** to an unpadded read of the first `n_comp` rows

The first half is right. The conclusion does not follow: the padded rows lengthen the reduction they join, and a longer parallel reduction sums in a different order, so the surviving non-zero terms round differently.

## Measurement

Radeon 8060S (gfx1151), ROCm 10, DeepSeek V4 Flash, DSpark q=4, temperature 0, a free-form prompt and 200 generated tokens. Each stride is deterministic across its own runs; they disagree with each other.

| stride | sha256 of the completion |
|---|---|
| 16 | `326182af…` (run twice, identical) |
| 128 | `973cc7a4…` |

A 128-token benchmark prompt **does** stay identical between the two, which is presumably how this went unnoticed — it never crosses a boundary where the two strides pad differently.

## Why it is worth correcting rather than shrugging at

The stride is worth real throughput, so someone will reach for it. The padded row count is part of the fused verify graph's shape key (`deepseek4_fused_verify.inc`, the `(padded << 4) | (b_idx + 1)` term), so a fine stride makes that key wander as the sequence grows and the graph cache misses — every miss rebuilding all ~5445 nodes.

One node, free-form 600-token generation:

| stride | decode | graph rebuild per step |
|---|---|---|
| 16 | 12.7 tok/s | 14.5 ms |
| 128 | 16.9 tok/s | 5.6 ms |

Quality is unaffected either way — 60/60 on the exact-copy fidelity check from `server/docs/DS4.md`.

I reached for it on the strength of the comment, shipped it as a default in my own fork, and had to revert it. The comment is what made that look safe.

## Scope

Comment only; no behaviour changes, nothing to build-test beyond a compile. I am deliberately **not** proposing a different default: on this evidence the stride is a speed/exactness trade of the same kind as `--ds4-prefill sparse`, and that choice belongs to whoever is running the model. If you would rather document it in `DS4.md` or `variables.md` alongside the other approximations, I am happy to move it there instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

