### PR TITLE
fix(qwen35): trim legacy pools during long prefills

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -922,7 +922,8 @@ if(DFLASH27B_TESTS)
             set_target_properties(test_cuda_pool_shutdown PROPERTIES HIP_ARCHITECTURES "${_dflash_archs}")
         endif()
         target_include_directories(test_cuda_pool_shutdown PRIVATE
-            ${CMAKE_CURRENT_SOURCE_DIR}/deps/llama.cpp/ggml/include)
+            ${CMAKE_CURRENT_SOURCE_DIR}/deps/llama.cpp/ggml/include
+            ${CMAKE_CURRENT_SOURCE_DIR}/deps/llama.cpp/ggml/src)
         target_link_libraries(test_cuda_pool_shutdown PRIVATE
             ${DFLASH27B_GGML_BACKEND_TARGET} ggml ggml-base)
         list(APPEND _raw_unit_test_targets test_cuda_pool_shutdown)

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -1783,6 +1783,7 @@ if(DFLASH27B_TESTS)
             TAIL_GUARD_USE_NEW_FORMULA)
         target_include_directories(test_server_unit PRIVATE
             ${DFLASH27B_SRC_INCLUDE_DIRS}
+            ${CMAKE_CURRENT_SOURCE_DIR}/deps/llama.cpp/ggml/src
             ${CMAKE_CURRENT_SOURCE_DIR}/deps/llama.cpp/ggml/src/ggml-cuda
             ${CMAKE_CURRENT_SOURCE_DIR}/src/common)
         if(DFLASH27B_GPU_BACKEND STREQUAL "hip")

--- a/server/deps/llama.cpp/ggml/include/ggml-cuda.h
+++ b/server/deps/llama.cpp/ggml/include/ggml-cuda.h
@@ -51,14 +51,16 @@ GGML_BACKEND_API size_t ggml_backend_cuda_graph_invalidate_range(
         const void *   begin,
         size_t         size);
 
-// Returns true when the backend has instantiated a legacy device pool. This
-// lets callers and tests distinguish a trimmable cache from a VMM arena.
+// Returns true when the CUDA/HIP backend has instantiated a legacy device
+// pool. Meta backends recursively inspect every rank-local backend. This lets
+// callers and tests distinguish a trimmable cache from a VMM arena.
 GGML_BACKEND_API bool ggml_backend_cuda_has_legacy_pool(ggml_backend_t backend);
 
-// Release cached temporary allocations held by a CUDA/HIP backend's legacy
-// device pools. The backend is synchronized first, and graph executables that
-// may reference released pool blocks are retired. VMM pools are already a
-// contiguous reusable arena and are left intact. Returns bytes released.
+// Release cached temporary allocations held by CUDA/HIP legacy device pools.
+// Meta backends recursively trim every rank-local backend. Each CUDA/HIP
+// backend is synchronized first, and graph executables that may reference
+// released pool blocks are retired. VMM pools are already a contiguous
+// reusable arena and are left intact. Returns total bytes released.
 GGML_BACKEND_API size_t ggml_backend_cuda_trim_pool(ggml_backend_t backend);
 
 // Disable CUDA/HIP graph capture and replay on the calling thread. Returns the

--- a/server/deps/llama.cpp/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/server/deps/llama.cpp/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -5197,7 +5197,22 @@ static bool ggml_cuda_has_legacy_pool(const ggml_backend_cuda_context * cuda_ctx
 }
 
 extern "C" bool ggml_backend_cuda_has_legacy_pool(ggml_backend_t backend) {
-    if (backend == nullptr || !ggml_backend_is_cuda(backend)) {
+    if (backend == nullptr) {
+        return false;
+    }
+
+    if (ggml_backend_is_meta(backend)) {
+        const size_t n_backends = ggml_backend_meta_n_backends(backend);
+        for (size_t i = 0; i < n_backends; ++i) {
+            if (ggml_backend_cuda_has_legacy_pool(
+                    ggml_backend_meta_simple_backend(backend, i))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    if (!ggml_backend_is_cuda(backend)) {
         return false;
     }
 
@@ -5206,7 +5221,21 @@ extern "C" bool ggml_backend_cuda_has_legacy_pool(ggml_backend_t backend) {
 }
 
 extern "C" size_t ggml_backend_cuda_trim_pool(ggml_backend_t backend) {
-    if (backend == nullptr || !ggml_backend_is_cuda(backend)) {
+    if (backend == nullptr) {
+        return 0;
+    }
+
+    if (ggml_backend_is_meta(backend)) {
+        size_t freed = 0;
+        const size_t n_backends = ggml_backend_meta_n_backends(backend);
+        for (size_t i = 0; i < n_backends; ++i) {
+            freed += ggml_backend_cuda_trim_pool(
+                ggml_backend_meta_simple_backend(backend, i));
+        }
+        return freed;
+    }
+
+    if (!ggml_backend_is_cuda(backend)) {
         return 0;
     }
 

--- a/server/docs/ENVIRONMENT.md
+++ b/server/docs/ENVIRONMENT.md
@@ -56,6 +56,7 @@ consolidation of this list into CLI flags is tracked as follow-up work.
 | `DFLASH_KVFLASH` | unset | Prefer the CLI: `--kvflash` (token count or `auto`). |
 | `DFLASH_PREFIX_CACHE_SLOTS` | 32 | Container-entrypoint equivalent of `--prefix-cache-slots`; not read directly by the native binary. |
 | `DFLASH_PREFILL_CACHE_SLOTS` | 0 | Container-entrypoint equivalent of `--prefill-cache-slots`; not read directly by the native binary. |
+| `DFLASH_PREFILL_POOL_TRIM_TOKENS` | unset | OPT-IN: trim cached allocations from legacy CUDA/HIP device pools at completed Qwen3.5 prefill chunk boundaries after each configured token interval. Intended for long, shape-changing prefills on non-VMM devices; each trim synchronizes the target backend and retires captured graphs. |
 | `DFLASH_SPLIT_FAST_ROLLBACK` | unset | OPT-IN: exact F32 checkpoints and replay-free rollback for local qwen35 target layer splits. Prefer `--target-split-fast-rollback`; adds checkpoint VRAM (~1.65 GiB for the measured Qwen3.6-27B q=16 split). |
 | `DFLASH_STALL_TOOL_PREFIX` | unset | OPT-IN: recover a stalled tool call by injecting the prepared tool prefix when generation stops after an action suffix. |
 | `DFLASH_DS4_SPEC` / `DFLASH_DS4_DRAFT` / `DFLASH_DS4_DRAFT_BACKEND` / `DFLASH_DS4_DRAFT_GPU` | unset | OPT-IN: enable DeepSeek4 DSpark, select its draft GGUF, and optionally select the local drafter backend/device. See `DS4.md`. |
@@ -223,6 +224,7 @@ consolidation of this list into CLI flags is tracked as follow-up work.
 - `DFLASH_NO_PREAD` - deepseek4_loader.cpp
 - `DFLASH_PROF` - prof_env.h
 - `DFLASH_PREFILL_CACHE_SLOTS` - scripts/entrypoint.sh (maps to `--prefill-cache-slots`)
+- `DFLASH_PREFILL_POOL_TRIM_TOKENS` - qwen35_backend.cpp (OPT-IN: trim legacy device pools during long prefills)
 - `DFLASH_PREFILL_TIMING` - qwen35_backend.cpp (DEBUG: per-ubatch prefill build/alloc/compute timing)
 - `DFLASH_PREFIX_CACHE_SLOTS` - scripts/entrypoint.sh (maps to `--prefix-cache-slots`)
 - `DFLASH_QWEN35MOE_CACHE_SLOTS` - qwen35moe_backend.cpp

--- a/server/src/qwen35/qwen35_backend.cpp
+++ b/server/src/qwen35/qwen35_backend.cpp
@@ -35,6 +35,7 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <climits>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
@@ -1712,6 +1713,29 @@ int Qwen35Backend::do_prefill(const std::vector<int32_t> & tokens,
     const int prompt_len = (int)tokens.size();
     prefill_last_logits_valid_ = false;
 
+    // The HIP legacy pool retains freed graph temporaries. During a long,
+    // shape-changing prefill those cached blocks can fragment VRAM until the
+    // next allocation fails even though a large part of the pool is idle.
+    // Trimming is deliberately opt-in and performed only between completed
+    // chunks: ggml_backend_cuda_trim_pool() synchronizes the backend and
+    // retires captured graphs before returning cached blocks to the driver.
+    static const int prefill_pool_trim_tokens = []() {
+        const char * value = std::getenv("DFLASH_PREFILL_POOL_TRIM_TOKENS");
+        if (value == nullptr || value[0] == '\0') return 0;
+        char * end = nullptr;
+        const long parsed = std::strtol(value, &end, 10);
+        if (end == value || *end != '\0' || parsed <= 0 || parsed > INT_MAX) {
+            std::fprintf(stderr,
+                "[vram] ignoring invalid DFLASH_PREFILL_POOL_TRIM_TOKENS=%s\n",
+                value);
+            return 0;
+        }
+        return (int)parsed;
+    }();
+    int64_t next_prefill_pool_trim = prefill_pool_trim_tokens > 0
+        ? ((int64_t)kv_offset / prefill_pool_trim_tokens + 1) * prefill_pool_trim_tokens
+        : INT64_MAX;
+
     // kvflash: a prompt that fits the pool prefills contiguously (identity
     // mapping, normal chunking). A LARGER prompt switches to POOLED CHUNKED
     // PREFILL: pager-chunk-sized batches whose KV rows are slot-mapped via
@@ -1940,6 +1964,22 @@ int Qwen35Backend::do_prefill(const std::vector<int32_t> & tokens,
         }
 
         start += n_tokens;
+
+        if (prefill_pool_trim_tokens > 0 && start < prompt_len &&
+            (int64_t)committed >= next_prefill_pool_trim &&
+            ggml_backend_cuda_has_legacy_pool(target_backend_)) {
+            const size_t freed = ggml_backend_cuda_trim_pool(target_backend_);
+            std::fprintf(stderr,
+                "[vram] prefill pool trim at token %d: freed %.1f MiB\n",
+                committed, (double)freed / (1024.0 * 1024.0));
+            while (next_prefill_pool_trim <= (int64_t)committed) {
+                if (next_prefill_pool_trim > INT64_MAX - prefill_pool_trim_tokens) {
+                    next_prefill_pool_trim = INT64_MAX;
+                    break;
+                }
+                next_prefill_pool_trim += prefill_pool_trim_tokens;
+            }
+        }
     }
 
     if (kvflash_active()) {

--- a/server/test/test_cuda_pool_shutdown.cpp
+++ b/server/test/test_cuda_pool_shutdown.cpp
@@ -1,6 +1,7 @@
 #include "CppUnitTestFramework.hpp"
 #include "scoped_env.h"
 #include "ggml-backend.h"
+#include "ggml-backend-impl.h"
 #include "ggml-cuda.h"
 #include "ggml.h"
 
@@ -13,7 +14,9 @@ namespace {
 struct CudaPoolShutdownFixture : CppUnitTestFramework::CommonFixture {
     using CppUnitTestFramework::CommonFixture::CommonFixture;
 
-    void exercise_pool_trim(ggml_backend_t backend);
+    void exercise_pool_trim(
+        ggml_backend_t backend,
+        ggml_backend_t expected_pool_backend = nullptr);
 };
 
 ggml_backend_meta_split_state mirrored_split_state(
@@ -21,7 +24,9 @@ ggml_backend_meta_split_state mirrored_split_state(
     return {GGML_BACKEND_SPLIT_AXIS_MIRRORED, {0}, 1, {1}};
 }
 
-void CudaPoolShutdownFixture::exercise_pool_trim(ggml_backend_t backend) {
+void CudaPoolShutdownFixture::exercise_pool_trim(
+        ggml_backend_t backend,
+        ggml_backend_t expected_pool_backend) {
     REQUIRE(backend != nullptr);
 
     ggml_init_params params{};
@@ -62,9 +67,12 @@ void CudaPoolShutdownFixture::exercise_pool_trim(ggml_backend_t backend) {
     // LUCE_Q8_MEMO intentionally retains a pool allocation after compute.
     // Trimming must first release that memo, then return its cached block to
     // the driver rather than retaining VRAM indefinitely.
+    const bool expected_has_legacy_pool = ggml_backend_cuda_has_legacy_pool(
+        expected_pool_backend ? expected_pool_backend : backend);
     const bool has_legacy_pool = ggml_backend_cuda_has_legacy_pool(backend);
+    REQUIRE(has_legacy_pool == expected_has_legacy_pool);
     const size_t trimmed = ggml_backend_cuda_trim_pool(backend);
-    if (has_legacy_pool) {
+    if (expected_has_legacy_pool) {
         REQUIRE(trimmed > 0);
     } else {
         REQUIRE(trimmed == 0);
@@ -114,7 +122,9 @@ TEST_CASE(CudaPoolShutdownFixture, meta_backend_pool_shutdown) {
         return;
     }
 
-    exercise_pool_trim(backend);
+    ggml_backend_t rank_backend = ggml_backend_meta_simple_backend(backend, 0);
+    REQUIRE(rank_backend != nullptr);
+    exercise_pool_trim(backend, rank_backend);
     ggml_backend_free(backend);
     REQUIRE_TRUE(true);
 }

--- a/server/test/test_cuda_pool_shutdown.cpp
+++ b/server/test/test_cuda_pool_shutdown.cpp
@@ -10,26 +10,25 @@
 #include <vector>
 
 namespace {
-struct CudaPoolShutdownFixture {};
+struct CudaPoolShutdownFixture : CppUnitTestFramework::CommonFixture {
+    using CppUnitTestFramework::CommonFixture::CommonFixture;
+
+    void exercise_pool_trim(ggml_backend_t backend);
+};
+
+ggml_backend_meta_split_state mirrored_split_state(
+        const ggml_tensor *, void *) {
+    return {GGML_BACKEND_SPLIT_AXIS_MIRRORED, {0}, 1, {1}};
 }
 
-TEST_CASE(CudaPoolShutdownFixture, backend_pool_shutdown) {
-    const luce_test::ScopedEnvVar q8_memo("LUCE_Q8_MEMO", "1");
-
-    ggml_backend_t backend = ggml_backend_cuda_init(0);
-    if (!backend) {
-        std::fprintf(stderr, "skip: no CUDA/HIP backend available\n");
-        return;
-    }
+void CudaPoolShutdownFixture::exercise_pool_trim(ggml_backend_t backend) {
+    REQUIRE(backend != nullptr);
 
     ggml_init_params params{};
     params.mem_size = 1024 * 1024;
     params.no_alloc = true;
     ggml_context * ctx = ggml_init(params);
-    if (!ctx) {
-        ggml_backend_free(backend);
-        REQUIRE_TRUE(false);
-    }
+    REQUIRE(ctx != nullptr);
 
     constexpr int64_t k = 256;
     constexpr int64_t n = 256;
@@ -43,11 +42,7 @@ TEST_CASE(CudaPoolShutdownFixture, backend_pool_shutdown) {
     ggml_build_forward_expand(graph, output);
 
     ggml_backend_buffer_t buffer = ggml_backend_alloc_ctx_tensors(ctx, backend);
-    if (!buffer) {
-        ggml_free(ctx);
-        ggml_backend_free(backend);
-        REQUIRE_TRUE(false);
-    }
+    REQUIRE(buffer != nullptr);
 
     std::vector<uint8_t> weights_data(ggml_nbytes(weights), 0);
     std::vector<float> input_data((size_t) k, 1.0f);
@@ -65,8 +60,8 @@ TEST_CASE(CudaPoolShutdownFixture, backend_pool_shutdown) {
     REQUIRE(compute() == GGML_STATUS_SUCCESS);
 
     // LUCE_Q8_MEMO intentionally retains a pool allocation after compute.
-    // Request-boundary trimming must first release that memo, then return its
-    // cached block to the driver rather than retaining VRAM indefinitely.
+    // Trimming must first release that memo, then return its cached block to
+    // the driver rather than retaining VRAM indefinitely.
     const bool has_legacy_pool = ggml_backend_cuda_has_legacy_pool(backend);
     const size_t trimmed = ggml_backend_cuda_trim_pool(backend);
     if (has_legacy_pool) {
@@ -80,9 +75,46 @@ TEST_CASE(CudaPoolShutdownFixture, backend_pool_shutdown) {
     // replaying a stale pointer. VMM pools safely keep the existing replay.
     REQUIRE(compute() == GGML_STATUS_SUCCESS);
 
-    // Backend teardown must remain safe after an explicit trim.
     ggml_backend_buffer_free(buffer);
     ggml_free(ctx);
+}
+}
+
+TEST_CASE(CudaPoolShutdownFixture, backend_pool_shutdown) {
+    const luce_test::ScopedEnvVar q8_memo("LUCE_Q8_MEMO", "1");
+
+    ggml_backend_t backend = ggml_backend_cuda_init(0);
+    if (!backend) {
+        std::fprintf(stderr, "skip: no CUDA/HIP backend available\n");
+        return;
+    }
+
+    exercise_pool_trim(backend);
+    ggml_backend_free(backend);
+    REQUIRE_TRUE(true);
+}
+
+TEST_CASE(CudaPoolShutdownFixture, meta_backend_pool_shutdown) {
+    const luce_test::ScopedEnvVar q8_memo("LUCE_Q8_MEMO", "1");
+
+    ggml_backend_reg_t cuda_reg = ggml_backend_cuda_reg();
+    if (!cuda_reg || ggml_backend_reg_dev_count(cuda_reg) == 0) {
+        std::fprintf(stderr, "skip: no CUDA/HIP device available\n");
+        return;
+    }
+
+    ggml_backend_dev_t device = ggml_backend_reg_dev_get(cuda_reg, 0);
+    ggml_backend_dev_t meta_device = ggml_backend_meta_device(
+        &device, 1, mirrored_split_state, nullptr);
+    ggml_backend_t backend = meta_device
+        ? ggml_backend_dev_init(meta_device, nullptr)
+        : nullptr;
+    if (!backend) {
+        std::fprintf(stderr, "skip: no CUDA/HIP meta backend available\n");
+        return;
+    }
+
+    exercise_pool_trim(backend);
     ggml_backend_free(backend);
     REQUIRE_TRUE(true);
 }

--- a/variables.md
+++ b/variables.md
@@ -149,6 +149,7 @@ Untagged variables are operational tuning knobs.
 | `DFLASH_PREFILL_DRAFTER` | Drafter participation during prefill. |
 | `DFLASH_PREFILL_KEEP` | Keep prefill cache across requests. |
 | `DFLASH_PREFILL_CACHE_SLOTS` / `DFLASH_PREFIX_CACHE_SLOTS` | Optional prefill/prefix cache slot override. When unset, the container preserves the native server defaults (prefix: 32; exact prefill: 0). Set either value to `0` for an explicit opt-out. |
+| `DFLASH_PREFILL_POOL_TRIM_TOKENS` | Opt-in interval for trimming cached legacy CUDA/HIP pool allocations between completed Qwen3.5 prefill chunks. Useful when a single long, shape-changing prefill would otherwise exhaust VRAM before request cleanup. |
 | `DFLASH_PREFILL_CACHE_TEST_LOG` / `DFLASH_PREFILL_CACHE_TEST_PORT` | 🧪 **test/bench** Prefill-cache test harness. |
 | `DFLASH27B_LAYER_PREFILL` / `DFLASH27B_PREFILL_UBATCH` | Layer-split prefill / prefill micro-batch. |
 | `DFLASH27B_CHUNKED` / `DFLASH27B_CHUNKED_CHUNK` / `DFLASH27B_CHUNKED_Q_BATCH` / `DFLASH27B_CHUNKED_THRESHOLD` | Chunked prefill controls. |


### PR DESCRIPTION
## Summary

- add an opt-in interval for trimming cached allocations from legacy CUDA/HIP pools between completed Qwen3.5 prefill chunks
- reuse the synchronized trim hook introduced by #668, which retires captured graphs and the Q8 memo before returning cached blocks
- document `DFLASH_PREFILL_POOL_TRIM_TOKENS`

## Problem

#668 trims legacy pools when request scratch is released. A single long, shape-changing prefill can still exhaust a non-VMM HIP device before reaching that request boundary. On `gfx1201`, a 60,363-token prefill OOMed in the stock runtime even though many retained pool blocks were no longer live.

This change trims only after a chunk has fully completed: target compute and argmax readback are done, the cache position is committed, and draft-side features have been synchronized. It is disabled unless the environment variable is set. VMM backends remain unaffected because `ggml_backend_cuda_has_legacy_pool()` returns false.

## Validation

Hardware and runtime:

- Radeon AI PRO R9700 (`gfx1201`, 31.859 GiB VRAM)
- ROCm 7.2.4
- Qwen3.8-27B Q4_K_M target with DFlash2 block 16
- Q8 K/V, `--max-ctx 262144`, concurrency 1
- `DFLASH_PREFILL_POOL_TRIM_TOKENS=8192`
- fresh server for every measurement

| Workload | Stock | Patched |
|---|---:|---:|
| 60,363 input tokens | OOM | PASS, 125.6 s |
| 60,363 peak VRAM | OOM near card limit | 29.789 GiB |
| 32,781 input prefill | 54.0 s | 53.9 s |
| 32,781 peak VRAM | 30.961 GiB | 29.637 GiB |
| 32,781 output | baseline | byte-identical content SHA-256 |

Long-context patched probes:

| Input tokens | Prefill | Average prefill | Peak VRAM | Free at peak |
|---:|---:|---:|---:|---:|
| 60,363 | 125.6 s | 480.6 tok/s | 29.789 GiB | 2.070 GiB |
| 100,013 | 270.9 s | 369.2 tok/s | 29.898 GiB | 1.961 GiB |
| 131,013 | 420.3 s | 311.7 tok/s | 30.319 GiB | 1.541 GiB |
| 200,013 | 861.7 s | 232.1 tok/s | 30.273 GiB | 1.586 GiB |
| 258,013 | 1351.1 s | 191.0 tok/s | 30.366 GiB | 1.494 GiB |

During the 258K run, process GTT remained about 8 MiB, swap was disabled, and `pswpin`/`pswpout` remained zero. The capacity result therefore did not rely on VRAM-to-RAM paging.

The 60K run logged seven trims at 8,192-token intervals, releasing 238-760 MiB per trim. The direct- and meta-backend allocator shutdown/trim tests passed 2/2 on `gfx1201`. The patched `dflash_server` also builds against current `main` (`d227a505`) with only pre-existing warnings, and `git diff --check` passes.

## Scope and tradeoffs

This was validated on the single-sequence Qwen3.5 path using a `gfx1201` HIP legacy pool. The pool API's meta-backend traversal was exercised through a one-rank meta backend; CUDA, VMM, `gfx1100`, multi-rank tensor parallelism, and concurrent-serving paths were not runtime-tested. The feature is opt-in because each trim synchronizes the target backend and requires graph recapture; the 32K A/B showed no measurable prefill regression, but very short intervals are not recommended.

The configured 262,144-token window was nearly reached: 258,013 input tokens plus one generated token completed successfully. This does not claim a full 4K-token completion at that prompt length.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
