### PR TITLE
fix(windows): use platform env helper in DeepSeek4 HIP path

### DIFF
--- a/server/src/deepseek4/deepseek4_backend.cpp
+++ b/server/src/deepseek4/deepseek4_backend.cpp
@@ -166,7 +166,7 @@ static bool configure_dspark_mmvq_defaults(int gpu) {
     // target device (which is gfx1201 in the R9700 + gfx1151 launch).
     if (env_flag_enabled("DFLASH_DS4_Q5_VERIFY")) {
         if (std::getenv("LUCE_MMVQ_MAX_NCOLS") == nullptr &&
-            ::setenv("LUCE_MMVQ_MAX_NCOLS", "5", 0) != 0) {
+            set_environment_variable("LUCE_MMVQ_MAX_NCOLS", "5", false) != 0) {
             std::fprintf(stderr,
                          "[deepseek4] failed to set LUCE_MMVQ_MAX_NCOLS=5\n");
             return false;
@@ -178,7 +178,7 @@ static bool configure_dspark_mmvq_defaults(int gpu) {
         }
 
         const char * fp4_x4 = std::getenv("DFLASH_CUDA_MMVQ_FP4_X4");
-        if (!fp4_x4 && ::setenv("DFLASH_CUDA_MMVQ_FP4_X4", "1", 0) != 0) {
+        if (!fp4_x4 && set_environment_variable("DFLASH_CUDA_MMVQ_FP4_X4", "1", false) != 0) {
             std::fprintf(stderr,
                          "[deepseek4] failed to enable ROCmFP4 x4 MMVQ\n");
             return false;
@@ -198,7 +198,7 @@ static bool configure_dspark_mmvq_defaults(int gpu) {
             std::getenv("DFLASH_CUDA_MMVQ_FP4_Q5_X4_PLUS1") == nullptr &&
             cudaGetDeviceProperties(&prop, gpu) == cudaSuccess &&
             std::strncmp(prop.gcnArchName, "gfx1201", 7) == 0 &&
-            ::setenv("DFLASH_CUDA_MMVQ_FP4_Q5_X4_PLUS1", "1", 0) == 0) {
+            set_environment_variable("DFLASH_CUDA_MMVQ_FP4_Q5_X4_PLUS1", "1", false) == 0) {
             std::fprintf(stderr,
                          "[deepseek4] gfx1201 DSpark q5: defaulting "
                          "ROCmFP4 x4+1 MMVQ\n");
@@ -216,7 +216,7 @@ static bool configure_dspark_mmvq_defaults(int gpu) {
         return true;
     }
 
-    if (::setenv("LUCE_MMVQ_MAX_NCOLS", "4", 0) == 0) {
+    if (set_environment_variable("LUCE_MMVQ_MAX_NCOLS", "4", false) == 0) {
         std::fprintf(stderr,
                      "[deepseek4] gfx1151 DSpark: defaulting "
                      "LUCE_MMVQ_MAX_NCOLS=4\n");
@@ -243,7 +243,7 @@ static void configure_gfx1201_hybrid_sub_batch_default(int gpu) {
     // older AMD parts.  ROCmFPX MMVQ on gfx1201 is qualified through q=4;
     // using that width removes 75% of hot-owner launches while retaining the
     // stable vector kernel instead of the pathological full-batch MMQ path.
-    if (::setenv("DFLASH_MMQ_SUB_BATCH", "4", 0) == 0) {
+    if (set_environment_variable("DFLASH_MMQ_SUB_BATCH", "4", false) == 0) {
         std::fprintf(stderr,
                      "[deepseek4] gfx1201 hybrid prefill: defaulting hot "
                      "expert sub-batch to 4\n");
@@ -1491,7 +1491,7 @@ bool DeepSeek4Backend::init_hybrid_model() {
             return false;
         }
         if ((!mix_mmq || !mix_mmq[0]) &&
-            ::setenv("DFLASH_DS4_MIX_MMQ_PREFILL", "1", 1) != 0) {
+            set_environment_variable("DFLASH_DS4_MIX_MMQ_PREFILL", "1", true) != 0) {
             std::fprintf(stderr,
                          "[deepseek4] failed to enable mixed-expert MMQ prefill\n");
             return false;


### PR DESCRIPTION
## Summary

Fixes native Windows/MSVC HIP build failure caused by direct POSIX ::setenv() calls in the DeepSeek4 backend.

## Root Cause

server/src/deepseek4/deepseek4_backend.cpp contained 6 direct ::setenv() calls under #if defined(DFLASH27B_BACKEND_HIP) || defined(GGML_USE_HIP) with no Windows exclusion. On Windows/MSVC, ::setenv does not exist in the global namespace, causing compile failure.

## Pre-fix Error

`
deepseek4_backend.cpp:169:15: error: no member named 'setenv' in the global namespace; did you mean 'getenv'?
deepseek4_backend.cpp:169:45: error: too many arguments to function call, expected single argument '_VarName', have 3 arguments
`

(6 identical errors at lines 169, 181, 201, 219, 246, 1494)

## Fix

Replaced all 6 ::setenv(name, value, overwrite) calls with the existing set_environment_variable(name, value, overwrite) helper from common/platform_env.h, which delegates to _putenv_s() on Windows and ::setenv() on POSIX.

No new wrappers, no new includes, no changes to platform_env.h.

## Changed Calls

| Line | Variable | Overwrite |
|------|----------|-----------|
| 169 | LUCE_MMVQ_MAX_NCOLS=5 | false |
| 181 | DFLASH_CUDA_MMVQ_FP4_X4=1 | false |
| 201 | DFLASH_CUDA_MMVQ_FP4_Q5_X4_PLUS1=1 | false |
| 219 | LUCE_MMVQ_MAX_NCOLS=4 | false |
| 246 | DFLASH_MMQ_SUB_BATCH=4 | false |
| 1494 | DFLASH_DS4_MIX_MMQ_PREFILL=1 | true |

All getenv guards, overwrite semantics, return-value checks, logging, HIP guards, and control flow are preserved unchanged.

## Post-fix Build

Same native Windows environment:
- Windows 11 / MSVC 19.44.35228.0 / HIP 7.14.60850 / ROCm 7.14.1
- R9700 gfx1201
- Generator: Ninja
- dflash_server.exe build: **PASS**
- SHA256: 29C0C160099A8235006F87BF194A27CD4CE339E35122F859F5356ABD87E8E317
- Smoke test dflash_server.exe --help: **PASS**

## POSIX Behavior

Unchanged. platform_env.h POSIX path still delegates to ::setenv(name, value, overwrite ? 1 : 0).

## No Changes To

- Parser / toolchain / runtime config
- platform_env.h
- qwen35_backend.cpp
- DFlash2
- Any unrelated files

## Related

- #537 added native Windows/MSVC compilation support. This PR is a follow-up for later DeepSeek4 HIP code paths that still used direct POSIX `::setenv()` calls.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

