### PR TITLE
feat(ds4): ondisk prefix cache export/adopt; fix continued checkpoint keying

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -468,6 +468,7 @@ add_library(dflash_common STATIC
     # DeepSeek V4 Flash target arch
     src/deepseek4/deepseek4_loader.cpp
     src/deepseek4/deepseek4_graph.cpp
+    src/deepseek4/deepseek4_snapshot.cpp
     src/deepseek4/deepseek4_roctx.cpp
     src/deepseek4/deepseek4_paged_cache.cpp
     src/deepseek4/deepseek4_seq_engine.cpp

--- a/server/src/deepseek4/deepseek4_backend.cpp
+++ b/server/src/deepseek4/deepseek4_backend.cpp
@@ -4,6 +4,7 @@
 #include "deepseek4_backend.h"
 #include "deepseek4_budget_hook.h"
 #include "deepseek4_internal.h"
+#include "deepseek4_snapshot.h"
 #include "deepseek4_page_layout.h"
 #include "common/dynamic_backend.h"
 #include "common/peer_access.h"
@@ -2764,67 +2765,28 @@ bool DeepSeek4Backend::snapshot_adopt(int slot, ggml_context * ctx,
     if (slot < 0 || slot >= PREFIX_SLOTS || !ctx || !buf || cur_pos <= 0) {
         return false;
     }
-    if (w_.n_layer <= 0 || w_.n_vocab <= 0 ||
-        w_.compress_ratios.size() != (size_t) w_.n_layer) {
+    auto reject = [&](const std::string & why) {
         std::fprintf(stderr,
-                     "[deepseek4] snapshot adopt slot=%d rejected: weights not "
-                     "loaded\n", slot);
-        return false;
-    }
-    // The live cache may be absent while the target is parked; the layer
-    // schedule from the weights is enough to validate the file. Capacity
-    // checks against the live cache happen below when it exists, and again
-    // in deepseek4_snapshot_restore().
-    const bool have_cache = cache_.ctx && cache_.layers.size() == (size_t) w_.n_layer;
-
-    DeepSeek4Snapshot snap;
-    DeepSeek4SnapshotBindInfo info;
-    if (!deepseek4_snapshot_bind(ctx, buf, nullptr, /*take_ownership=*/true,
-                                 snap, &info)) {
-        std::fprintf(stderr,
-                     "[deepseek4] snapshot adopt slot=%d rejected: bind failed\n",
-                     slot);
-        return false;
-    }
-    // `snap` now points at ctx/buf but must not free them on the error paths
-    // below: the caller keeps ownership until we return true.
-    snap.owns_storage = false;
-
-    auto reject = [&](const char * why) {
-        std::fprintf(stderr,
-                     "[deepseek4] snapshot adopt slot=%d rejected: %s "
-                     "(pos=%d meta_pos=%d layers=%d/%d vocab=%d/%d)\n",
-                     slot, why, cur_pos, info.cur_pos, info.n_layer,
-                     w_.n_layer, info.n_vocab, w_.n_vocab);
+                     "[deepseek4] snapshot adopt slot=%d pos=%d rejected: %s\n",
+                     slot, cur_pos, why.c_str());
         return false;
     };
+
+    // Structural rebind, then a full type/shape check against the geometry
+    // the loaded weights imply. The live cache may be absent while the
+    // target is parked; its capacity is checked when it exists and again by
+    // deepseek4_snapshot_restore().
+    DeepSeek4Snapshot snap;
+    DeepSeek4SnapshotBindInfo info;
+    if (!deepseek4_snapshot_bind(ctx, buf, nullptr, /*take_ownership=*/false, snap, &info)) {
+        return reject("bind failed");
+    }
     if (info.cur_pos != cur_pos) return reject("position mismatch");
-    if (info.n_layer != w_.n_layer) return reject("layer count mismatch");
     if (info.n_vocab != w_.n_vocab) return reject("vocab mismatch");
-    if (have_cache && cur_pos > cache_.max_ctx) return reject("exceeds max_ctx");
-    // The compression schedule decides which tensors each layer needs; a
-    // snapshot from another schedule cannot be adopted.
-    for (size_t il = 0; il < snap.layers.size(); ++il) {
-        const uint32_t ratio = w_.compress_ratios[il];
-        const bool want_comp = ratio > 0;
-        const bool want_index = ratio == 4;
-        const auto & got = snap.layers[il];
-        if ((!!got.comp_kv) != want_comp ||
-            (!!got.index_comp_kv) != want_index ||
-            (!!got.attn_compressor.state_kv) != want_comp ||
-            (!!got.attn_compressor.state_score) != want_comp ||
-            (!!got.indexer_compressor.state_kv) != want_index ||
-            (!!got.indexer_compressor.state_score) != want_index) {
-            return reject("layer layout mismatch");
-        }
-        if (have_cache) {
-            const auto & live = cache_.layers[il];
-            if ((live.comp_kv && got.n_comp > live.comp_kv->ne[1]) ||
-                (live.index_comp_kv && got.n_index_comp > live.index_comp_kv->ne[1]) ||
-                (!!live.comp_kv) != want_comp || (!!live.index_comp_kv) != want_index) {
-                return reject("compressed rows exceed cache capacity");
-            }
-        }
+    const bool have_cache = cache_.ctx && cache_.layers.size() == (size_t) w_.n_layer;
+    std::string why;
+    if (!deepseek4_snapshot_validate(w_, have_cache ? cache_.max_ctx : 0, snap, &why)) {
+        return reject(why);
     }
 
     SnapshotAux aux;
@@ -2843,7 +2805,7 @@ bool DeepSeek4Backend::snapshot_adopt(int slot, ggml_context * ctx,
     }
 
     snapshot_free(slot);
-    snap.owns_storage = true;
+    snap.owns_storage = true;  // ownership of ctx/buf transfers on success
     snapshots_[slot] = snap;
     snapshot_aux_[slot] = std::move(aux);
     std::fprintf(stderr,

--- a/server/src/deepseek4/deepseek4_backend.cpp
+++ b/server/src/deepseek4/deepseek4_backend.cpp
@@ -2679,16 +2679,29 @@ bool DeepSeek4Backend::snapshot_save(int slot) {
     }
 
     snapshot_free(slot);
-    if (!deepseek4_snapshot_save(cache_, snap_backend_, snapshots_[slot])) {
+
+    // Host-side decode state travels inside the snapshot context as well, so
+    // the ondisk prefix cache can persist and rebind it (see snapshot_adopt).
+    std::vector<float> feat_tail;
+    try {
+        feat_tail = spec_feat_window_;
+        keep_spec_feature_tail(feat_tail, (size_t) std::max(0, w_.n_swa));
+    } catch (const std::bad_alloc &) {
+        return false;
+    }
+    DeepSeek4SnapshotAux aux_in;
+    aux_in.logits = last_logits_.data();
+    aux_in.n_logits = last_logits_.size();
+    aux_in.spec_feat = feat_tail.empty() ? nullptr : feat_tail.data();
+    aux_in.n_spec_feat = feat_tail.size();
+    if (!deepseek4_snapshot_save(cache_, snap_backend_, snapshots_[slot], &aux_in)) {
         return false;
     }
 
     try {
         auto & aux = snapshot_aux_[slot];
         aux.last_logits = last_logits_;
-        aux.spec_feat_window = spec_feat_window_;
-        keep_spec_feature_tail(aux.spec_feat_window,
-                               (size_t) std::max(0, w_.n_swa));
+        aux.spec_feat_window = std::move(feat_tail);
         aux.used = true;
     } catch (const std::bad_alloc &) {
         snapshot_free(slot);
@@ -2725,6 +2738,119 @@ bool DeepSeek4Backend::snapshot_used(int slot) const {
 int DeepSeek4Backend::snapshot_cur_pos(int slot) const {
     if (slot < 0 || slot >= PREFIX_SLOTS) return 0;
     return snapshots_[slot].cur_pos;
+}
+
+ModelBackend::SnapshotRef DeepSeek4Backend::snapshot_ref(int slot) const {
+    SnapshotRef ref;
+    // Paged concurrent serving has no monolithic cache to restore into.
+    if (cfg_.paged_attention || !snapshot_used(slot)) return ref;
+    const auto & snap = snapshots_[slot];
+    // Only snapshots that carry the serialization sidecar are exportable.
+    if (!snap.meta_snap || !snap.last_logits_snap || !snap.spec_feat_snap) {
+        return ref;
+    }
+    ref.ctx = snap.ctx;
+    ref.buf = snap.buf;
+    ref.cur_pos = snap.cur_pos;
+    ref.last_tok = -1;  // DeepSeek resumes from stored logits, not a seed token
+    return ref;
+}
+
+bool DeepSeek4Backend::snapshot_adopt(int slot, ggml_context * ctx,
+                                      ggml_backend_buffer_t buf, int cur_pos,
+                                      int32_t last_tok) {
+    (void) last_tok;
+    if (cfg_.paged_attention) return false;  // see snapshot_ref()
+    if (slot < 0 || slot >= PREFIX_SLOTS || !ctx || !buf || cur_pos <= 0) {
+        return false;
+    }
+    if (w_.n_layer <= 0 || w_.n_vocab <= 0 ||
+        w_.compress_ratios.size() != (size_t) w_.n_layer) {
+        std::fprintf(stderr,
+                     "[deepseek4] snapshot adopt slot=%d rejected: weights not "
+                     "loaded\n", slot);
+        return false;
+    }
+    // The live cache may be absent while the target is parked; the layer
+    // schedule from the weights is enough to validate the file. Capacity
+    // checks against the live cache happen below when it exists, and again
+    // in deepseek4_snapshot_restore().
+    const bool have_cache = cache_.ctx && cache_.layers.size() == (size_t) w_.n_layer;
+
+    DeepSeek4Snapshot snap;
+    DeepSeek4SnapshotBindInfo info;
+    if (!deepseek4_snapshot_bind(ctx, buf, nullptr, /*take_ownership=*/true,
+                                 snap, &info)) {
+        std::fprintf(stderr,
+                     "[deepseek4] snapshot adopt slot=%d rejected: bind failed\n",
+                     slot);
+        return false;
+    }
+    // `snap` now points at ctx/buf but must not free them on the error paths
+    // below: the caller keeps ownership until we return true.
+    snap.owns_storage = false;
+
+    auto reject = [&](const char * why) {
+        std::fprintf(stderr,
+                     "[deepseek4] snapshot adopt slot=%d rejected: %s "
+                     "(pos=%d meta_pos=%d layers=%d/%d vocab=%d/%d)\n",
+                     slot, why, cur_pos, info.cur_pos, info.n_layer,
+                     w_.n_layer, info.n_vocab, w_.n_vocab);
+        return false;
+    };
+    if (info.cur_pos != cur_pos) return reject("position mismatch");
+    if (info.n_layer != w_.n_layer) return reject("layer count mismatch");
+    if (info.n_vocab != w_.n_vocab) return reject("vocab mismatch");
+    if (have_cache && cur_pos > cache_.max_ctx) return reject("exceeds max_ctx");
+    // The compression schedule decides which tensors each layer needs; a
+    // snapshot from another schedule cannot be adopted.
+    for (size_t il = 0; il < snap.layers.size(); ++il) {
+        const uint32_t ratio = w_.compress_ratios[il];
+        const bool want_comp = ratio > 0;
+        const bool want_index = ratio == 4;
+        const auto & got = snap.layers[il];
+        if ((!!got.comp_kv) != want_comp ||
+            (!!got.index_comp_kv) != want_index ||
+            (!!got.attn_compressor.state_kv) != want_comp ||
+            (!!got.attn_compressor.state_score) != want_comp ||
+            (!!got.indexer_compressor.state_kv) != want_index ||
+            (!!got.indexer_compressor.state_score) != want_index) {
+            return reject("layer layout mismatch");
+        }
+        if (have_cache) {
+            const auto & live = cache_.layers[il];
+            if ((live.comp_kv && got.n_comp > live.comp_kv->ne[1]) ||
+                (live.index_comp_kv && got.n_index_comp > live.index_comp_kv->ne[1]) ||
+                (!!live.comp_kv) != want_comp || (!!live.index_comp_kv) != want_index) {
+                return reject("compressed rows exceed cache capacity");
+            }
+        }
+    }
+
+    SnapshotAux aux;
+    try {
+        aux.last_logits.resize((size_t) info.n_vocab);
+        ggml_backend_tensor_get(snap.last_logits_snap, aux.last_logits.data(), 0,
+                                aux.last_logits.size() * sizeof(float));
+        aux.spec_feat_window.resize((size_t) info.n_spec_feat);
+        if (info.n_spec_feat > 0) {
+            ggml_backend_tensor_get(snap.spec_feat_snap, aux.spec_feat_window.data(),
+                                    0, aux.spec_feat_window.size() * sizeof(float));
+        }
+        aux.used = true;
+    } catch (const std::bad_alloc &) {
+        return reject("out of memory");
+    }
+
+    snapshot_free(slot);
+    snap.owns_storage = true;
+    snapshots_[slot] = snap;
+    snapshot_aux_[slot] = std::move(aux);
+    std::fprintf(stderr,
+                 "[deepseek4] snapshot adopted slot=%d pos=%d size=%.1f MiB\n",
+                 slot, cur_pos,
+                 (double) ggml_backend_buffer_get_size(buf) / (1024.0 * 1024.0));
+    return true;
 }
 
 bool DeepSeek4Backend::snapshot_restore(int slot) {

--- a/server/src/deepseek4/deepseek4_backend.h
+++ b/server/src/deepseek4/deepseek4_backend.h
@@ -66,6 +66,13 @@ public:
     void snapshot_free(int slot) override;
     bool snapshot_used(int slot) const override;
     int  snapshot_cur_pos(int slot) const override;
+    // Ondisk prefix cache: DeepSeek snapshots are CPU ggml contexts whose
+    // tensors carry stable names plus a meta/logits/feature sidecar, so they
+    // serialize and rebind like the Qwen snapshots do.
+    SnapshotRef snapshot_ref(int slot) const override;
+    bool snapshot_adopt(int slot, ggml_context * ctx,
+                        ggml_backend_buffer_t buf, int cur_pos,
+                        int32_t last_tok = -1) override;
 
     GenerateResult restore_and_generate_impl(int slot,
                                              const GenerateRequest & req,

--- a/server/src/deepseek4/deepseek4_dspark_spec.cpp
+++ b/server/src/deepseek4/deepseek4_dspark_spec.cpp
@@ -23,6 +23,7 @@
 
 #include "deepseek4_dspark.h"
 #include "deepseek4_internal.h"
+#include "deepseek4_snapshot.h"
 #include "deepseek4_roctx.h"
 #include "internal.h"
 #include "common/dspark_head.h"

--- a/server/src/deepseek4/deepseek4_graph.cpp
+++ b/server/src/deepseek4/deepseek4_graph.cpp
@@ -9281,6 +9281,31 @@ bool deepseek4_step_layer_range(
 
 // ─── Cache management ───────────────────────────────────────────────────
 
+DeepSeek4LayerGeometry deepseek4_layer_geometry(const DeepSeek4Weights & w, int layer) {
+    DeepSeek4LayerGeometry g;
+    g.ratio = (layer >= 0 && (size_t) layer < w.compress_ratios.size())
+        ? w.compress_ratios[(size_t) layer] : 0;
+    g.head_dim = w.head_dim;
+    g.raw_rows = w.n_swa;
+    g.has_comp = g.ratio > 0;
+    g.has_index = g.ratio == 4;
+    if (g.has_comp) {
+        // Compressor state: width = coff * head_dim (2x for ratio-4, 1x for
+        // ratio-128); rows = 2*ratio for ratio-4 (prev + current window),
+        // ratio otherwise.
+        const int64_t coff = g.has_index ? 2 : 1;
+        g.comp_width = coff * (int64_t) w.head_dim;
+        g.comp_state_rows = g.has_index ? 2 * (int64_t) g.ratio : (int64_t) g.ratio;
+    }
+    if (g.has_index) {
+        // Indexer compressor: width = 2 * indexer head dim, same double buffer.
+        g.index_dim = w.n_indexer_head_dim;
+        g.index_state_width = 2 * (int64_t) w.n_indexer_head_dim;
+        g.index_state_rows = 2 * (int64_t) g.ratio;
+    }
+    return g;
+}
+
 bool create_deepseek4_cache(ggml_backend_t backend,
                              const DeepSeek4Weights & w,
                              int max_ctx,
@@ -9300,9 +9325,9 @@ bool create_deepseek4_cache(ggml_backend_t backend,
 
     for (int il = 0; il < w.n_layer; ++il) {
         DeepSeek4LayerCache & lc = out.layers[il];
-        const uint32_t ratio = w.compress_ratios[il];
+        const DeepSeek4LayerGeometry g = deepseek4_layer_geometry(w, il);
 
-        lc.raw_kv = ggml_new_tensor_2d(out.ctx, GGML_TYPE_F16, w.head_dim, w.n_swa);
+        lc.raw_kv = ggml_new_tensor_2d(out.ctx, GGML_TYPE_F16, g.head_dim, g.raw_rows);
         char name[64];
         std::snprintf(name, sizeof(name), "ds4_raw_kv_%d", il);
         ggml_set_name(lc.raw_kv, name);
@@ -9310,37 +9335,28 @@ bool create_deepseek4_cache(ggml_backend_t backend,
         lc.n_comp = 0;
         lc.n_index_comp = 0;
 
-        if (ratio <= 0) {
+        if (!g.has_comp) {
             continue;
         }
 
-        const int comp_cap = max_ctx / (int) ratio + 16;
-        lc.comp_kv = ggml_new_tensor_2d(out.ctx, GGML_TYPE_F16, w.head_dim, comp_cap);
+        const int64_t comp_cap = g.comp_capacity(max_ctx);
+        lc.comp_kv = ggml_new_tensor_2d(out.ctx, GGML_TYPE_F16, g.head_dim, comp_cap);
         std::snprintf(name, sizeof(name), "ds4_comp_kv_%d", il);
         ggml_set_name(lc.comp_kv, name);
 
-        // Compressor state dimensions: comp_width = coff * head_dim
-        // Number of state rows: 2*ratio for ratio-4 (prev+cur windows), ratio for ratio-128
-        const int coff = (ratio == 4) ? 2 : 1;
-        const int comp_width = coff * (int)w.head_dim;
-        const int n_state_rows = (ratio == 4) ? (2 * ratio) : ratio;
-        lc.attn_compressor.state_kv = ggml_new_tensor_2d(out.ctx, GGML_TYPE_F32, comp_width, n_state_rows);
-        lc.attn_compressor.state_score = ggml_new_tensor_2d(out.ctx, GGML_TYPE_F32, comp_width, n_state_rows);
+        lc.attn_compressor.state_kv = ggml_new_tensor_2d(out.ctx, GGML_TYPE_F32, g.comp_width, g.comp_state_rows);
+        lc.attn_compressor.state_score = ggml_new_tensor_2d(out.ctx, GGML_TYPE_F32, g.comp_width, g.comp_state_rows);
         std::snprintf(name, sizeof(name), "ds4_comp_state_kv_%d", il);
         ggml_set_name(lc.attn_compressor.state_kv, name);
         std::snprintf(name, sizeof(name), "ds4_comp_state_score_%d", il);
         ggml_set_name(lc.attn_compressor.state_score, name);
 
-        if (ratio == 4) {
-            // Indexer comp_width = 2 * indexer_head_dim = 256
-            const int index_comp_width = 2 * (int)w.n_indexer_head_dim;
-            const int index_state_rows = 2 * ratio;  // same double-buffer for ratio-4
-            lc.index_comp_kv = ggml_new_tensor_2d(out.ctx, GGML_TYPE_F16,
-                                                  w.n_indexer_head_dim, comp_cap);
+        if (g.has_index) {
+            lc.index_comp_kv = ggml_new_tensor_2d(out.ctx, GGML_TYPE_F16, g.index_dim, comp_cap);
             lc.indexer_compressor.state_kv = ggml_new_tensor_2d(out.ctx, GGML_TYPE_F32,
-                                                                index_comp_width, index_state_rows);
+                                                                g.index_state_width, g.index_state_rows);
             lc.indexer_compressor.state_score = ggml_new_tensor_2d(out.ctx, GGML_TYPE_F32,
-                                                                   index_comp_width, index_state_rows);
+                                                                   g.index_state_width, g.index_state_rows);
             std::snprintf(name, sizeof(name), "ds4_index_comp_kv_%d", il);
             ggml_set_name(lc.index_comp_kv, name);
             std::snprintf(name, sizeof(name), "ds4_index_state_kv_%d", il);
@@ -9350,7 +9366,7 @@ bool create_deepseek4_cache(ggml_backend_t backend,
         }
     }
 
-    out.hc_state = ggml_new_tensor_1d(out.ctx, GGML_TYPE_F32, (int64_t)w.n_hc * w.n_embd);
+    out.hc_state = ggml_new_tensor_1d(out.ctx, GGML_TYPE_F32, deepseek4_hc_state_elements(w));
     ggml_set_name(out.hc_state, "ds4_hc_state");
 
     out.buf = ggml_backend_alloc_ctx_tensors(out.ctx, backend);
@@ -9439,509 +9455,6 @@ void deepseek4_release_prefill_scratch(
                      free_before / (1024.0 * 1024.0),
                      free_after / (1024.0 * 1024.0));
     }
-}
-
-namespace {
-
-ggml_tensor * clone_snapshot_tensor(ggml_context * ctx,
-                                    const ggml_tensor * src,
-                                    const char * name) {
-    if (!ctx || !src) return nullptr;
-    ggml_tensor * dst = ggml_dup_tensor(ctx, const_cast<ggml_tensor *>(src));
-    if (!dst) return nullptr;
-    if (name && *name) ggml_set_name(dst, name);
-    return dst;
-}
-
-ggml_tensor * clone_snapshot_rows(ggml_context * ctx,
-                                  const ggml_tensor * src,
-                                  int live_rows,
-                                  const char * name) {
-    if (!ctx || !src || ggml_n_dims(src) != 2 || live_rows < 0 ||
-        live_rows > src->ne[1]) {
-        return nullptr;
-    }
-    // GGML tensors cannot have an empty physical dimension. Keep one
-    // allocated row for an empty logical prefix, but copy zero bytes below.
-    const int64_t allocated_rows = std::max(1, live_rows);
-    ggml_tensor * dst = ggml_new_tensor_2d(
-        ctx, src->type, src->ne[0], allocated_rows);
-    if (!dst) return nullptr;
-    if (name && *name) ggml_set_name(dst, name);
-    return dst;
-}
-
-size_t tensor_prefix_bytes(const ggml_tensor * tensor, int rows) {
-    if (!tensor || rows <= 0) return 0;
-    return ggml_row_size(tensor->type, tensor->ne[0]) * (size_t) rows;
-}
-
-bool copy_tensor_prefix_from_backend(const ggml_tensor * src,
-                                     ggml_tensor * dst,
-                                     int rows) {
-    if (!src || !dst || rows < 0) return false;
-    const size_t bytes = tensor_prefix_bytes(src, rows);
-    if (bytes > ggml_nbytes(src) || bytes > ggml_nbytes(dst)) return false;
-    if (bytes > 0) ggml_backend_tensor_get(src, dst->data, 0, bytes);
-    return true;
-}
-
-bool copy_tensor_prefix_to_backend(const ggml_tensor * src,
-                                   ggml_tensor * dst,
-                                   int rows) {
-    if (!src || !dst || rows < 0) return false;
-    const size_t bytes = tensor_prefix_bytes(src, rows);
-    if (bytes > ggml_nbytes(src) || bytes > ggml_nbytes(dst)) return false;
-    if (bytes > 0) ggml_backend_tensor_set(dst, src->data, 0, bytes);
-    return true;
-}
-
-bool copy_tensor_from_backend(const ggml_tensor * src, ggml_tensor * dst) {
-    if (!src || !dst) return false;
-    const size_t bytes = ggml_nbytes(src);
-    if (bytes != ggml_nbytes(dst)) return false;
-    ggml_backend_tensor_get(src, dst->data, 0, bytes);
-    return true;
-}
-
-bool copy_tensor_to_backend(const ggml_tensor * src, ggml_tensor * dst) {
-    if (!src || !dst) return false;
-    const size_t bytes = ggml_nbytes(src);
-    if (bytes != ggml_nbytes(dst)) return false;
-    ggml_backend_tensor_set(dst, src->data, 0, bytes);
-    return true;
-}
-
-bool tensors_compatible(const ggml_tensor * a, const ggml_tensor * b) {
-    if (!!a != !!b) return false;
-    if (!a) return true;
-    if (a->type != b->type || ggml_n_dims(a) != ggml_n_dims(b)) return false;
-    for (int i = 0; i < GGML_MAX_DIMS; ++i) {
-        if (a->ne[i] != b->ne[i]) return false;
-    }
-    return true;
-}
-
-bool prefix_tensors_compatible(const ggml_tensor * snap,
-                               const ggml_tensor * cache,
-                               int live_rows) {
-    if (!!snap != !!cache) return false;
-    if (!snap) return live_rows == 0;
-    // A right-sized zero/one-row tensor reports one logical GGML dimension,
-    // while its full-capacity cache tensor reports two. Compare the physical
-    // row layout instead of ggml_n_dims() so those valid snapshots restore.
-    if (live_rows < 0 || cache->ne[1] <= 0 ||
-        snap->type != cache->type ||
-        snap->ne[0] != cache->ne[0] || live_rows > cache->ne[1]) {
-        return false;
-    }
-    for (int i = 2; i < GGML_MAX_DIMS; ++i) {
-        if (snap->ne[i] != cache->ne[i]) return false;
-    }
-    return snap->ne[1] == std::max(1, live_rows);
-}
-
-}  // namespace
-
-namespace {
-
-// Stable per-layer snapshot tensor names (ondisk prefix cache keys on them).
-const char * const kDs4SnapLayerNames[7] = {
-    "ds4_snap_raw_kv_%d",
-    "ds4_snap_comp_kv_%d",
-    "ds4_snap_index_kv_%d",
-    "ds4_snap_attn_cs_kv_%d",
-    "ds4_snap_attn_cs_score_%d",
-    "ds4_snap_idx_cs_kv_%d",
-    "ds4_snap_idx_cs_score_%d",
-};
-const char * const kDs4SnapHcName     = "ds4_hc_state_snap";
-const char * const kDs4SnapMetaName   = "ds4_snap_meta";
-const char * const kDs4SnapLogitsName = "ds4_snap_last_logits";
-const char * const kDs4SnapFeatName   = "ds4_snap_spec_feat";
-
-std::string ds4_snap_name(const char * prefix, const char * fmt, int il) {
-    char buf[GGML_MAX_NAME];
-    std::snprintf(buf, sizeof(buf), fmt, il);
-    std::string name = prefix ? prefix : "";
-    name += buf;
-    return name;
-}
-
-ggml_tensor * ds4_find_snap_tensor(ggml_context * ctx, const std::string & name) {
-    if (!ctx || name.empty() || name.size() >= (size_t) GGML_MAX_NAME) {
-        return nullptr;
-    }
-    return ggml_get_tensor(ctx, name.c_str());
-}
-
-}  // namespace
-
-bool deepseek4_snapshot_save(const DeepSeek4Cache & cache,
-                             ggml_backend_t snapshot_backend,
-                             DeepSeek4Snapshot & out,
-                             const DeepSeek4SnapshotAux * aux) {
-    if (!snapshot_backend || !cache.ctx || !cache.buf || !cache.hc_state ||
-        cache.layers.size() != (size_t)cache.n_layer || cache.cur_pos < 0 ||
-        cache.cur_pos > cache.max_ctx) {
-        return false;
-    }
-    if (aux && ((aux->n_logits > 0 && !aux->logits) ||
-                (aux->n_spec_feat > 0 && !aux->spec_feat) ||
-                aux->n_logits > (size_t) std::numeric_limits<int>::max() ||
-                aux->n_spec_feat > (size_t) std::numeric_limits<int>::max())) {
-        return false;
-    }
-    for (const auto & layer : cache.layers) {
-        if (layer.n_comp < 0 || layer.n_index_comp < 0 ||
-            (layer.comp_kv && layer.n_comp > layer.comp_kv->ne[1]) ||
-            (!layer.comp_kv && layer.n_comp != 0) ||
-            (layer.index_comp_kv &&
-             layer.n_index_comp > layer.index_comp_kv->ne[1]) ||
-            (!layer.index_comp_kv && layer.n_index_comp != 0)) {
-            return false;
-        }
-    }
-
-    free_deepseek4_snapshot(out);
-
-    ggml_init_params ip{};
-    ip.mem_size = ggml_tensor_overhead() * (size_t)(cache.n_layer * 8 + 8) + 4096;
-    ip.no_alloc = true;
-    out.ctx = ggml_init(ip);
-    if (!out.ctx) {
-        return false;
-    }
-
-    out.layers.resize((size_t)cache.n_layer);
-    out.hc_state_snap = clone_snapshot_tensor(out.ctx, cache.hc_state, kDs4SnapHcName);
-    if (!out.hc_state_snap) {
-        free_deepseek4_snapshot(out);
-        return false;
-    }
-
-    for (int il = 0; il < cache.n_layer; ++il) {
-        const auto & src = cache.layers[(size_t)il];
-        auto & dst = out.layers[(size_t)il];
-        const std::string nm_raw   = ds4_snap_name(nullptr, kDs4SnapLayerNames[0], il);
-        const std::string nm_comp  = ds4_snap_name(nullptr, kDs4SnapLayerNames[1], il);
-        const std::string nm_index = ds4_snap_name(nullptr, kDs4SnapLayerNames[2], il);
-        const std::string nm_a_kv  = ds4_snap_name(nullptr, kDs4SnapLayerNames[3], il);
-        const std::string nm_a_sc  = ds4_snap_name(nullptr, kDs4SnapLayerNames[4], il);
-        const std::string nm_i_kv  = ds4_snap_name(nullptr, kDs4SnapLayerNames[5], il);
-        const std::string nm_i_sc  = ds4_snap_name(nullptr, kDs4SnapLayerNames[6], il);
-        dst.raw_kv = clone_snapshot_tensor(out.ctx, src.raw_kv, nm_raw.c_str());
-        dst.comp_kv = src.comp_kv
-            ? clone_snapshot_rows(out.ctx, src.comp_kv, src.n_comp, nm_comp.c_str())
-            : nullptr;
-        dst.index_comp_kv = src.index_comp_kv
-            ? clone_snapshot_rows(out.ctx, src.index_comp_kv,
-                                  src.n_index_comp, nm_index.c_str())
-            : nullptr;
-        dst.attn_compressor.state_kv =
-            clone_snapshot_tensor(out.ctx, src.attn_compressor.state_kv, nm_a_kv.c_str());
-        dst.attn_compressor.state_score =
-            clone_snapshot_tensor(out.ctx, src.attn_compressor.state_score, nm_a_sc.c_str());
-        dst.indexer_compressor.state_kv =
-            clone_snapshot_tensor(out.ctx, src.indexer_compressor.state_kv, nm_i_kv.c_str());
-        dst.indexer_compressor.state_score =
-            clone_snapshot_tensor(out.ctx, src.indexer_compressor.state_score, nm_i_sc.c_str());
-        if (!dst.raw_kv ||
-            (src.comp_kv && !dst.comp_kv) ||
-            (src.index_comp_kv && !dst.index_comp_kv) ||
-            (src.attn_compressor.state_kv && !dst.attn_compressor.state_kv) ||
-            (src.attn_compressor.state_score && !dst.attn_compressor.state_score) ||
-            (src.indexer_compressor.state_kv && !dst.indexer_compressor.state_kv) ||
-            (src.indexer_compressor.state_score && !dst.indexer_compressor.state_score)) {
-            free_deepseek4_snapshot(out);
-            return false;
-        }
-    }
-
-    if (aux) {
-        const int64_t n_meta = kDeepSeek4SnapMetaBase + 2 * (int64_t) cache.n_layer;
-        out.meta_snap = ggml_new_tensor_1d(out.ctx, GGML_TYPE_I32, n_meta);
-        out.last_logits_snap = ggml_new_tensor_1d(
-            out.ctx, GGML_TYPE_F32, (int64_t) std::max<size_t>(1, aux->n_logits));
-        // Variable length lives in ne[1]: the ondisk layout fingerprint
-        // normalizes that dimension, so short and long windows share a layout.
-        out.spec_feat_snap = ggml_new_tensor_2d(
-            out.ctx, GGML_TYPE_F32, 1, (int64_t) std::max<size_t>(1, aux->n_spec_feat));
-        if (!out.meta_snap || !out.last_logits_snap || !out.spec_feat_snap) {
-            free_deepseek4_snapshot(out);
-            return false;
-        }
-        ggml_set_name(out.meta_snap, kDs4SnapMetaName);
-        ggml_set_name(out.last_logits_snap, kDs4SnapLogitsName);
-        ggml_set_name(out.spec_feat_snap, kDs4SnapFeatName);
-    }
-
-    out.buf = ggml_backend_alloc_ctx_tensors(out.ctx, snapshot_backend);
-    if (!out.buf) {
-        free_deepseek4_snapshot(out);
-        return false;
-    }
-    if (aux) {
-        // Unused physical slots (one-row placeholders, empty logits / window)
-        // are zeroed so serialized bytes are deterministic.
-        ggml_backend_buffer_clear(out.buf, 0);
-    }
-
-    if (!copy_tensor_from_backend(cache.hc_state, out.hc_state_snap)) {
-        free_deepseek4_snapshot(out);
-        return false;
-    }
-    if (aux) {
-        std::vector<int32_t> meta((size_t) (kDeepSeek4SnapMetaBase + 2 * cache.n_layer), 0);
-        meta[0] = kDeepSeek4SnapMetaVersion;
-        meta[1] = cache.n_layer;
-        meta[2] = (int32_t) aux->n_logits;
-        meta[3] = (int32_t) aux->n_spec_feat;
-        meta[4] = cache.cur_pos;
-        for (int il = 0; il < cache.n_layer; ++il) {
-            meta[(size_t) (kDeepSeek4SnapMetaBase + 2 * il)]     = cache.layers[(size_t) il].n_comp;
-            meta[(size_t) (kDeepSeek4SnapMetaBase + 2 * il + 1)] = cache.layers[(size_t) il].n_index_comp;
-        }
-        ggml_backend_tensor_set(out.meta_snap, meta.data(), 0, meta.size() * sizeof(int32_t));
-        if (aux->n_logits > 0) {
-            ggml_backend_tensor_set(out.last_logits_snap, aux->logits, 0,
-                                    aux->n_logits * sizeof(float));
-        }
-        if (aux->n_spec_feat > 0) {
-            ggml_backend_tensor_set(out.spec_feat_snap, aux->spec_feat, 0,
-                                    aux->n_spec_feat * sizeof(float));
-        }
-    }
-    for (int il = 0; il < cache.n_layer; ++il) {
-        const auto & src = cache.layers[(size_t)il];
-        auto & dst = out.layers[(size_t)il];
-        dst.n_comp = src.n_comp;
-        dst.n_index_comp = src.n_index_comp;
-        if (!copy_tensor_from_backend(src.raw_kv, dst.raw_kv) ||
-            (src.comp_kv &&
-             !copy_tensor_prefix_from_backend(src.comp_kv, dst.comp_kv,
-                                              src.n_comp)) ||
-            (src.index_comp_kv &&
-             !copy_tensor_prefix_from_backend(src.index_comp_kv,
-                                              dst.index_comp_kv,
-                                              src.n_index_comp)) ||
-            (src.attn_compressor.state_kv &&
-             !copy_tensor_from_backend(src.attn_compressor.state_kv,
-                                       dst.attn_compressor.state_kv)) ||
-            (src.attn_compressor.state_score &&
-             !copy_tensor_from_backend(src.attn_compressor.state_score,
-                                       dst.attn_compressor.state_score)) ||
-            (src.indexer_compressor.state_kv &&
-             !copy_tensor_from_backend(src.indexer_compressor.state_kv,
-                                       dst.indexer_compressor.state_kv)) ||
-            (src.indexer_compressor.state_score &&
-             !copy_tensor_from_backend(src.indexer_compressor.state_score,
-                                       dst.indexer_compressor.state_score))) {
-            free_deepseek4_snapshot(out);
-            return false;
-        }
-    }
-
-    out.cur_pos = cache.cur_pos;
-    return true;
-}
-
-bool deepseek4_snapshot_restore(const DeepSeek4Snapshot & snap,
-                                DeepSeek4Cache & cache) {
-    if (!snap.ctx || !cache.ctx || !cache.buf || !snap.hc_state_snap ||
-        snap.layers.size() != cache.layers.size() || snap.cur_pos < 0 ||
-        snap.cur_pos > cache.max_ctx) {
-        std::fprintf(stderr,
-                     "[deepseek4] snapshot restore: invalid header "
-                     "(snap_ctx=%d cache_ctx=%d snap_layers=%zu "
-                     "cache_layers=%zu pos=%d max_ctx=%d)\n",
-                     snap.ctx != nullptr, cache.ctx != nullptr,
-                     snap.layers.size(), cache.layers.size(),
-                     snap.cur_pos, cache.max_ctx);
-        return false;
-    }
-    if (!tensors_compatible(snap.hc_state_snap, cache.hc_state)) {
-        std::fprintf(stderr,
-                     "[deepseek4] snapshot restore: incompatible HC state\n");
-        return false;
-    }
-
-    // Validate the complete layout before changing the live cache. Compressed
-    // tensors are deliberately right-sized to their logical row counts;
-    // inactive capacity rows are not part of the snapshot contract.
-    for (size_t il = 0; il < cache.layers.size(); ++il) {
-        const auto & src = snap.layers[il];
-        const auto & dst = cache.layers[il];
-        const bool raw_ok = tensors_compatible(src.raw_kv, dst.raw_kv);
-        const bool comp_ok = prefix_tensors_compatible(
-            src.comp_kv, dst.comp_kv, src.n_comp);
-        const bool index_ok = prefix_tensors_compatible(
-            src.index_comp_kv, dst.index_comp_kv, src.n_index_comp);
-        const bool attn_kv_ok = tensors_compatible(
-            src.attn_compressor.state_kv, dst.attn_compressor.state_kv);
-        const bool attn_score_ok = tensors_compatible(
-            src.attn_compressor.state_score, dst.attn_compressor.state_score);
-        const bool index_kv_ok = tensors_compatible(
-            src.indexer_compressor.state_kv, dst.indexer_compressor.state_kv);
-        const bool index_score_ok = tensors_compatible(
-            src.indexer_compressor.state_score,
-            dst.indexer_compressor.state_score);
-        if (!raw_ok || !comp_ok || !index_ok || !attn_kv_ok ||
-            !attn_score_ok || !index_kv_ok || !index_score_ok) {
-            std::fprintf(stderr,
-                         "[deepseek4] snapshot restore: incompatible layer %zu "
-                         "(raw=%d comp=%d[%d/%lld/%lld] "
-                         "index=%d[%d/%lld/%lld] states=%d/%d/%d/%d)\n",
-                         il, raw_ok, comp_ok, src.n_comp,
-                         (long long) (src.comp_kv ? src.comp_kv->ne[1] : 0),
-                         (long long) (dst.comp_kv ? dst.comp_kv->ne[1] : 0),
-                         index_ok, src.n_index_comp,
-                         (long long) (src.index_comp_kv
-                             ? src.index_comp_kv->ne[1] : 0),
-                         (long long) (dst.index_comp_kv
-                             ? dst.index_comp_kv->ne[1] : 0),
-                         attn_kv_ok, attn_score_ok,
-                         index_kv_ok, index_score_ok);
-            return false;
-        }
-    }
-
-    if (!copy_tensor_to_backend(snap.hc_state_snap, cache.hc_state)) {
-        std::fprintf(stderr,
-                     "[deepseek4] snapshot restore: HC copy failed\n");
-        return false;
-    }
-    for (size_t il = 0; il < cache.layers.size(); ++il) {
-        const auto & src = snap.layers[il];
-        auto & dst = cache.layers[il];
-        if (!copy_tensor_to_backend(src.raw_kv, dst.raw_kv) ||
-            (src.comp_kv &&
-             !copy_tensor_prefix_to_backend(src.comp_kv, dst.comp_kv,
-                                            src.n_comp)) ||
-            (src.index_comp_kv &&
-             !copy_tensor_prefix_to_backend(src.index_comp_kv,
-                                            dst.index_comp_kv,
-                                            src.n_index_comp)) ||
-            (src.attn_compressor.state_kv &&
-             !copy_tensor_to_backend(src.attn_compressor.state_kv,
-                                     dst.attn_compressor.state_kv)) ||
-            (src.attn_compressor.state_score &&
-             !copy_tensor_to_backend(src.attn_compressor.state_score,
-                                     dst.attn_compressor.state_score)) ||
-            (src.indexer_compressor.state_kv &&
-             !copy_tensor_to_backend(src.indexer_compressor.state_kv,
-                                     dst.indexer_compressor.state_kv)) ||
-            (src.indexer_compressor.state_score &&
-             !copy_tensor_to_backend(src.indexer_compressor.state_score,
-                                       dst.indexer_compressor.state_score))) {
-            std::fprintf(stderr,
-                         "[deepseek4] snapshot restore: layer %zu copy failed\n",
-                         il);
-            return false;
-        }
-        dst.n_comp = src.n_comp;
-        dst.n_index_comp = src.n_index_comp;
-    }
-
-    cache.cur_pos = snap.cur_pos;
-    return true;
-}
-
-
-void free_deepseek4_snapshot(DeepSeek4Snapshot & s) {
-    if (s.owns_storage) {
-        if (s.buf) { ggml_backend_buffer_free(s.buf); }
-        if (s.ctx) { ggml_free(s.ctx); }
-    }
-    s.buf = nullptr;
-    s.ctx = nullptr;
-    s.owns_storage = true;
-    s.layers.clear();
-    s.cur_pos = 0;
-    s.hc_state_snap = nullptr;
-    s.meta_snap = nullptr;
-    s.last_logits_snap = nullptr;
-    s.spec_feat_snap = nullptr;
-}
-
-bool deepseek4_snapshot_bind(ggml_context * ctx,
-                             ggml_backend_buffer_t buf,
-                             const char * name_prefix,
-                             bool take_ownership,
-                             DeepSeek4Snapshot & out,
-                             DeepSeek4SnapshotBindInfo * info) {
-    free_deepseek4_snapshot(out);
-    if (!ctx || !buf) return false;
-
-    const std::string pfx = name_prefix ? name_prefix : "";
-    ggml_tensor * meta = ds4_find_snap_tensor(ctx, pfx + kDs4SnapMetaName);
-    if (!meta || meta->type != GGML_TYPE_I32 || ggml_n_dims(meta) != 1 ||
-        meta->ne[0] < kDeepSeek4SnapMetaBase || !meta->data) {
-        return false;
-    }
-    std::vector<int32_t> m((size_t) meta->ne[0], 0);
-    ggml_backend_tensor_get(meta, m.data(), 0, m.size() * sizeof(int32_t));
-    if (m[0] != kDeepSeek4SnapMetaVersion) return false;
-    const int n_layer = m[1];
-    const int n_vocab = m[2];
-    const int n_spec_feat = m[3];
-    const int cur_pos = m[4];
-    if (n_layer <= 0 || n_layer > 4096 || n_vocab < 0 || n_spec_feat < 0 ||
-        cur_pos < 0 ||
-        meta->ne[0] != (int64_t) (kDeepSeek4SnapMetaBase + 2 * n_layer)) {
-        return false;
-    }
-
-    DeepSeek4Snapshot tmp;
-    tmp.hc_state_snap = ds4_find_snap_tensor(ctx, pfx + kDs4SnapHcName);
-    tmp.meta_snap = meta;
-    tmp.last_logits_snap = ds4_find_snap_tensor(ctx, pfx + kDs4SnapLogitsName);
-    tmp.spec_feat_snap = ds4_find_snap_tensor(ctx, pfx + kDs4SnapFeatName);
-    if (!tmp.hc_state_snap || !tmp.last_logits_snap || !tmp.spec_feat_snap ||
-        tmp.last_logits_snap->type != GGML_TYPE_F32 ||
-        tmp.spec_feat_snap->type != GGML_TYPE_F32 ||
-        ggml_nelements(tmp.last_logits_snap) < (int64_t) std::max(1, n_vocab) ||
-        ggml_nelements(tmp.spec_feat_snap) < (int64_t) std::max(1, n_spec_feat)) {
-        return false;
-    }
-
-    tmp.layers.resize((size_t) n_layer);
-    for (int il = 0; il < n_layer; ++il) {
-        auto & L = tmp.layers[(size_t) il];
-        L.raw_kv = ds4_find_snap_tensor(ctx, ds4_snap_name(name_prefix, kDs4SnapLayerNames[0], il));
-        L.comp_kv = ds4_find_snap_tensor(ctx, ds4_snap_name(name_prefix, kDs4SnapLayerNames[1], il));
-        L.index_comp_kv = ds4_find_snap_tensor(ctx, ds4_snap_name(name_prefix, kDs4SnapLayerNames[2], il));
-        L.attn_compressor.state_kv = ds4_find_snap_tensor(ctx, ds4_snap_name(name_prefix, kDs4SnapLayerNames[3], il));
-        L.attn_compressor.state_score = ds4_find_snap_tensor(ctx, ds4_snap_name(name_prefix, kDs4SnapLayerNames[4], il));
-        L.indexer_compressor.state_kv = ds4_find_snap_tensor(ctx, ds4_snap_name(name_prefix, kDs4SnapLayerNames[5], il));
-        L.indexer_compressor.state_score = ds4_find_snap_tensor(ctx, ds4_snap_name(name_prefix, kDs4SnapLayerNames[6], il));
-        L.n_comp = m[(size_t) (kDeepSeek4SnapMetaBase + 2 * il)];
-        L.n_index_comp = m[(size_t) (kDeepSeek4SnapMetaBase + 2 * il + 1)];
-        if (!L.raw_kv || L.n_comp < 0 || L.n_index_comp < 0 ||
-            (!L.comp_kv && L.n_comp != 0) ||
-            (!L.index_comp_kv && L.n_index_comp != 0) ||
-            (L.comp_kv && L.comp_kv->ne[1] != std::max(1, L.n_comp)) ||
-            (L.index_comp_kv && L.index_comp_kv->ne[1] != std::max(1, L.n_index_comp))) {
-            return false;
-        }
-    }
-    // Every tensor must be backed by host memory (CPU snapshot buffer).
-    for (ggml_tensor * t = ggml_get_first_tensor(ctx); t; t = ggml_get_next_tensor(ctx, t)) {
-        if (!t->data) return false;
-    }
-
-    out = tmp;
-    out.cur_pos = cur_pos;
-    out.ctx = ctx;
-    out.buf = buf;
-    out.owns_storage = take_ownership;
-    if (info) {
-        info->n_layer = n_layer;
-        info->n_vocab = n_vocab;
-        info->n_spec_feat = n_spec_feat;
-        info->cur_pos = cur_pos;
-    }
-    return true;
 }
 
 }  // namespace dflash::common

--- a/server/src/deepseek4/deepseek4_graph.cpp
+++ b/server/src/deepseek4/deepseek4_graph.cpp
@@ -9543,12 +9543,53 @@ bool prefix_tensors_compatible(const ggml_tensor * snap,
 
 }  // namespace
 
+namespace {
+
+// Stable per-layer snapshot tensor names (ondisk prefix cache keys on them).
+const char * const kDs4SnapLayerNames[7] = {
+    "ds4_snap_raw_kv_%d",
+    "ds4_snap_comp_kv_%d",
+    "ds4_snap_index_kv_%d",
+    "ds4_snap_attn_cs_kv_%d",
+    "ds4_snap_attn_cs_score_%d",
+    "ds4_snap_idx_cs_kv_%d",
+    "ds4_snap_idx_cs_score_%d",
+};
+const char * const kDs4SnapHcName     = "ds4_hc_state_snap";
+const char * const kDs4SnapMetaName   = "ds4_snap_meta";
+const char * const kDs4SnapLogitsName = "ds4_snap_last_logits";
+const char * const kDs4SnapFeatName   = "ds4_snap_spec_feat";
+
+std::string ds4_snap_name(const char * prefix, const char * fmt, int il) {
+    char buf[GGML_MAX_NAME];
+    std::snprintf(buf, sizeof(buf), fmt, il);
+    std::string name = prefix ? prefix : "";
+    name += buf;
+    return name;
+}
+
+ggml_tensor * ds4_find_snap_tensor(ggml_context * ctx, const std::string & name) {
+    if (!ctx || name.empty() || name.size() >= (size_t) GGML_MAX_NAME) {
+        return nullptr;
+    }
+    return ggml_get_tensor(ctx, name.c_str());
+}
+
+}  // namespace
+
 bool deepseek4_snapshot_save(const DeepSeek4Cache & cache,
                              ggml_backend_t snapshot_backend,
-                             DeepSeek4Snapshot & out) {
+                             DeepSeek4Snapshot & out,
+                             const DeepSeek4SnapshotAux * aux) {
     if (!snapshot_backend || !cache.ctx || !cache.buf || !cache.hc_state ||
         cache.layers.size() != (size_t)cache.n_layer || cache.cur_pos < 0 ||
         cache.cur_pos > cache.max_ctx) {
+        return false;
+    }
+    if (aux && ((aux->n_logits > 0 && !aux->logits) ||
+                (aux->n_spec_feat > 0 && !aux->spec_feat) ||
+                aux->n_logits > (size_t) std::numeric_limits<int>::max() ||
+                aux->n_spec_feat > (size_t) std::numeric_limits<int>::max())) {
         return false;
     }
     for (const auto & layer : cache.layers) {
@@ -9573,7 +9614,7 @@ bool deepseek4_snapshot_save(const DeepSeek4Cache & cache,
     }
 
     out.layers.resize((size_t)cache.n_layer);
-    out.hc_state_snap = clone_snapshot_tensor(out.ctx, cache.hc_state, "ds4_hc_state_snap");
+    out.hc_state_snap = clone_snapshot_tensor(out.ctx, cache.hc_state, kDs4SnapHcName);
     if (!out.hc_state_snap) {
         free_deepseek4_snapshot(out);
         return false;
@@ -9582,22 +9623,29 @@ bool deepseek4_snapshot_save(const DeepSeek4Cache & cache,
     for (int il = 0; il < cache.n_layer; ++il) {
         const auto & src = cache.layers[(size_t)il];
         auto & dst = out.layers[(size_t)il];
-        dst.raw_kv = clone_snapshot_tensor(out.ctx, src.raw_kv, nullptr);
+        const std::string nm_raw   = ds4_snap_name(nullptr, kDs4SnapLayerNames[0], il);
+        const std::string nm_comp  = ds4_snap_name(nullptr, kDs4SnapLayerNames[1], il);
+        const std::string nm_index = ds4_snap_name(nullptr, kDs4SnapLayerNames[2], il);
+        const std::string nm_a_kv  = ds4_snap_name(nullptr, kDs4SnapLayerNames[3], il);
+        const std::string nm_a_sc  = ds4_snap_name(nullptr, kDs4SnapLayerNames[4], il);
+        const std::string nm_i_kv  = ds4_snap_name(nullptr, kDs4SnapLayerNames[5], il);
+        const std::string nm_i_sc  = ds4_snap_name(nullptr, kDs4SnapLayerNames[6], il);
+        dst.raw_kv = clone_snapshot_tensor(out.ctx, src.raw_kv, nm_raw.c_str());
         dst.comp_kv = src.comp_kv
-            ? clone_snapshot_rows(out.ctx, src.comp_kv, src.n_comp, nullptr)
+            ? clone_snapshot_rows(out.ctx, src.comp_kv, src.n_comp, nm_comp.c_str())
             : nullptr;
         dst.index_comp_kv = src.index_comp_kv
             ? clone_snapshot_rows(out.ctx, src.index_comp_kv,
-                                  src.n_index_comp, nullptr)
+                                  src.n_index_comp, nm_index.c_str())
             : nullptr;
         dst.attn_compressor.state_kv =
-            clone_snapshot_tensor(out.ctx, src.attn_compressor.state_kv, nullptr);
+            clone_snapshot_tensor(out.ctx, src.attn_compressor.state_kv, nm_a_kv.c_str());
         dst.attn_compressor.state_score =
-            clone_snapshot_tensor(out.ctx, src.attn_compressor.state_score, nullptr);
+            clone_snapshot_tensor(out.ctx, src.attn_compressor.state_score, nm_a_sc.c_str());
         dst.indexer_compressor.state_kv =
-            clone_snapshot_tensor(out.ctx, src.indexer_compressor.state_kv, nullptr);
+            clone_snapshot_tensor(out.ctx, src.indexer_compressor.state_kv, nm_i_kv.c_str());
         dst.indexer_compressor.state_score =
-            clone_snapshot_tensor(out.ctx, src.indexer_compressor.state_score, nullptr);
+            clone_snapshot_tensor(out.ctx, src.indexer_compressor.state_score, nm_i_sc.c_str());
         if (!dst.raw_kv ||
             (src.comp_kv && !dst.comp_kv) ||
             (src.index_comp_kv && !dst.index_comp_kv) ||
@@ -9610,15 +9658,59 @@ bool deepseek4_snapshot_save(const DeepSeek4Cache & cache,
         }
     }
 
+    if (aux) {
+        const int64_t n_meta = kDeepSeek4SnapMetaBase + 2 * (int64_t) cache.n_layer;
+        out.meta_snap = ggml_new_tensor_1d(out.ctx, GGML_TYPE_I32, n_meta);
+        out.last_logits_snap = ggml_new_tensor_1d(
+            out.ctx, GGML_TYPE_F32, (int64_t) std::max<size_t>(1, aux->n_logits));
+        // Variable length lives in ne[1]: the ondisk layout fingerprint
+        // normalizes that dimension, so short and long windows share a layout.
+        out.spec_feat_snap = ggml_new_tensor_2d(
+            out.ctx, GGML_TYPE_F32, 1, (int64_t) std::max<size_t>(1, aux->n_spec_feat));
+        if (!out.meta_snap || !out.last_logits_snap || !out.spec_feat_snap) {
+            free_deepseek4_snapshot(out);
+            return false;
+        }
+        ggml_set_name(out.meta_snap, kDs4SnapMetaName);
+        ggml_set_name(out.last_logits_snap, kDs4SnapLogitsName);
+        ggml_set_name(out.spec_feat_snap, kDs4SnapFeatName);
+    }
+
     out.buf = ggml_backend_alloc_ctx_tensors(out.ctx, snapshot_backend);
     if (!out.buf) {
         free_deepseek4_snapshot(out);
         return false;
     }
+    if (aux) {
+        // Unused physical slots (one-row placeholders, empty logits / window)
+        // are zeroed so serialized bytes are deterministic.
+        ggml_backend_buffer_clear(out.buf, 0);
+    }
 
     if (!copy_tensor_from_backend(cache.hc_state, out.hc_state_snap)) {
         free_deepseek4_snapshot(out);
         return false;
+    }
+    if (aux) {
+        std::vector<int32_t> meta((size_t) (kDeepSeek4SnapMetaBase + 2 * cache.n_layer), 0);
+        meta[0] = kDeepSeek4SnapMetaVersion;
+        meta[1] = cache.n_layer;
+        meta[2] = (int32_t) aux->n_logits;
+        meta[3] = (int32_t) aux->n_spec_feat;
+        meta[4] = cache.cur_pos;
+        for (int il = 0; il < cache.n_layer; ++il) {
+            meta[(size_t) (kDeepSeek4SnapMetaBase + 2 * il)]     = cache.layers[(size_t) il].n_comp;
+            meta[(size_t) (kDeepSeek4SnapMetaBase + 2 * il + 1)] = cache.layers[(size_t) il].n_index_comp;
+        }
+        ggml_backend_tensor_set(out.meta_snap, meta.data(), 0, meta.size() * sizeof(int32_t));
+        if (aux->n_logits > 0) {
+            ggml_backend_tensor_set(out.last_logits_snap, aux->logits, 0,
+                                    aux->n_logits * sizeof(float));
+        }
+        if (aux->n_spec_feat > 0) {
+            ggml_backend_tensor_set(out.spec_feat_snap, aux->spec_feat, 0,
+                                    aux->n_spec_feat * sizeof(float));
+        }
     }
     for (int il = 0; il < cache.n_layer; ++il) {
         const auto & src = cache.layers[(size_t)il];
@@ -9757,11 +9849,99 @@ bool deepseek4_snapshot_restore(const DeepSeek4Snapshot & snap,
 
 
 void free_deepseek4_snapshot(DeepSeek4Snapshot & s) {
-    if (s.buf) { ggml_backend_buffer_free(s.buf); s.buf = nullptr; }
-    if (s.ctx) { ggml_free(s.ctx); s.ctx = nullptr; }
+    if (s.owns_storage) {
+        if (s.buf) { ggml_backend_buffer_free(s.buf); }
+        if (s.ctx) { ggml_free(s.ctx); }
+    }
+    s.buf = nullptr;
+    s.ctx = nullptr;
+    s.owns_storage = true;
     s.layers.clear();
     s.cur_pos = 0;
     s.hc_state_snap = nullptr;
+    s.meta_snap = nullptr;
+    s.last_logits_snap = nullptr;
+    s.spec_feat_snap = nullptr;
+}
+
+bool deepseek4_snapshot_bind(ggml_context * ctx,
+                             ggml_backend_buffer_t buf,
+                             const char * name_prefix,
+                             bool take_ownership,
+                             DeepSeek4Snapshot & out,
+                             DeepSeek4SnapshotBindInfo * info) {
+    free_deepseek4_snapshot(out);
+    if (!ctx || !buf) return false;
+
+    const std::string pfx = name_prefix ? name_prefix : "";
+    ggml_tensor * meta = ds4_find_snap_tensor(ctx, pfx + kDs4SnapMetaName);
+    if (!meta || meta->type != GGML_TYPE_I32 || ggml_n_dims(meta) != 1 ||
+        meta->ne[0] < kDeepSeek4SnapMetaBase || !meta->data) {
+        return false;
+    }
+    std::vector<int32_t> m((size_t) meta->ne[0], 0);
+    ggml_backend_tensor_get(meta, m.data(), 0, m.size() * sizeof(int32_t));
+    if (m[0] != kDeepSeek4SnapMetaVersion) return false;
+    const int n_layer = m[1];
+    const int n_vocab = m[2];
+    const int n_spec_feat = m[3];
+    const int cur_pos = m[4];
+    if (n_layer <= 0 || n_layer > 4096 || n_vocab < 0 || n_spec_feat < 0 ||
+        cur_pos < 0 ||
+        meta->ne[0] != (int64_t) (kDeepSeek4SnapMetaBase + 2 * n_layer)) {
+        return false;
+    }
+
+    DeepSeek4Snapshot tmp;
+    tmp.hc_state_snap = ds4_find_snap_tensor(ctx, pfx + kDs4SnapHcName);
+    tmp.meta_snap = meta;
+    tmp.last_logits_snap = ds4_find_snap_tensor(ctx, pfx + kDs4SnapLogitsName);
+    tmp.spec_feat_snap = ds4_find_snap_tensor(ctx, pfx + kDs4SnapFeatName);
+    if (!tmp.hc_state_snap || !tmp.last_logits_snap || !tmp.spec_feat_snap ||
+        tmp.last_logits_snap->type != GGML_TYPE_F32 ||
+        tmp.spec_feat_snap->type != GGML_TYPE_F32 ||
+        ggml_nelements(tmp.last_logits_snap) < (int64_t) std::max(1, n_vocab) ||
+        ggml_nelements(tmp.spec_feat_snap) < (int64_t) std::max(1, n_spec_feat)) {
+        return false;
+    }
+
+    tmp.layers.resize((size_t) n_layer);
+    for (int il = 0; il < n_layer; ++il) {
+        auto & L = tmp.layers[(size_t) il];
+        L.raw_kv = ds4_find_snap_tensor(ctx, ds4_snap_name(name_prefix, kDs4SnapLayerNames[0], il));
+        L.comp_kv = ds4_find_snap_tensor(ctx, ds4_snap_name(name_prefix, kDs4SnapLayerNames[1], il));
+        L.index_comp_kv = ds4_find_snap_tensor(ctx, ds4_snap_name(name_prefix, kDs4SnapLayerNames[2], il));
+        L.attn_compressor.state_kv = ds4_find_snap_tensor(ctx, ds4_snap_name(name_prefix, kDs4SnapLayerNames[3], il));
+        L.attn_compressor.state_score = ds4_find_snap_tensor(ctx, ds4_snap_name(name_prefix, kDs4SnapLayerNames[4], il));
+        L.indexer_compressor.state_kv = ds4_find_snap_tensor(ctx, ds4_snap_name(name_prefix, kDs4SnapLayerNames[5], il));
+        L.indexer_compressor.state_score = ds4_find_snap_tensor(ctx, ds4_snap_name(name_prefix, kDs4SnapLayerNames[6], il));
+        L.n_comp = m[(size_t) (kDeepSeek4SnapMetaBase + 2 * il)];
+        L.n_index_comp = m[(size_t) (kDeepSeek4SnapMetaBase + 2 * il + 1)];
+        if (!L.raw_kv || L.n_comp < 0 || L.n_index_comp < 0 ||
+            (!L.comp_kv && L.n_comp != 0) ||
+            (!L.index_comp_kv && L.n_index_comp != 0) ||
+            (L.comp_kv && L.comp_kv->ne[1] != std::max(1, L.n_comp)) ||
+            (L.index_comp_kv && L.index_comp_kv->ne[1] != std::max(1, L.n_index_comp))) {
+            return false;
+        }
+    }
+    // Every tensor must be backed by host memory (CPU snapshot buffer).
+    for (ggml_tensor * t = ggml_get_first_tensor(ctx); t; t = ggml_get_next_tensor(ctx, t)) {
+        if (!t->data) return false;
+    }
+
+    out = tmp;
+    out.cur_pos = cur_pos;
+    out.ctx = ctx;
+    out.buf = buf;
+    out.owns_storage = take_ownership;
+    if (info) {
+        info->n_layer = n_layer;
+        info->n_vocab = n_vocab;
+        info->n_spec_feat = n_spec_feat;
+        info->cur_pos = cur_pos;
+    }
+    return true;
 }
 
 }  // namespace dflash::common

--- a/server/src/deepseek4/deepseek4_internal.h
+++ b/server/src/deepseek4/deepseek4_internal.h
@@ -317,6 +317,8 @@ struct DeepSeek4PagedCache {
 };
 
 struct DeepSeek4Snapshot;
+struct DeepSeek4SnapshotAux;
+struct DeepSeek4SnapshotBindInfo;
 
 struct DeepSeek4RawRingSpan {
     int row = 0;
@@ -411,11 +413,29 @@ bool build_deepseek4_head4_tail2_routes(
     ggml_tensor * router_weights,
     int n_tokens,
     DeepSeek4Head4Tail2Routes & out);
+// Copy the live cache into a right-sized CPU snapshot. Every tensor gets a
+// stable name (ds4_snap_*) so the ondisk prefix cache can serialize the
+// context and deepseek4_snapshot_bind() can rebind it after a reload. When
+// `aux` is given, the host-side logits / DSpark feature window are stored as
+// extra tensors together with an I32 meta tensor (row counts, cur_pos).
 bool deepseek4_snapshot_save(const DeepSeek4Cache & cache,
                              ggml_backend_t snapshot_backend,
-                             DeepSeek4Snapshot & out);
+                             DeepSeek4Snapshot & out,
+                             const DeepSeek4SnapshotAux * aux = nullptr);
 bool deepseek4_snapshot_restore(const DeepSeek4Snapshot & snap,
                                 DeepSeek4Cache & cache);
+// Rebind a deserialized snapshot context (tensors named as written by
+// deepseek4_snapshot_save, optionally prefixed by `name_prefix`) into `out`.
+// Requires the meta tensor; fills row counts and cur_pos from it and
+// validates that every tensor referenced by the meta exists with a sane
+// shape. `out` takes ownership of ctx/buf iff `take_ownership`. Returns
+// false (and leaves `out` empty) on any inconsistency.
+bool deepseek4_snapshot_bind(ggml_context * ctx,
+                             ggml_backend_buffer_t buf,
+                             const char * name_prefix,
+                             bool take_ownership,
+                             DeepSeek4Snapshot & out,
+                             DeepSeek4SnapshotBindInfo * info);
 
 // Largest prefix of [kv_start, kv_start + n_tokens) that reaches at most the
 // next learned-compressor boundary. Multi-token dynamic forwards split on
@@ -533,8 +553,42 @@ struct DeepSeek4Snapshot {
         DeepSeek4CompressorState indexer_compressor;
     };
     std::vector<LayerSnap> layers;
+    // Optional serialization sidecars (ondisk prefix cache). Present when the
+    // snapshot was saved with DeepSeek4SnapshotAux or adopted from disk.
+    //   meta_snap        I32 [kDeepSeek4SnapMetaBase + 2 * n_layer]
+    //   last_logits_snap F32 [n_vocab]
+    //   spec_feat_snap   F32 [1, max(1, n_spec_feat)]  (logical length in meta)
+    ggml_tensor * meta_snap        = nullptr;
+    ggml_tensor * last_logits_snap = nullptr;
+    ggml_tensor * spec_feat_snap   = nullptr;
     ggml_context *        ctx = nullptr;
     ggml_backend_buffer_t buf = nullptr;
+    // false when ctx/buf are shared with (and freed by) another owner, e.g.
+    // one merged ondisk context bound into several layer-split shard snapshots.
+    bool                  owns_storage = true;
+};
+
+// Host-side decode state persisted next to the cache tensors so an adopted
+// (deserialized) snapshot can resume exactly like an in-memory one.
+struct DeepSeek4SnapshotAux {
+    const float * logits = nullptr;
+    size_t        n_logits = 0;
+    const float * spec_feat = nullptr;
+    size_t        n_spec_feat = 0;
+};
+
+// Layout of DeepSeek4Snapshot::meta_snap (I32):
+//   [0] version, [1] n_layer, [2] n_vocab, [3] n_spec_feat, [4] cur_pos,
+//   then per layer: n_comp, n_index_comp.
+constexpr int kDeepSeek4SnapMetaVersion = 1;
+constexpr int kDeepSeek4SnapMetaBase = 5;
+
+// Metadata recovered by deepseek4_snapshot_bind().
+struct DeepSeek4SnapshotBindInfo {
+    int n_layer = 0;
+    int n_vocab = 0;
+    int n_spec_feat = 0;
+    int cur_pos = 0;
 };
 
 void free_deepseek4_snapshot(DeepSeek4Snapshot & s);

--- a/server/src/deepseek4/deepseek4_internal.h
+++ b/server/src/deepseek4/deepseek4_internal.h
@@ -317,8 +317,6 @@ struct DeepSeek4PagedCache {
 };
 
 struct DeepSeek4Snapshot;
-struct DeepSeek4SnapshotAux;
-struct DeepSeek4SnapshotBindInfo;
 
 struct DeepSeek4RawRingSpan {
     int row = 0;
@@ -371,6 +369,30 @@ bool create_deepseek4_cache(ggml_backend_t backend,
                              int max_ctx,
                              DeepSeek4Cache & out);
 
+// Per-layer cache geometry implied by the weights. Single source of truth for
+// create_deepseek4_cache() and for snapshot declaration/validation
+// (deepseek4_snapshot.h), so the two can never disagree on shapes.
+struct DeepSeek4LayerGeometry {
+    uint32_t ratio = 0;            // compress ratio: 0 (raw window only), 4 or 128
+    int64_t  head_dim = 0;         // raw / compressed row width (F16)
+    int64_t  raw_rows = 0;         // n_swa
+    bool     has_comp = false;     // ratio > 0: comp_kv + attn compressor state
+    int64_t  comp_width = 0;       // attn compressor state width (F32)
+    int64_t  comp_state_rows = 0;
+    bool     has_index = false;    // ratio == 4: index_comp_kv + indexer state
+    int64_t  index_dim = 0;        // indexer row width (F16)
+    int64_t  index_state_width = 0;  // indexer compressor state width (F32)
+    int64_t  index_state_rows = 0;
+    // Compressed-row capacity for a cache of `max_ctx` tokens (0 if !has_comp).
+    int64_t comp_capacity(int max_ctx) const {
+        return has_comp ? (int64_t) max_ctx / (int64_t) ratio + 16 : 0;
+    }
+};
+DeepSeek4LayerGeometry deepseek4_layer_geometry(const DeepSeek4Weights & w, int layer);
+inline int64_t deepseek4_hc_state_elements(const DeepSeek4Weights & w) {
+    return (int64_t) w.n_hc * (int64_t) w.n_embd;
+}
+
 void free_deepseek4_cache(DeepSeek4Cache & c);
 bool create_deepseek4_paged_cache(ggml_backend_t backend,
                                   const DeepSeek4Weights & w,
@@ -413,29 +435,6 @@ bool build_deepseek4_head4_tail2_routes(
     ggml_tensor * router_weights,
     int n_tokens,
     DeepSeek4Head4Tail2Routes & out);
-// Copy the live cache into a right-sized CPU snapshot. Every tensor gets a
-// stable name (ds4_snap_*) so the ondisk prefix cache can serialize the
-// context and deepseek4_snapshot_bind() can rebind it after a reload. When
-// `aux` is given, the host-side logits / DSpark feature window are stored as
-// extra tensors together with an I32 meta tensor (row counts, cur_pos).
-bool deepseek4_snapshot_save(const DeepSeek4Cache & cache,
-                             ggml_backend_t snapshot_backend,
-                             DeepSeek4Snapshot & out,
-                             const DeepSeek4SnapshotAux * aux = nullptr);
-bool deepseek4_snapshot_restore(const DeepSeek4Snapshot & snap,
-                                DeepSeek4Cache & cache);
-// Rebind a deserialized snapshot context (tensors named as written by
-// deepseek4_snapshot_save, optionally prefixed by `name_prefix`) into `out`.
-// Requires the meta tensor; fills row counts and cur_pos from it and
-// validates that every tensor referenced by the meta exists with a sane
-// shape. `out` takes ownership of ctx/buf iff `take_ownership`. Returns
-// false (and leaves `out` empty) on any inconsistency.
-bool deepseek4_snapshot_bind(ggml_context * ctx,
-                             ggml_backend_buffer_t buf,
-                             const char * name_prefix,
-                             bool take_ownership,
-                             DeepSeek4Snapshot & out,
-                             DeepSeek4SnapshotBindInfo * info);
 
 // Largest prefix of [kv_start, kv_start + n_tokens) that reaches at most the
 // next learned-compressor boundary. Multi-token dynamic forwards split on
@@ -568,29 +567,5 @@ struct DeepSeek4Snapshot {
     bool                  owns_storage = true;
 };
 
-// Host-side decode state persisted next to the cache tensors so an adopted
-// (deserialized) snapshot can resume exactly like an in-memory one.
-struct DeepSeek4SnapshotAux {
-    const float * logits = nullptr;
-    size_t        n_logits = 0;
-    const float * spec_feat = nullptr;
-    size_t        n_spec_feat = 0;
-};
-
-// Layout of DeepSeek4Snapshot::meta_snap (I32):
-//   [0] version, [1] n_layer, [2] n_vocab, [3] n_spec_feat, [4] cur_pos,
-//   then per layer: n_comp, n_index_comp.
-constexpr int kDeepSeek4SnapMetaVersion = 1;
-constexpr int kDeepSeek4SnapMetaBase = 5;
-
-// Metadata recovered by deepseek4_snapshot_bind().
-struct DeepSeek4SnapshotBindInfo {
-    int n_layer = 0;
-    int n_vocab = 0;
-    int n_spec_feat = 0;
-    int cur_pos = 0;
-};
-
-void free_deepseek4_snapshot(DeepSeek4Snapshot & s);
 
 }  // namespace dflash::common

--- a/server/src/deepseek4/deepseek4_layer_split_adapter.cpp
+++ b/server/src/deepseek4/deepseek4_layer_split_adapter.cpp
@@ -7,6 +7,7 @@
 #include "deepseek4_layer_split_adapter.h"
 #include "deepseek4_roctx.h"
 #include "deepseek4_internal.h"
+#include "ggml-cpu.h"
 #include "common/layer_split_runtime.h"
 #include "common/gguf_inspect.h"
 
@@ -20,6 +21,8 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
+#include <string>
 
 namespace dflash::common {
 
@@ -642,9 +645,12 @@ bool DeepSeek4LayerSplitAdapter::snapshot_save(int slot) {
     auto & snap = snapshots_[slot];
     snapshot_free(slot);
     if (snap.shards.size() != shards_.size()) snap.shards.resize(shards_.size());
+    // Shard snapshots carry an (empty) aux sidecar so each one has the meta
+    // tensor deepseek4_snapshot_bind() needs after an ondisk reload.
+    const DeepSeek4SnapshotAux empty_aux;
     for (size_t i = 0; i < shards_.size(); ++i) {
         if (!deepseek4_snapshot_save(shards_[i].cache, snapshot_backends_[i],
-                                     snap.shards[i])) {
+                                     snap.shards[i], &empty_aux)) {
             snapshot_free(slot);
             return false;
         }
@@ -658,6 +664,224 @@ bool DeepSeek4LayerSplitAdapter::snapshot_save(int slot) {
     snap.hc_state = hc_state_;
     snap.prefill_last_logits = prefill_last_logits_;
     snap.used = true;
+    if (!use_mixed_target_split() && !rebuild_disk_snapshot(slot)) {
+        // Memory snapshot is still valid; only ondisk export is unavailable.
+        std::fprintf(stderr,
+                     "[deepseek4-split] slot=%d: merged disk snapshot build "
+                     "failed; snapshot stays memory-only\n", slot);
+        free_disk_snapshot(slot);
+    }
+    return true;
+}
+
+namespace {
+constexpr int kDs4SplitMetaVersion = 1;
+constexpr int kDs4SplitMetaLen = 6;  // version, n_shards, cur_pos, last_tok, hc_len, logits_len
+const char * const kDs4SplitMetaName   = "ls_meta";
+const char * const kDs4SplitHcName     = "ls_hc_state";
+const char * const kDs4SplitLogitsName = "ls_prefill_logits";
+
+std::string ds4_split_prefix(size_t shard_idx) {
+    return "ls" + std::to_string(shard_idx) + "_";
+}
+}  // namespace
+
+void DeepSeek4LayerSplitAdapter::free_disk_snapshot(int slot) {
+    if (slot < 0 || slot >= (int) snapshots_.size()) return;
+    auto & snap = snapshots_[(size_t) slot];
+    if (snap.disk_buf) { ggml_backend_buffer_free(snap.disk_buf); snap.disk_buf = nullptr; }
+    if (snap.disk_ctx) { ggml_free(snap.disk_ctx); snap.disk_ctx = nullptr; }
+    if (snap.disk_backend) { ggml_backend_free(snap.disk_backend); snap.disk_backend = nullptr; }
+}
+
+bool DeepSeek4LayerSplitAdapter::rebuild_disk_snapshot(int slot) {
+    if (slot < 0 || slot >= (int) snapshots_.size()) return false;
+    auto & snap = snapshots_[(size_t) slot];
+    free_disk_snapshot(slot);
+    if (!snap.used || snap.shards.size() != shards_.size()) return false;
+    if (snap.hc_state.size() > (size_t) std::numeric_limits<int>::max() ||
+        snap.prefill_last_logits.size() > (size_t) std::numeric_limits<int>::max()) {
+        return false;
+    }
+
+    size_t n_tensors = 3;
+    for (const auto & shard_snap : snap.shards) {
+        if (!shard_snap.ctx || !shard_snap.buf) return false;
+        for (ggml_tensor * t = ggml_get_first_tensor(shard_snap.ctx); t;
+             t = ggml_get_next_tensor(shard_snap.ctx, t)) {
+            n_tensors++;
+        }
+    }
+
+    ggml_init_params ip{};
+    ip.mem_size = ggml_tensor_overhead() * (n_tensors + 8) + 4096;
+    ip.no_alloc = true;
+    ggml_context * ctx = ggml_init(ip);
+    if (!ctx) return false;
+
+    struct CopyPair { ggml_tensor * src; ggml_tensor * dst; };
+    std::vector<CopyPair> copies;
+    copies.reserve(n_tensors);
+    for (size_t i = 0; i < snap.shards.size(); ++i) {
+        const std::string pfx = ds4_split_prefix(i);
+        for (ggml_tensor * src = ggml_get_first_tensor(snap.shards[i].ctx); src;
+             src = ggml_get_next_tensor(snap.shards[i].ctx, src)) {
+            const std::string name = pfx + src->name;
+            if (!src->name[0] || name.size() >= (size_t) GGML_MAX_NAME) {
+                ggml_free(ctx);
+                return false;
+            }
+            ggml_tensor * dst = ggml_dup_tensor(ctx, src);
+            if (!dst) { ggml_free(ctx); return false; }
+            ggml_set_name(dst, name.c_str());
+            copies.push_back({src, dst});
+        }
+    }
+    ggml_tensor * meta = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, kDs4SplitMetaLen);
+    ggml_tensor * hc = ggml_new_tensor_2d(
+        ctx, GGML_TYPE_F32, 1, (int64_t) std::max<size_t>(1, snap.hc_state.size()));
+    ggml_tensor * logits = ggml_new_tensor_2d(
+        ctx, GGML_TYPE_F32, 1, (int64_t) std::max<size_t>(1, snap.prefill_last_logits.size()));
+    if (!meta || !hc || !logits) { ggml_free(ctx); return false; }
+    ggml_set_name(meta, kDs4SplitMetaName);
+    ggml_set_name(hc, kDs4SplitHcName);
+    ggml_set_name(logits, kDs4SplitLogitsName);
+
+    ggml_backend_t cpu = ggml_backend_cpu_init();
+    if (!cpu) { ggml_free(ctx); return false; }
+    ggml_backend_buffer_t buf = ggml_backend_alloc_ctx_tensors(ctx, cpu);
+    if (!buf) { ggml_free(ctx); ggml_backend_free(cpu); return false; }
+    ggml_backend_buffer_clear(buf, 0);
+
+    for (const auto & cp : copies) {
+        const size_t bytes = ggml_nbytes(cp.src);
+        if (bytes != ggml_nbytes(cp.dst)) {
+            ggml_backend_buffer_free(buf); ggml_free(ctx); ggml_backend_free(cpu);
+            return false;
+        }
+        ggml_backend_tensor_get(cp.src, cp.dst->data, 0, bytes);
+    }
+    const int32_t m[kDs4SplitMetaLen] = {
+        kDs4SplitMetaVersion,
+        (int32_t) snap.shards.size(),
+        snap.cur_pos,
+        snap.last_tok,
+        (int32_t) snap.hc_state.size(),
+        (int32_t) snap.prefill_last_logits.size(),
+    };
+    ggml_backend_tensor_set(meta, m, 0, sizeof(m));
+    if (!snap.hc_state.empty()) {
+        ggml_backend_tensor_set(hc, snap.hc_state.data(), 0,
+                                snap.hc_state.size() * sizeof(float));
+    }
+    if (!snap.prefill_last_logits.empty()) {
+        ggml_backend_tensor_set(logits, snap.prefill_last_logits.data(), 0,
+                                snap.prefill_last_logits.size() * sizeof(float));
+    }
+    snap.disk_ctx = ctx;
+    snap.disk_buf = buf;
+    snap.disk_backend = cpu;
+    return true;
+}
+
+ModelBackend::SnapshotRef DeepSeek4LayerSplitAdapter::snapshot_ref(int slot) const {
+    ModelBackend::SnapshotRef ref;
+    if (!snapshot_used(slot) || use_mixed_target_split()) return ref;
+    const auto & snap = snapshots_[(size_t) slot];
+    if (!snap.disk_ctx || !snap.disk_buf) return ref;
+    ref.ctx = snap.disk_ctx;
+    ref.buf = snap.disk_buf;
+    ref.cur_pos = snap.cur_pos;
+    ref.last_tok = snap.last_tok;
+    return ref;
+}
+
+bool DeepSeek4LayerSplitAdapter::snapshot_adopt(int slot, ggml_context * ctx,
+                                                ggml_backend_buffer_t buf,
+                                                int cur_pos, int32_t last_tok) {
+    if (slot < 0 || slot >= PREFIX_SLOTS || slot >= (int) snapshots_.size() ||
+        !ctx || !buf || cur_pos <= 0 || shards_.empty() ||
+        use_mixed_target_split()) {
+        return false;
+    }
+    auto reject = [&](const char * why) {
+        std::fprintf(stderr,
+                     "[deepseek4-split] snapshot adopt slot=%d rejected: %s\n",
+                     slot, why);
+        return false;
+    };
+
+    ggml_tensor * meta = ggml_get_tensor(ctx, kDs4SplitMetaName);
+    ggml_tensor * hc = ggml_get_tensor(ctx, kDs4SplitHcName);
+    ggml_tensor * logits = ggml_get_tensor(ctx, kDs4SplitLogitsName);
+    if (!meta || meta->type != GGML_TYPE_I32 || ggml_nelements(meta) != kDs4SplitMetaLen ||
+        !hc || hc->type != GGML_TYPE_F32 || !logits || logits->type != GGML_TYPE_F32) {
+        return reject("missing adapter meta");
+    }
+    int32_t m[kDs4SplitMetaLen] = {0};
+    ggml_backend_tensor_get(meta, m, 0, sizeof(m));
+    if (m[0] != kDs4SplitMetaVersion) return reject("meta version");
+    if (m[1] != (int32_t) shards_.size()) return reject("shard count mismatch");
+    if (m[2] != cur_pos) return reject("position mismatch");
+    if (m[4] < 0 || m[5] < 0 || ggml_nelements(hc) < std::max(1, m[4]) ||
+        ggml_nelements(logits) < std::max(1, m[5])) {
+        return reject("hc/logits length");
+    }
+
+    std::vector<DeepSeek4Snapshot> shard_snaps(shards_.size());
+    for (size_t i = 0; i < shards_.size(); ++i) {
+        DeepSeek4SnapshotBindInfo info;
+        const std::string pfx = ds4_split_prefix(i);
+        if (!deepseek4_snapshot_bind(ctx, buf, pfx.c_str(), /*take_ownership=*/false,
+                                     shard_snaps[i], &info)) {
+            return reject("shard bind failed");
+        }
+        const auto & live = shards_[i].cache;
+        if (info.cur_pos != cur_pos || cur_pos > live.max_ctx ||
+            shard_snaps[i].layers.size() != live.layers.size()) {
+            return reject("shard geometry mismatch");
+        }
+        for (size_t il = 0; il < live.layers.size(); ++il) {
+            const auto & lv = live.layers[il];
+            const auto & got = shard_snaps[i].layers[il];
+            if ((!!lv.comp_kv) != (!!got.comp_kv) ||
+                (!!lv.index_comp_kv) != (!!got.index_comp_kv) ||
+                (lv.comp_kv && got.n_comp > lv.comp_kv->ne[1]) ||
+                (lv.index_comp_kv && got.n_index_comp > lv.index_comp_kv->ne[1])) {
+                return reject("shard layer layout mismatch");
+            }
+        }
+    }
+
+    Snapshot adopted;
+    try {
+        adopted.hc_state.resize((size_t) m[4]);
+        if (m[4] > 0) {
+            ggml_backend_tensor_get(hc, adopted.hc_state.data(), 0,
+                                    adopted.hc_state.size() * sizeof(float));
+        }
+        adopted.prefill_last_logits.resize((size_t) m[5]);
+        if (m[5] > 0) {
+            ggml_backend_tensor_get(logits, adopted.prefill_last_logits.data(), 0,
+                                    adopted.prefill_last_logits.size() * sizeof(float));
+        }
+    } catch (const std::bad_alloc &) {
+        return reject("out of memory");
+    }
+    adopted.shards = std::move(shard_snaps);
+    adopted.cur_pos = cur_pos;
+    adopted.last_tok = (m[3] != -1) ? m[3] : last_tok;
+    adopted.used = true;
+    adopted.disk_ctx = ctx;
+    adopted.disk_buf = buf;
+    adopted.disk_backend = nullptr;  // reader-owned CPU backend (see DiskPrefixCache)
+
+    snapshot_free(slot);
+    snapshots_[(size_t) slot] = std::move(adopted);
+    std::fprintf(stderr,
+                 "[deepseek4-split] snapshot adopted slot=%d pos=%d size=%.1f MiB\n",
+                 slot, cur_pos,
+                 (double) ggml_backend_buffer_get_size(buf) / (1024.0 * 1024.0));
     return true;
 }
 
@@ -667,6 +891,7 @@ void DeepSeek4LayerSplitAdapter::snapshot_free(int slot) {
     for (auto & shard_snap : snap.shards) {
         free_deepseek4_snapshot(shard_snap);
     }
+    free_disk_snapshot(slot);
     snap.cur_pos = 0;
     snap.last_tok = -1;
     snap.hc_state.clear();

--- a/server/src/deepseek4/deepseek4_layer_split_adapter.cpp
+++ b/server/src/deepseek4/deepseek4_layer_split_adapter.cpp
@@ -7,7 +7,7 @@
 #include "deepseek4_layer_split_adapter.h"
 #include "deepseek4_roctx.h"
 #include "deepseek4_internal.h"
-#include "ggml-cpu.h"
+#include "deepseek4_snapshot.h"
 #include "common/layer_split_runtime.h"
 #include "common/gguf_inspect.h"
 
@@ -639,42 +639,10 @@ bool DeepSeek4LayerSplitAdapter::decode_ar(
         forward_one, is_eos, out_tokens, io);
 }
 
-bool DeepSeek4LayerSplitAdapter::snapshot_save(int slot) {
-    if (slot < 0 || slot >= PREFIX_SLOTS || shards_.empty()) return false;
-    if (snapshot_backends_.size() != shards_.size()) return false;
-    auto & snap = snapshots_[slot];
-    snapshot_free(slot);
-    if (snap.shards.size() != shards_.size()) snap.shards.resize(shards_.size());
-    // Shard snapshots carry an (empty) aux sidecar so each one has the meta
-    // tensor deepseek4_snapshot_bind() needs after an ondisk reload.
-    const DeepSeek4SnapshotAux empty_aux;
-    for (size_t i = 0; i < shards_.size(); ++i) {
-        if (!deepseek4_snapshot_save(shards_[i].cache, snapshot_backends_[i],
-                                     snap.shards[i], &empty_aux)) {
-            snapshot_free(slot);
-            return false;
-        }
-    }
-    if (use_mixed_target_split() && !remote_target_shard_.snapshot_save(slot)) {
-        snapshot_free(slot);
-        return false;
-    }
-    snap.cur_pos = cur_pos_;
-    snap.last_tok = last_tok_;
-    snap.hc_state = hc_state_;
-    snap.prefill_last_logits = prefill_last_logits_;
-    snap.used = true;
-    if (!use_mixed_target_split() && !rebuild_disk_snapshot(slot)) {
-        // Memory snapshot is still valid; only ondisk export is unavailable.
-        std::fprintf(stderr,
-                     "[deepseek4-split] slot=%d: merged disk snapshot build "
-                     "failed; snapshot stays memory-only\n", slot);
-        free_disk_snapshot(slot);
-    }
-    return true;
-}
-
 namespace {
+
+// Adapter-level tensors stored next to the shard snapshots in the merged
+// context: hc_state / prefill logits vectors and a small I32 meta.
 constexpr int kDs4SplitMetaVersion = 1;
 constexpr int kDs4SplitMetaLen = 6;  // version, n_shards, cur_pos, last_tok, hc_len, logits_len
 const char * const kDs4SplitMetaName   = "ls_meta";
@@ -684,113 +652,115 @@ const char * const kDs4SplitLogitsName = "ls_prefill_logits";
 std::string ds4_split_prefix(size_t shard_idx) {
     return "ls" + std::to_string(shard_idx) + "_";
 }
-}  // namespace
 
-void DeepSeek4LayerSplitAdapter::free_disk_snapshot(int slot) {
-    if (slot < 0 || slot >= (int) snapshots_.size()) return;
-    auto & snap = snapshots_[(size_t) slot];
-    if (snap.disk_buf) { ggml_backend_buffer_free(snap.disk_buf); snap.disk_buf = nullptr; }
-    if (snap.disk_ctx) { ggml_free(snap.disk_ctx); snap.disk_ctx = nullptr; }
-    if (snap.disk_backend) { ggml_backend_free(snap.disk_backend); snap.disk_backend = nullptr; }
+ggml_tensor * ds4_split_new_vec(ggml_context * ctx, const char * name, size_t len) {
+    // Variable length in ne[1] (normalized by the ondisk layout fingerprint).
+    ggml_tensor * t = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, 1, (int64_t) std::max<size_t>(1, len));
+    if (t) ggml_set_name(t, name);
+    return t;
 }
 
-bool DeepSeek4LayerSplitAdapter::rebuild_disk_snapshot(int slot) {
-    if (slot < 0 || slot >= (int) snapshots_.size()) return false;
-    auto & snap = snapshots_[(size_t) slot];
-    free_disk_snapshot(slot);
-    if (!snap.used || snap.shards.size() != shards_.size()) return false;
-    if (snap.hc_state.size() > (size_t) std::numeric_limits<int>::max() ||
-        snap.prefill_last_logits.size() > (size_t) std::numeric_limits<int>::max()) {
+void ds4_split_set_vec(ggml_tensor * t, const std::vector<float> & v) {
+    if (!v.empty()) ggml_backend_tensor_set(t, v.data(), 0, v.size() * sizeof(float));
+}
+
+}  // namespace
+
+// One merged host context per slot holds every shard snapshot (prefixed
+// ls<shard>_) plus the adapter-level tensors. The shard snapshots alias that
+// context (owns_storage=false); the slot owns it. The same context is what
+// the ondisk prefix cache serializes, so there is no second copy.
+bool DeepSeek4LayerSplitAdapter::snapshot_save(int slot) {
+    if (slot < 0 || slot >= PREFIX_SLOTS || shards_.empty()) return false;
+    if (hc_state_.size() > (size_t) std::numeric_limits<int>::max() ||
+        prefill_last_logits_.size() > (size_t) std::numeric_limits<int>::max()) {
         return false;
     }
+    auto & snap = snapshots_[(size_t) slot];
+    snapshot_free(slot);
+    snap.shards.assign(shards_.size(), DeepSeek4Snapshot{});
 
     size_t n_tensors = 3;
-    for (const auto & shard_snap : snap.shards) {
-        if (!shard_snap.ctx || !shard_snap.buf) return false;
-        for (ggml_tensor * t = ggml_get_first_tensor(shard_snap.ctx); t;
-             t = ggml_get_next_tensor(shard_snap.ctx, t)) {
-            n_tensors++;
-        }
+    for (const auto & shard : shards_) {
+        n_tensors += deepseek4_snapshot_tensor_count(shard.cache.n_layer, /*with_aux=*/true);
     }
-
     ggml_init_params ip{};
     ip.mem_size = ggml_tensor_overhead() * (n_tensors + 8) + 4096;
     ip.no_alloc = true;
     ggml_context * ctx = ggml_init(ip);
     if (!ctx) return false;
 
-    struct CopyPair { ggml_tensor * src; ggml_tensor * dst; };
-    std::vector<CopyPair> copies;
-    copies.reserve(n_tensors);
-    for (size_t i = 0; i < snap.shards.size(); ++i) {
-        const std::string pfx = ds4_split_prefix(i);
-        for (ggml_tensor * src = ggml_get_first_tensor(snap.shards[i].ctx); src;
-             src = ggml_get_next_tensor(snap.shards[i].ctx, src)) {
-            const std::string name = pfx + src->name;
-            if (!src->name[0] || name.size() >= (size_t) GGML_MAX_NAME) {
-                ggml_free(ctx);
-                return false;
-            }
-            ggml_tensor * dst = ggml_dup_tensor(ctx, src);
-            if (!dst) { ggml_free(ctx); return false; }
-            ggml_set_name(dst, name.c_str());
-            copies.push_back({src, dst});
+    auto fail = [&]() {
+        for (auto & shard_snap : snap.shards) shard_snap = DeepSeek4Snapshot{};
+        ggml_free(ctx);
+        return false;
+    };
+
+    // Shard snapshots carry an (empty) aux sidecar so each one has the meta
+    // tensor deepseek4_snapshot_bind() needs after an ondisk reload.
+    const DeepSeek4SnapshotAux empty_aux;
+    std::vector<std::string> prefixes(shards_.size());
+    for (size_t i = 0; i < shards_.size(); ++i) {
+        prefixes[i] = ds4_split_prefix(i);
+        if (!deepseek4_snapshot_declare(ctx, shards_[i].cache, prefixes[i].c_str(),
+                                        &empty_aux, snap.shards[i])) {
+            return fail();
         }
+        snap.shards[i].owns_storage = false;
     }
     ggml_tensor * meta = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, kDs4SplitMetaLen);
-    ggml_tensor * hc = ggml_new_tensor_2d(
-        ctx, GGML_TYPE_F32, 1, (int64_t) std::max<size_t>(1, snap.hc_state.size()));
-    ggml_tensor * logits = ggml_new_tensor_2d(
-        ctx, GGML_TYPE_F32, 1, (int64_t) std::max<size_t>(1, snap.prefill_last_logits.size()));
-    if (!meta || !hc || !logits) { ggml_free(ctx); return false; }
+    ggml_tensor * hc = ds4_split_new_vec(ctx, kDs4SplitHcName, hc_state_.size());
+    ggml_tensor * logits = ds4_split_new_vec(ctx, kDs4SplitLogitsName, prefill_last_logits_.size());
+    if (!meta || !hc || !logits) return fail();
     ggml_set_name(meta, kDs4SplitMetaName);
-    ggml_set_name(hc, kDs4SplitHcName);
-    ggml_set_name(logits, kDs4SplitLogitsName);
 
-    ggml_backend_t cpu = ggml_backend_cpu_init();
-    if (!cpu) { ggml_free(ctx); return false; }
-    ggml_backend_buffer_t buf = ggml_backend_alloc_ctx_tensors(ctx, cpu);
-    if (!buf) { ggml_free(ctx); ggml_backend_free(cpu); return false; }
+    ggml_backend_buffer_t buf =
+        ggml_backend_alloc_ctx_tensors_from_buft(ctx, ggml_backend_cpu_buffer_type());
+    if (!buf) return fail();
     ggml_backend_buffer_clear(buf, 0);
 
-    for (const auto & cp : copies) {
-        const size_t bytes = ggml_nbytes(cp.src);
-        if (bytes != ggml_nbytes(cp.dst)) {
-            ggml_backend_buffer_free(buf); ggml_free(ctx); ggml_backend_free(cpu);
+    for (size_t i = 0; i < shards_.size(); ++i) {
+        snap.shards[i].ctx = ctx;
+        snap.shards[i].buf = buf;
+        if (!deepseek4_snapshot_fill(shards_[i].cache, &empty_aux, snap.shards[i])) {
+            for (auto & shard_snap : snap.shards) shard_snap = DeepSeek4Snapshot{};
+            ggml_backend_buffer_free(buf);
+            ggml_free(ctx);
             return false;
         }
-        ggml_backend_tensor_get(cp.src, cp.dst->data, 0, bytes);
     }
+    if (use_mixed_target_split() && !remote_target_shard_.snapshot_save(slot)) {
+        for (auto & shard_snap : snap.shards) shard_snap = DeepSeek4Snapshot{};
+        ggml_backend_buffer_free(buf);
+        ggml_free(ctx);
+        return false;
+    }
+
     const int32_t m[kDs4SplitMetaLen] = {
-        kDs4SplitMetaVersion,
-        (int32_t) snap.shards.size(),
-        snap.cur_pos,
-        snap.last_tok,
-        (int32_t) snap.hc_state.size(),
-        (int32_t) snap.prefill_last_logits.size(),
+        kDs4SplitMetaVersion, (int32_t) shards_.size(), cur_pos_, last_tok_,
+        (int32_t) hc_state_.size(), (int32_t) prefill_last_logits_.size(),
     };
     ggml_backend_tensor_set(meta, m, 0, sizeof(m));
-    if (!snap.hc_state.empty()) {
-        ggml_backend_tensor_set(hc, snap.hc_state.data(), 0,
-                                snap.hc_state.size() * sizeof(float));
-    }
-    if (!snap.prefill_last_logits.empty()) {
-        ggml_backend_tensor_set(logits, snap.prefill_last_logits.data(), 0,
-                                snap.prefill_last_logits.size() * sizeof(float));
-    }
-    snap.disk_ctx = ctx;
-    snap.disk_buf = buf;
-    snap.disk_backend = cpu;
+    ds4_split_set_vec(hc, hc_state_);
+    ds4_split_set_vec(logits, prefill_last_logits_);
+
+    snap.ctx = ctx;
+    snap.buf = buf;
+    snap.cur_pos = cur_pos_;
+    snap.last_tok = last_tok_;
+    snap.hc_state = hc_state_;
+    snap.prefill_last_logits = prefill_last_logits_;
+    snap.used = true;
     return true;
 }
 
 ModelBackend::SnapshotRef DeepSeek4LayerSplitAdapter::snapshot_ref(int slot) const {
     ModelBackend::SnapshotRef ref;
+    // Remote (IPC) shards are not part of the merged context: memory-only.
     if (!snapshot_used(slot) || use_mixed_target_split()) return ref;
     const auto & snap = snapshots_[(size_t) slot];
-    if (!snap.disk_ctx || !snap.disk_buf) return ref;
-    ref.ctx = snap.disk_ctx;
-    ref.buf = snap.disk_buf;
+    ref.ctx = snap.ctx;
+    ref.buf = snap.buf;
     ref.cur_pos = snap.cur_pos;
     ref.last_tok = snap.last_tok;
     return ref;
@@ -804,10 +774,10 @@ bool DeepSeek4LayerSplitAdapter::snapshot_adopt(int slot, ggml_context * ctx,
         use_mixed_target_split()) {
         return false;
     }
-    auto reject = [&](const char * why) {
+    auto reject = [&](const std::string & why) {
         std::fprintf(stderr,
-                     "[deepseek4-split] snapshot adopt slot=%d rejected: %s\n",
-                     slot, why);
+                     "[deepseek4-split] snapshot adopt slot=%d pos=%d rejected: %s\n",
+                     slot, cur_pos, why.c_str());
         return false;
     };
 
@@ -828,32 +798,22 @@ bool DeepSeek4LayerSplitAdapter::snapshot_adopt(int slot, ggml_context * ctx,
         return reject("hc/logits length");
     }
 
-    std::vector<DeepSeek4Snapshot> shard_snaps(shards_.size());
+    Snapshot adopted;
+    adopted.shards.assign(shards_.size(), DeepSeek4Snapshot{});
     for (size_t i = 0; i < shards_.size(); ++i) {
         DeepSeek4SnapshotBindInfo info;
         const std::string pfx = ds4_split_prefix(i);
         if (!deepseek4_snapshot_bind(ctx, buf, pfx.c_str(), /*take_ownership=*/false,
-                                     shard_snaps[i], &info)) {
-            return reject("shard bind failed");
+                                     adopted.shards[i], &info)) {
+            return reject("shard " + std::to_string(i) + ": bind failed");
         }
-        const auto & live = shards_[i].cache;
-        if (info.cur_pos != cur_pos || cur_pos > live.max_ctx ||
-            shard_snaps[i].layers.size() != live.layers.size()) {
-            return reject("shard geometry mismatch");
-        }
-        for (size_t il = 0; il < live.layers.size(); ++il) {
-            const auto & lv = live.layers[il];
-            const auto & got = shard_snaps[i].layers[il];
-            if ((!!lv.comp_kv) != (!!got.comp_kv) ||
-                (!!lv.index_comp_kv) != (!!got.index_comp_kv) ||
-                (lv.comp_kv && got.n_comp > lv.comp_kv->ne[1]) ||
-                (lv.index_comp_kv && got.n_index_comp > lv.index_comp_kv->ne[1])) {
-                return reject("shard layer layout mismatch");
-            }
+        if (info.cur_pos != cur_pos) return reject("shard " + std::to_string(i) + ": position mismatch");
+        std::string why;
+        if (!deepseek4_snapshot_validate(shards_[i].weights, shards_[i].cache.max_ctx,
+                                         adopted.shards[i], &why)) {
+            return reject("shard " + std::to_string(i) + ": " + why);
         }
     }
-
-    Snapshot adopted;
     try {
         adopted.hc_state.resize((size_t) m[4]);
         if (m[4] > 0) {
@@ -868,13 +828,11 @@ bool DeepSeek4LayerSplitAdapter::snapshot_adopt(int slot, ggml_context * ctx,
     } catch (const std::bad_alloc &) {
         return reject("out of memory");
     }
-    adopted.shards = std::move(shard_snaps);
     adopted.cur_pos = cur_pos;
     adopted.last_tok = (m[3] != -1) ? m[3] : last_tok;
     adopted.used = true;
-    adopted.disk_ctx = ctx;
-    adopted.disk_buf = buf;
-    adopted.disk_backend = nullptr;  // reader-owned CPU backend (see DiskPrefixCache)
+    adopted.ctx = ctx;
+    adopted.buf = buf;
 
     snapshot_free(slot);
     snapshots_[(size_t) slot] = std::move(adopted);
@@ -889,9 +847,10 @@ void DeepSeek4LayerSplitAdapter::snapshot_free(int slot) {
     if (slot < 0 || slot >= PREFIX_SLOTS) return;
     auto & snap = snapshots_[slot];
     for (auto & shard_snap : snap.shards) {
-        free_deepseek4_snapshot(shard_snap);
+        free_deepseek4_snapshot(shard_snap);  // aliases: releases nothing
     }
-    free_disk_snapshot(slot);
+    if (snap.buf) { ggml_backend_buffer_free(snap.buf); snap.buf = nullptr; }
+    if (snap.ctx) { ggml_free(snap.ctx); snap.ctx = nullptr; }
     snap.cur_pos = 0;
     snap.last_tok = -1;
     snap.hc_state.clear();
@@ -906,7 +865,8 @@ void DeepSeek4LayerSplitAdapter::snapshot_free(int slot) {
 bool DeepSeek4LayerSplitAdapter::snapshot_used(int slot) const {
     if (slot < 0 || slot >= PREFIX_SLOTS) return false;
     const auto & snap = snapshots_[slot];
-    if (!snap.used || snap.cur_pos < 0 || snap.shards.size() != shards_.size()) {
+    if (!snap.used || snap.cur_pos < 0 || !snap.ctx || !snap.buf ||
+        snap.shards.size() != shards_.size()) {
         return false;
     }
     for (const auto & shard_snap : snap.shards) {

--- a/server/src/deepseek4/deepseek4_layer_split_adapter.cpp
+++ b/server/src/deepseek4/deepseek4_layer_split_adapter.cpp
@@ -719,20 +719,20 @@ bool DeepSeek4LayerSplitAdapter::snapshot_save(int slot) {
     if (!buf) return fail();
     ggml_backend_buffer_clear(buf, 0);
 
+    // From here on the slot owns ctx/buf; snapshot_free() releases them and
+    // the remote shard's slot together on every later failure path.
+    snap.ctx = ctx;
+    snap.buf = buf;
     for (size_t i = 0; i < shards_.size(); ++i) {
         snap.shards[i].ctx = ctx;
         snap.shards[i].buf = buf;
         if (!deepseek4_snapshot_fill(shards_[i].cache, &empty_aux, snap.shards[i])) {
-            for (auto & shard_snap : snap.shards) shard_snap = DeepSeek4Snapshot{};
-            ggml_backend_buffer_free(buf);
-            ggml_free(ctx);
+            snapshot_free(slot);
             return false;
         }
     }
     if (use_mixed_target_split() && !remote_target_shard_.snapshot_save(slot)) {
-        for (auto & shard_snap : snap.shards) shard_snap = DeepSeek4Snapshot{};
-        ggml_backend_buffer_free(buf);
-        ggml_free(ctx);
+        snapshot_free(slot);
         return false;
     }
 
@@ -744,8 +744,6 @@ bool DeepSeek4LayerSplitAdapter::snapshot_save(int slot) {
     ds4_split_set_vec(hc, hc_state_);
     ds4_split_set_vec(logits, prefill_last_logits_);
 
-    snap.ctx = ctx;
-    snap.buf = buf;
     snap.cur_pos = cur_pos_;
     snap.last_tok = last_tok_;
     snap.hc_state = hc_state_;

--- a/server/src/deepseek4/deepseek4_layer_split_adapter.h
+++ b/server/src/deepseek4/deepseek4_layer_split_adapter.h
@@ -99,6 +99,8 @@ private:
     DeepSeek4LayerSplitAdapterConfig cfg_;
     std::vector<DeepSeek4LayerSplitShard> shards_;
     TargetShardIpcSession remote_target_shard_;
+    // Filled by the shared layer-split runtime helpers; DeepSeek snapshots
+    // do not use them (one merged host context per slot, see snapshot_save).
     std::vector<ggml_backend_t> snapshot_backends_;
 
     // HC state persists across all layers (shared between shards)
@@ -114,16 +116,13 @@ private:
         std::vector<float> prefill_last_logits;
         std::vector<DeepSeek4Snapshot> shards;
         bool used = false;
-        // Merged serialization context (owned here). After snapshot_save it
-        // is a copy of the shard snapshots; after snapshot_adopt the shard
-        // snapshots alias it (owns_storage=false).
-        ggml_context *        disk_ctx = nullptr;
-        ggml_backend_buffer_t disk_buf = nullptr;
-        ggml_backend_t        disk_backend = nullptr;  // CPU backend owning disk_buf (save path)
+        // One merged host context holds every shard snapshot (aliased with
+        // owns_storage=false) plus the adapter-level tensors; it is also what
+        // the ondisk prefix cache serializes. Owned by the slot.
+        ggml_context *        ctx = nullptr;
+        ggml_backend_buffer_t buf = nullptr;
     };
     std::vector<Snapshot> snapshots_;
-    bool rebuild_disk_snapshot(int slot);
-    void free_disk_snapshot(int slot);
 
     SamplerCfg sampler_;
     std::mt19937_64 sampler_rng_{std::random_device{}()};

--- a/server/src/deepseek4/deepseek4_layer_split_adapter.h
+++ b/server/src/deepseek4/deepseek4_layer_split_adapter.h
@@ -66,6 +66,13 @@ public:
     bool snapshot_used(int slot) const override;
     int snapshot_cur_pos(int slot) const override;
     bool snapshot_restore(int slot) override;
+    // Ondisk prefix cache: per-shard snapshots are merged into one named CPU
+    // context (ls<shard>_ prefix + adapter-level meta/hc/logits tensors).
+    // Mixed (remote IPC) target splits stay memory-only.
+    ModelBackend::SnapshotRef snapshot_ref(int slot) const override;
+    bool snapshot_adopt(int slot, ggml_context * ctx,
+                        ggml_backend_buffer_t buf, int cur_pos,
+                        int32_t last_tok) override;
     int current_last_token() const override { return last_tok_; }
 
     void free_drafter() override {}
@@ -107,8 +114,16 @@ private:
         std::vector<float> prefill_last_logits;
         std::vector<DeepSeek4Snapshot> shards;
         bool used = false;
+        // Merged serialization context (owned here). After snapshot_save it
+        // is a copy of the shard snapshots; after snapshot_adopt the shard
+        // snapshots alias it (owns_storage=false).
+        ggml_context *        disk_ctx = nullptr;
+        ggml_backend_buffer_t disk_buf = nullptr;
+        ggml_backend_t        disk_backend = nullptr;  // CPU backend owning disk_buf (save path)
     };
     std::vector<Snapshot> snapshots_;
+    bool rebuild_disk_snapshot(int slot);
+    void free_disk_snapshot(int slot);
 
     SamplerCfg sampler_;
     std::mt19937_64 sampler_rng_{std::random_device{}()};

--- a/server/src/deepseek4/deepseek4_snapshot.cpp
+++ b/server/src/deepseek4/deepseek4_snapshot.cpp
@@ -1,0 +1,590 @@
+// DeepSeek V4 KV snapshots: declare / fill / restore / bind / validate.
+// See deepseek4_snapshot.h for the contract.
+
+#include "deepseek4_snapshot.h"
+
+#include "ggml.h"
+#include "ggml-backend.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <limits>
+#include <vector>
+
+namespace dflash::common {
+
+const char * const kDeepSeek4SnapHcName     = "ds4_hc_state_snap";
+const char * const kDeepSeek4SnapMetaName   = "ds4_snap_meta";
+const char * const kDeepSeek4SnapLogitsName = "ds4_snap_last_logits";
+const char * const kDeepSeek4SnapFeatName   = "ds4_snap_spec_feat";
+
+namespace {
+
+// Per-layer tensor name formats, in DeepSeek4Snapshot::LayerSnap order.
+enum LayerTensor {
+    kRawKv = 0, kCompKv, kIndexKv, kAttnStateKv, kAttnStateScore,
+    kIdxStateKv, kIdxStateScore, kLayerTensorCount
+};
+const char * const kLayerTensorFmt[kLayerTensorCount] = {
+    "ds4_snap_raw_kv_%d",
+    "ds4_snap_comp_kv_%d",
+    "ds4_snap_index_kv_%d",
+    "ds4_snap_attn_cs_kv_%d",
+    "ds4_snap_attn_cs_score_%d",
+    "ds4_snap_idx_cs_kv_%d",
+    "ds4_snap_idx_cs_score_%d",
+};
+
+ggml_tensor * find_named(ggml_context * ctx, const std::string & name) {
+    if (!ctx || name.empty() || name.size() >= (size_t) GGML_MAX_NAME) return nullptr;
+    return ggml_get_tensor(ctx, name.c_str());
+}
+
+ggml_tensor * new_named(ggml_context * ctx, ggml_tensor * t, const std::string & name) {
+    if (!t) return nullptr;
+    if (name.size() >= (size_t) GGML_MAX_NAME) return nullptr;
+    ggml_set_name(t, name.c_str());
+    return t;
+}
+
+// Same type/shape as `src` (full-capacity tensors: raw ring, states, HC).
+ggml_tensor * declare_like(ggml_context * ctx, const ggml_tensor * src, const std::string & name) {
+    if (!ctx || !src) return nullptr;
+    return new_named(ctx, ggml_dup_tensor(ctx, const_cast<ggml_tensor *>(src)), name);
+}
+
+// Right-sized row prefix of a 2-D tensor. GGML tensors cannot have an empty
+// physical dimension, so an empty logical prefix keeps one allocated row and
+// copies zero bytes.
+ggml_tensor * declare_rows(ggml_context * ctx, const ggml_tensor * src, int live_rows,
+                           const std::string & name) {
+    if (!ctx || !src || ggml_n_dims(src) > 2 || live_rows < 0 || live_rows > src->ne[1]) {
+        return nullptr;
+    }
+    return new_named(ctx, ggml_new_tensor_2d(ctx, src->type, src->ne[0],
+                                             std::max(1, live_rows)), name);
+}
+
+size_t prefix_bytes(const ggml_tensor * t, int rows) {
+    if (!t || rows <= 0) return 0;
+    return (size_t) rows * t->nb[1];
+}
+
+bool copy_prefix_from_backend(const ggml_tensor * src, ggml_tensor * dst, int rows) {
+    if (!src || !dst || rows < 0) return false;
+    const size_t bytes = prefix_bytes(src, rows);
+    if (bytes > ggml_nbytes(src) || bytes > ggml_nbytes(dst)) return false;
+    if (bytes > 0) ggml_backend_tensor_get(src, dst->data, 0, bytes);
+    return true;
+}
+
+bool copy_prefix_to_backend(const ggml_tensor * src, ggml_tensor * dst, int rows) {
+    if (!src || !dst || rows < 0) return false;
+    const size_t bytes = prefix_bytes(src, rows);
+    if (bytes > ggml_nbytes(src) || bytes > ggml_nbytes(dst)) return false;
+    if (bytes > 0) ggml_backend_tensor_set(dst, src->data, 0, bytes);
+    return true;
+}
+
+bool copy_from_backend(const ggml_tensor * src, ggml_tensor * dst) {
+    if (!src || !dst || ggml_nbytes(src) != ggml_nbytes(dst)) return false;
+    ggml_backend_tensor_get(src, dst->data, 0, ggml_nbytes(src));
+    return true;
+}
+
+bool copy_to_backend(const ggml_tensor * src, ggml_tensor * dst) {
+    if (!src || !dst || ggml_nbytes(src) != ggml_nbytes(dst)) return false;
+    ggml_backend_tensor_set(dst, src->data, 0, ggml_nbytes(src));
+    return true;
+}
+
+// Optional pair copy: both null is fine, one null is not.
+bool copy_opt_from_backend(const ggml_tensor * src, ggml_tensor * dst) {
+    if (!src && !dst) return true;
+    return copy_from_backend(src, dst);
+}
+bool copy_opt_to_backend(const ggml_tensor * src, ggml_tensor * dst) {
+    if (!src && !dst) return true;
+    return copy_to_backend(src, dst);
+}
+
+bool tensors_compatible(const ggml_tensor * a, const ggml_tensor * b) {
+    if (!!a != !!b) return false;
+    if (!a) return true;
+    if (a->type != b->type || ggml_n_dims(a) != ggml_n_dims(b)) return false;
+    for (int i = 0; i < GGML_MAX_DIMS; ++i) {
+        if (a->ne[i] != b->ne[i]) return false;
+    }
+    return true;
+}
+
+// A right-sized zero/one-row tensor reports one logical GGML dimension while
+// its full-capacity cache tensor reports two, so compare the physical row
+// layout instead of ggml_n_dims().
+bool prefix_tensors_compatible(const ggml_tensor * snap, const ggml_tensor * cache, int live_rows) {
+    if (!!snap != !!cache) return false;
+    if (!snap) return live_rows == 0;
+    if (live_rows < 0 || cache->ne[1] <= 0 || snap->type != cache->type ||
+        snap->ne[0] != cache->ne[0] || live_rows > cache->ne[1]) {
+        return false;
+    }
+    for (int i = 2; i < GGML_MAX_DIMS; ++i) {
+        if (snap->ne[i] != cache->ne[i]) return false;
+    }
+    return snap->ne[1] == std::max(1, live_rows);
+}
+
+// Shape predicates used by validate(): a 2-D tensor with exact width/rows.
+bool is_2d(const ggml_tensor * t, ggml_type type, int64_t ne0, int64_t ne1) {
+    return t && t->type == type && t->ne[0] == ne0 && t->ne[1] == ne1 &&
+           t->ne[2] == 1 && t->ne[3] == 1;
+}
+
+bool layer_snapshot_shape_ok(const DeepSeek4LayerGeometry & g,
+                             const DeepSeek4Snapshot::LayerSnap & L,
+                             int64_t comp_capacity,   // <= 0: skip capacity checks
+                             std::string * why) {
+    auto fail = [&](const char * what) { if (why) *why = what; return false; };
+    if (L.n_comp < 0 || L.n_index_comp < 0) return fail("negative row count");
+    if (!is_2d(L.raw_kv, GGML_TYPE_F16, g.head_dim, g.raw_rows)) return fail("raw window shape");
+    if ((!!L.comp_kv) != g.has_comp) return fail("compressed rows presence");
+    if ((!!L.attn_compressor.state_kv) != g.has_comp ||
+        (!!L.attn_compressor.state_score) != g.has_comp) {
+        return fail("attention compressor state presence");
+    }
+    if ((!!L.index_comp_kv) != g.has_index) return fail("indexer rows presence");
+    if ((!!L.indexer_compressor.state_kv) != g.has_index ||
+        (!!L.indexer_compressor.state_score) != g.has_index) {
+        return fail("indexer compressor state presence");
+    }
+    if (!g.has_comp && L.n_comp != 0) return fail("compressed rows without capacity");
+    if (!g.has_index && L.n_index_comp != 0) return fail("indexer rows without capacity");
+    if (g.has_comp) {
+        if (!is_2d(L.comp_kv, GGML_TYPE_F16, g.head_dim, std::max(1, L.n_comp))) {
+            return fail("compressed rows shape");
+        }
+        if (!is_2d(L.attn_compressor.state_kv, GGML_TYPE_F32, g.comp_width, g.comp_state_rows) ||
+            !is_2d(L.attn_compressor.state_score, GGML_TYPE_F32, g.comp_width, g.comp_state_rows)) {
+            return fail("attention compressor state shape");
+        }
+        if (comp_capacity > 0 && L.n_comp > comp_capacity) return fail("compressed rows exceed capacity");
+    }
+    if (g.has_index) {
+        if (!is_2d(L.index_comp_kv, GGML_TYPE_F16, g.index_dim, std::max(1, L.n_index_comp))) {
+            return fail("indexer rows shape");
+        }
+        if (!is_2d(L.indexer_compressor.state_kv, GGML_TYPE_F32, g.index_state_width, g.index_state_rows) ||
+            !is_2d(L.indexer_compressor.state_score, GGML_TYPE_F32, g.index_state_width, g.index_state_rows)) {
+            return fail("indexer compressor state shape");
+        }
+        if (comp_capacity > 0 && L.n_index_comp > comp_capacity) return fail("indexer rows exceed capacity");
+    }
+    return true;
+}
+
+}  // namespace
+
+std::string deepseek4_snapshot_tensor_name(const char * prefix, const char * base) {
+    std::string name = prefix ? prefix : "";
+    name += base;
+    return name;
+}
+
+std::string deepseek4_snapshot_layer_tensor_name(const char * prefix, const char * fmt, int layer) {
+    char buf[GGML_MAX_NAME];
+    std::snprintf(buf, sizeof(buf), fmt, layer);
+    return deepseek4_snapshot_tensor_name(prefix, buf);
+}
+
+size_t deepseek4_snapshot_tensor_count(int n_layer, bool with_aux) {
+    return 1 + (size_t) std::max(0, n_layer) * kLayerTensorCount + (with_aux ? 3 : 0);
+}
+
+namespace {
+
+// The aux tensors are sized from the aux lengths; the meta records the
+// logical lengths. Variable lengths go in ne[1]: the ondisk layout
+// fingerprint normalizes that dimension, so every snapshot shares one layout.
+bool declare_aux_payload(ggml_context * ctx, const char * name_prefix,
+                         const DeepSeek4SnapshotAux & aux, DeepSeek4Snapshot & out) {
+    if (aux.n_logits > (size_t) std::numeric_limits<int>::max() ||
+        aux.n_spec_feat > (size_t) std::numeric_limits<int>::max() ||
+        (aux.n_logits > 0 && !aux.logits) || (aux.n_spec_feat > 0 && !aux.spec_feat)) {
+        return false;
+    }
+    out.last_logits_snap = new_named(ctx,
+        ggml_new_tensor_1d(ctx, GGML_TYPE_F32, (int64_t) std::max<size_t>(1, aux.n_logits)),
+        deepseek4_snapshot_tensor_name(name_prefix, kDeepSeek4SnapLogitsName));
+    out.spec_feat_snap = new_named(ctx,
+        ggml_new_tensor_2d(ctx, GGML_TYPE_F32, 1, (int64_t) std::max<size_t>(1, aux.n_spec_feat)),
+        deepseek4_snapshot_tensor_name(name_prefix, kDeepSeek4SnapFeatName));
+    return out.last_logits_snap && out.spec_feat_snap;
+}
+
+}  // namespace
+
+bool deepseek4_snapshot_declare(ggml_context * ctx,
+                                const DeepSeek4Cache & cache,
+                                const char * name_prefix,
+                                const DeepSeek4SnapshotAux * aux,
+                                DeepSeek4Snapshot & out) {
+    if (!ctx || !cache.ctx || !cache.buf || !cache.hc_state ||
+        cache.layers.size() != (size_t) cache.n_layer || cache.cur_pos < 0 ||
+        cache.cur_pos > cache.max_ctx) {
+        return false;
+    }
+    for (const auto & layer : cache.layers) {
+        if (layer.n_comp < 0 || layer.n_index_comp < 0 ||
+            (layer.comp_kv && layer.n_comp > layer.comp_kv->ne[1]) ||
+            (!layer.comp_kv && layer.n_comp != 0) ||
+            (layer.index_comp_kv && layer.n_index_comp > layer.index_comp_kv->ne[1]) ||
+            (!layer.index_comp_kv && layer.n_index_comp != 0)) {
+            return false;
+        }
+    }
+
+    out.layers.assign((size_t) cache.n_layer, {});
+    out.meta_snap = out.last_logits_snap = out.spec_feat_snap = nullptr;
+    out.hc_state_snap = declare_like(
+        ctx, cache.hc_state, deepseek4_snapshot_tensor_name(name_prefix, kDeepSeek4SnapHcName));
+    if (!out.hc_state_snap) return false;
+
+    auto lname = [&](int which, int il) {
+        return deepseek4_snapshot_layer_tensor_name(name_prefix, kLayerTensorFmt[which], il);
+    };
+    for (int il = 0; il < cache.n_layer; ++il) {
+        const auto & src = cache.layers[(size_t) il];
+        auto & dst = out.layers[(size_t) il];
+        dst.n_comp = src.n_comp;
+        dst.n_index_comp = src.n_index_comp;
+        dst.raw_kv = declare_like(ctx, src.raw_kv, lname(kRawKv, il));
+        dst.comp_kv = src.comp_kv
+            ? declare_rows(ctx, src.comp_kv, src.n_comp, lname(kCompKv, il)) : nullptr;
+        dst.index_comp_kv = src.index_comp_kv
+            ? declare_rows(ctx, src.index_comp_kv, src.n_index_comp, lname(kIndexKv, il)) : nullptr;
+        dst.attn_compressor.state_kv =
+            declare_like(ctx, src.attn_compressor.state_kv, lname(kAttnStateKv, il));
+        dst.attn_compressor.state_score =
+            declare_like(ctx, src.attn_compressor.state_score, lname(kAttnStateScore, il));
+        dst.indexer_compressor.state_kv =
+            declare_like(ctx, src.indexer_compressor.state_kv, lname(kIdxStateKv, il));
+        dst.indexer_compressor.state_score =
+            declare_like(ctx, src.indexer_compressor.state_score, lname(kIdxStateScore, il));
+        if (!dst.raw_kv ||
+            (src.comp_kv && !dst.comp_kv) ||
+            (src.index_comp_kv && !dst.index_comp_kv) ||
+            (src.attn_compressor.state_kv && !dst.attn_compressor.state_kv) ||
+            (src.attn_compressor.state_score && !dst.attn_compressor.state_score) ||
+            (src.indexer_compressor.state_kv && !dst.indexer_compressor.state_kv) ||
+            (src.indexer_compressor.state_score && !dst.indexer_compressor.state_score)) {
+            return false;
+        }
+    }
+
+    if (aux) {
+        out.meta_snap = new_named(ctx,
+            ggml_new_tensor_1d(ctx, GGML_TYPE_I32,
+                               kDeepSeek4SnapMetaBase + 2 * (int64_t) cache.n_layer),
+            deepseek4_snapshot_tensor_name(name_prefix, kDeepSeek4SnapMetaName));
+        if (!out.meta_snap || !declare_aux_payload(ctx, name_prefix, *aux, out)) return false;
+    }
+    return true;
+}
+
+bool deepseek4_snapshot_fill(const DeepSeek4Cache & cache,
+                             const DeepSeek4SnapshotAux * aux,
+                             DeepSeek4Snapshot & out) {
+    if (!cache.ctx || !cache.hc_state || out.layers.size() != cache.layers.size() ||
+        !out.hc_state_snap || !out.hc_state_snap->data) {
+        return false;
+    }
+    if (!copy_from_backend(cache.hc_state, out.hc_state_snap)) return false;
+    for (size_t il = 0; il < cache.layers.size(); ++il) {
+        const auto & src = cache.layers[il];
+        auto & dst = out.layers[il];
+        dst.n_comp = src.n_comp;
+        dst.n_index_comp = src.n_index_comp;
+        if (!copy_from_backend(src.raw_kv, dst.raw_kv) ||
+            (src.comp_kv && !copy_prefix_from_backend(src.comp_kv, dst.comp_kv, src.n_comp)) ||
+            (src.index_comp_kv &&
+             !copy_prefix_from_backend(src.index_comp_kv, dst.index_comp_kv, src.n_index_comp)) ||
+            !copy_opt_from_backend(src.attn_compressor.state_kv, dst.attn_compressor.state_kv) ||
+            !copy_opt_from_backend(src.attn_compressor.state_score, dst.attn_compressor.state_score) ||
+            !copy_opt_from_backend(src.indexer_compressor.state_kv, dst.indexer_compressor.state_kv) ||
+            !copy_opt_from_backend(src.indexer_compressor.state_score, dst.indexer_compressor.state_score)) {
+            return false;
+        }
+    }
+
+    if (out.meta_snap) {
+        if (!out.last_logits_snap || !out.spec_feat_snap) return false;
+        const size_t n_logits = aux ? aux->n_logits : 0;
+        const size_t n_feat = aux ? aux->n_spec_feat : 0;
+        if ((int64_t) std::max<size_t>(1, n_logits) != ggml_nelements(out.last_logits_snap) ||
+            (int64_t) std::max<size_t>(1, n_feat) != ggml_nelements(out.spec_feat_snap)) {
+            return false;  // declared with a different aux
+        }
+        std::vector<int32_t> meta((size_t) (kDeepSeek4SnapMetaBase + 2 * cache.n_layer), 0);
+        meta[0] = kDeepSeek4SnapMetaVersion;
+        meta[1] = cache.n_layer;
+        meta[2] = (int32_t) n_logits;
+        meta[3] = (int32_t) n_feat;
+        meta[4] = cache.cur_pos;
+        for (int il = 0; il < cache.n_layer; ++il) {
+            meta[(size_t) (kDeepSeek4SnapMetaBase + 2 * il)]     = cache.layers[(size_t) il].n_comp;
+            meta[(size_t) (kDeepSeek4SnapMetaBase + 2 * il + 1)] = cache.layers[(size_t) il].n_index_comp;
+        }
+        ggml_backend_tensor_set(out.meta_snap, meta.data(), 0, meta.size() * sizeof(int32_t));
+        if (n_logits > 0) {
+            ggml_backend_tensor_set(out.last_logits_snap, aux->logits, 0, n_logits * sizeof(float));
+        } else {
+            const float zero = 0.0f;
+            ggml_backend_tensor_set(out.last_logits_snap, &zero, 0, sizeof(zero));
+        }
+        if (n_feat > 0) {
+            ggml_backend_tensor_set(out.spec_feat_snap, aux->spec_feat, 0, n_feat * sizeof(float));
+        } else {
+            const float zero = 0.0f;
+            ggml_backend_tensor_set(out.spec_feat_snap, &zero, 0, sizeof(zero));
+        }
+    }
+    out.cur_pos = cache.cur_pos;
+    return true;
+}
+
+bool deepseek4_snapshot_save(const DeepSeek4Cache & cache,
+                             ggml_backend_t snapshot_backend,
+                             DeepSeek4Snapshot & out,
+                             const DeepSeek4SnapshotAux * aux) {
+    free_deepseek4_snapshot(out);
+    if (!snapshot_backend) return false;
+
+    ggml_init_params ip{};
+    ip.mem_size = ggml_tensor_overhead() *
+                  (deepseek4_snapshot_tensor_count(cache.n_layer, aux != nullptr) + 4) + 4096;
+    ip.no_alloc = true;
+    ggml_context * ctx = ggml_init(ip);
+    if (!ctx) return false;
+
+    if (!deepseek4_snapshot_declare(ctx, cache, nullptr, aux, out)) {
+        ggml_free(ctx);
+        out = DeepSeek4Snapshot{};
+        return false;
+    }
+    ggml_backend_buffer_t buf = ggml_backend_alloc_ctx_tensors(ctx, snapshot_backend);
+    if (!buf) {
+        ggml_free(ctx);
+        out = DeepSeek4Snapshot{};
+        return false;
+    }
+    // Placeholder rows (empty logical prefixes) are zeroed so serialized
+    // bytes are deterministic.
+    ggml_backend_buffer_clear(buf, 0);
+    out.ctx = ctx;
+    out.buf = buf;
+    out.owns_storage = true;
+    if (!deepseek4_snapshot_fill(cache, aux, out)) {
+        free_deepseek4_snapshot(out);
+        return false;
+    }
+    return true;
+}
+
+bool deepseek4_snapshot_restore(const DeepSeek4Snapshot & snap,
+                                DeepSeek4Cache & cache) {
+    if (!snap.ctx || !cache.ctx || !cache.buf || !snap.hc_state_snap ||
+        snap.layers.size() != cache.layers.size() || snap.cur_pos < 0 ||
+        snap.cur_pos > cache.max_ctx) {
+        std::fprintf(stderr,
+                     "[deepseek4] snapshot restore: invalid header "
+                     "(snap_ctx=%d cache_ctx=%d snap_layers=%zu "
+                     "cache_layers=%zu pos=%d max_ctx=%d)\n",
+                     snap.ctx != nullptr, cache.ctx != nullptr,
+                     snap.layers.size(), cache.layers.size(),
+                     snap.cur_pos, cache.max_ctx);
+        return false;
+    }
+    if (!tensors_compatible(snap.hc_state_snap, cache.hc_state)) {
+        std::fprintf(stderr, "[deepseek4] snapshot restore: incompatible HC state\n");
+        return false;
+    }
+
+    // Validate the complete layout before changing the live cache. Compressed
+    // tensors are deliberately right-sized to their logical row counts;
+    // inactive capacity rows are not part of the snapshot contract.
+    for (size_t il = 0; il < cache.layers.size(); ++il) {
+        const auto & src = snap.layers[il];
+        const auto & dst = cache.layers[il];
+        const bool raw_ok = tensors_compatible(src.raw_kv, dst.raw_kv);
+        const bool comp_ok = prefix_tensors_compatible(src.comp_kv, dst.comp_kv, src.n_comp);
+        const bool index_ok = prefix_tensors_compatible(src.index_comp_kv, dst.index_comp_kv, src.n_index_comp);
+        const bool attn_kv_ok = tensors_compatible(src.attn_compressor.state_kv, dst.attn_compressor.state_kv);
+        const bool attn_score_ok = tensors_compatible(src.attn_compressor.state_score, dst.attn_compressor.state_score);
+        const bool index_kv_ok = tensors_compatible(src.indexer_compressor.state_kv, dst.indexer_compressor.state_kv);
+        const bool index_score_ok = tensors_compatible(src.indexer_compressor.state_score, dst.indexer_compressor.state_score);
+        if (!raw_ok || !comp_ok || !index_ok || !attn_kv_ok ||
+            !attn_score_ok || !index_kv_ok || !index_score_ok) {
+            std::fprintf(stderr,
+                         "[deepseek4] snapshot restore: incompatible layer %zu "
+                         "(raw=%d comp=%d[%d/%lld/%lld] "
+                         "index=%d[%d/%lld/%lld] states=%d/%d/%d/%d)\n",
+                         il, raw_ok, comp_ok, src.n_comp,
+                         (long long) (src.comp_kv ? src.comp_kv->ne[1] : 0),
+                         (long long) (dst.comp_kv ? dst.comp_kv->ne[1] : 0),
+                         index_ok, src.n_index_comp,
+                         (long long) (src.index_comp_kv ? src.index_comp_kv->ne[1] : 0),
+                         (long long) (dst.index_comp_kv ? dst.index_comp_kv->ne[1] : 0),
+                         attn_kv_ok, attn_score_ok, index_kv_ok, index_score_ok);
+            return false;
+        }
+    }
+
+    if (!copy_to_backend(snap.hc_state_snap, cache.hc_state)) {
+        std::fprintf(stderr, "[deepseek4] snapshot restore: HC copy failed\n");
+        return false;
+    }
+    for (size_t il = 0; il < cache.layers.size(); ++il) {
+        const auto & src = snap.layers[il];
+        auto & dst = cache.layers[il];
+        if (!copy_to_backend(src.raw_kv, dst.raw_kv) ||
+            (src.comp_kv && !copy_prefix_to_backend(src.comp_kv, dst.comp_kv, src.n_comp)) ||
+            (src.index_comp_kv &&
+             !copy_prefix_to_backend(src.index_comp_kv, dst.index_comp_kv, src.n_index_comp)) ||
+            !copy_opt_to_backend(src.attn_compressor.state_kv, dst.attn_compressor.state_kv) ||
+            !copy_opt_to_backend(src.attn_compressor.state_score, dst.attn_compressor.state_score) ||
+            !copy_opt_to_backend(src.indexer_compressor.state_kv, dst.indexer_compressor.state_kv) ||
+            !copy_opt_to_backend(src.indexer_compressor.state_score, dst.indexer_compressor.state_score)) {
+            std::fprintf(stderr, "[deepseek4] snapshot restore: layer %zu copy failed\n", il);
+            return false;
+        }
+        dst.n_comp = src.n_comp;
+        dst.n_index_comp = src.n_index_comp;
+    }
+    cache.cur_pos = snap.cur_pos;
+    return true;
+}
+
+void free_deepseek4_snapshot(DeepSeek4Snapshot & s) {
+    if (s.owns_storage) {
+        if (s.buf) ggml_backend_buffer_free(s.buf);
+        if (s.ctx) ggml_free(s.ctx);
+    }
+    s = DeepSeek4Snapshot{};
+}
+
+bool deepseek4_snapshot_bind(ggml_context * ctx,
+                             ggml_backend_buffer_t buf,
+                             const char * name_prefix,
+                             bool take_ownership,
+                             DeepSeek4Snapshot & out,
+                             DeepSeek4SnapshotBindInfo * info) {
+    free_deepseek4_snapshot(out);
+    if (!ctx || !buf) return false;
+
+    ggml_tensor * meta = find_named(ctx, deepseek4_snapshot_tensor_name(name_prefix, kDeepSeek4SnapMetaName));
+    if (!meta || meta->type != GGML_TYPE_I32 || ggml_n_dims(meta) != 1 ||
+        meta->ne[0] < kDeepSeek4SnapMetaBase || !meta->data) {
+        return false;
+    }
+    std::vector<int32_t> m((size_t) meta->ne[0], 0);
+    ggml_backend_tensor_get(meta, m.data(), 0, m.size() * sizeof(int32_t));
+    if (m[0] != kDeepSeek4SnapMetaVersion) return false;
+    const int n_layer = m[1], n_vocab = m[2], n_spec_feat = m[3], cur_pos = m[4];
+    if (n_layer <= 0 || n_layer > 4096 || n_vocab < 0 || n_spec_feat < 0 || cur_pos < 0 ||
+        meta->ne[0] != (int64_t) (kDeepSeek4SnapMetaBase + 2 * n_layer)) {
+        return false;
+    }
+
+    DeepSeek4Snapshot tmp;
+    tmp.meta_snap = meta;
+    tmp.hc_state_snap = find_named(ctx, deepseek4_snapshot_tensor_name(name_prefix, kDeepSeek4SnapHcName));
+    tmp.last_logits_snap = find_named(ctx, deepseek4_snapshot_tensor_name(name_prefix, kDeepSeek4SnapLogitsName));
+    tmp.spec_feat_snap = find_named(ctx, deepseek4_snapshot_tensor_name(name_prefix, kDeepSeek4SnapFeatName));
+    if (!tmp.hc_state_snap || !tmp.last_logits_snap || !tmp.spec_feat_snap ||
+        tmp.last_logits_snap->type != GGML_TYPE_F32 || tmp.spec_feat_snap->type != GGML_TYPE_F32 ||
+        ggml_nelements(tmp.last_logits_snap) != (int64_t) std::max(1, n_vocab) ||
+        ggml_nelements(tmp.spec_feat_snap) != (int64_t) std::max(1, n_spec_feat)) {
+        return false;
+    }
+
+    tmp.layers.resize((size_t) n_layer);
+    for (int il = 0; il < n_layer; ++il) {
+        auto & L = tmp.layers[(size_t) il];
+        auto lookup = [&](int which) {
+            return find_named(ctx, deepseek4_snapshot_layer_tensor_name(name_prefix, kLayerTensorFmt[which], il));
+        };
+        L.raw_kv = lookup(kRawKv);
+        L.comp_kv = lookup(kCompKv);
+        L.index_comp_kv = lookup(kIndexKv);
+        L.attn_compressor.state_kv = lookup(kAttnStateKv);
+        L.attn_compressor.state_score = lookup(kAttnStateScore);
+        L.indexer_compressor.state_kv = lookup(kIdxStateKv);
+        L.indexer_compressor.state_score = lookup(kIdxStateScore);
+        L.n_comp = m[(size_t) (kDeepSeek4SnapMetaBase + 2 * il)];
+        L.n_index_comp = m[(size_t) (kDeepSeek4SnapMetaBase + 2 * il + 1)];
+        if (!L.raw_kv || L.n_comp < 0 || L.n_index_comp < 0 ||
+            (!L.comp_kv && L.n_comp != 0) || (!L.index_comp_kv && L.n_index_comp != 0) ||
+            (L.comp_kv && L.comp_kv->ne[1] != std::max(1, L.n_comp)) ||
+            (L.index_comp_kv && L.index_comp_kv->ne[1] != std::max(1, L.n_index_comp))) {
+            return false;
+        }
+    }
+    // Every tensor must be backed by host memory (CPU snapshot buffer).
+    for (ggml_tensor * t = ggml_get_first_tensor(ctx); t; t = ggml_get_next_tensor(ctx, t)) {
+        if (!t->data) return false;
+    }
+
+    out = tmp;
+    out.cur_pos = cur_pos;
+    out.ctx = ctx;
+    out.buf = buf;
+    out.owns_storage = take_ownership;
+    if (info) {
+        info->n_layer = n_layer;
+        info->n_vocab = n_vocab;
+        info->n_spec_feat = n_spec_feat;
+        info->cur_pos = cur_pos;
+    }
+    return true;
+}
+
+bool deepseek4_snapshot_validate(const DeepSeek4Weights & w,
+                                 int max_ctx,
+                                 const DeepSeek4Snapshot & snap,
+                                 std::string * why) {
+    auto fail = [&](const std::string & what) { if (why) *why = what; return false; };
+    if (w.n_layer <= 0 || w.compress_ratios.size() != (size_t) w.n_layer) {
+        return fail("weights not loaded");
+    }
+    if (snap.layers.size() != (size_t) w.n_layer) return fail("layer count mismatch");
+    if (snap.cur_pos < 0 || (max_ctx > 0 && snap.cur_pos > max_ctx)) return fail("position out of range");
+    if (!snap.hc_state_snap || snap.hc_state_snap->type != GGML_TYPE_F32 ||
+        ggml_nelements(snap.hc_state_snap) != deepseek4_hc_state_elements(w)) {
+        return fail("HC state shape");
+    }
+    // The logits sidecar is either empty (one placeholder element, e.g. the
+    // layer-split shards, which keep logits at the adapter level) or a full
+    // vocabulary row. Callers that need logits check the meta's n_vocab.
+    if (snap.last_logits_snap &&
+        (snap.last_logits_snap->type != GGML_TYPE_F32 ||
+         (ggml_nelements(snap.last_logits_snap) != 1 &&
+          ggml_nelements(snap.last_logits_snap) != (int64_t) w.n_vocab))) {
+        return fail("logits shape");
+    }
+    if (snap.spec_feat_snap &&
+        (snap.spec_feat_snap->type != GGML_TYPE_F32 || snap.spec_feat_snap->ne[0] != 1)) {
+        return fail("feature window shape");
+    }
+    for (int il = 0; il < w.n_layer; ++il) {
+        const DeepSeek4LayerGeometry g = deepseek4_layer_geometry(w, il);
+        std::string layer_why;
+        if (!layer_snapshot_shape_ok(g, snap.layers[(size_t) il],
+                                     max_ctx > 0 ? g.comp_capacity(max_ctx) : 0, &layer_why)) {
+            return fail("layer " + std::to_string(il) + ": " + layer_why);
+        }
+    }
+    return true;
+}
+
+}  // namespace dflash::common

--- a/server/src/deepseek4/deepseek4_snapshot.cpp
+++ b/server/src/deepseek4/deepseek4_snapshot.cpp
@@ -482,16 +482,20 @@ bool deepseek4_snapshot_bind(ggml_context * ctx,
     free_deepseek4_snapshot(out);
     if (!ctx || !buf) return false;
 
+    // Bound the meta length before allocating from it: a corrupt file must
+    // not drive the read size.
+    constexpr int64_t kMaxLayers = 4096;
+    constexpr int64_t kMaxMetaLen = kDeepSeek4SnapMetaBase + 2 * kMaxLayers;
     ggml_tensor * meta = find_named(ctx, deepseek4_snapshot_tensor_name(name_prefix, kDeepSeek4SnapMetaName));
     if (!meta || meta->type != GGML_TYPE_I32 || ggml_n_dims(meta) != 1 ||
-        meta->ne[0] < kDeepSeek4SnapMetaBase || !meta->data) {
+        meta->ne[0] < kDeepSeek4SnapMetaBase || meta->ne[0] > kMaxMetaLen || !meta->data) {
         return false;
     }
     std::vector<int32_t> m((size_t) meta->ne[0], 0);
     ggml_backend_tensor_get(meta, m.data(), 0, m.size() * sizeof(int32_t));
     if (m[0] != kDeepSeek4SnapMetaVersion) return false;
     const int n_layer = m[1], n_vocab = m[2], n_spec_feat = m[3], cur_pos = m[4];
-    if (n_layer <= 0 || n_layer > 4096 || n_vocab < 0 || n_spec_feat < 0 || cur_pos < 0 ||
+    if (n_layer <= 0 || n_layer > kMaxLayers || n_vocab < 0 || n_spec_feat < 0 || cur_pos < 0 ||
         meta->ne[0] != (int64_t) (kDeepSeek4SnapMetaBase + 2 * n_layer)) {
         return false;
     }

--- a/server/src/deepseek4/deepseek4_snapshot.h
+++ b/server/src/deepseek4/deepseek4_snapshot.h
@@ -1,0 +1,116 @@
+// DeepSeek V4 KV snapshots.
+//
+// A snapshot is a right-sized, host-resident copy of a DeepSeek4Cache: the raw
+// sliding-window rows, the compressed rows, the indexer rows, the compressor
+// states and the HC residual state, plus an optional aux sidecar with the
+// host-side decode state (last logits, DSpark feature tail) and an I32 meta
+// tensor carrying the per-layer row counts and the cache position.
+//
+// Every tensor has a stable name, so the ondisk prefix cache can serialize a
+// snapshot context and deepseek4_snapshot_bind() can rebind it after a reload.
+//
+// Two ways to build one:
+//   * deepseek4_snapshot_save(): own context + buffer (monolithic backend,
+//     DSpark rollback, IPC target shards).
+//   * deepseek4_snapshot_declare() + deepseek4_snapshot_fill(): several
+//     snapshots share one caller-owned context (layer-split adapter merges
+//     all shards into a single serializable context, no second copy).
+//
+// deepseek4_snapshot_validate() checks every tensor against the geometry the
+// weights imply, so a malformed or foreign file is rejected before it is
+// adopted.
+#pragma once
+
+#include "deepseek4_internal.h"
+
+#include <string>
+
+namespace dflash::common {
+
+// Host-side decode state persisted next to the cache tensors so an adopted
+// (deserialized) snapshot resumes exactly like an in-memory one.
+struct DeepSeek4SnapshotAux {
+    const float * logits = nullptr;
+    size_t        n_logits = 0;
+    const float * spec_feat = nullptr;
+    size_t        n_spec_feat = 0;
+};
+
+// Layout of DeepSeek4Snapshot::meta_snap (I32):
+//   [0] version, [1] n_layer, [2] n_vocab, [3] n_spec_feat, [4] cur_pos,
+//   then per layer: n_comp, n_index_comp.
+constexpr int kDeepSeek4SnapMetaVersion = 1;
+constexpr int kDeepSeek4SnapMetaBase = 5;
+
+// Metadata recovered by deepseek4_snapshot_bind().
+struct DeepSeek4SnapshotBindInfo {
+    int n_layer = 0;
+    int n_vocab = 0;
+    int n_spec_feat = 0;
+    int cur_pos = 0;
+};
+
+// Tensor names. `prefix` (may be null) is prepended verbatim; the layer-split
+// adapter uses "ls<shard>_" so several shards share one context.
+std::string deepseek4_snapshot_tensor_name(const char * prefix, const char * base);
+std::string deepseek4_snapshot_layer_tensor_name(const char * prefix, const char * fmt, int layer);
+extern const char * const kDeepSeek4SnapHcName;
+extern const char * const kDeepSeek4SnapMetaName;
+extern const char * const kDeepSeek4SnapLogitsName;
+extern const char * const kDeepSeek4SnapFeatName;
+
+// Number of ggml tensors one snapshot declares (context sizing).
+size_t deepseek4_snapshot_tensor_count(int n_layer, bool with_aux);
+
+// Create the snapshot tensors in `ctx` (a no_alloc context) without copying
+// any data. `aux == nullptr` declares no sidecar; otherwise the sidecar is
+// sized from the aux lengths (which may be 0). `out` describes the tensors
+// afterwards; the caller allocates a buffer for `ctx`, then calls
+// deepseek4_snapshot_fill() with the same `aux`. `out.ctx`/`out.buf`/
+// `out.owns_storage` are left for the caller to set.
+bool deepseek4_snapshot_declare(ggml_context * ctx,
+                                const DeepSeek4Cache & cache,
+                                const char * name_prefix,
+                                const DeepSeek4SnapshotAux * aux,
+                                DeepSeek4Snapshot & out);
+
+// Copy the live cache (and the aux the snapshot was declared with) into the
+// allocated snapshot tensors and set `out.cur_pos`.
+bool deepseek4_snapshot_fill(const DeepSeek4Cache & cache,
+                             const DeepSeek4SnapshotAux * aux,
+                             DeepSeek4Snapshot & out);
+
+// declare + allocate on `snapshot_backend` + fill, in a context owned by `out`.
+// `aux == nullptr` produces a snapshot without the aux sidecar (not
+// exportable to disk; used by DSpark rollback and IPC target shards).
+bool deepseek4_snapshot_save(const DeepSeek4Cache & cache,
+                             ggml_backend_t snapshot_backend,
+                             DeepSeek4Snapshot & out,
+                             const DeepSeek4SnapshotAux * aux = nullptr);
+
+bool deepseek4_snapshot_restore(const DeepSeek4Snapshot & snap,
+                                DeepSeek4Cache & cache);
+
+// Rebind a deserialized context (tensors named as declared above, optionally
+// prefixed) into `out` using the meta tensor for row counts and position.
+// Structural only; call deepseek4_snapshot_validate() for types and shapes.
+// `out` takes ownership of ctx/buf iff `take_ownership`. Returns false and
+// leaves `out` empty on any inconsistency.
+bool deepseek4_snapshot_bind(ggml_context * ctx,
+                             ggml_backend_buffer_t buf,
+                             const char * name_prefix,
+                             bool take_ownership,
+                             DeepSeek4Snapshot & out,
+                             DeepSeek4SnapshotBindInfo * info);
+
+// Check every snapshot tensor against the geometry `w` implies (types, widths,
+// state rows, HC size, vocab) and, when `max_ctx > 0`, that the row counts fit
+// a cache of that size. `why` receives a short reason on failure.
+bool deepseek4_snapshot_validate(const DeepSeek4Weights & w,
+                                 int max_ctx,
+                                 const DeepSeek4Snapshot & snap,
+                                 std::string * why);
+
+void free_deepseek4_snapshot(DeepSeek4Snapshot & s);
+
+}  // namespace dflash::common

--- a/server/src/deepseek4/deepseek4_target_shard_ipc_daemon.cpp
+++ b/server/src/deepseek4/deepseek4_target_shard_ipc_daemon.cpp
@@ -6,6 +6,7 @@
 
 #include "deepseek4_layer_split_adapter.h"
 #include "deepseek4_internal.h"
+#include "deepseek4_snapshot.h"
 #include "deepseek4_roctx.h"
 #include "common/target_shard_ipc.h"
 #include "common/target_shard_ipc_daemon.h"

--- a/server/src/server/disk_prefix_cache.cpp
+++ b/server/src/server/disk_prefix_cache.cpp
@@ -444,6 +444,17 @@ bool DiskPrefixCache::save(int slot, const std::vector<int32_t> & prompt_ids) {
     auto ref = backend_.snapshot_ref(slot);
     if (!ref.ctx) return false;
 
+    // A file is keyed by the hash of `prompt_ids` only, and a hit restores
+    // the whole snapshot. A snapshot that extends past its key would be
+    // restored for any prompt sharing just the key prefix, with unverified
+    // tokens in between, so such files are never written.
+    if (ref.cur_pos > (int)prompt_ids.size()) {
+        std::fprintf(stderr,
+                     "[disk-cache] skip save: snapshot pos=%d exceeds key of "
+                     "%zu tokens\n", ref.cur_pos, prompt_ids.size());
+        return false;
+    }
+
     PrefixHash hash = hash_prefix(prompt_ids.data(), (int)prompt_ids.size());
 
     std::lock_guard<std::mutex> lock(mu_);
@@ -520,20 +531,20 @@ bool DiskPrefixCache::maybe_store_continued(int slot,
     const int interval = config_.continued_interval;
     if (interval <= 0) return false;
 
-    // Check if cur_pos crosses a new interval boundary since last save.
-    // DS4 uses absolute-aligned frontiers: save only when cur_pos is a
-    // multiple of interval AND exceeds the last store position.
+    // The interval only paces the checkpoints: fire once each time cur_pos
+    // crosses a new multiple of it. The file itself is keyed by the full
+    // token prefix the snapshot covers (cur_pos tokens), so a hit can only
+    // come from a prompt that actually contains everything in the snapshot.
     int target = (cur_pos / interval) * interval;
     if (target <= continued_last_store_pos_) return false;
     if (target < config_.min_tokens) return false;
+    if (cur_pos > (int)all_tokens.size()) return false;
 
-    // Save the prefix up to `target` tokens.
-    std::vector<int32_t> prefix(all_tokens.begin(),
-                                all_tokens.begin() + std::min(target, (int)all_tokens.size()));
+    std::vector<int32_t> prefix(all_tokens.begin(), all_tokens.begin() + cur_pos);
     bool ok = save(slot, prefix);
     if (ok) {
         continued_last_store_pos_ = target;
-        std::fprintf(stderr, "[disk-cache] continued checkpoint at %d tokens\n", target);
+        std::fprintf(stderr, "[disk-cache] continued checkpoint at %d tokens\n", cur_pos);
     }
     return ok;
 }
@@ -704,6 +715,15 @@ bool DiskPrefixCache::read_file(const std::string & path, int slot) {
     if (std::memcmp(hdr.magic, "DKVC", 4) != 0) { std::fclose(f); return false; }
     if (hdr.version != DISK_CACHE_VERSION) { std::fclose(f); return false; }
     if (std::memcmp(hdr.layout_id, layout_id_.data(), 16) != 0) { std::fclose(f); return false; }
+    // Never restore a snapshot that extends past the tokens its key covers
+    // (see save()). Older files written that way are dropped by the caller.
+    if (hdr.cur_pos > hdr.token_count) {
+        std::fprintf(stderr,
+                     "[disk-cache] rejecting %s: snapshot pos=%u exceeds key of "
+                     "%u tokens\n", path.c_str(), hdr.cur_pos, hdr.token_count);
+        std::fclose(f);
+        return false;
+    }
 
     // Read tensor table.
     std::vector<DiskTensorEntry> table;

--- a/server/src/server/disk_prefix_cache.cpp
+++ b/server/src/server/disk_prefix_cache.cpp
@@ -764,14 +764,12 @@ bool DiskPrefixCache::read_file(const std::string & path, int slot) {
         ggml_set_name(t, ent.name.c_str());
     }
 
-    // Allocate buffer on CPU backend.
-    ggml_backend_t cpu = ggml_backend_cpu_init();
-    if (!cpu) { ggml_free(ctx); std::fclose(f); return false; }
-
-    ggml_backend_buffer_t buf = ggml_backend_alloc_ctx_tensors(ctx, cpu);
+    // Host buffer from the CPU buffer type: no backend object to keep alive;
+    // the adopting backend frees the buffer in snapshot_free().
+    ggml_backend_buffer_t buf =
+        ggml_backend_alloc_ctx_tensors_from_buft(ctx, ggml_backend_cpu_buffer_type());
     if (!buf) {
         ggml_free(ctx);
-        ggml_backend_free(cpu);
         std::fclose(f);
         return false;
     }
@@ -786,7 +784,6 @@ bool DiskPrefixCache::read_file(const std::string & path, int slot) {
             if (std::fread(read_buf.data(), 1, chunk, f) != chunk) {
                 ggml_backend_buffer_free(buf);
                 ggml_free(ctx);
-                ggml_backend_free(cpu);
                 std::fclose(f);
                 return false;
             }
@@ -800,16 +797,8 @@ bool DiskPrefixCache::read_file(const std::string & path, int slot) {
     if (!backend_.snapshot_adopt(slot, ctx, buf, (int)hdr.cur_pos, hdr.last_tok)) {
         ggml_backend_buffer_free(buf);
         ggml_free(ctx);
-        ggml_backend_free(cpu);
         return false;
     }
-
-    // The cpu backend must persist as long as the buffer is alive. The buffer
-    // does NOT own the backend, so we cannot free it here. Since snapshot_free
-    // only frees buf + ctx, we accept a small leak of the lightweight cpu
-    // backend object (~64 bytes per load). For a bounded disk cache this is
-    // negligible. A proper fix would store cpu alongside the snapshot.
-
     return true;
 }
 

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -5030,10 +5030,115 @@ static std::array<uint8_t, 16> read_layout_id_from_cache_dir(const std::string &
     return id;
 }
 
+// Layout mock that can also adopt deserialized snapshots (lookup path).
+struct MockBackendWithAdopt : MockBackendWithLayout {
+    std::vector<std::pair<ggml_context *, ggml_backend_buffer_t>> adopted_;
+    int adopted_cur_pos_ = 0;
+    ~MockBackendWithAdopt() {
+        for (auto & p : adopted_) {
+            if (p.second) ggml_backend_buffer_free(p.second);
+            if (p.first) ggml_free(p.first);
+        }
+    }
+    bool snapshot_adopt(int, ggml_context * ctx, ggml_backend_buffer_t buf,
+                        int cur_pos, int32_t) override {
+        adopted_.push_back({ctx, buf});
+        adopted_cur_pos_ = cur_pos;
+        return true;
+    }
+};
+
+TEST_CASE(ServerUnitFixture, test_disk_cache_rejects_snapshot_past_key) {
+    // A snapshot of kMaxPos positions may only be filed under a key that
+    // covers at least kMaxPos tokens; shorter keys are refused on save and,
+    // for files that already exist, on read.
+    MockBackendWithAdopt backend;
+    std::string dir = test_tmp_path("dflash_test_past_key").string();
+    rm_rf(dir);
+    DiskCacheConfig cfg; cfg.cache_dir = dir; cfg.min_tokens = 1;
+    DiskPrefixCache cache(cfg, backend);
+    TEST_ASSERT(cache.init());
+    cache.learn_layout(0);
+
+    std::vector<int32_t> short_key;
+    for (int i = 0; i < MockBackendWithLayout::kMaxPos - 4; ++i) short_key.push_back(i + 1);
+    std::vector<int32_t> full_key;
+    for (int i = 0; i < MockBackendWithLayout::kMaxPos; ++i) full_key.push_back(i + 1);
+
+    TEST_ASSERT(!cache.save(0, short_key));
+    TEST_ASSERT(cache.total_bytes() == 0);
+    TEST_ASSERT(cache.save(0, full_key));
+    TEST_ASSERT(cache.total_bytes() > 0);
+    TEST_ASSERT(!cache.lookup(short_key, 1));
+    TEST_ASSERT(cache.lookup(full_key, 1));
+    TEST_ASSERT(backend.adopted_cur_pos_ == MockBackendWithLayout::kMaxPos);
+
+    // Forge the pre-fix shape on disk: key shorter than the snapshot. The
+    // scan keys entries by the header's token hash, so only the header
+    // fields need rewriting (token_count at byte 32, token_hash at byte 36
+    // of the 80-byte field-by-field header).
+    {
+        std::string forged;
+        for (auto & entry : fs::recursive_directory_iterator(dir)) {
+            if (entry.path().extension() == ".dkv") {
+                forged = (entry.path().parent_path() /
+                          (std::string(32, 'f') + ".dkv")).string();
+                fs::copy_file(entry.path(), forged, fs::copy_options::overwrite_existing);
+                break;
+            }
+        }
+        TEST_ASSERT(!forged.empty());
+        FILE * f = std::fopen(forged.c_str(), "r+b");
+        TEST_ASSERT(f != nullptr);
+        if (f) {
+            const uint32_t short_count = (uint32_t)short_key.size();
+            PrefixHash ph = hash_prefix(short_key.data(), (int)short_key.size());
+            std::fseek(f, 32, SEEK_SET);
+            TEST_ASSERT(std::fwrite(&short_count, 4, 1, f) == 1);
+            TEST_ASSERT(std::fwrite(ph.data(), 16, 1, f) == 1);
+            std::fclose(f);
+        }
+        DiskPrefixCache reopened(cfg, backend);
+        TEST_ASSERT(reopened.init());
+        reopened.learn_layout(0);
+        TEST_ASSERT(!reopened.lookup(short_key, 2));   // rejected + removed
+        TEST_ASSERT(!fs::exists(forged));
+        TEST_ASSERT(reopened.lookup(full_key, 2));     // consistent file survives
+    }
+    rm_rf(dir);
+}
+
+TEST_CASE(ServerUnitFixture, test_disk_cache_continued_keys_full_prefix) {
+    // Continued checkpoints are paced by the interval but keyed by the
+    // tokens the snapshot really covers, so only a prompt containing all of
+    // them can hit.
+    MockBackendWithAdopt backend;
+    std::string dir = test_tmp_path("dflash_test_continued_key").string();
+    rm_rf(dir);
+    DiskCacheConfig cfg; cfg.cache_dir = dir; cfg.min_tokens = 1;
+    cfg.continued_interval = 10;   // 32 positions -> crosses at 30
+    DiskPrefixCache cache(cfg, backend);
+    TEST_ASSERT(cache.init());
+    cache.learn_layout(0);
+
+    std::vector<int32_t> tokens;
+    for (int i = 0; i < 40; ++i) tokens.push_back(100 + i);
+    const int cur_pos = MockBackendWithLayout::kMaxPos;  // 32
+    TEST_ASSERT(cache.maybe_store_continued(0, tokens, cur_pos));
+    std::vector<int32_t> aligned(tokens.begin(), tokens.begin() + 30);
+    std::vector<int32_t> covered(tokens.begin(), tokens.begin() + cur_pos);
+    TEST_ASSERT(!cache.lookup(aligned, 1));
+    TEST_ASSERT(cache.lookup(covered, 1));
+    TEST_ASSERT(backend.adopted_cur_pos_ == cur_pos);
+    // Same interval bucket: no second checkpoint.
+    TEST_ASSERT(!cache.maybe_store_continued(0, tokens, cur_pos));
+    rm_rf(dir);
+}
+
 TEST_CASE(ServerUnitFixture, test_disk_identity_salt_changes_layout_id) {
     MockBackendWithLayout backend;
     std::vector<int32_t> prompt;
-    for (int i = 0; i < 10; ++i) prompt.push_back(i + 1);
+    for (int i = 0; i < MockBackendWithLayout::kMaxPos; ++i) prompt.push_back(i + 1);
 
     // Salt A: non-zero.
     std::array<uint8_t, 16> salt_a{};
@@ -5095,7 +5200,7 @@ TEST_CASE(ServerUnitFixture, test_disk_identity_salt_zero_is_backcompat) {
     // (default-constructed identity_salt_ is already all-zero).
     MockBackendWithLayout backend;
     std::vector<int32_t> prompt;
-    for (int i = 0; i < 10; ++i) prompt.push_back(i + 1);
+    for (int i = 0; i < MockBackendWithLayout::kMaxPos; ++i) prompt.push_back(i + 1);
 
     std::string dir1 = test_tmp_path("dflash_test_salt_zero1").string();
     rm_rf(dir1);

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -5030,16 +5030,24 @@ static std::array<uint8_t, 16> read_layout_id_from_cache_dir(const std::string &
     return id;
 }
 
-// Layout mock that can also adopt deserialized snapshots (lookup path).
+// Layout mock with a settable live position that can also adopt
+// deserialized snapshots (lookup path).
 struct MockBackendWithAdopt : MockBackendWithLayout {
     std::vector<std::pair<ggml_context *, ggml_backend_buffer_t>> adopted_;
     int adopted_cur_pos_ = 0;
+    int cur_pos_ = kMaxPos;
     ~MockBackendWithAdopt() {
         for (auto & p : adopted_) {
             if (p.second) ggml_backend_buffer_free(p.second);
             if (p.first) ggml_free(p.first);
         }
     }
+    SnapshotRef snapshot_ref(int slot) const override {
+        SnapshotRef ref = MockBackendWithLayout::snapshot_ref(slot);
+        ref.cur_pos = cur_pos_;
+        return ref;
+    }
+    int snapshot_cur_pos(int) const override { return cur_pos_; }
     bool snapshot_adopt(int, ggml_context * ctx, ggml_backend_buffer_t buf,
                         int cur_pos, int32_t) override {
         adopted_.push_back({ctx, buf});
@@ -5122,16 +5130,37 @@ TEST_CASE(ServerUnitFixture, test_disk_cache_continued_keys_full_prefix) {
     cache.learn_layout(0);
 
     std::vector<int32_t> tokens;
-    for (int i = 0; i < 40; ++i) tokens.push_back(100 + i);
-    const int cur_pos = MockBackendWithLayout::kMaxPos;  // 32
+    for (int i = 0; i < 60; ++i) tokens.push_back(100 + i);
+    const int cur_pos = MockBackendWithLayout::kMaxPos;  // 32 -> bucket 30
+    backend.cur_pos_ = cur_pos;
     TEST_ASSERT(cache.maybe_store_continued(0, tokens, cur_pos));
     std::vector<int32_t> aligned(tokens.begin(), tokens.begin() + 30);
     std::vector<int32_t> covered(tokens.begin(), tokens.begin() + cur_pos);
     TEST_ASSERT(!cache.lookup(aligned, 1));
     TEST_ASSERT(cache.lookup(covered, 1));
     TEST_ASSERT(backend.adopted_cur_pos_ == cur_pos);
+    const size_t bytes_after_first = cache.total_bytes();
+    TEST_ASSERT(bytes_after_first > 0);
+
     // Same interval bucket: no second checkpoint.
     TEST_ASSERT(!cache.maybe_store_continued(0, tokens, cur_pos));
+    backend.cur_pos_ = 38;  // still bucket 30
+    TEST_ASSERT(!cache.maybe_store_continued(0, tokens, 38));
+    TEST_ASSERT(cache.total_bytes() == bytes_after_first);
+
+    // Crossing into bucket 40 fires again, keyed by the 42 covered tokens.
+    backend.cur_pos_ = 42;
+    TEST_ASSERT(cache.maybe_store_continued(0, tokens, 42));
+    TEST_ASSERT(cache.total_bytes() > bytes_after_first);
+    std::vector<int32_t> bucket(tokens.begin(), tokens.begin() + 40);
+    std::vector<int32_t> covered2(tokens.begin(), tokens.begin() + 42);
+    TEST_ASSERT(!cache.lookup(bucket, 2));
+    TEST_ASSERT(cache.lookup(covered2, 2));
+    TEST_ASSERT(backend.adopted_cur_pos_ == 42);
+    // The earlier checkpoint is still there, and bucket 40 does not refire.
+    TEST_ASSERT(cache.lookup(covered, 3));
+    backend.cur_pos_ = 47;
+    TEST_ASSERT(!cache.maybe_store_continued(0, tokens, 47));
     rm_rf(dir);
 }
 

--- a/server/tests/test_deepseek4_unit.cpp
+++ b/server/tests/test_deepseek4_unit.cpp
@@ -11,6 +11,7 @@
 #include "common/backend_ipc.h"
 #include "common/dspark_head.h"
 #include "common/layer_split_backend.h"
+#include "server/disk_prefix_cache.h"
 #include "common/layer_split_runtime.h"
 #include "common/layer_split_utils.h"
 #include "common/moe_hybrid_ffn_eval.h"
@@ -2172,6 +2173,343 @@ static void test_monolithic_snapshot_preserves_decode_state() {
     TEST_ASSERT(backend.snapshot_aux_[0].last_logits.empty());
     TEST_ASSERT(backend.snapshot_aux_[0].spec_feat_window.empty());
     TEST_ASSERT(!backend.snapshot_restore(0));
+
+    std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
+}
+
+// Every DeepSeek snapshot tensor must carry a stable name: the ondisk prefix
+// cache keys on names and fingerprints the layout from them.
+static bool all_snapshot_tensors_named(ggml_context * ctx, size_t * count_out) {
+    size_t n = 0;
+    for (ggml_tensor * t = ggml_get_first_tensor(ctx); t; t = ggml_get_next_tensor(ctx, t)) {
+        if (!t->name[0]) return false;
+        n++;
+    }
+    if (count_out) *count_out = n;
+    return true;
+}
+
+static std::string make_test_disk_cache_dir(const char * tag) {
+    return "/tmp/dflash_test_ds4_disk_" + std::string(tag) + "_" +
+           std::to_string((long) getpid());
+}
+
+static void remove_test_disk_cache_dir(const std::string & dir) {
+    const std::string cmd = "rm -rf '" + dir + "'";
+    const int rc = std::system(cmd.c_str());
+    (void) rc;
+}
+
+// Rebuild a snapshot context the way DiskPrefixCache::read_file() does after
+// deserializing: fresh 4-D tensors by name/type/shape in a CPU buffer with
+// the bytes copied over. Lets adapter-level tests exercise snapshot_adopt
+// without going through a ModelBackend.
+static bool clone_snapshot_context_like_disk_reader(ggml_context * src_ctx,
+                                                    ggml_context ** ctx_out,
+                                                    ggml_backend_buffer_t * buf_out,
+                                                    ggml_backend_t * backend_out) {
+    size_t n = 0;
+    for (ggml_tensor * t = ggml_get_first_tensor(src_ctx); t; t = ggml_get_next_tensor(src_ctx, t)) n++;
+    ggml_init_params ip{};
+    ip.mem_size = ggml_tensor_overhead() * (n + 4) + 4096;
+    ip.no_alloc = true;
+    ggml_context * ctx = ggml_init(ip);
+    if (!ctx) return false;
+    for (ggml_tensor * t = ggml_get_first_tensor(src_ctx); t; t = ggml_get_next_tensor(src_ctx, t)) {
+        ggml_tensor * d = ggml_new_tensor(ctx, t->type, 4, t->ne);
+        if (!d) { ggml_free(ctx); return false; }
+        ggml_set_name(d, t->name);
+    }
+    ggml_backend_t cpu = ggml_backend_cpu_init();
+    if (!cpu) { ggml_free(ctx); return false; }
+    ggml_backend_buffer_t buf = ggml_backend_alloc_ctx_tensors(ctx, cpu);
+    if (!buf) { ggml_free(ctx); ggml_backend_free(cpu); return false; }
+    std::vector<uint8_t> tmp;
+    for (ggml_tensor * t = ggml_get_first_tensor(src_ctx); t; t = ggml_get_next_tensor(src_ctx, t)) {
+        ggml_tensor * d = ggml_get_tensor(ctx, t->name);
+        if (!d || ggml_nbytes(d) != ggml_nbytes(t)) {
+            ggml_backend_buffer_free(buf); ggml_free(ctx); ggml_backend_free(cpu);
+            return false;
+        }
+        tmp.resize(ggml_nbytes(t));
+        ggml_backend_tensor_get(t, tmp.data(), 0, tmp.size());
+        ggml_backend_tensor_set(d, tmp.data(), 0, tmp.size());
+    }
+    *ctx_out = ctx;
+    *buf_out = buf;
+    *backend_out = cpu;
+    return true;
+}
+
+static void test_monolithic_snapshot_disk_roundtrip() {
+    std::fprintf(stderr, "  test_monolithic_snapshot_disk_roundtrip ...");
+
+    DeepSeek4BackendConfig cfg;
+    DeepSeek4Backend backend(cfg);
+    TEST_ASSERT(init_monolithic_snapshot_test_backend(backend));
+    if (!backend.cache_.buf || backend.cache_.layers.empty()) {
+        std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
+        return;
+    }
+
+    // Slots that were never saved export nothing.
+    TEST_ASSERT(backend.snapshot_ref(0).ctx == nullptr);
+
+    auto & layer = backend.cache_.layers[0];
+    write_tensor_pattern(layer.raw_kv, 5);
+    write_tensor_pattern(layer.comp_kv, 23);
+    write_tensor_pattern(layer.index_comp_kv, 37);
+    write_tensor_pattern(layer.attn_compressor.state_kv, 43);
+    write_tensor_pattern(layer.attn_compressor.state_score, 61);
+    write_tensor_pattern(layer.indexer_compressor.state_kv, 73);
+    write_tensor_pattern(layer.indexer_compressor.state_score, 89);
+    write_tensor_pattern(backend.cache_.hc_state, 101);
+    layer.n_comp = 5;
+    layer.n_index_comp = 3;
+    backend.cache_.cur_pos = 7;
+    backend.last_logits_ = {1.0f, 4.0f, 2.0f};
+    backend.last_logits_pos_ = 7;
+    backend.spec_feat_window_ = {9.0f, 8.0f, 7.0f, 6.0f};
+
+    const auto raw_before = read_tensor_bytes(layer.raw_kv);
+    const auto comp_before = read_tensor_rows(layer.comp_kv, layer.n_comp);
+    const auto index_before = read_tensor_rows(layer.index_comp_kv, layer.n_index_comp);
+    const auto attn_kv_before = read_tensor_bytes(layer.attn_compressor.state_kv);
+    const auto attn_score_before = read_tensor_bytes(layer.attn_compressor.state_score);
+    const auto idx_kv_before = read_tensor_bytes(layer.indexer_compressor.state_kv);
+    const auto idx_score_before = read_tensor_bytes(layer.indexer_compressor.state_score);
+    const auto hc_before = read_tensor_bytes(backend.cache_.hc_state);
+
+    TEST_ASSERT(backend.snapshot_save(0));
+    const ModelBackend::SnapshotRef ref = backend.snapshot_ref(0);
+    TEST_ASSERT(ref.ctx != nullptr);
+    TEST_ASSERT(ref.buf != nullptr);
+    TEST_ASSERT(ref.cur_pos == 7);
+    size_t n_named = 0;
+    TEST_ASSERT(all_snapshot_tensors_named(ref.ctx, &n_named));
+    // hc + 7 per-layer + meta + logits + features
+    TEST_ASSERT(n_named == 11);
+    TEST_ASSERT(backend.snapshots_[0].meta_snap != nullptr);
+    TEST_ASSERT(backend.snapshots_[0].last_logits_snap != nullptr);
+    TEST_ASSERT(backend.snapshots_[0].spec_feat_snap != nullptr);
+
+    // Real ondisk cache: write slot 0, then read it back into slot 1.
+    const std::string dir = make_test_disk_cache_dir("mono");
+    remove_test_disk_cache_dir(dir);
+    DiskCacheConfig dcfg;
+    dcfg.cache_dir = dir;
+    dcfg.min_tokens = 1;
+    DiskPrefixCache disk(dcfg, backend);
+    TEST_ASSERT(disk.init());
+    TEST_ASSERT(!disk.disabled());
+    const std::vector<int32_t> prompt = {11, 12, 13, 14, 15, 16, 17};
+    TEST_ASSERT(disk.save(0, prompt));
+    TEST_ASSERT(!disk.disabled());
+    TEST_ASSERT(disk.total_bytes() > 0);
+
+    // Wipe the in-memory snapshot and the live cache before reloading.
+    backend.snapshot_free(0);
+    TEST_ASSERT(!backend.snapshot_used(0));
+    ggml_backend_buffer_clear(backend.cache_.buf, 0);
+    backend.cache_.cur_pos = 0;
+    layer.n_comp = 0;
+    layer.n_index_comp = 0;
+    backend.last_logits_ = {-1.0f};
+    backend.last_logits_pos_ = -1;
+    backend.spec_feat_window_.clear();
+
+    TEST_ASSERT(disk.lookup(prompt, 1));
+    TEST_ASSERT(backend.snapshot_used(1));
+    TEST_ASSERT(backend.snapshot_cur_pos(1) == 7);
+    TEST_ASSERT(backend.snapshots_[1].layers.size() == 1);
+    TEST_ASSERT(backend.snapshots_[1].layers[0].n_comp == 5);
+    TEST_ASSERT(backend.snapshots_[1].layers[0].n_index_comp == 3);
+    TEST_ASSERT(backend.snapshot_aux_[1].last_logits ==
+                std::vector<float>({1.0f, 4.0f, 2.0f}));
+    TEST_ASSERT(backend.snapshot_aux_[1].spec_feat_window ==
+                std::vector<float>({9.0f, 8.0f, 7.0f, 6.0f}));
+    // An adopted snapshot is exportable again (re-save after restart).
+    TEST_ASSERT(backend.snapshot_ref(1).ctx != nullptr);
+
+    TEST_ASSERT(backend.snapshot_restore(1));
+    TEST_ASSERT(backend.cache_.cur_pos == 7);
+    TEST_ASSERT(layer.n_comp == 5);
+    TEST_ASSERT(layer.n_index_comp == 3);
+    TEST_ASSERT(read_tensor_bytes(layer.raw_kv) == raw_before);
+    TEST_ASSERT(read_tensor_rows(layer.comp_kv, 5) == comp_before);
+    TEST_ASSERT(read_tensor_rows(layer.index_comp_kv, 3) == index_before);
+    TEST_ASSERT(read_tensor_bytes(layer.attn_compressor.state_kv) == attn_kv_before);
+    TEST_ASSERT(read_tensor_bytes(layer.attn_compressor.state_score) == attn_score_before);
+    TEST_ASSERT(read_tensor_bytes(layer.indexer_compressor.state_kv) == idx_kv_before);
+    TEST_ASSERT(read_tensor_bytes(layer.indexer_compressor.state_score) == idx_score_before);
+    TEST_ASSERT(read_tensor_bytes(backend.cache_.hc_state) == hc_before);
+    TEST_ASSERT(backend.last_logits_ == std::vector<float>({1.0f, 4.0f, 2.0f}));
+    TEST_ASSERT(backend.spec_feat_window_ ==
+                std::vector<float>({9.0f, 8.0f, 7.0f, 6.0f}));
+    TEST_ASSERT(backend.last_logits_pos_ == 7);
+
+    // Exact full-prompt hit decodes from the reloaded logits.
+    GenerateRequest exact;
+    exact.prompt.assign(7, 0);
+    exact.n_gen = 1;
+    const GenerateResult exact_result =
+        backend.restore_and_generate_impl(1, exact, DaemonIO{});
+    TEST_ASSERT(exact_result.ok());
+    TEST_ASSERT(exact_result.tokens == std::vector<int32_t>({1}));
+
+    // A snapshot with a different length, zero compressed rows and an empty
+    // DSpark window must land in the SAME layout (no fingerprint churn).
+    backend.cache_.cur_pos = 3;
+    layer.n_comp = 0;
+    layer.n_index_comp = 0;
+    backend.last_logits_ = {0.5f, 0.25f, 0.125f};
+    backend.last_logits_pos_ = 3;
+    backend.spec_feat_window_.clear();
+    TEST_ASSERT(backend.snapshot_save(2));
+    const std::vector<int32_t> prompt3 = {21, 22, 23};
+    const size_t bytes_before = disk.total_bytes();
+    TEST_ASSERT(disk.save(2, prompt3));
+    TEST_ASSERT(disk.total_bytes() > bytes_before);
+    backend.snapshot_free(2);
+    TEST_ASSERT(disk.lookup(prompt3, 4));
+    TEST_ASSERT(backend.snapshot_used(4));
+    TEST_ASSERT(backend.snapshot_cur_pos(4) == 3);
+    TEST_ASSERT(backend.snapshots_[4].layers[0].n_comp == 0);
+    TEST_ASSERT(backend.snapshots_[4].layers[0].n_index_comp == 0);
+    TEST_ASSERT(backend.snapshot_aux_[4].spec_feat_window.empty());
+    TEST_ASSERT(backend.snapshot_aux_[4].last_logits ==
+                std::vector<float>({0.5f, 0.25f, 0.125f}));
+    TEST_ASSERT(backend.snapshot_restore(4));
+    TEST_ASSERT(backend.cache_.cur_pos == 3);
+    TEST_ASSERT(layer.n_comp == 0);
+    // The first entry is still readable after the second save.
+    TEST_ASSERT(disk.lookup(prompt, 5));
+    TEST_ASSERT(backend.snapshot_cur_pos(5) == 7);
+
+    // Adopt rejects a context whose position disagrees with the header.
+    {
+        ggml_init_params ip{};
+        ip.mem_size = ggml_tensor_overhead() * 4 + 1024;
+        ip.no_alloc = true;
+        ggml_context * bad_ctx = ggml_init(ip);
+        TEST_ASSERT(bad_ctx != nullptr);
+        ggml_tensor * junk = ggml_new_tensor_1d(bad_ctx, GGML_TYPE_F32, 4);
+        ggml_set_name(junk, "not_a_snapshot");
+        ggml_backend_t cpu = ggml_backend_cpu_init();
+        ggml_backend_buffer_t bad_buf = ggml_backend_alloc_ctx_tensors(bad_ctx, cpu);
+        TEST_ASSERT(bad_buf != nullptr);
+        TEST_ASSERT(!backend.snapshot_adopt(6, bad_ctx, bad_buf, 7, -1));
+        TEST_ASSERT(!backend.snapshot_used(6));
+        ggml_backend_buffer_free(bad_buf);
+        ggml_free(bad_ctx);
+        ggml_backend_free(cpu);
+    }
+
+    for (int i = 0; i < 8; ++i) backend.snapshot_free(i);
+    remove_test_disk_cache_dir(dir);
+    std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
+}
+
+static void test_layer_split_snapshot_disk_roundtrip() {
+    std::fprintf(stderr, "  test_layer_split_snapshot_disk_roundtrip ...");
+
+    auto adapter = make_test_adapter();
+    TEST_ASSERT(init_snapshot_test_shard(adapter));
+    if (adapter.shards_.empty() || !adapter.shards_[0].backend) {
+        std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
+        return;
+    }
+    adapter.snapshot_backends_.assign(1, adapter.shards_[0].backend);
+
+    auto & cache = adapter.shards_[0].cache;
+    auto & layer = cache.layers[0];
+    write_tensor_pattern(layer.raw_kv, 7);
+    write_tensor_pattern(layer.comp_kv, 19);
+    write_tensor_pattern(layer.index_comp_kv, 31);
+    write_tensor_pattern(layer.attn_compressor.state_kv, 47);
+    write_tensor_pattern(layer.attn_compressor.state_score, 59);
+    write_tensor_pattern(layer.indexer_compressor.state_kv, 71);
+    write_tensor_pattern(layer.indexer_compressor.state_score, 83);
+    write_tensor_pattern(cache.hc_state, 97);
+    const auto raw_before = read_tensor_bytes(layer.raw_kv);
+    const auto comp_before = read_tensor_rows(layer.comp_kv, 5);
+    const auto index_before = read_tensor_rows(layer.index_comp_kv, 3);
+    const auto hc_before = read_tensor_bytes(cache.hc_state);
+
+    layer.n_comp = 5;
+    layer.n_index_comp = 3;
+    cache.cur_pos = 7;
+    adapter.cur_pos_ = 7;
+    adapter.last_tok_ = 4242;
+    adapter.hc_state_ = {1.0f, 2.0f, 3.0f, 4.0f};
+    adapter.prefill_last_logits_ = {9.0f, 8.0f, 7.0f};
+
+    TEST_ASSERT(adapter.snapshot_save(0));
+    const ModelBackend::SnapshotRef ref = adapter.snapshot_ref(0);
+    TEST_ASSERT(ref.ctx != nullptr);
+    TEST_ASSERT(ref.cur_pos == 7);
+    TEST_ASSERT(ref.last_tok == 4242);
+    size_t n_named = 0;
+    TEST_ASSERT(all_snapshot_tensors_named(ref.ctx, &n_named));
+    // shard: hc + 7 layer + meta + logits + feat = 11, plus 3 adapter tensors
+    TEST_ASSERT(n_named == 14);
+    TEST_ASSERT(ggml_get_tensor(ref.ctx, "ls0_ds4_snap_comp_kv_0") != nullptr);
+    TEST_ASSERT(ggml_get_tensor(ref.ctx, "ls_meta") != nullptr);
+
+    // Simulate the ondisk roundtrip (serialize -> deserialize) by rebuilding
+    // the merged context exactly like DiskPrefixCache::read_file() does.
+    ggml_context * re_ctx = nullptr;
+    ggml_backend_buffer_t re_buf = nullptr;
+    ggml_backend_t re_cpu = nullptr;
+    TEST_ASSERT(clone_snapshot_context_like_disk_reader(ref.ctx, &re_ctx, &re_buf, &re_cpu));
+    if (!re_ctx) {
+        std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
+        return;
+    }
+
+    adapter.snapshot_free(0);
+    TEST_ASSERT(!adapter.snapshot_used(0));
+    TEST_ASSERT(adapter.snapshots_[0].disk_ctx == nullptr);
+    ggml_backend_buffer_clear(cache.buf, 0);
+    cache.cur_pos = 0;
+    layer.n_comp = 0;
+    layer.n_index_comp = 0;
+    adapter.cur_pos_ = 0;
+    adapter.last_tok_ = -1;
+    adapter.hc_state_.assign(4, 0.0f);
+    adapter.prefill_last_logits_.clear();
+
+    // A context with the wrong position is rejected and left to the caller.
+    TEST_ASSERT(!adapter.snapshot_adopt(2, re_ctx, re_buf, 6, 4242));
+    TEST_ASSERT(!adapter.snapshot_used(2));
+    TEST_ASSERT(adapter.snapshot_adopt(2, re_ctx, re_buf, 7, 4242));
+    TEST_ASSERT(adapter.snapshot_used(2));
+    TEST_ASSERT(adapter.snapshot_cur_pos(2) == 7);
+    TEST_ASSERT(adapter.snapshots_[2].shards.size() == 1);
+    TEST_ASSERT(!adapter.snapshots_[2].shards[0].owns_storage);
+    TEST_ASSERT(adapter.snapshots_[2].disk_ctx != nullptr);
+    // Re-exportable after adoption.
+    TEST_ASSERT(adapter.snapshot_ref(2).ctx != nullptr);
+
+    TEST_ASSERT(adapter.snapshot_restore(2));
+    TEST_ASSERT(adapter.cur_pos_ == 7);
+    TEST_ASSERT(adapter.last_tok_ == 4242);
+    TEST_ASSERT(adapter.hc_state_ == std::vector<float>({1.0f, 2.0f, 3.0f, 4.0f}));
+    TEST_ASSERT(adapter.prefill_last_logits_ == std::vector<float>({9.0f, 8.0f, 7.0f}));
+    TEST_ASSERT(cache.cur_pos == 7);
+    TEST_ASSERT(layer.n_comp == 5);
+    TEST_ASSERT(layer.n_index_comp == 3);
+    TEST_ASSERT(read_tensor_bytes(layer.raw_kv) == raw_before);
+    TEST_ASSERT(read_tensor_rows(layer.comp_kv, 5) == comp_before);
+    TEST_ASSERT(read_tensor_rows(layer.index_comp_kv, 3) == index_before);
+    TEST_ASSERT(read_tensor_bytes(cache.hc_state) == hc_before);
+
+    // Freeing an adopted slot must not double-free the shared context.
+    adapter.snapshot_free(2);
+    TEST_ASSERT(!adapter.snapshot_used(2));
+    TEST_ASSERT(adapter.snapshots_[2].disk_ctx == nullptr);
+    TEST_ASSERT(adapter.snapshots_[2].shards[0].ctx == nullptr);
+    ggml_backend_free(re_cpu);  // buffer/context were owned by the adopted slot
 
     std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
 }
@@ -4393,6 +4731,8 @@ int main() {
     test_dspark_raw_ring_rollback_after_wrap(backend);
     test_snapshot_save_restore();
     test_monolithic_snapshot_preserves_decode_state();
+    test_monolithic_snapshot_disk_roundtrip();
+    test_layer_split_snapshot_disk_roundtrip();
     test_spec_feature_tail_is_bounded();
     test_dspark_prefill_capture_boundaries();
     test_reset_request_state();

--- a/server/tests/test_deepseek4_unit.cpp
+++ b/server/tests/test_deepseek4_unit.cpp
@@ -12,11 +12,13 @@
 #include "common/dspark_head.h"
 #include "common/layer_split_backend.h"
 #include "server/disk_prefix_cache.h"
+#include "deepseek4/deepseek4_snapshot.h"
 #include "common/layer_split_runtime.h"
 #include "common/layer_split_utils.h"
 #include "common/moe_hybrid_ffn_eval.h"
 #include "deepseek4/deepseek4_dspark.h"
 
+#include <filesystem>
 #include <memory>
 #include <random>
 #include <sstream>
@@ -1968,7 +1970,6 @@ static void test_snapshot_save_restore() {
         std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
         return;
     }
-    adapter.snapshot_backends_.assign(1, adapter.shards_[0].backend);
 
     auto & cache = adapter.shards_[0].cache;
     auto & layer = cache.layers[0];
@@ -2195,19 +2196,20 @@ static std::string make_test_disk_cache_dir(const char * tag) {
 }
 
 static void remove_test_disk_cache_dir(const std::string & dir) {
-    const std::string cmd = "rm -rf '" + dir + "'";
-    const int rc = std::system(cmd.c_str());
-    (void) rc;
+    std::error_code ec;
+    std::filesystem::remove_all(dir, ec);
 }
 
 // Rebuild a snapshot context the way DiskPrefixCache::read_file() does after
-// deserializing: fresh 4-D tensors by name/type/shape in a CPU buffer with
-// the bytes copied over. Lets adapter-level tests exercise snapshot_adopt
-// without going through a ModelBackend.
+// deserializing: fresh 4-D tensors by name/type/shape in a host buffer with
+// the bytes copied over. `override_name`/`override_ne1` corrupt one tensor's
+// row count to exercise validation. Lets adapter-level tests exercise
+// snapshot_adopt without going through a ModelBackend.
 static bool clone_snapshot_context_like_disk_reader(ggml_context * src_ctx,
                                                     ggml_context ** ctx_out,
                                                     ggml_backend_buffer_t * buf_out,
-                                                    ggml_backend_t * backend_out) {
+                                                    const char * override_name = nullptr,
+                                                    int64_t override_ne1 = 0) {
     size_t n = 0;
     for (ggml_tensor * t = ggml_get_first_tensor(src_ctx); t; t = ggml_get_next_tensor(src_ctx, t)) n++;
     ggml_init_params ip{};
@@ -2216,28 +2218,27 @@ static bool clone_snapshot_context_like_disk_reader(ggml_context * src_ctx,
     ggml_context * ctx = ggml_init(ip);
     if (!ctx) return false;
     for (ggml_tensor * t = ggml_get_first_tensor(src_ctx); t; t = ggml_get_next_tensor(src_ctx, t)) {
-        ggml_tensor * d = ggml_new_tensor(ctx, t->type, 4, t->ne);
+        int64_t ne[4] = {t->ne[0], t->ne[1], t->ne[2], t->ne[3]};
+        if (override_name && std::strcmp(t->name, override_name) == 0) ne[1] = override_ne1;
+        ggml_tensor * d = ggml_new_tensor(ctx, t->type, 4, ne);
         if (!d) { ggml_free(ctx); return false; }
         ggml_set_name(d, t->name);
     }
-    ggml_backend_t cpu = ggml_backend_cpu_init();
-    if (!cpu) { ggml_free(ctx); return false; }
-    ggml_backend_buffer_t buf = ggml_backend_alloc_ctx_tensors(ctx, cpu);
-    if (!buf) { ggml_free(ctx); ggml_backend_free(cpu); return false; }
+    ggml_backend_buffer_t buf =
+        ggml_backend_alloc_ctx_tensors_from_buft(ctx, ggml_backend_cpu_buffer_type());
+    if (!buf) { ggml_free(ctx); return false; }
+    ggml_backend_buffer_clear(buf, 0);
     std::vector<uint8_t> tmp;
     for (ggml_tensor * t = ggml_get_first_tensor(src_ctx); t; t = ggml_get_next_tensor(src_ctx, t)) {
         ggml_tensor * d = ggml_get_tensor(ctx, t->name);
-        if (!d || ggml_nbytes(d) != ggml_nbytes(t)) {
-            ggml_backend_buffer_free(buf); ggml_free(ctx); ggml_backend_free(cpu);
-            return false;
-        }
-        tmp.resize(ggml_nbytes(t));
-        ggml_backend_tensor_get(t, tmp.data(), 0, tmp.size());
-        ggml_backend_tensor_set(d, tmp.data(), 0, tmp.size());
+        if (!d) { ggml_backend_buffer_free(buf); ggml_free(ctx); return false; }
+        const size_t bytes = std::min(ggml_nbytes(t), ggml_nbytes(d));
+        tmp.resize(bytes);
+        ggml_backend_tensor_get(t, tmp.data(), 0, bytes);
+        ggml_backend_tensor_set(d, tmp.data(), 0, bytes);
     }
     *ctx_out = ctx;
     *buf_out = buf;
-    *backend_out = cpu;
     return true;
 }
 
@@ -2386,7 +2387,7 @@ static void test_monolithic_snapshot_disk_roundtrip() {
     TEST_ASSERT(disk.lookup(prompt, 5));
     TEST_ASSERT(backend.snapshot_cur_pos(5) == 7);
 
-    // Adopt rejects a context whose position disagrees with the header.
+    // Adopt rejects a context that is not a snapshot at all ...
     {
         ggml_init_params ip{};
         ip.mem_size = ggml_tensor_overhead() * 4 + 1024;
@@ -2395,14 +2396,40 @@ static void test_monolithic_snapshot_disk_roundtrip() {
         TEST_ASSERT(bad_ctx != nullptr);
         ggml_tensor * junk = ggml_new_tensor_1d(bad_ctx, GGML_TYPE_F32, 4);
         ggml_set_name(junk, "not_a_snapshot");
-        ggml_backend_t cpu = ggml_backend_cpu_init();
-        ggml_backend_buffer_t bad_buf = ggml_backend_alloc_ctx_tensors(bad_ctx, cpu);
+        ggml_backend_buffer_t bad_buf =
+            ggml_backend_alloc_ctx_tensors_from_buft(bad_ctx, ggml_backend_cpu_buffer_type());
         TEST_ASSERT(bad_buf != nullptr);
         TEST_ASSERT(!backend.snapshot_adopt(6, bad_ctx, bad_buf, 7, -1));
         TEST_ASSERT(!backend.snapshot_used(6));
         ggml_backend_buffer_free(bad_buf);
         ggml_free(bad_ctx);
-        ggml_backend_free(cpu);
+    }
+    // ... a snapshot whose tensors do not match the model geometry (raw
+    // window with the wrong row count) ...
+    {
+        const ModelBackend::SnapshotRef good = backend.snapshot_ref(5);
+        TEST_ASSERT(good.ctx != nullptr);
+        ggml_context * bad_ctx = nullptr;
+        ggml_backend_buffer_t bad_buf = nullptr;
+        TEST_ASSERT(clone_snapshot_context_like_disk_reader(
+            good.ctx, &bad_ctx, &bad_buf, "ds4_snap_raw_kv_0", backend.w_.n_swa + 1));
+        TEST_ASSERT(!backend.snapshot_adopt(6, bad_ctx, bad_buf, good.cur_pos, -1));
+        TEST_ASSERT(!backend.snapshot_used(6));
+        ggml_backend_buffer_free(bad_buf);
+        ggml_free(bad_ctx);
+    }
+    // ... and one whose header position disagrees with the meta.
+    {
+        const ModelBackend::SnapshotRef good = backend.snapshot_ref(5);
+        ggml_context * re_ctx = nullptr;
+        ggml_backend_buffer_t re_buf = nullptr;
+        TEST_ASSERT(clone_snapshot_context_like_disk_reader(good.ctx, &re_ctx, &re_buf));
+        TEST_ASSERT(!backend.snapshot_adopt(6, re_ctx, re_buf, good.cur_pos + 1, -1));
+        TEST_ASSERT(!backend.snapshot_used(6));
+        // A faithful clone is adopted and owned by the slot afterwards.
+        TEST_ASSERT(backend.snapshot_adopt(6, re_ctx, re_buf, good.cur_pos, -1));
+        TEST_ASSERT(backend.snapshot_used(6));
+        TEST_ASSERT(backend.snapshots_[6].owns_storage);
     }
 
     for (int i = 0; i < 8; ++i) backend.snapshot_free(i);
@@ -2419,7 +2446,6 @@ static void test_layer_split_snapshot_disk_roundtrip() {
         std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
         return;
     }
-    adapter.snapshot_backends_.assign(1, adapter.shards_[0].backend);
 
     auto & cache = adapter.shards_[0].cache;
     auto & layer = cache.layers[0];
@@ -2449,6 +2475,9 @@ static void test_layer_split_snapshot_disk_roundtrip() {
     TEST_ASSERT(ref.ctx != nullptr);
     TEST_ASSERT(ref.cur_pos == 7);
     TEST_ASSERT(ref.last_tok == 4242);
+    // The shard snapshot aliases the slot's single merged context: no copy.
+    TEST_ASSERT(adapter.snapshots_[0].shards[0].ctx == ref.ctx);
+    TEST_ASSERT(!adapter.snapshots_[0].shards[0].owns_storage);
     size_t n_named = 0;
     TEST_ASSERT(all_snapshot_tensors_named(ref.ctx, &n_named));
     // shard: hc + 7 layer + meta + logits + feat = 11, plus 3 adapter tensors
@@ -2456,20 +2485,37 @@ static void test_layer_split_snapshot_disk_roundtrip() {
     TEST_ASSERT(ggml_get_tensor(ref.ctx, "ls0_ds4_snap_comp_kv_0") != nullptr);
     TEST_ASSERT(ggml_get_tensor(ref.ctx, "ls_meta") != nullptr);
 
+    // In-memory restore works from the merged context.
+    cache.cur_pos = 0;
+    layer.n_comp = 0;
+    TEST_ASSERT(adapter.snapshot_restore(0));
+    TEST_ASSERT(cache.cur_pos == 7);
+    TEST_ASSERT(layer.n_comp == 5);
+
     // Simulate the ondisk roundtrip (serialize -> deserialize) by rebuilding
     // the merged context exactly like DiskPrefixCache::read_file() does.
     ggml_context * re_ctx = nullptr;
     ggml_backend_buffer_t re_buf = nullptr;
-    ggml_backend_t re_cpu = nullptr;
-    TEST_ASSERT(clone_snapshot_context_like_disk_reader(ref.ctx, &re_ctx, &re_buf, &re_cpu));
+    TEST_ASSERT(clone_snapshot_context_like_disk_reader(ref.ctx, &re_ctx, &re_buf));
     if (!re_ctx) {
         std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
         return;
     }
+    // A geometry mismatch inside one shard is rejected before adoption.
+    {
+        ggml_context * bad_ctx = nullptr;
+        ggml_backend_buffer_t bad_buf = nullptr;
+        TEST_ASSERT(clone_snapshot_context_like_disk_reader(
+            ref.ctx, &bad_ctx, &bad_buf, "ls0_ds4_snap_attn_cs_kv_0", 3));
+        TEST_ASSERT(!adapter.snapshot_adopt(3, bad_ctx, bad_buf, 7, 4242));
+        TEST_ASSERT(!adapter.snapshot_used(3));
+        ggml_backend_buffer_free(bad_buf);
+        ggml_free(bad_ctx);
+    }
 
     adapter.snapshot_free(0);
     TEST_ASSERT(!adapter.snapshot_used(0));
-    TEST_ASSERT(adapter.snapshots_[0].disk_ctx == nullptr);
+    TEST_ASSERT(adapter.snapshots_[0].ctx == nullptr);
     ggml_backend_buffer_clear(cache.buf, 0);
     cache.cur_pos = 0;
     layer.n_comp = 0;
@@ -2487,7 +2533,7 @@ static void test_layer_split_snapshot_disk_roundtrip() {
     TEST_ASSERT(adapter.snapshot_cur_pos(2) == 7);
     TEST_ASSERT(adapter.snapshots_[2].shards.size() == 1);
     TEST_ASSERT(!adapter.snapshots_[2].shards[0].owns_storage);
-    TEST_ASSERT(adapter.snapshots_[2].disk_ctx != nullptr);
+    TEST_ASSERT(adapter.snapshots_[2].ctx == re_ctx);
     // Re-exportable after adoption.
     TEST_ASSERT(adapter.snapshot_ref(2).ctx != nullptr);
 
@@ -2507,9 +2553,8 @@ static void test_layer_split_snapshot_disk_roundtrip() {
     // Freeing an adopted slot must not double-free the shared context.
     adapter.snapshot_free(2);
     TEST_ASSERT(!adapter.snapshot_used(2));
-    TEST_ASSERT(adapter.snapshots_[2].disk_ctx == nullptr);
+    TEST_ASSERT(adapter.snapshots_[2].ctx == nullptr);
     TEST_ASSERT(adapter.snapshots_[2].shards[0].ctx == nullptr);
-    ggml_backend_free(re_cpu);  // buffer/context were owned by the adopted slot
 
     std::fprintf(stderr, g_failures ? " done\n" : " ok\n");
 }


### PR DESCRIPTION
## Summary

DeepSeek V4 snapshots were memory-only: the backend left `snapshot_ref` / `snapshot_adopt` at their defaults, so `DiskPrefixCache` detected a memory-only backend and disabled itself for this model (the gating added in #579). This PR implements the two hooks for DeepSeek V4 on the same shared disk cache used by Qwen3 / Qwen3.5 / Laguna, and fixes a keying inconsistency in the shared continued-checkpoint path.

### DeepSeek V4 ondisk prefix cache (`server/src/deepseek4`)
- Every snapshot tensor gets a stable name (`ds4_snap_*`), so the disk cache can serialize the context and rebind it after a reload.
- The host-side decode state (last logits, DSpark feature tail) and the per-layer compressed row counts travel as sidecar tensors in the same context. Variable lengths live in `ne[1]`, which the layout fingerprint normalizes, so snapshots of different lengths share one layout id.
- `deepseek4_snapshot_bind()` rebinds a deserialized context by name, with an optional per-shard prefix and shared-storage ownership.
- `DeepSeek4Backend::snapshot_ref` / `snapshot_adopt`: adopt validates against the compression schedule of the loaded weights (not the live cache), so a valid file is never dropped as corrupt while the target is parked. Paged concurrent serving stays memory-only, as in the Qwen3.5 backend.
- `DeepSeek4LayerSplitAdapter`: shard snapshots are merged into one named context (`ls<i>_` prefix plus adapter-level meta / HC state / prefill logits), mirroring the Qwen3.5 adapter. Mixed remote-shard splits stay memory-only.

### Continued checkpoint keying (`server/src/server/disk_prefix_cache.cpp`)
A disk entry is keyed by the hash of its prompt prefix and a hit restores the whole snapshot. `maybe_store_continued()` keyed files by the interval-aligned prefix while the snapshot extended to the generation's final position, so a later prompt sharing only the key prefix could restore a snapshot covering tokens it never contained. Now:
- continued checkpoints are keyed by the full token prefix the snapshot covers; the interval only paces them;
- `save()` refuses a snapshot whose position exceeds its key, and `read_file()` rejects such files so existing ones are dropped on lookup.

## Validation

Unit (lucebox5, HIP gfx1151;gfx1201 build on top of #598):
- `test_deepseek4_unit`: all cases pass, including new `test_monolithic_snapshot_disk_roundtrip` (real `DiskPrefixCache` save → lookup → adopt → restore → exact-hit decode, layout stability across lengths, rejection of a bogus context) and `test_layer_split_snapshot_disk_roundtrip`.
- `test_server_unit`: 453 passed, 0 failed, including new `test_disk_cache_rejects_snapshot_past_key` and `test_disk_cache_continued_keys_full_prefix`.

End to end (lucebox5, DeepSeek-V4-Flash-0731 ROCmFPX on R9700 + Strix, long-context profile, greedy, two-turn conversations of ~950 tokens, `--kv-cache-dir` set, prefix cache slots enabled):
- Files: 29.7 MB per 930-position snapshot; layout id identical across restarts.
- After a server restart, a new last turn on the cached conversation hits the disk entry (`--disk-prefix-cache auto`), is adopted, and prefills only the new turn: 17 to 28 tokens in 0.4 to 1.4 s (including the file read) versus 7 to 9 s for a cold prefill of ~950 tokens.
- Disk-restored outputs matched cold outputs in every cross-process comparison run (3/3, plus one repeat on the final build).

## Notes for reviewers
- `--disk-prefix-cache full` keys the exact full prompt, so a conversation with a new last turn misses; cross-session reuse needs `auto` (per request via `prefix_cache.scope`, or as the server default).
- DeepSeek chat markers produce a reusable boundary only after a completed assistant turn (BOS / EOS / User / Assistant markers), so single-turn prompts do not snapshot.
- Not covered: mixed remote-shard target split (memory-only), PFlash-compressed disk snapshots (DeepSeek V4 has no PFlash yet).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

