### PR TITLE
fix(ds4): restore rejected compressor rows during speculative rollback

### DIFF
--- a/server/src/deepseek4/deepseek4_dspark.h
+++ b/server/src/deepseek4/deepseek4_dspark.h
@@ -179,7 +179,8 @@ bool deepseek4_dspark_verify_forward(ggml_backend_t backend,
 // the physical SWA rows they overwrote after the ring wraps; otherwise a later
 // causal verify reads rejected-token KV as if it were older committed history.
 // This remains much smaller than a full target-cache snapshot because the
-// verifier width is bounded by the DSpark block (currently q <= 5).
+// verifier width is bounded by the DSpark block (currently q <= 5). Compressor
+// staging holds both ratio-4 windows and the touched ratio-128 ring rows.
 struct DeepSeek4SpecRollback {
     int raw_pos = 0;
     int raw_count = 0;
@@ -207,16 +208,23 @@ struct DeepSeek4SpecRollback {
     DeepSeek4SpecRollback & operator=(const DeepSeek4SpecRollback &) = delete;
 };
 
+// Supplying backend selects stream-ordered copies; pinned_copy requests the
+// same pinned-host staging used by the speculative loop. Backend must outlive
+// rollback. For q>4 rejection, restore to raw_pos and replay the accepted prefix.
 void deepseek4_spec_rollback_save(const DeepSeek4Cache & cache,
                                   DeepSeek4SpecRollback & rollback,
                                   int raw_pos,
-                                  int raw_count);
+                                  int raw_count,
+                                  ggml_backend_t backend = nullptr,
+                                  bool pinned_copy = false);
 
 void deepseek4_spec_rollback_apply(const DeepSeek4SpecRollback & rollback,
                                    const DeepSeek4Weights & weights,
                                    DeepSeek4Cache & cache,
                                    int commit_pos,
-                                   bool restore_prev);
+                                   bool restore_prev,
+                                   ggml_backend_t backend = nullptr,
+                                   bool pinned_copy = false);
 
 // Run DSpark speculative decode: draft block_size candidates with `drafter`,
 // verify against the DS4 target in one batched forward, accept the matching

--- a/server/src/deepseek4/deepseek4_dspark.h
+++ b/server/src/deepseek4/deepseek4_dspark.h
@@ -201,6 +201,7 @@ struct DeepSeek4SpecRollback {
     ggml_backend_buffer_t pinned_buf = nullptr;
     uint8_t * pinned_base = nullptr;
     ggml_backend_t async_backend = nullptr;
+    bool uses_pinned_copy = false;
 
     DeepSeek4SpecRollback() = default;
     ~DeepSeek4SpecRollback();
@@ -209,8 +210,9 @@ struct DeepSeek4SpecRollback {
 };
 
 // Supplying backend selects stream-ordered copies; pinned_copy requests the
-// same pinned-host staging used by the speculative loop. Backend must outlive
-// rollback. For q>4 rejection, restore to raw_pos and replay the accepted prefix.
+// same pinned-host staging used by the speculative loop. The saved copy mode
+// is also used by apply. Backend must outlive rollback. For q>4 rejection,
+// restore to raw_pos and replay the accepted prefix.
 void deepseek4_spec_rollback_save(const DeepSeek4Cache & cache,
                                   DeepSeek4SpecRollback & rollback,
                                   int raw_pos,
@@ -222,9 +224,7 @@ void deepseek4_spec_rollback_apply(const DeepSeek4SpecRollback & rollback,
                                    const DeepSeek4Weights & weights,
                                    DeepSeek4Cache & cache,
                                    int commit_pos,
-                                   bool restore_prev,
-                                   ggml_backend_t backend = nullptr,
-                                   bool pinned_copy = false);
+                                   bool restore_prev);
 
 // Run DSpark speculative decode: draft block_size candidates with `drafter`,
 // verify against the DS4 target in one batched forward, accept the matching

--- a/server/src/deepseek4/deepseek4_dspark_spec.cpp
+++ b/server/src/deepseek4/deepseek4_dspark_spec.cpp
@@ -14,10 +14,10 @@
 //     restored after wrap (accepted rows remain committed),
 //   - comp rows are index-addressed (pos / ratio)        -> idempotent,
 //   - n_comp / n_index_comp are pure functions of commit position,
-//   - the other non-idempotent state is the ratio-4 compressor prev-half
-//     (4 rows/state, flushed cur->prev at chunk boundaries), a few KB/layer,
-//     saved host-side before the verify and restored only when the flush
-//     happened at-or-past the rollback point.
+//   - rejected compressor ring rows are restored in both ratio-4 and
+//     ratio-128 layers; a later pool reads these even before replacement,
+//   - the ratio-4 prev-half is also restored when a rejected boundary flushed
+//     current rows into it. Accepted boundaries and current rows are kept.
 // The legacy full-snapshot + double-verify path is kept behind
 // DFLASH_DS4_FULL_SNAP=1 for A/B validation.
 
@@ -256,13 +256,27 @@ constexpr float kConfidenceQ3Threshold = 0.40f;
 constexpr float kConfidenceQ4Threshold = 0.30f;
 
 // ── Light rollback state ────────────────────────────────────────────────
-// Save the ratio-4 rolling state, HC state, and the raw SWA rows that a q<=5
+// Save the ratio-4 rolling state, HC state, and the ring rows a speculative
 // verify may overwrite. Pinned host storage lets the GPU copy this compact
 // rollback state on its stream before the verifier without a host fence.
 // prev-half = first 4 rows of a [comp_width, 8] ratio-4 rolling state.
-// ratio-128 states ([comp_width, 128]) are pure position rings -> skip.
+// Ratio-128 states need only the touched ring rows, not the full 128 rows.
+constexpr int kRollbackMaxTokens = 6; // Preserve the existing raw-ring staging capacity.
+
 size_t prev_half_bytes(const ggml_tensor * t) {
     return t && t->ne[1] == 8 ? (size_t) t->nb[1] * 4 : 0;
+}
+
+size_t rollback_state_bytes(const ggml_tensor * t) {
+    if (!t) return 0;
+    if (t->ne[1] == 8) return 2 * prev_half_bytes(t);
+    return t->ne[1] == 128 ? t->nb[1] * kRollbackMaxTokens : 0;
+}
+
+int rollback_ring_row(const ggml_tensor * t, int pos) {
+    const int period = t->ne[1] == 8 ? 4 : (int) t->ne[1];
+    const int row = pos % period;
+    return row < 0 ? row + period : row;
 }
 
 size_t align_up_rollback(size_t value, size_t alignment) {
@@ -291,18 +305,18 @@ bool init_pinned_rollback(const DeepSeek4Cache & cache, DeepSeek4SpecRollback & 
         const DeepSeek4LayerCache & lc = cache.layers[il];
         DeepSeek4SpecRollback::Layer & s = rb.layers[il];
         assign_pinned_span(
-            s.pinned_attn_kv, prev_half_bytes(lc.attn_compressor.state_kv), total);
+            s.pinned_attn_kv, rollback_state_bytes(lc.attn_compressor.state_kv), total);
         assign_pinned_span(
-            s.pinned_attn_sc, prev_half_bytes(lc.attn_compressor.state_score), total);
+            s.pinned_attn_sc, rollback_state_bytes(lc.attn_compressor.state_score), total);
         assign_pinned_span(
-            s.pinned_idx_kv, prev_half_bytes(lc.indexer_compressor.state_kv), total);
+            s.pinned_idx_kv, rollback_state_bytes(lc.indexer_compressor.state_kv), total);
         assign_pinned_span(
-            s.pinned_idx_sc, prev_half_bytes(lc.indexer_compressor.state_score), total);
+            s.pinned_idx_sc, rollback_state_bytes(lc.indexer_compressor.state_score), total);
         s.raw_row_bytes = lc.raw_kv
             ? ggml_row_size(lc.raw_kv->type, lc.raw_kv->ne[0]) : 0;
         // The DSpark artifact exposes five proposal rows, so the widest
         // verifier batch is seed + five candidates.
-        assign_pinned_span(s.pinned_raw_rows, s.raw_row_bytes * 6, total);
+        assign_pinned_span(s.pinned_raw_rows, s.raw_row_bytes * kRollbackMaxTokens, total);
     }
     assign_pinned_span(
         rb.pinned_hc, cache.hc_state ? ggml_nbytes(cache.hc_state) : 0, total);
@@ -325,51 +339,50 @@ bool init_pinned_rollback(const DeepSeek4Cache & cache, DeepSeek4SpecRollback & 
     return true;
 }
 
-void save_prev_half(ggml_backend_t backend, ggml_tensor * t,
-                    std::vector<uint8_t> & buf, bool async_copy) {
-    if (!t || t->ne[1] != 8) { buf.clear(); return; }
-    const size_t bytes = (size_t) t->nb[1] * 4;
-    if (buf.size() != bytes) buf.resize(bytes);
-    if (async_copy) {
-        ggml_backend_tensor_get_async(backend, t, buf.data(), 0, bytes);
-    } else {
-        ggml_backend_tensor_get(t, buf.data(), 0, bytes);
+void save_rollback_state(ggml_backend_t backend, ggml_tensor * t,
+                         uint8_t * dst, bool async_copy, int pos, int count) {
+    if (rollback_state_bytes(t) == 0) return;
+    const bool rolling = t->ne[1] == 8;
+    const size_t bytes = rolling ? rollback_state_bytes(t) : t->nb[1];
+    for (int i = 0; i < (rolling ? 1 : count); ++i) {
+        const size_t offset = rolling ? 0 : rollback_ring_row(t, pos + i) * t->nb[1];
+        if (async_copy) {
+            ggml_backend_tensor_get_async(backend, t, dst + i * bytes, offset, bytes);
+        } else {
+            ggml_backend_tensor_get(t, dst + i * bytes, offset, bytes);
+        }
     }
 }
 
-void restore_prev_half(ggml_backend_t backend, ggml_tensor * t,
-                       const std::vector<uint8_t> & buf, bool async_copy) {
-    if (!t || buf.empty()) return;
-    if (async_copy) {
-        ggml_backend_tensor_set_async(backend, t, buf.data(), 0, buf.size());
-    } else {
-        ggml_backend_tensor_set(t, buf.data(), 0, buf.size());
+void restore_rollback_state(ggml_backend_t backend, ggml_tensor * t,
+                            const uint8_t * src, bool async_copy,
+                            int pos, int count, int first_rejected, bool restore_prev) {
+    if (rollback_state_bytes(t) == 0) return;
+    const bool rolling = t->ne[1] == 8;
+    if (rolling && restore_prev) {
+        const size_t bytes = prev_half_bytes(t);
+        if (async_copy) ggml_backend_tensor_set_async(backend, t, src, 0, bytes);
+        else            ggml_backend_tensor_set(t, src, 0, bytes);
     }
-}
-
-void save_prev_half_pinned(ggml_backend_t backend, ggml_tensor * t,
-                           uint8_t * base,
-                           const DeepSeek4SpecRollback::PinnedSpan & span) {
-    if (!t || span.size == 0) return;
-    GGML_ASSERT(span.size == prev_half_bytes(t));
-    ggml_backend_tensor_get_async(
-        backend, t, base + span.offset, 0, span.size);
-}
-
-void restore_prev_half_pinned(ggml_backend_t backend, ggml_tensor * t,
-                              const uint8_t * base,
-                              const DeepSeek4SpecRollback::PinnedSpan & span) {
-    if (!t || span.size == 0) return;
-    GGML_ASSERT(span.size == prev_half_bytes(t));
-    ggml_backend_tensor_set_async(
-        backend, t, base + span.offset, 0, span.size);
+    // Direct truncation is used for q<=4 (no aliased current-window slots).
+    // Wider rejected verifies restore to pos and replay the accepted prefix.
+    for (int i = first_rejected; i < count; ++i) {
+        const int row = (rolling ? 4 : 0) + rollback_ring_row(t, pos + i);
+        const size_t offset = row * t->nb[1];
+        const uint8_t * saved = src + (rolling ? offset : i * t->nb[1]);
+        if (async_copy) {
+            ggml_backend_tensor_set_async(backend, t, saved, offset, t->nb[1]);
+        } else {
+            ggml_backend_tensor_set(t, saved, offset, t->nb[1]);
+        }
+    }
 }
 
 void spec_rollback_save(const DeepSeek4Cache & cache, DeepSeek4SpecRollback & rb,
                         ggml_backend_t backend, bool async_copy,
                         bool pinned_copy, int raw_pos, int raw_count) {
     rb.raw_pos = raw_pos;
-    rb.raw_count = std::clamp(raw_count, 0, 6);
+    rb.raw_count = std::clamp(raw_count, 0, kRollbackMaxTokens);
     rb.layers.resize(cache.layers.size());
     if (async_copy || pinned_copy) {
         rb.async_backend = backend;
@@ -379,25 +392,23 @@ void spec_rollback_save(const DeepSeek4Cache & cache, DeepSeek4SpecRollback & rb
     for (size_t il = 0; il < cache.layers.size(); ++il) {
         const DeepSeek4LayerCache & lc = cache.layers[il];
         DeepSeek4SpecRollback::Layer & s = rb.layers[il];
-        if (use_pinned) {
-            save_prev_half_pinned(
-                backend, lc.attn_compressor.state_kv,
-                rb.pinned_base, s.pinned_attn_kv);
-            save_prev_half_pinned(
-                backend, lc.attn_compressor.state_score,
-                rb.pinned_base, s.pinned_attn_sc);
-            save_prev_half_pinned(
-                backend, lc.indexer_compressor.state_kv,
-                rb.pinned_base, s.pinned_idx_kv);
-            save_prev_half_pinned(
-                backend, lc.indexer_compressor.state_score,
-                rb.pinned_base, s.pinned_idx_sc);
-        } else {
-            save_prev_half(backend, lc.attn_compressor.state_kv,       s.attn_kv, async_copy);
-            save_prev_half(backend, lc.attn_compressor.state_score,    s.attn_sc, async_copy);
-            save_prev_half(backend, lc.indexer_compressor.state_kv,    s.idx_kv, async_copy);
-            save_prev_half(backend, lc.indexer_compressor.state_score, s.idx_sc, async_copy);
-        }
+        auto save_state = [&](ggml_tensor * t, std::vector<uint8_t> & buf,
+                              const DeepSeek4SpecRollback::PinnedSpan & span) {
+            const size_t bytes = rollback_state_bytes(t);
+            if (bytes == 0) { buf.clear(); return; }
+            if (use_pinned) {
+                GGML_ASSERT(span.size == bytes);
+            } else {
+                buf.resize(bytes);
+            }
+            save_rollback_state(backend, t,
+                use_pinned ? rb.pinned_base + span.offset : buf.data(),
+                use_pinned || async_copy, rb.raw_pos, rb.raw_count);
+        };
+        save_state(lc.attn_compressor.state_kv, s.attn_kv, s.pinned_attn_kv);
+        save_state(lc.attn_compressor.state_score, s.attn_sc, s.pinned_attn_sc);
+        save_state(lc.indexer_compressor.state_kv, s.idx_kv, s.pinned_idx_kv);
+        save_state(lc.indexer_compressor.state_score, s.idx_sc, s.pinned_idx_sc);
 
         s.raw_row_bytes = lc.raw_kv
             ? ggml_row_size(lc.raw_kv->type, lc.raw_kv->ne[0]) : 0;
@@ -449,7 +460,8 @@ void spec_rollback_save(const DeepSeek4Cache & cache, DeepSeek4SpecRollback & rb
 // crossed a ratio-4 boundary at-or-past commit_pos: that flush filled the
 // prev-half rows with a chunk containing rejected tokens, so put the
 // pre-verify rows back. (A boundary strictly inside the committed range is a
-// legitimate flush and must be kept.)
+// legitimate flush and must be kept.) Rejected current/ring rows are restored
+// regardless of whether a ratio-4 boundary was crossed.
 void spec_rollback_apply(const DeepSeek4SpecRollback & rb, const DeepSeek4Weights & w,
                          DeepSeek4Cache & cache, int commit_pos, bool restore_prev,
                          ggml_backend_t backend, bool async_copy,
@@ -461,31 +473,26 @@ void spec_rollback_apply(const DeepSeek4SpecRollback & rb, const DeepSeek4Weight
         const uint32_t ratio = il < w.compress_ratios.size() ? w.compress_ratios[il] : 0;
         if (ratio > 0) lc.n_comp = commit_pos / (int) ratio;
         if (ratio == 4) lc.n_index_comp = commit_pos / 4;
-        if (restore_prev && il < rb.layers.size()) {
+        const int first_rejected = std::clamp(commit_pos - rb.raw_pos, 0, rb.raw_count);
+        if (il < rb.layers.size()) {
             const DeepSeek4SpecRollback::Layer & s = rb.layers[il];
-            if (use_pinned) {
-                restore_prev_half_pinned(
-                    backend, lc.attn_compressor.state_kv,
-                    rb.pinned_base, s.pinned_attn_kv);
-                restore_prev_half_pinned(
-                    backend, lc.attn_compressor.state_score,
-                    rb.pinned_base, s.pinned_attn_sc);
-                restore_prev_half_pinned(
-                    backend, lc.indexer_compressor.state_kv,
-                    rb.pinned_base, s.pinned_idx_kv);
-                restore_prev_half_pinned(
-                    backend, lc.indexer_compressor.state_score,
-                    rb.pinned_base, s.pinned_idx_sc);
-            } else {
-                restore_prev_half(backend, lc.attn_compressor.state_kv,       s.attn_kv, async_copy);
-                restore_prev_half(backend, lc.attn_compressor.state_score,    s.attn_sc, async_copy);
-                restore_prev_half(backend, lc.indexer_compressor.state_kv,    s.idx_kv, async_copy);
-                restore_prev_half(backend, lc.indexer_compressor.state_score, s.idx_sc, async_copy);
-            }
+            auto restore_state = [&](ggml_tensor * t, const std::vector<uint8_t> & buf,
+                                     const DeepSeek4SpecRollback::PinnedSpan & span) {
+                const size_t bytes = rollback_state_bytes(t);
+                if (bytes == 0) return;
+                GGML_ASSERT((use_pinned ? span.size : buf.size()) == bytes);
+                restore_rollback_state(backend, t,
+                    use_pinned ? rb.pinned_base + span.offset : buf.data(),
+                    use_pinned || async_copy, rb.raw_pos, rb.raw_count,
+                    first_rejected, restore_prev);
+            };
+            restore_state(lc.attn_compressor.state_kv, s.attn_kv, s.pinned_attn_kv);
+            restore_state(lc.attn_compressor.state_score, s.attn_sc, s.pinned_attn_sc);
+            restore_state(lc.indexer_compressor.state_kv, s.idx_kv, s.pinned_idx_kv);
+            restore_state(lc.indexer_compressor.state_score, s.idx_sc, s.pinned_idx_sc);
         }
         if (il < rb.layers.size() && lc.raw_kv && lc.raw_kv->ne[1] > 0) {
             const DeepSeek4SpecRollback::Layer & s = rb.layers[il];
-            const int first_rejected = std::max(0, commit_pos - rb.raw_pos);
             for (int t = first_rejected;
                  t < rb.raw_count && s.raw_row_bytes > 0;
                  ++t) {
@@ -552,9 +559,12 @@ DeepSeek4SpecRollback::~DeepSeek4SpecRollback() {
 void deepseek4_spec_rollback_save(const DeepSeek4Cache & cache,
                                   DeepSeek4SpecRollback & rollback,
                                   int raw_pos,
-                                  int raw_count) {
-    spec_rollback_save(cache, rollback, nullptr,
-                       /*async_copy=*/false, /*pinned_copy=*/false,
+                                  int raw_count,
+                                  ggml_backend_t backend,
+                                  bool pinned_copy) {
+    GGML_ASSERT(!pinned_copy || backend);
+    spec_rollback_save(cache, rollback, backend,
+                       /*async_copy=*/backend != nullptr, pinned_copy,
                        raw_pos, raw_count);
 }
 
@@ -562,10 +572,12 @@ void deepseek4_spec_rollback_apply(const DeepSeek4SpecRollback & rollback,
                                    const DeepSeek4Weights & weights,
                                    DeepSeek4Cache & cache,
                                    int commit_pos,
-                                   bool restore_prev) {
+                                   bool restore_prev,
+                                   ggml_backend_t backend,
+                                   bool pinned_copy) {
+    GGML_ASSERT(!pinned_copy || backend);
     spec_rollback_apply(rollback, weights, cache, commit_pos, restore_prev,
-                        nullptr, /*async_copy=*/false,
-                        /*pinned_copy=*/false);
+                        backend, /*async_copy=*/backend != nullptr, pinned_copy);
 }
 
 // Batched target verify + capture: wraps the existing multi-token

--- a/server/src/deepseek4/deepseek4_dspark_spec.cpp
+++ b/server/src/deepseek4/deepseek4_dspark_spec.cpp
@@ -381,14 +381,17 @@ void restore_rollback_state(ggml_backend_t backend, ggml_tensor * t,
 void spec_rollback_save(const DeepSeek4Cache & cache, DeepSeek4SpecRollback & rb,
                         ggml_backend_t backend, bool async_copy,
                         bool pinned_copy, int raw_pos, int raw_count) {
+    ggml_backend_t saved_backend = (async_copy || pinned_copy) ? backend : nullptr;
+    if (rb.async_backend && rb.async_backend != saved_backend) {
+        ggml_backend_synchronize(rb.async_backend);
+    }
+    rb.async_backend = saved_backend;
     rb.raw_pos = raw_pos;
     rb.raw_count = std::clamp(raw_count, 0, kRollbackMaxTokens);
     rb.layers.resize(cache.layers.size());
-    if (async_copy || pinned_copy) {
-        rb.async_backend = backend;
-    }
     const bool use_pinned =
         pinned_copy && init_pinned_rollback(cache, rb, backend);
+    rb.uses_pinned_copy = use_pinned;
     for (size_t il = 0; il < cache.layers.size(); ++il) {
         const DeepSeek4LayerCache & lc = cache.layers[il];
         DeepSeek4SpecRollback::Layer & s = rb.layers[il];
@@ -418,7 +421,7 @@ void spec_rollback_save(const DeepSeek4Cache & cache, DeepSeek4SpecRollback & rb
             continue;
         }
         if (!use_pinned) {
-            s.raw_rows.resize(s.raw_row_bytes * (size_t) rb.raw_count);
+            s.raw_rows.resize(s.raw_row_bytes * kRollbackMaxTokens);
         }
         for (int t = 0; t < rb.raw_count; ++t) {
             int row = (rb.raw_pos + t) % (int) lc.raw_kv->ne[1];
@@ -463,10 +466,11 @@ void spec_rollback_save(const DeepSeek4Cache & cache, DeepSeek4SpecRollback & rb
 // legitimate flush and must be kept.) Rejected current/ring rows are restored
 // regardless of whether a ratio-4 boundary was crossed.
 void spec_rollback_apply(const DeepSeek4SpecRollback & rb, const DeepSeek4Weights & w,
-                         DeepSeek4Cache & cache, int commit_pos, bool restore_prev,
-                         ggml_backend_t backend, bool async_copy,
-                         bool pinned_copy) {
-    const bool use_pinned = pinned_copy && rb.pinned_buf && rb.pinned_base;
+                         DeepSeek4Cache & cache, int commit_pos, bool restore_prev) {
+    ggml_backend_t backend = rb.async_backend;
+    const bool async_copy = backend != nullptr;
+    const bool use_pinned = rb.uses_pinned_copy;
+    GGML_ASSERT(!use_pinned || (backend && rb.pinned_buf && rb.pinned_base));
     cache.cur_pos = commit_pos;
     for (size_t il = 0; il < cache.layers.size(); ++il) {
         DeepSeek4LayerCache & lc = cache.layers[il];
@@ -572,12 +576,8 @@ void deepseek4_spec_rollback_apply(const DeepSeek4SpecRollback & rollback,
                                    const DeepSeek4Weights & weights,
                                    DeepSeek4Cache & cache,
                                    int commit_pos,
-                                   bool restore_prev,
-                                   ggml_backend_t backend,
-                                   bool pinned_copy) {
-    GGML_ASSERT(!pinned_copy || backend);
-    spec_rollback_apply(rollback, weights, cache, commit_pos, restore_prev,
-                        backend, /*async_copy=*/backend != nullptr, pinned_copy);
+                                   bool restore_prev) {
+    spec_rollback_apply(rollback, weights, cache, commit_pos, restore_prev);
 }
 
 // Batched target verify + capture: wraps the existing multi-token
@@ -1032,9 +1032,7 @@ bool run_deepseek4_dspark_spec_decode(
                 }
             } else {
                 spec_rollback_apply(
-                    rollback, target_w, target_cache, pos, boundary_crossed,
-                    backend, async_rollback || pinned_rollback,
-                    pinned_rollback);
+                    rollback, target_w, target_cache, pos, boundary_crossed);
             }
             std::fprintf(stderr, "[ds4-spec] verify failed\n");
             ok = false;
@@ -1090,9 +1088,7 @@ bool run_deepseek4_dspark_spec_decode(
             // accepted prefix (at most q5), which is exact and rare at high
             // acceptance.
             spec_rollback_apply(
-                rollback, target_w, target_cache, pos, true,
-                backend, async_rollback || pinned_rollback,
-                pinned_rollback);
+                rollback, target_w, target_cache, pos, true);
             std::vector<int32_t> kv_toks;
             kv_toks.reserve((size_t) accept);
             kv_toks.push_back(lt);
@@ -1109,9 +1105,7 @@ bool run_deepseek4_dspark_spec_decode(
             // the commit point (its chunk then contains rejected tokens).
             const bool restore_prev = boundary_crossed && first_boundary >= commit_pos;
             spec_rollback_apply(
-                rollback, target_w, target_cache, commit_pos, restore_prev,
-                backend, async_rollback || pinned_rollback,
-                pinned_rollback);
+                rollback, target_w, target_cache, commit_pos, restore_prev);
         }
         // accept == q on the fast path: cur_pos/n_comp already exact, keep.
         tm_apply += spec_ms_since(t0);

--- a/server/tests/test_deepseek4_unit.cpp
+++ b/server/tests/test_deepseek4_unit.cpp
@@ -1812,6 +1812,113 @@ static void test_dspark_raw_ring_rollback_after_wrap(ggml_backend_t backend) {
     std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
 }
 
+static void test_dspark_compressor_rollback(ggml_backend_t backend, int copy_mode = 0) {
+    std::fprintf(stderr, "  test_dspark_compressor_rollback (%s, mode=%d) ...",
+                 ggml_backend_name(backend), copy_mode);
+    ggml_backend_t copy_backend = copy_mode == 0 ? nullptr : backend;
+    const bool pinned = copy_mode == 2;
+    ggml_context * ctx = ggml_init({64 * ggml_tensor_overhead(), nullptr, true});
+    TEST_ASSERT(ctx != nullptr);
+    if (!ctx) return;
+    DeepSeek4Weights weights;
+    weights.compress_ratios = {4, 128};
+    DeepSeek4Cache cache;
+    cache.layers.resize(2);
+    std::vector<ggml_tensor *> tensors;
+    for (int il = 0; il < 2; ++il) {
+        for (auto * state : {&cache.layers[il].attn_compressor,
+                            &cache.layers[il].indexer_compressor}) {
+            state->state_kv = ggml_new_tensor_2d(ctx, GGML_TYPE_F16, 3, il == 0 ? 8 : 128);
+            state->state_score = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, 3, il == 0 ? 8 : 128);
+            tensors.push_back(state->state_kv);
+            tensors.push_back(state->state_score);
+        }
+    }
+    auto buffer = ggml_backend_alloc_ctx_tensors(ctx, backend);
+    TEST_ASSERT(buffer != nullptr);
+    if (!buffer) { ggml_free(ctx); return; }
+    std::vector<std::vector<uint8_t>> initial;
+    for (size_t ti = 0; ti < tensors.size(); ++ti) {
+        write_tensor_pattern(tensors[ti], 11 + (int) ti);
+        initial.push_back(read_tensor_bytes(tensors[ti]));
+    }
+    auto load = [&](const std::vector<std::vector<uint8_t>> & state) {
+        for (size_t ti = 0; ti < tensors.size(); ++ti)
+            ggml_backend_tensor_set(tensors[ti], state[ti].data(), 0, state[ti].size());
+    };
+    // Independent sequential state transition. Distinct byte patterns exercise
+    // exact restoration of both F16 KV and F32 score rows without rounding.
+    auto advance = [&](std::vector<std::vector<uint8_t>> & state, int pos, int count) {
+        for (size_t ti = 0; ti < tensors.size(); ++ti) {
+            const int ratio = ti < 4 ? 4 : 128;
+            const size_t stride = tensors[ti]->nb[1];
+            for (int i = 0; i < count; ++i) {
+                const int slot = (pos + i) % ratio;
+                const int row = ratio == 4 ? 4 + slot : slot;
+                std::fill_n(state[ti].begin() + row * stride, stride,
+                            (uint8_t) (160 + 8 * ti + i));
+                if (ratio == 4 && slot == 3)
+                    std::copy_n(state[ti].begin() + 4 * stride, 4 * stride, state[ti].begin());
+            }
+        }
+    };
+    {
+        DeepSeek4SpecRollback rollback;
+        for (int pos = 0; pos < 128; ++pos) {
+            // Six exercises legacy staging capacity, not q6 verifier support.
+            for (int q = 1; q <= 6; ++q) {
+                for (int accepted = 0; accepted <= q; ++accepted) {
+                    load(initial);
+                    deepseek4_spec_rollback_save(cache, rollback, pos, q, copy_backend, pinned);
+                    ggml_backend_synchronize(backend);
+                    if (pinned && pos == 0 && q == 1 && accepted == 0) {
+                        const auto host_type = ggml_backend_dev_host_buffer_type(
+                            ggml_backend_get_device(backend));
+                        TEST_ASSERT(rollback.pinned_buf && rollback.pinned_base);
+                        TEST_ASSERT(rollback.pinned_buf &&
+                            ggml_backend_buffer_get_type(rollback.pinned_buf) == host_type);
+                    }
+                    auto verified = initial;
+                    advance(verified, pos, q);
+                    load(verified);
+                    // Production restores to the start and replays for q>4.
+                    const int keep = q > 4 && accepted < q ? 0 : accepted;
+                    const int boundary = pos + 3 - (pos & 3);
+                    const bool restore_prev = boundary < pos + q && boundary >= pos + keep;
+                    deepseek4_spec_rollback_apply(rollback, weights, cache, pos + keep,
+                                                 restore_prev, copy_backend, pinned);
+                    ggml_backend_synchronize(backend);
+                    if (q > 4 && accepted < q) {
+                        std::vector<std::vector<uint8_t>> restored;
+                        for (auto * t : tensors) restored.push_back(read_tensor_bytes(t));
+                        advance(restored, pos, accepted);
+                        load(restored);
+                    }
+                    auto expected = initial;
+                    advance(expected, pos, accepted);
+                    for (size_t ti = 0; ti < tensors.size(); ++ti) {
+                        if (read_tensor_bytes(tensors[ti]) != expected[ti]) {
+                            std::fprintf(stderr, " pos=%d q=%d accepted=%d tensor=%zu", pos, q, accepted, ti);
+                            TEST_ASSERT(false);
+                            // One actionable failure, not thousands of duplicates.
+                            ggml_backend_buffer_free(buffer);
+                            ggml_free(ctx);
+                            return;
+                        }
+                    }
+                    TEST_ASSERT(cache.cur_pos == pos + keep);
+                    TEST_ASSERT(cache.layers[0].n_comp == (pos + keep) / 4);
+                    TEST_ASSERT(cache.layers[0].n_index_comp == (pos + keep) / 4);
+                    TEST_ASSERT(cache.layers[1].n_comp == (pos + keep) / 128);
+                }
+            }
+        }
+    }
+    ggml_backend_buffer_free(buffer);
+    ggml_free(ctx);
+    std::fprintf(stderr, " done\n");
+}
+
 static void test_snapshot_save_restore() {
     std::fprintf(stderr, "  test_snapshot_save_restore ...");
 
@@ -4154,6 +4261,7 @@ int main() {
     test_hybrid_prefill_chunk_tokens();
     test_dspark_park_all_releases_drafter();
     test_dspark_raw_ring_rollback_after_wrap(backend);
+    test_dspark_compressor_rollback(backend);
     test_snapshot_save_restore();
     test_monolithic_snapshot_preserves_decode_state();
     test_spec_feature_tail_is_bounded();
@@ -4166,6 +4274,15 @@ int main() {
     test_ffn_graph_reuse_microbench(backend);
     test_output_graph_reuse_microbench(backend);
 #if defined(GGML_USE_CUDA) || defined(GGML_USE_HIP)
+    {
+        auto gpu = ggml_backend_cuda_init(0);
+        if (gpu) {
+            for (int mode = 0; mode < 3; ++mode) test_dspark_compressor_rollback(gpu, mode);
+            ggml_backend_free(gpu);
+        } else {
+            std::fprintf(stderr, "  test_dspark_compressor_rollback GPU skipped (no device)\n");
+        }
+    }
     test_ds4_flash_attention_keep_cap_gpu();
     test_ds4_flash_attention_parallel_index_scan_gpu();
     test_ds4_indexer_score_packed_q4_gpu();

--- a/server/tests/test_deepseek4_unit.cpp
+++ b/server/tests/test_deepseek4_unit.cpp
@@ -1842,9 +1842,17 @@ static void test_dspark_compressor_rollback(ggml_backend_t backend, int copy_mod
         write_tensor_pattern(tensors[ti], 11 + (int) ti);
         initial.push_back(read_tensor_bytes(tensors[ti]));
     }
-    auto load = [&](const std::vector<std::vector<uint8_t>> & state) {
-        for (size_t ti = 0; ti < tensors.size(); ++ti)
-            ggml_backend_tensor_set(tensors[ti], state[ti].data(), 0, state[ti].size());
+    auto load = [&](const std::vector<std::vector<uint8_t>> & state,
+                    bool async = false) {
+        for (size_t ti = 0; ti < tensors.size(); ++ti) {
+            if (async) {
+                ggml_backend_tensor_set_async(
+                    copy_backend, tensors[ti], state[ti].data(), 0, state[ti].size());
+            } else {
+                ggml_backend_tensor_set(
+                    tensors[ti], state[ti].data(), 0, state[ti].size());
+            }
+        }
     };
     // Independent sequential state transition. Distinct byte patterns exercise
     // exact restoration of both F16 KV and F32 score rows without rounding.
@@ -1868,9 +1876,8 @@ static void test_dspark_compressor_rollback(ggml_backend_t backend, int copy_mod
             // Six exercises legacy staging capacity, not q6 verifier support.
             for (int q = 1; q <= 6; ++q) {
                 for (int accepted = 0; accepted <= q; ++accepted) {
-                    load(initial);
+                    load(initial, copy_backend != nullptr);
                     deepseek4_spec_rollback_save(cache, rollback, pos, q, copy_backend, pinned);
-                    ggml_backend_synchronize(backend);
                     if (pinned && pos == 0 && q == 1 && accepted == 0) {
                         const auto host_type = ggml_backend_dev_host_buffer_type(
                             ggml_backend_get_device(backend));
@@ -1880,13 +1887,13 @@ static void test_dspark_compressor_rollback(ggml_backend_t backend, int copy_mod
                     }
                     auto verified = initial;
                     advance(verified, pos, q);
-                    load(verified);
+                    load(verified, copy_backend != nullptr);
                     // Production restores to the start and replays for q>4.
                     const int keep = q > 4 && accepted < q ? 0 : accepted;
                     const int boundary = pos + 3 - (pos & 3);
                     const bool restore_prev = boundary < pos + q && boundary >= pos + keep;
-                    deepseek4_spec_rollback_apply(rollback, weights, cache, pos + keep,
-                                                 restore_prev, copy_backend, pinned);
+                    deepseek4_spec_rollback_apply(
+                        rollback, weights, cache, pos + keep, restore_prev);
                     ggml_backend_synchronize(backend);
                     if (q > 4 && accepted < q) {
                         std::vector<std::vector<uint8_t>> restored;


### PR DESCRIPTION
## Summary

Fix the compact DS4 speculative rollback path so rejected tokens cannot leave
data in compressor rolling state. This is a correctness fix, independent of
decode optimizations and prefill PR #684.

Before verification, save both halves of each ratio-4 compressor and the
at-risk rows of each ratio-128 compressor. On rejection, restore the rejected
current/ring rows regardless of whether a ratio-4 boundary was crossed. Keep
accepted current rows and legitimate previous-window rotations. Q5 continues
to use the existing restore-to-start plus accepted-prefix replay path.

The old code saved only the ratio-4 previous half and skipped ratio-128 state.
Position-addressed writes alone are insufficient: a later compressor pool can
read a rejected future row before that row is overwritten by committed work.

## Scope

- Reuse existing vectors and pinned spans. A saved-mode boolean records whether
  pinned staging was actually selected (including allocation fallback).
- Share the row-copy logic between synchronous, asynchronous, and pinned-host
  staging. Save accepts optional backend/pinned arguments; apply derives its
  transport from the saved state and cannot independently select the wrong mode.
- Preserve raw-ring restoration, HC handling, compressed-row count truncation,
  the full-snapshot mode, verifier width policy, and wide rejection replay.
- Retain the existing six-row staging capacity. This does **not** enable Q6
  verification, which remains explicitly unsupported.

## Regression

The new checked-in `test_deepseek4_unit` case compares exact bytes against an
independent sequential accepted-prefix state transition. It covers all 128
starting phases, widths 1–6, every accepted count including zero/all, all four
KV/score tensors for each ratio, and F16 KV plus F32 score storage. Widths above
four exercise restore-to-start/replay, and width six tests staging capacity
only. There are 3,456 transactions per copy mode.

The regression fails against unmodified public `main` (`b1c88230`), first at
`pos=0 q=1 accepted=0 tensor=0`, and passes after this repair.

## Validation

- Base: `b1c88230e3ab584ab90ff0b224ddc69e6f8f6b58`.
- Candidate: `2722c1c05d863c34809e60cf73bf99d053b86f99`.
- Review follow-up: reproduced the configured-save/default-apply pinned
  assertion on the preceding head. The regression now queues save, overwrite,
  and default apply without a post-save synchronization; async/pinned modes pass.
- Current-head full CUDA build: pass. Full CTest: 525 tests, zero failures,
  five expected skips (61.87 seconds).
- The following original qualification results were collected on predecessor
  `aef40f182d50f33dedb8a4f72372a3dd77b3258d`; AMD/sanitizer requalification of
  the follow-up is separate:
- Public-branch CUDA builds of `test_deepseek4_unit` and `dflash_server`: pass,
  with build parallelism capped at four.
- Complete `ctest -R '^deepseek4_unit$'`: pass in 12.87 seconds on RTX 3090.
  The new CPU sweep and all three CUDA copy modes ran and passed. Six existing
  HIP-only/two-GPU checks skipped on this single-CUDA-device machine.
- Focused sweep on AMD R9700 (`gfx1201`): all three copy modes pass.
- Focused sweep on AMD 8060S (`gfx1151`): all three copy modes pass.
- The AMD checks compile the exact candidate helper and checked-in regression
  against the existing staging HIP backend. They are not a fresh full HIP
  server build or a model-backed test. Pinned mode verifies the allocated
  buffer type, so pageable fallback cannot masquerade as pinned coverage.
- CPU focused sweep with AddressSanitizer and UndefinedBehaviorSanitizer:
  pass (`vptr` instrumentation and leak detection disabled in the isolated
  test driver; GGML shared libraries are not sanitizer-instrumented).
- `git diff --check`: pass.

Reproduce the checked-in regression on a configured build:

```sh
cmake --build server/build --target test_deepseek4_unit dflash_server -j4
ctest --test-dir server/build -R '^deepseek4_unit$' --output-on-failure
```

No throughput, full-model token parity, or general verifier-numerics claim is
made by this PR. In particular, it does not claim to deliver 51 tok/s on public
`main`. Upstream CI/review and maintainer merge are still required.
