### PR TITLE
feat(server): separate model placement and load balancing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,7 @@ jobs:
             grep -q '^DFLASH27B_EFFECTIVE_BLACKWELL_CONSUMER:INTERNAL=OFF$' build/CMakeCache.txt
           fi
           targets=(
+            test_server_unit
             test_cuda_pool_shutdown
             test_deepseek4_mmid_grouped_cuda
             test_deepseek4_unit
@@ -237,6 +238,11 @@ jobs:
           ./server/build/test_deepseek4_unit
           ctest --test-dir server/build --output-on-failure \
             -R 'cuda_pool_shutdown|rocmfp3_mix_registry|rocmfp_mix_slice_matvec|rocmfp_mix_gateup_glu|ds4_mix_registry_teardown'
+
+      - name: Run GPU sampler and draft top-K tests
+        run: |
+          ctest --test-dir server/build --output-on-failure \
+            -R '^test_server_unit\.(GpuSamplerCudaFixture|DraftTopkCudaFixture)\.' --no-tests=error
 
       - name: Run concurrent-serving kernel tests
         run: |
@@ -356,7 +362,7 @@ jobs:
           cmake --build "$RUNNER_TEMP/rocmfp-build" \
             --target test_rocmfp4 test_rocmfpx test_rocmfp4_hip_tail test_rocmfpx_mmq \
               test_deepseek4_mmid_grouped_cuda test_deepseek4_unit \
-              test_recurrent_snapshot test_server_unit test_rocmfp3_mix_registry \
+              test_recurrent_snapshot test_server_unit test_draft_topk_cuda test_rocmfp3_mix_registry \
               test_rocmfp_mix_slice_matvec test_rocmfp_mix_gateup_glu \
               test_ds4_mix_registry_teardown test_model_smoke test_batched_gdn \
               test_kernel_qualification_core test_kernel_qualification_gdn \
@@ -366,6 +372,11 @@ jobs:
           ctest --test-dir "$RUNNER_TEMP/rocmfp-build" \
             --output-on-failure \
             -R 'cuda_pool_shutdown|rocmfp4_reference|rocmfpx_reference|rocmfp4_hip_tail|rocmfpx_mmq|deepseek4_mmid_grouped_cuda|deepseek4_unit|recurrent_snapshot|ChainRollbackPolicy|rocmfp3_mix_registry|rocmfp_mix_slice_matvec|rocmfp_mix_gateup_glu|ds4_mix_registry_teardown|test_model_smoke\.PagedAttention\.|batched_gdn$|test_kernel_qualification_core\.|kernel_qualification_gdn$|kernel_qualification_moe_ds4$|concat_transpose$'
+
+      - name: Run GPU draft top-K tests
+        run: |
+          ctest --test-dir "$RUNNER_TEMP/rocmfp-build" --output-on-failure \
+            -R '^draft_topk_cuda$' --no-tests=error
 
       - name: Build + test affine ROCmFP2 GPU paths
         # Keep the default wire-format build above and compile the affine layout

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -1751,6 +1751,7 @@ if(DFLASH27B_TESTS)
         set(_server_unit_sources
             test/test_unit_main.cpp
             test/test_server_unit.cpp
+            test/test_model_routing.cpp
             test/test_anchor_params.cpp
             test/test_derived_scalars.cpp
             test/test_adaptive_spec_width.cpp
@@ -1931,7 +1932,8 @@ if(DFLASH27B_TESTS)
             src/placement/placement_config.cpp)
         target_include_directories(test_feature_gate PRIVATE
             ${CMAKE_CURRENT_SOURCE_DIR}/src
-            ${CMAKE_CURRENT_SOURCE_DIR}/src/common)
+            ${CMAKE_CURRENT_SOURCE_DIR}/src/common
+            ${CMAKE_CURRENT_SOURCE_DIR}/deps/llama.cpp/ggml/include)
         # compiled_placement_backend() is decided by these defines, so the
         # gate must be tested with the same ones the server is built with.
         if(DFLASH27B_GPU_BACKEND STREQUAL "hip")
@@ -2344,6 +2346,18 @@ if(DFLASH27B_SERVER)
             src/server/prompt_normalize.cpp
         )
         target_include_directories(dflash_server PRIVATE ${DFLASH27B_SRC_INCLUDE_DIRS})
+        # This script executes the server directly on the build host.
+        if(DFLASH27B_TESTS AND NOT CMAKE_CROSSCOMPILING)
+            add_dependencies(check dflash_server)
+            if(TARGET coverage)
+                add_dependencies(coverage dflash_server)
+            endif()
+            add_test(NAME server_cli_model_names
+                COMMAND ${CMAKE_COMMAND}
+                    -DSERVER=$<TARGET_FILE:dflash_server>
+                    -DBACKEND=${DFLASH27B_GPU_BACKEND}
+                    -P ${CMAKE_CURRENT_SOURCE_DIR}/test/test_model_names.cmake)
+        endif()
         if(DFLASH27B_GPU_BACKEND STREQUAL "hip")
             target_compile_definitions(dflash_server PRIVATE DFLASH27B_BACKEND_HIP=1 GGML_USE_HIP)
             if(DFLASH27B_ENABLE_MIXED_CUDA_HIP)

--- a/server/README.md
+++ b/server/README.md
@@ -42,6 +42,9 @@ This repo provides the GGUF target path and runtime pieces needed to run that st
 
 The default setup fits on a 24 GB RTX 3090: ~16 GB Q4_K_M target, 1.84 GB GGUF draft, DDTree verify state, and KV cache.
 
+For one listener with Qwen on R9700 and DS4 on Strix Halo, see
+[model load balancing](docs/MODEL_LOAD_BALANCING.md).
+
 ## Results
 
 Qwen3.5-27B Q4_K_M, concurrency=1, n_gen=256, 10 prompts/dataset:

--- a/server/docs/MODEL_LOAD_BALANCING.md
+++ b/server/docs/MODEL_LOAD_BALANCING.md
@@ -1,0 +1,210 @@
+# Model load balancing
+
+Model load balancing lets one `dflash_server` process serve requests across
+models on different GPUs through one HTTP listener. It prefers the configured
+primary and sends new requests to a secondary when the primary cannot accept
+them. If all eligible models are busy, requests enter a bounded waiting queue.
+
+Model placement, primary GPU selection and enabling load balancing are separate
+settings. For example, Qwen can stay on R9700 and DeepSeek4 on Strix Halo while
+either GPU is selected as primary. Every generation request follows this
+capacity-based policy, regardless of the request's `model` field. The response
+identifies the model that actually generated the answer.
+
+Each model keeps its own tokenizer, defaults, backend and scheduler. Clients
+use the existing Chat Completions, Messages and Responses endpoints.
+
+## Configure placement and load balancing
+
+Model placement and load-balancing priority are independent. Each `--model <path>`
+begins a model option block; its `--target-device <backend:gpu>` chooses where
+that model loads. The first path may also be positional for single-model CLI
+compatibility. The first block owns listener options and `--routing-queue-limit`.
+
+`--load-balancing-primary-gpu <backend:gpu>` selects the primary by its
+configured target device, independently of block order. It must match exactly one block; if
+omitted, the first block is primary. Use explicit device IDs after checking
+which GPU each ID names; the example assumes R9700 is `hip:0` and Strix Halo
+is `hip:1`.
+
+`--load-balancing` enables primary-first fallback. Without it, only the selected
+primary loads and serves requests, even if other model blocks are configured.
+With it, all configured models load and the remaining blocks are tried in their
+original order after the primary. The old `--load-balancing-next-model` and
+`--next-model` flags are removed.
+
+```bash
+dflash_server --load-balancing --load-balancing-primary-gpu hip:0 \
+  --model /models/qwen38-27b.gguf \
+  --model-name qwen --target-device hip:0 \
+  --draft /models/qwen38-dflash2.gguf --draft-device hip:0 \
+  --max-ctx 4096 --max-concurrency 4 --kv-pool-tokens 16384 \
+  --cache-type-k q8_0 --cache-type-v q8_0 --fa-window 0 \
+  --default-max-tokens 2048 --hard-limit-reply-budget 1024 \
+  --host 127.0.0.1 --port 8080 --routing-queue-limit 32 \
+  --model /models/deepseek-v4-flash.gguf \
+  --model-name ds4 --target-device hip:1 \
+  --max-ctx 8192 --max-concurrency 1 \
+  --default-max-tokens 2048 --hard-limit-reply-budget 1024 \
+  --prefix-cache-slots 0 --prefill-cache-slots 0 --disk-prefix-cache off \
+  --ds4-fused-decode --ds4-expert-top-k 6 --ds4-prefill exact
+```
+
+Change only `--load-balancing-primary-gpu hip:1` to prefer DS4 on Strix Halo
+while keeping both model placements intact. Remove `--load-balancing` to serve only that
+selected primary.
+
+Use the installed model paths and a binary built for both GPU architectures.
+Here Qwen uses continuous batching and DS4 uses its existing native worker.
+The latter has one active request; raising a supported model's concurrency
+selects its paged scheduler. `--max-concurrency` is per model, not a shared
+limit or a promise that every sequence will fit in the KV pool.
+
+```json
+{"model":"auto","messages":[{"role":"user","content":"Write a Python parser."}],"max_tokens":512,"stream":true}
+```
+
+## How requests are balanced
+
+- Every generation request follows operator-configured priority. An omitted,
+  empty, `auto`, explicit model name, or other client alias has the same
+  load-balancing behavior. There is no model pinning. With balancing enabled, requests try the
+  primary and then the remaining models; without it, only the primary serves.
+  This is preference with capacity fallback, not round-robin.
+- The listener reserves an available model slot. Its scheduler then calls
+  `SeqEngine::admit` on the worker thread, which atomically checks actual
+  slots, prompt KV reservation and existing decoders' headroom. The listener
+  never reads a live KV pool from another thread or estimates free VRAM.
+- A busy engine returns the request before any SSE header, output or prefill.
+  The listener retries with the next model, re-rendering and re-tokenizing the
+  original request and applying that model's defaults. Response `model`
+  identifies the model that actually generates.
+- If all eligible targets are busy, requests wait in memory, up to
+  `--routing-queue-limit` (default 32; 0 rejects immediately). Capacity release
+  wakes waiters; a 250 ms retry also observes engine-only changes, disconnects
+  and shutdown. Waiting does not consume a GPU sequence slot. Waiters compete
+  for the next available reservation; there is no FIFO or starvation guarantee.
+- Context/pool limits that can never fit skip that target; when none can fit,
+  the request returns 400 instead of waiting.
+  Other validation and backend failures terminate the request without fallback.
+- A reservation lasts through engine retirement and output draining. A slow
+  reader can therefore retain admission capacity after generation finishes.
+  Cancellation does not expose a slot while its GPU work is still running.
+- Waiting ends when capacity becomes available, the client disconnects, or the
+  server stops. There is no server queue deadline or pre-admission SSE heartbeat;
+  clients/proxies may impose their own timeout. Shutdown answers waiters with 503
+  and joins all worker/client users before releasing model state. Active native
+  single-request workers finish generation and send their normal terminal
+  response; a real client disconnect still cancels them. Batched workers keep
+  their existing shutdown cancellation and error-finalization policy.
+
+`/v1/models` lists loaded model names. With balancing disabled, only the
+selected primary is loaded; other configured model blocks are absent from
+this list. With balancing enabled, token-counting requests require an
+explicit name because tokenizers differ; naming the primary here always counts
+with its own tokenizer and never falls back. `/props` and `/status/json` expose
+`routing: "primary-first"`, `waiting`, `queue_limit`, and each model's
+`capacity`, `in_flight`, execution mode, placement and existing status.
+A single-model launch uses the ordinary server path and reports its configured
+model identity, regardless of the client alias.
+
+With balancing enabled, model names must be unique, nonempty and cannot be
+`auto`. With balancing enabled, startup rejects model-block
+options that mutate shared process policy, including KVFlash, Spark, PFlash,
+remote drafts and target splitting. Environment variables remain process-wide;
+this does not establish arbitrary model/environment isolation. Qwen's explicit
+KV types are stored per backend rather than in shared environment state.
+With balancing disabled, the selected primary retains single-model CLI
+features. Unused blocks are syntax-checked but do not apply process policy.
+GPU draft top-K and sampling scratch belong to each worker thread and are
+released on their owning device when the worker exits.
+
+## Active requests and load-balancing limits
+
+Load balancing selects a model before generation starts. Once admitted, a
+request remains on that model. If decode later exhausts its pool, the existing
+scheduler error and retirement behavior still applies. Load balancing does not
+move an active stream to another model or recover it from that failure.
+
+Qwen and DS4 have incompatible tokenizers, cache layouts and recurrent state.
+Moving an active Qwen request to DS4 would require replaying its conversation
+and accepted generated text, then continuing with a different model. Before
+implementing that, define stream/model identity, assistant continuation,
+thinking/tool-call boundaries, output budgets and cancellation across replay.
+Raw KV copying cannot implement this handoff.
+
+Active SSD suspension is not a small extension of the existing prefix cache:
+`Qwen35Backend::snapshot_save` rejects paged attention, DeepSeek4's paged path
+cannot export/adopt its monolithic snapshots, and `SeqEngine` has no active
+sequence suspend/restore API. Those contracts must exist before eviction can
+safely preserve a streaming request.
+
+KVFlash currently pages cold attention chunks to host RAM. It is neither a
+continuous-batching sequence checkpoint nor an SSD request spool. Integrating
+it requires sequence-owned paging state and reclaim/restore synchronization.
+Exact same-model suspension also needs KV plus recurrent/compressor state,
+accepted/pending tokens, RNG/sampler state, speculative state and response
+formatting state. SSD suspension additionally needs atomic durable records,
+model/version validation, disk quotas, cancellation cleanup and crash recovery.
+None of those mechanisms is enabled by this draft. Requests waiting here have
+not begun generation and retain the parsed request in memory only.
+
+## Provenance and checks
+
+The single-listener and per-model loader are adapted from the local runtime
+behind [research PR 105](https://github.com/Luce-Org/luce_box/pull/105), commit
+`63151ff8`. [Research PR 103](https://github.com/Luce-Org/luce_box/pull/103)
+records earlier batched and hybrid serving attempts. This branch adds
+model load balancing through primary-first admission, capacity feedback and
+bounded waiting;
+it does not import the planning, synthesis or benchmark workflows.
+
+`test_model_routing.cpp` exercises real HTTP with deterministic host backends:
+independent workers, distinct tokenizers/defaults, primary preference, slot and
+KV fallback, permanent rejection, queue overflow/drain, cancellation and
+shutdown. `test_seq_slot_manager` verifies the real pool's atomic reservation
+and permanent-capacity result. Hardware qualification is reported in the PR;
+these host checks alone do not establish numerical GPU correctness, long-context
+survival, a latency improvement or production readiness.
+
+### Model load-balancing checks (2026-09-09)
+
+The updated host suite passed 496 checks. Coverage exercises primary-first
+load balancing for omitted, automatic, explicit and unknown client aliases; reversed
+priority; fallback before response headers; bounded waiting; and cancellation.
+Twenty-one CLI checks cover separate model blocks and balancing enablement,
+invalid or ambiguous primary selection, GPU index overflow, queue validation,
+and rejection of the removed separator flags.
+
+Functional GPU results and launch provenance for the modular interface are
+retained under `profile-runs/primary-capacity-routing-20260909/modular/` in the
+hub workspace. The R9700-primary run verified fallback, bounded waiting, queue
+overflow, cancellation and capacity reuse. The reversed-priority run kept Qwen
+on R9700 and DS4 on Strix Halo: a request naming Qwen went to DS4, and a request
+naming DS4 fell back to Qwen while DS4 was occupied. With balancing disabled,
+both blocks were configured but only the selected Strix Halo model loaded and
+served, including requests naming Qwen. All three runs exited cleanly and left
+no KFD compute processes.
+
+### Earlier functional qualification (2026-09-09)
+
+The following results predate the modular flags and removal of model pinning;
+they describe the earlier implementation, not verification of the current CLI.
+
+Runtime commit `8d550fcf` passed 500 host checks and 11 CLI checks. The HIP
+binary includes `gfx1201` and `gfx1151`; the observed devices were R9700 at
+`0000:c4:00.0` and Radeon 8060S/Strix Halo at `0000:c5:00.0`.
+
+| Run | Observed result |
+| --- | --- |
+| Opted-in Qwen C4, 16,384 shared KV tokens; native DS4 C1 | Primary filled to 4/4. A request naming Qwen fell back to DS4. Another primary-named request waited, queue overflow returned 503, and cancellation admitted the waiter to Qwen. |
+| Same models, Qwen pool reduced to 1,024 tokens | After the primary emitted a token for a 685-token prompt, a second 685-token prompt fell back with only 1/4 primary slots occupied. DS4 independently tokenized it to 674 tokens. |
+| Small deterministic output control | Primary-name and automatic routing returned `routing-ok` on Qwen. Primary-name fallback matched explicitly named DS4 on that prompt. This is not a broad numerical or quality qualification. |
+| No opt-in separator | Only Qwen was listed and served the request; the ordinary single-model path had no routing metadata. |
+| Cancellation and cleanup | Both balanced runs reused capacity after cancellation. All three runs exited 0 and left no KFD compute processes. The pressure run canceled DS4 during prefill; it does not establish successful long-prompt completion. |
+
+Artifacts, exact launch arguments, binary hashes and raw responses are retained
+locally under `profile-runs/primary-capacity-routing-20260909/opt-in/` in the hub
+workspace. No DSpark draft was enabled for DS4 in these runs. Active-request
+migration, decode-growth recovery, SSD resume and throughput benefits remain
+unimplemented or unmeasured as described above.

--- a/server/src/common/backend_args.h
+++ b/server/src/common/backend_args.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <limits>
+#include "ggml.h"
 
 #include "placement/draft_residency.h"
 #include "placement/placement_config.h"
@@ -67,6 +68,9 @@ struct BackendArgs {
 
     // Attention and speculative-decode options. Individual backends consume
     // only the fields they support.
+    // Explicit per-model overrides; COUNT preserves environment/family defaults.
+    ggml_type    cache_type_k = GGML_TYPE_COUNT;
+    ggml_type    cache_type_v = GGML_TYPE_COUNT;
     int             fa_window        = 0;  // 0 = full attention. qwen3.6 full-attn layers must see the whole context; a finite window drops the system prompt/tools -> breaks tool calls.
     bool            paged_attention  = false;  // model-specific paged K/V blocks for AR decode
     // Concurrent decode slots (--max-concurrency). > 1 requires paged_attention;

--- a/server/src/common/backend_factory.cpp
+++ b/server/src/common/backend_factory.cpp
@@ -276,6 +276,8 @@ std::unique_ptr<ModelBackend> create_backend(
         cfg.remote_draft       = args.remote_draft;
         cfg.stream_fd          = args.stream_fd;
         cfg.fa_window          = args.fa_window;
+        cfg.cache_type_k       = args.cache_type_k;
+        cfg.cache_type_v       = args.cache_type_v;
         cfg.paged_attention    = args.paged_attention;
         cfg.max_concurrency    = args.max_concurrency;
         cfg.kv_pool_tokens     = args.kv_pool_tokens;

--- a/server/src/common/concurrency/seq_engine.h
+++ b/server/src/common/concurrency/seq_engine.h
@@ -155,6 +155,7 @@ public:
         enum class Status {
             admitted,
             busy,
+            capacity_exceeded, // prompt cannot fit even in an otherwise idle pool
             failed,
         };
 

--- a/server/src/common/concurrency/seq_slot_manager.cpp
+++ b/server/src/common/concurrency/seq_slot_manager.cpp
@@ -108,6 +108,7 @@ SeqEngine::AdmitResult SeqSlotManager::admit(
         return r;
     }
     if (prompt.size() > static_cast<size_t>(max_ctx_)) {
+        r.status = AdmitStatus::capacity_exceeded;
         r.error = "prompt exceeds max_ctx";
         return r;
     }
@@ -119,6 +120,7 @@ SeqEngine::AdmitResult SeqSlotManager::admit(
     const uint64_t pool_capacity =
         (uint64_t)pool_.physical_block_count() * pool_.block_size();
     if ((uint64_t)prompt_len > pool_capacity) {
+        r.status = AdmitStatus::capacity_exceeded;
         r.error = "prompt needs " + std::to_string(prompt_len) +
                   " KV tokens but the pool holds " +
                   std::to_string(pool_capacity) +

--- a/server/src/common/geometric_draft_topk_cuda.cu
+++ b/server/src/common/geometric_draft_topk_cuda.cu
@@ -248,10 +248,8 @@ __global__ void geometric_draft_topk_combine(const float * __restrict__ part_max
     }
 }
 
-// Per-device scratch for the [n_positions × K] outputs plus the
-// [n_positions × split × K] pass-1 partials, grown as needed. The decode loop
-// is single-threaded, so a plain static cache is safe and avoids a
-// cudaMalloc/cudaFree on every step.
+// Each worker owns its persistent scratch. Device changes and thread exit
+// release allocations on their owning device without touching another worker.
 struct Scratch {
     int       device   = -1;
     size_t    cap       = 0;       // output elements (n_positions*K)
@@ -262,39 +260,57 @@ struct Scratch {
     float *   d_psum    = nullptr; // [n_positions*split]
     float *   d_pv      = nullptr; // [n_positions*split*kMaxK]
     int32_t * d_pi      = nullptr; // [n_positions*split*kMaxK]
-};
-Scratch g_scratch;
 
-void free_scratch() {
-    if (g_scratch.d_lp)   cudaFree(g_scratch.d_lp);
-    if (g_scratch.d_ids)  cudaFree(g_scratch.d_ids);
-    if (g_scratch.d_pmax) cudaFree(g_scratch.d_pmax);
-    if (g_scratch.d_psum) cudaFree(g_scratch.d_psum);
-    if (g_scratch.d_pv)   cudaFree(g_scratch.d_pv);
-    if (g_scratch.d_pi)   cudaFree(g_scratch.d_pi);
-    g_scratch = Scratch{};
-}
+    Scratch() = default;
+    Scratch(const Scratch &) = delete;
+    Scratch & operator=(const Scratch &) = delete;
+    ~Scratch() { reset(); }
+
+    void reset() {
+        if (device < 0) return;
+        int previous = -1;
+        cudaGetDevice(&previous);
+        if (previous != device) cudaSetDevice(device);
+        if (d_lp) cudaFree(d_lp);
+        d_lp = nullptr;
+        if (d_ids) cudaFree(d_ids);
+        d_ids = nullptr;
+        if (d_pmax) cudaFree(d_pmax);
+        d_pmax = nullptr;
+        if (d_psum) cudaFree(d_psum);
+        d_psum = nullptr;
+        if (d_pv) cudaFree(d_pv);
+        d_pv = nullptr;
+        if (d_pi) cudaFree(d_pi);
+        d_pi = nullptr;
+        if (previous >= 0 && previous != device) cudaSetDevice(previous);
+        device = -1;
+        cap = 0;
+        part_cap = 0;
+    }
+};
+thread_local Scratch scratch;
 
 // Allocate output + partial buffers. n = n_positions*K outputs;
 // n_parts = n_positions*split partials (each carrying K entries).
 bool ensure_scratch(int device, size_t n, size_t n_parts) {
     const size_t n_part_lists = n_parts * (size_t)kMaxK;  // upper bound on K
-    if (g_scratch.device == device && g_scratch.cap >= n &&
-        g_scratch.part_cap >= n_part_lists)
+    if (scratch.device == device && scratch.cap >= n &&
+        scratch.part_cap >= n_part_lists)
         return true;
-    free_scratch();
-    if (cudaMalloc(&g_scratch.d_lp,   n            * sizeof(float))   != cudaSuccess) goto fail;
-    if (cudaMalloc(&g_scratch.d_ids,  n            * sizeof(int32_t)) != cudaSuccess) goto fail;
-    if (cudaMalloc(&g_scratch.d_pmax, n_parts      * sizeof(float))   != cudaSuccess) goto fail;
-    if (cudaMalloc(&g_scratch.d_psum, n_parts      * sizeof(float))   != cudaSuccess) goto fail;
-    if (cudaMalloc(&g_scratch.d_pv,   n_part_lists * sizeof(float))   != cudaSuccess) goto fail;
-    if (cudaMalloc(&g_scratch.d_pi,   n_part_lists * sizeof(int32_t)) != cudaSuccess) goto fail;
-    g_scratch.device   = device;
-    g_scratch.cap      = n;
-    g_scratch.part_cap = n_part_lists;
+    scratch.reset();
+    scratch.device = device; // Also owns partial allocations on failure.
+    if (cudaMalloc(&scratch.d_lp,   n            * sizeof(float))   != cudaSuccess) goto fail;
+    if (cudaMalloc(&scratch.d_ids,  n            * sizeof(int32_t)) != cudaSuccess) goto fail;
+    if (cudaMalloc(&scratch.d_pmax, n_parts      * sizeof(float))   != cudaSuccess) goto fail;
+    if (cudaMalloc(&scratch.d_psum, n_parts      * sizeof(float))   != cudaSuccess) goto fail;
+    if (cudaMalloc(&scratch.d_pv,   n_part_lists * sizeof(float))   != cudaSuccess) goto fail;
+    if (cudaMalloc(&scratch.d_pi,   n_part_lists * sizeof(int32_t)) != cudaSuccess) goto fail;
+    scratch.cap      = n;
+    scratch.part_cap = n_part_lists;
     return true;
 fail:
-    free_scratch();
+    scratch.reset();
     return false;
 }
 
@@ -368,10 +384,10 @@ bool geometric_extract_draft_topk_cuda(const void * d_logits,
 #define DFLASH_TOPK_LAUNCH(KV, VEC)                                                             \
             geometric_draft_topk_partial<KV, VEC><<<grid1, kBlock>>>(                                     \
                 lp_in, vocab, inv_t, split,                                                     \
-                g_scratch.d_pmax, g_scratch.d_psum, g_scratch.d_pv, g_scratch.d_pi);           \
+                scratch.d_pmax, scratch.d_psum, scratch.d_pv, scratch.d_pi);           \
             geometric_draft_topk_combine<KV><<<n_positions, comb_block>>>(                                \
-                g_scratch.d_pmax, g_scratch.d_psum, g_scratch.d_pv, g_scratch.d_pi,            \
-                split, g_scratch.d_lp, g_scratch.d_ids);
+                scratch.d_pmax, scratch.d_psum, scratch.d_pv, scratch.d_pi,            \
+                split, scratch.d_lp, scratch.d_ids);
 #define DFLASH_TOPK_CASE(KV)                                                                    \
             case KV:                                                                            \
                 if (use_vec) { DFLASH_TOPK_LAUNCH(KV, true) }                                   \
@@ -392,9 +408,9 @@ bool geometric_extract_draft_topk_cuda(const void * d_logits,
 
         if (kProfile) cudaEventRecord(e_k1);
         if (launched && cudaGetLastError() == cudaSuccess && cudaDeviceSynchronize() == cudaSuccess) {
-            const cudaError_t e1 = cudaMemcpy(out_log_probs, g_scratch.d_lp,
+            const cudaError_t e1 = cudaMemcpy(out_log_probs, scratch.d_lp,
                                               n * sizeof(float), cudaMemcpyDeviceToHost);
-            const cudaError_t e2 = cudaMemcpy(out_token_ids, g_scratch.d_ids,
+            const cudaError_t e2 = cudaMemcpy(out_token_ids, scratch.d_ids,
                                               n * sizeof(int32_t), cudaMemcpyDeviceToHost);
             ok = (e1 == cudaSuccess && e2 == cudaSuccess);
         }

--- a/server/src/common/geometric_sampler_cuda.cu
+++ b/server/src/common/geometric_sampler_cuda.cu
@@ -124,7 +124,7 @@ __device__ __forceinline__ void block_reduce_argmax(float & val, int & idx,
 constexpr size_t kSampleShmemPerThread = 2 * sizeof(float);
 
 // Per-device sample-kernel block size (threads per row), cached after the
-// first call — same single-threaded-decode-loop assumption as Scratch below.
+// first call on each worker thread, like Scratch below.
 // Queried rather than hardcoded because maxThreadsPerBlock and
 // sharedMemPerBlock vary across GPUs (e.g. older compute-capability parts cap
 // at 512 threads and/or less shared memory than the 1024-thread/8-byte-per-
@@ -133,7 +133,7 @@ struct BlockCfg {
     int device = -1;
     int block  = 0;
 };
-BlockCfg g_block_cfg;
+thread_local BlockCfg g_block_cfg;
 
 int pick_block_size(int device) {
     if (g_block_cfg.device == device) return g_block_cfg.block;
@@ -229,7 +229,7 @@ __global__ void geometric_sample_kernel(float * __restrict__ work, int vocab,
     // pass below walks `work` as float4: thread t reads groups v = t, t+nthreads,
     // ... so consecutive threads touch consecutive 16-byte groups (a coalesced
     // warp transaction).
-    // `work` is g_scratch.d_work, a cudaMalloc allocation (>=256-byte aligned),
+    // `work` is scratch.d_work, a cudaMalloc allocation (>=256-byte aligned),
     // so the float4 reinterpret is safe. `nvec` full groups cover [0, tail); the
     // <=3 leftover ids in [tail, vocab) are handled by a scalar grid-stride tail.
     // Within a thread, group ids ascend (v grows, and x<y<z<w within a group)
@@ -356,8 +356,8 @@ __global__ void geometric_sample_kernel(float * __restrict__ work, int vocab,
     }
 }
 
-// Per-device persistent scratch. The decode loop is single-threaded, so a plain
-// static cache avoids a cudaMalloc/cudaFree per token (mirrors geometric_draft_topk_cuda).
+// Each worker owns its persistent scratch. Device changes and thread exit
+// release allocations on their owning device without touching another worker.
 struct Scratch {
     int       device   = -1;
     int       vocab_cap = 0;
@@ -367,42 +367,59 @@ struct Scratch {
     int32_t * d_pen_id = nullptr;  // [pen_cap]
     float *   d_pen_add = nullptr; // [pen_cap]
     int32_t * d_out    = nullptr;  // [1]
-};
-Scratch g_scratch;
 
-void free_scratch() {
-    if (g_scratch.d_work)   cudaFree(g_scratch.d_work);
-    if (g_scratch.d_probs)  cudaFree(g_scratch.d_probs);
-    if (g_scratch.d_pen_id) cudaFree(g_scratch.d_pen_id);
-    if (g_scratch.d_pen_add) cudaFree(g_scratch.d_pen_add);
-    if (g_scratch.d_out)    cudaFree(g_scratch.d_out);
-    g_scratch = Scratch{};
-}
+    Scratch() = default;
+    Scratch(const Scratch &) = delete;
+    Scratch & operator=(const Scratch &) = delete;
+    ~Scratch() { reset(); }
+
+    void reset() {
+        if (device < 0) return;
+        int previous = -1;
+        cudaGetDevice(&previous);
+        if (previous != device) cudaSetDevice(device);
+        if (d_work) cudaFree(d_work);
+        d_work = nullptr;
+        if (d_probs) cudaFree(d_probs);
+        d_probs = nullptr;
+        if (d_pen_id) cudaFree(d_pen_id);
+        d_pen_id = nullptr;
+        if (d_pen_add) cudaFree(d_pen_add);
+        d_pen_add = nullptr;
+        if (d_out) cudaFree(d_out);
+        d_out = nullptr;
+        if (previous >= 0 && previous != device) cudaSetDevice(previous);
+        device = -1;
+        vocab_cap = 0;
+        pen_cap = 0;
+    }
+};
+thread_local Scratch scratch;
 
 bool ensure_scratch(int device, int vocab, int pen) {
-    const bool ok = g_scratch.device == device &&
-                    g_scratch.vocab_cap >= vocab &&
-                    g_scratch.pen_cap >= pen;
+    const bool ok = scratch.device == device &&
+                    scratch.vocab_cap >= vocab &&
+                    scratch.pen_cap >= pen;
     if (ok) return true;
-    free_scratch();
-    if (cudaMalloc(&g_scratch.d_out, sizeof(int32_t)) != cudaSuccess) goto fail;
-    if (cudaMalloc(&g_scratch.d_work, (size_t)vocab * sizeof(float)) != cudaSuccess) goto fail;
-    if (cudaMalloc(&g_scratch.d_probs, (size_t)vocab * sizeof(float)) != cudaSuccess) goto fail;
+    scratch.reset();
+    scratch.device = device; // Also owns partial allocations on failure.
+    if (cudaMalloc(&scratch.d_out, sizeof(int32_t)) != cudaSuccess) goto fail;
+    if (cudaMalloc(&scratch.d_work, (size_t)vocab * sizeof(float)) != cudaSuccess) goto fail;
+    if (cudaMalloc(&scratch.d_probs, (size_t)vocab * sizeof(float)) != cudaSuccess) goto fail;
     if (pen > 0) {
-        if (cudaMalloc(&g_scratch.d_pen_id, (size_t)pen * sizeof(int32_t)) != cudaSuccess) goto fail;
-        if (cudaMalloc(&g_scratch.d_pen_add, (size_t)pen * sizeof(float)) != cudaSuccess) goto fail;
+        if (cudaMalloc(&scratch.d_pen_id, (size_t)pen * sizeof(int32_t)) != cudaSuccess) goto fail;
+        if (cudaMalloc(&scratch.d_pen_add, (size_t)pen * sizeof(float)) != cudaSuccess) goto fail;
     }
-    g_scratch.device    = device;
-    g_scratch.vocab_cap = vocab;
-    g_scratch.pen_cap   = pen;
+    scratch.vocab_cap = vocab;
+    scratch.pen_cap   = pen;
     return true;
 fail:
-    free_scratch();
+    scratch.reset();
     return false;
 }
 
-// Uploads `logits` (host or device) into g_scratch.d_work and the sparse
-// penalty set into g_scratch.d_pen_id/d_pen_add — the shared prefix of
+// Uploads `logits` (host or device) into scratch.d_work and the sparse
+// penalty set into scratch.d_pen_id/d_pen_add — the shared prefix of
 // geometric_sample_logits_cuda and geometric_compute_probs_cuda. Penalty
 // *application* itself is no longer done here: it's fused into pass 0 of
 // geometric_sample_kernel (see apply_penalties_inplace), so this function
@@ -431,15 +448,15 @@ bool stage_and_penalize(int dev, const float * logits, int vocab, const SamplerC
     const int m = (int)pen_id.size();
 
     if (!ensure_scratch(dev, vocab, m)) return false;
-    if (cudaMemcpy(g_scratch.d_work, logits, (size_t)vocab * sizeof(float),
+    if (cudaMemcpy(scratch.d_work, logits, (size_t)vocab * sizeof(float),
                    logits_on_device ? cudaMemcpyDeviceToDevice
                                     : cudaMemcpyHostToDevice) != cudaSuccess) {
         return false;
     }
     if (m > 0) {
-        if (cudaMemcpy(g_scratch.d_pen_id, pen_id.data(), (size_t)m * sizeof(int32_t),
+        if (cudaMemcpy(scratch.d_pen_id, pen_id.data(), (size_t)m * sizeof(int32_t),
                        cudaMemcpyHostToDevice) != cudaSuccess) return false;
-        if (cudaMemcpy(g_scratch.d_pen_add, pen_add.data(), (size_t)m * sizeof(float),
+        if (cudaMemcpy(scratch.d_pen_add, pen_add.data(), (size_t)m * sizeof(float),
                        cudaMemcpyHostToDevice) != cudaSuccess) return false;
     }
     *out_m = m;
@@ -495,13 +512,13 @@ int geometric_sample_logits_cuda(const float * logits,
         // Only kModeSample's inverse-CDF draw touches geometric_smem; skip
         // sizing it for the (cheaper, no-shared-mem) greedy launch.
         const size_t shmem_bytes  = (mode == kModeSample) ? (size_t)block * kSampleShmemPerThread : 0;
-        geometric_sample_kernel<<<1, block, shmem_bytes>>>(g_scratch.d_work, vocab, inv_t, mode,
-                                     r_uniform, g_scratch.d_out, /*out_probs=*/nullptr,
-                                     g_scratch.d_pen_id, g_scratch.d_pen_add, m,
+        geometric_sample_kernel<<<1, block, shmem_bytes>>>(scratch.d_work, vocab, inv_t, mode,
+                                     r_uniform, scratch.d_out, /*out_probs=*/nullptr,
+                                     scratch.d_pen_id, scratch.d_pen_add, m,
                                      cfg.rep_pen, cfg.rep_pen > 1.0f ? 1 : 0);
         int32_t tok = -1;
         if (cudaGetLastError() == cudaSuccess &&
-            cudaMemcpy(&tok, g_scratch.d_out, sizeof(int32_t),
+            cudaMemcpy(&tok, scratch.d_out, sizeof(int32_t),
                        cudaMemcpyDeviceToHost) == cudaSuccess) {
             result = tok;
         }
@@ -539,12 +556,12 @@ bool geometric_compute_probs_cuda(const float * logits,
         const int   block = pick_block_size(dev);
         // kModeEmitProbs never touches geometric_smem (no inverse-CDF draw),
         // so no dynamic shared memory needed.
-        geometric_sample_kernel<<<1, block>>>(g_scratch.d_work, vocab, inv_t, kModeEmitProbs,
-                                     /*r_uniform=*/0.0, /*out_token=*/nullptr, g_scratch.d_probs,
-                                     g_scratch.d_pen_id, g_scratch.d_pen_add, m,
+        geometric_sample_kernel<<<1, block>>>(scratch.d_work, vocab, inv_t, kModeEmitProbs,
+                                     /*r_uniform=*/0.0, /*out_token=*/nullptr, scratch.d_probs,
+                                     scratch.d_pen_id, scratch.d_pen_add, m,
                                      cfg.rep_pen, cfg.rep_pen > 1.0f ? 1 : 0);
         if (cudaGetLastError() == cudaSuccess &&
-            cudaMemcpy(out_probs, g_scratch.d_probs, (size_t)vocab * sizeof(float),
+            cudaMemcpy(out_probs, scratch.d_probs, (size_t)vocab * sizeof(float),
                        cudaMemcpyDeviceToHost) == cudaSuccess) {
             ok = true;
         }

--- a/server/src/internal.h
+++ b/server/src/internal.h
@@ -697,7 +697,9 @@ bool create_target_cache(const TargetWeights & w,
                          int ctx_alloc = 0,
                          bool paged_attention = false,
                          int n_seq_slots = 1,
-                         bool concurrent_tree = false);
+                         bool concurrent_tree = false,
+                         ggml_type cache_type_k = GGML_TYPE_COUNT,
+                         ggml_type cache_type_v = GGML_TYPE_COUNT);
 
 // `f32_ssm_intermediates` enables exact per-token checkpoints for the opt-in
 // layer-split fast rollback path. The default preserves the established Q8_0
@@ -715,7 +717,9 @@ bool create_target_cache_partial(const TargetWeights & w,
                                  bool f32_ssm_intermediates = false,
                                  bool paged_attention = false,
                                  int n_seq_slots = 1,
-                                 bool concurrent_tree = false);
+                                 bool concurrent_tree = false,
+                         ggml_type cache_type_k = GGML_TYPE_COUNT,
+                         ggml_type cache_type_v = GGML_TYPE_COUNT);
 
 void free_target_cache(TargetCache & c);
 

--- a/server/src/kv_quant.cpp
+++ b/server/src/kv_quant.cpp
@@ -170,7 +170,8 @@ void validate_kv_pair_or_abort(ggml_type k, ggml_type v, const char * who) {
     std::abort();
 }
 
-void resolve_kv_types(ggml_type & k_out, ggml_type & v_out) {
+void resolve_kv_types(ggml_type & k_out, ggml_type & v_out,
+                      ggml_type k_override, ggml_type v_override) {
     ggml_type k = GGML_TYPE_Q4_0;
     ggml_type v = GGML_TYPE_Q4_0;
 
@@ -186,7 +187,7 @@ void resolve_kv_types(ggml_type & k_out, ggml_type & v_out) {
     }
 
     // Layer 1: explicit per-axis override (highest precedence)
-    if (const char * s = std::getenv("DFLASH27B_KV_K")) {
+    if (const char * s = k_override == GGML_TYPE_COUNT ? std::getenv("DFLASH27B_KV_K") : nullptr) {
         const ggml_type parsed = parse_kv_type(s);
         if (parsed == GGML_TYPE_COUNT) {
             std::fprintf(stderr, "[dflash] Unknown KV K type: \"%s\"\n", s);
@@ -194,7 +195,7 @@ void resolve_kv_types(ggml_type & k_out, ggml_type & v_out) {
         }
         k = parsed;
     }
-    if (const char * s = std::getenv("DFLASH27B_KV_V")) {
+    if (const char * s = v_override == GGML_TYPE_COUNT ? std::getenv("DFLASH27B_KV_V") : nullptr) {
         const ggml_type parsed = parse_kv_type(s);
         if (parsed == GGML_TYPE_COUNT) {
             std::fprintf(stderr, "[dflash] Unknown KV V type: \"%s\"\n", s);
@@ -202,6 +203,9 @@ void resolve_kv_types(ggml_type & k_out, ggml_type & v_out) {
         }
         v = parsed;
     }
+
+    if (k_override != GGML_TYPE_COUNT) k = k_override;
+    if (v_override != GGML_TYPE_COUNT) v = v_override;
 
     // Validate the resolved (K, V) pair
     validate_kv_pair_or_abort(k, v, "[dflash]");

--- a/server/src/kv_quant.h
+++ b/server/src/kv_quant.h
@@ -23,14 +23,17 @@ bool is_supported_kv_pair(ggml_type k, ggml_type v);
 // the compiled fattn kernels. `who` is the log prefix (e.g. "[laguna]").
 void validate_kv_pair_or_abort(ggml_type k, ggml_type v, const char * who);
 
-// Resolves K and V types from environment variables.
+// Resolves K and V types with optional per-model overrides.
 // Precedence (high -> low):
+//   0. Explicit k_override / v_override (COUNT means unspecified)
 //   1. DFLASH27B_KV_K=<type> / DFLASH27B_KV_V=<type>  (independent override)
 //   2. DFLASH27B_KV_F16 / _KV_Q4 / _KV_TQ3            (legacy shorthand, K==V)
 //   3. Default: GGML_TYPE_Q4_0 for both (with FWHT K-rotation)
 // On invalid input or unsupported (K,V) pair, prints an explanatory message
 // and calls std::abort(). Returns the resolved pair via out params.
-void resolve_kv_types(ggml_type & k_out, ggml_type & v_out);
+void resolve_kv_types(ggml_type & k_out, ggml_type & v_out,
+                      ggml_type k_override = GGML_TYPE_COUNT,
+                      ggml_type v_override = GGML_TYPE_COUNT);
 
 // KV reservation bytes per token for a hybrid attention/SSM model. Single source
 // of truth for both qwen35 (dense) and qwen35moe expert-placement budgeting.

--- a/server/src/placement/placement_config.h
+++ b/server/src/placement/placement_config.h
@@ -9,7 +9,9 @@
 
 #include "placement_backend.h"
 
+#include <cerrno>
 #include <cstdlib>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -93,8 +95,10 @@ inline bool parse_placement_device(const std::string & value,
 
     const std::string gpu_text = value.substr(sep + 1);
     char * end = nullptr;
+    errno = 0;
     long gpu = std::strtol(gpu_text.c_str(), &end, 10);
-    if (end == gpu_text.c_str() || *end != '\0' || gpu < 0) {
+    if (end == gpu_text.c_str() || *end != '\0' || errno == ERANGE ||
+        gpu < 0 || gpu > (std::numeric_limits<int>::max)()) {
         return false;
     }
 

--- a/server/src/qwen35/qwen35_backend.cpp
+++ b/server/src/qwen35/qwen35_backend.cpp
@@ -269,7 +269,7 @@ Qwen35Backend::~Qwen35Backend() { shutdown(); }
 KvFlashAutoBudget Qwen35Backend::make_kvflash_budget(const TargetWeights & w,
                                                      int64_t gpu_free) const {
     ggml_type kv_k = GGML_TYPE_Q8_0, kv_v = GGML_TYPE_Q8_0;
-    dflash::resolve_kv_types(kv_k, kv_v);
+    dflash::resolve_kv_types(kv_k, kv_v, cfg_.cache_type_k, cfg_.cache_type_v);
     KvFlashAutoBudget b;
     b.free_bytes      = gpu_free;
     // Single source of truth with the qwen35moe placement path — see kv_quant.h.
@@ -555,7 +555,7 @@ bool Qwen35Backend::init() {
     if (!create_target_cache(w_, cfg_.device.max_ctx, max_verify_tokens, target_backend_, cache_,
                              /*prefill_only=*/true, ctx_alloc,
                              cfg_.paged_attention, n_slots,
-                             fixed_chain.enabled)) {
+                             fixed_chain.enabled, cfg_.cache_type_k, cfg_.cache_type_v)) {
         std::fprintf(stderr, "cache: %s\n", dflash27b_last_error());
         return false;
     }

--- a/server/src/qwen35/qwen35_backend.h
+++ b/server/src/qwen35/qwen35_backend.h
@@ -54,6 +54,9 @@ struct Qwen35Config {
     int          stream_fd   = -1;
 
     // FA/KV
+    // Explicit per-model overrides; COUNT preserves environment/family defaults.
+    ggml_type    cache_type_k = GGML_TYPE_COUNT;
+    ggml_type    cache_type_v = GGML_TYPE_COUNT;
     int          fa_window       = 0;  // 0 = full attention. qwen3.6 full-attn layers must see the whole context; a finite window drops the system prompt/tools -> breaks tool calls.
     bool         paged_attention = false;
     int          kq_stride_pad   = 32;   // KQ_MASK_PAD or 256 for TBQ

--- a/server/src/qwen35/qwen35_target_graph.cpp
+++ b/server/src/qwen35/qwen35_target_graph.cpp
@@ -108,13 +108,14 @@ bool create_target_cache(const TargetWeights & w,
                          int ctx_alloc,
                          bool paged_attention,
                          int n_seq_slots,
-                         bool concurrent_tree) {
+                         bool concurrent_tree,
+                         ggml_type cache_type_k, ggml_type cache_type_v) {
     return create_target_cache_partial(w, max_ctx, max_verify_tokens, backend,
                                        out, prefill_only,
                                        0, w.n_layer, true, ctx_alloc,
                                        /*f32_ssm_intermediates=*/false,
                                        paged_attention, n_seq_slots,
-                                       concurrent_tree);
+                                       concurrent_tree, cache_type_k, cache_type_v);
 }
 
 // concurrent_fixed_cache_bytes() in qwen35_backend.cpp mirrors this
@@ -133,7 +134,8 @@ bool create_target_cache_partial(const TargetWeights & w,
                                  bool f32_ssm_intermediates,
                                  bool paged_attention,
                                  int n_seq_slots,
-                                 bool concurrent_tree) {
+                                 bool concurrent_tree,
+                         ggml_type cache_type_k, ggml_type cache_type_v) {
     if (layer_begin < 0) layer_begin = 0;
     if (layer_end < 0 || layer_end > w.n_layer) layer_end = w.n_layer;
     if (layer_begin > layer_end) {
@@ -176,7 +178,7 @@ bool create_target_cache_partial(const TargetWeights & w,
     // KV cache element types (resolved from env; aborts on unsupported pair).
     ggml_type kv_k_type = GGML_TYPE_Q8_0;
     ggml_type kv_v_type = GGML_TYPE_Q8_0;
-    dflash::resolve_kv_types(kv_k_type, kv_v_type);
+    dflash::resolve_kv_types(kv_k_type, kv_v_type, cache_type_k, cache_type_v);
     out.kv_k_type = kv_k_type;
     out.kv_v_type = kv_v_type;
 

--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -18,6 +18,7 @@
 
 #include "http_server.h"
 #include "admission.h"
+#include "common/concurrency/seq_engine.h"
 #include "sse_emitter.h"
 #include "prompt_normalize.h"
 #include "tool_hint.h"
@@ -1112,6 +1113,67 @@ static std::array<uint8_t, 16> compute_disk_cache_salt(const ServerConfig & cfg)
     return salt;
 }
 
+// One source for model discovery in both single- and multi-model serving.
+static json model_list(const ServerConfig & config, bool codex_schema) {
+    // Codex sends ?client_version= — serve the Codex-specific schema.
+    if (codex_schema) {
+        json codex_models = {
+            {"models", json::array({
+                {{"slug", config.model_name},
+                 {"display_name", config.model_name},
+                 {"description", "Local DFlash speculative-decoding server"},
+                 {"default_reasoning_level", "low"},
+                 // Spec §4.2: every tier activates the phase-1 envelope;
+                 // the difference is the budget cap selected from the
+                 // model card's effort_tiers. Descriptions surface the
+                 // resolved cap so clients can pick a tier purposefully.
+                 {"supported_reasoning_levels", json::array({
+                     {{"effort", "low"},
+                      {"description", "Phase-1 budget at the model card's low tier ("
+                                      + std::to_string(config.effort_tiers.low)
+                                      + " tokens)"}},
+                     {{"effort", "medium"},
+                      {"description", "Phase-1 budget at the model card's medium tier ("
+                                      + std::to_string(config.effort_tiers.medium)
+                                      + " tokens)"}},
+                     {{"effort", "high"},
+                      {"description", "Phase-1 budget at the model card's standard recommendation ("
+                                      + std::to_string(config.effort_tiers.high)
+                                      + " tokens)"}},
+                     {{"effort", "x-high"},
+                      {"description", "Phase-1 budget between high and the complex-problem ceiling ("
+                                      + std::to_string(config.effort_tiers.x_high)
+                                      + " tokens)"}},
+                     {{"effort", "max"},
+                      {"description", "Phase-1 budget at the model card's complex-problem ceiling ("
+                                      + std::to_string(config.effort_tiers.max)
+                                      + " tokens)"}},
+                 })},
+                 {"shell_type", "shell_command"},
+                 {"visibility", "list"},
+                 {"supported_in_api", true},
+                 {"priority", 1},
+                 {"context_window", config.max_ctx},
+                 {"supports_reasoning_summaries", false},
+                 {"supports_parallel_tool_calls", false}}
+            })}
+        };
+        return codex_models;
+    }
+    json models = {
+        {"object", "list"},
+        {"data", json::array({
+            {{"id", config.model_name},
+             {"object", "model"},
+             {"owned_by", "dflash"},
+             {"created", 1700000000},
+             {"context_length", config.max_ctx},
+             {"max_context_length", config.max_ctx}}
+        })}
+    };
+    return models;
+}
+
 // ─── HttpServer ─────────────────────────────────────────────────────────
 
 HttpServer::HttpServer(ModelBackend & backend,
@@ -1370,7 +1432,47 @@ void HttpServer::shutdown() {
     }
 }
 
-int HttpServer::run() {
+void HttpServer::start_worker() {
+    // A backend-provided sequence engine replaces the one-request worker
+    // with the concurrent scheduler. Upstream forwarding stays on the
+    // classic path even when the local backend exposes an engine.
+    if (SeqEngine * engine = backend_.seq_engine();
+        engine && config_.pflash_upstream_base.empty()) {
+        worker_thread_ =
+            std::thread([this, engine]() { scheduler_loop(*engine); });
+    } else {
+        worker_thread_ = std::thread([this]() { worker_loop(); });
+    }
+}
+
+int HttpServer::run(const std::vector<HttpServer *> & models) {
+    if (!models.empty()) {
+        if (models.size() < 2 || models.front() != this) {
+            std::fprintf(stderr, "[server] model routing requires this listener first and at least two models\n");
+            return 2;
+        }
+        std::unordered_set<std::string> names;
+        std::unordered_set<ModelBackend *> backends;
+        for (HttpServer * model : models) {
+            SeqEngine * engine = model ? model->backend_.seq_engine() : nullptr;
+            if (!model || (engine && engine->slot_count() < 1) ||
+                model->worker_thread_.joinable() ||
+                !model->config_.pflash_upstream_base.empty() ||
+                model->config_.model_name.empty() || model->config_.model_name == "auto" ||
+                !names.insert(model->config_.model_name).second ||
+                !backends.insert(&model->backend_).second) {
+                std::fprintf(stderr, "[server] model routing requires distinct local backends and unique names other than auto\n");
+                return 2;
+            }
+        }
+        for (HttpServer * model : models) {
+            SeqEngine * engine = model->backend_.seq_engine();
+            models_.push_back({model, engine ? engine->slot_count() : 1});
+            // CORS belongs to the one listener even when a peer formats output.
+            model->config_.enable_cors = config_.enable_cors;
+        }
+    }
+
 #if !defined(_WIN32)
     // Ignore SIGPIPE so send() returns EPIPE instead of killing the process.
     signal(SIGPIPE, SIG_IGN);
@@ -1437,15 +1539,10 @@ int HttpServer::run() {
     std::fprintf(stderr, "[server] listening on http://%s:%d\n",
                  config_.host.c_str(), config_.port);
 
-    // A backend-provided sequence engine replaces the one-request worker
-    // with the concurrent scheduler. Upstream forwarding stays on the
-    // classic path even when the local backend exposes an engine.
-    if (SeqEngine * engine = backend_.seq_engine();
-        engine && config_.pflash_upstream_base.empty()) {
-        worker_thread_ =
-            std::thread([this, engine]() { scheduler_loop(*engine); });
+    if (models_.empty()) {
+        start_worker();
     } else {
-        worker_thread_ = std::thread([this]() { worker_loop(); });
+        for (auto & model : models_) model.server->start_worker();
     }
 
     // Accept loop.
@@ -1479,35 +1576,31 @@ int HttpServer::run() {
         active_clients_.fetch_add(1);
         std::thread([this, client_fd]() {
             handle_client(client_fd);
-            if (active_clients_.fetch_sub(1) == 1) {
-                std::lock_guard<std::mutex> lk(clients_mu_);
-                clients_cv_.notify_all();
-            }
+            // Publish completion under the same lock used by run()'s wait.
+            // Once it observes zero, no detached handler may touch this object.
+            std::lock_guard<std::mutex> lk(clients_mu_);
+            if (active_clients_.fetch_sub(1) == 1) clients_cv_.notify_all();
         }).detach();
     }
 
-    // Wake the worker thread so it can observe stopping_ and exit.
-    queue_cv_.notify_all();
-
-    // Wait for client threads to drain, but bound it: a client mid-stream (long
-    // SSE generation) must not hold the process resident on shutdown. After the
-    // grace period we proceed — detached client threads are torn down on exit.
-    {
-        std::unique_lock<std::mutex> lk(clients_mu_);
-        bool drained = clients_cv_.wait_for(
-            lk, std::chrono::seconds(5),
-            [this]() { return active_clients_.load() == 0; });
-        if (!drained) {
-            std::fprintf(stderr,
-                         "[server] shutdown: %d client thread(s) still active "
-                         "after grace period, exiting anyway\n",
-                         active_clients_.load());
-        }
+    auto stop_worker = [](HttpServer * server) {
+        server->request_stop();
+        server->queue_cv_.notify_all();
+    };
+    routing_cv_.notify_all();
+    stop_worker(this);
+    for (auto & model : models_) stop_worker(model.server);
+    if (worker_thread_.joinable()) worker_thread_.join();
+    for (auto & model : models_) {
+        if (model.server->worker_thread_.joinable()) model.server->worker_thread_.join();
     }
 
-    // Wait for worker to finish.
-    if (worker_thread_.joinable()) {
-        worker_thread_.join();
+    // Every handler borrows a model context. Do not destroy those contexts
+    // after an arbitrary grace period. Reads poll stopping_; workers have
+    // retired all jobs and unblocked their client monitors before this wait.
+    {
+        std::unique_lock<std::mutex> lk(clients_mu_);
+        clients_cv_.wait(lk, [this]() { return active_clients_.load() == 0; });
     }
 
     // Persist disk cache (worker joined — no race on slot_tokens_).
@@ -1524,12 +1617,8 @@ int HttpServer::run() {
     }
 
 #if defined(_WIN32)
-    // Intentionally NOT calling WSACleanup() here. Detached client threads
-    // may still be running after the 5-second shutdown grace period (e.g. a
-    // client mid-stream on a long SSE generation). Tearing down Winsock
-    // underneath them causes spurious socket errors. The OS reclaims all
-    // Winsock resources on process exit, so retaining it for the full process
-    // lifetime is safe and avoids the race.
+    // Status-event sockets remain owned until shutdown(). Keep Winsock alive
+    // for their cleanup; the process reclaims the global runtime on exit.
 #endif
 
     return 0;
@@ -1557,6 +1646,23 @@ void HttpServer::handle_client(SocketHandle fd) {
         send_response(fd, 200, "application/json", "{\"status\":\"ok\"}\n");
         socket_close(fd);
         return;
+    }
+
+    if (!models_.empty() && hr.method == "GET") {
+        if (hr.path == "/props" || hr.path == "/status/json") {
+            json body = hr.path == "/props"
+                ? build_props_body(config_, prefix_cache_, tool_memory_)
+                : status_.to_json();
+            body.update(model_routing_status());
+            send_response(fd, 200, "application/json", body.dump() + "\n");
+            socket_close(fd);
+            return;
+        }
+        if (hr.path == "/status" || hr.path == "/status/events") {
+            send_error(fd, 404, "multi-model status is available at /status/json");
+            socket_close(fd);
+            return;
+        }
     }
 
     // Introspection: server config + cache stats + arch + capabilities.
@@ -1622,67 +1728,18 @@ void HttpServer::handle_client(SocketHandle fd) {
         return;  // Do NOT close fd — it's now owned by the SSE broadcast loop.
     }
 
-    // Models endpoint.
+    // Models endpoint (including the existing Codex discovery schema).
     if (hr.method == "GET" && hr.path == "/v1/models") {
-        // Codex sends ?client_version= — serve the Codex-specific schema.
-        if (hr.query.find("client_version") != std::string::npos) {
-            json codex_models = {
-                {"models", json::array({
-                    {{"slug", config_.model_name},
-                     {"display_name", config_.model_name},
-                     {"description", "Local DFlash speculative-decoding server"},
-                     {"default_reasoning_level", "low"},
-                     // Spec §4.2: every tier activates the phase-1 envelope;
-                     // the difference is the budget cap selected from the
-                     // model card's effort_tiers. Descriptions surface the
-                     // resolved cap so clients can pick a tier purposefully.
-                     {"supported_reasoning_levels", json::array({
-                         {{"effort", "low"},
-                          {"description", "Phase-1 budget at the model card's low tier ("
-                                          + std::to_string(config_.effort_tiers.low)
-                                          + " tokens)"}},
-                         {{"effort", "medium"},
-                          {"description", "Phase-1 budget at the model card's medium tier ("
-                                          + std::to_string(config_.effort_tiers.medium)
-                                          + " tokens)"}},
-                         {{"effort", "high"},
-                          {"description", "Phase-1 budget at the model card's standard recommendation ("
-                                          + std::to_string(config_.effort_tiers.high)
-                                          + " tokens)"}},
-                         {{"effort", "x-high"},
-                          {"description", "Phase-1 budget between high and the complex-problem ceiling ("
-                                          + std::to_string(config_.effort_tiers.x_high)
-                                          + " tokens)"}},
-                         {{"effort", "max"},
-                          {"description", "Phase-1 budget at the model card's complex-problem ceiling ("
-                                          + std::to_string(config_.effort_tiers.max)
-                                          + " tokens)"}},
-                     })},
-                     {"shell_type", "shell_command"},
-                     {"visibility", "list"},
-                     {"supported_in_api", true},
-                     {"priority", 1},
-                     {"context_window", config_.max_ctx},
-                     {"supports_reasoning_summaries", false},
-                     {"supports_parallel_tool_calls", false}}
-                })}
-            };
-            send_response(fd, 200, "application/json", codex_models.dump() + "\n");
-            socket_close(fd);
-            return;
+        const bool codex_schema = hr.query.find("client_version") != std::string::npos;
+        json response = model_list(config_, codex_schema);
+        if (!models_.empty()) {
+            const char * key = codex_schema ? "models" : "data";
+            for (size_t i = 0; i < models_.size(); ++i) {
+                const auto & cfg = models_[i].server->config_;
+                if (i != 0) response[key].push_back(model_list(cfg, codex_schema)[key][0]);
+            }
         }
-        json models = {
-            {"object", "list"},
-            {"data", json::array({
-                {{"id", config_.model_name},
-                 {"object", "model"},
-                 {"owned_by", "dflash"},
-                 {"created", 1700000000},
-                 {"context_length", config_.max_ctx},
-                 {"max_context_length", config_.max_ctx}}
-            })}
-        };
-        send_response(fd, 200, "application/json", models.dump() + "\n");
+        send_response(fd, 200, "application/json", response.dump() + "\n");
         socket_close(fd);
         return;
     }
@@ -1694,6 +1751,131 @@ void HttpServer::handle_client(SocketHandle fd) {
     socket_close(fd);
 }
 
+// Endpoint structure is parsed once by the listener. Model defaults, templates
+// and token IDs are resolved only by the selected model's handler.
+bool HttpServer::route_model_request(SocketHandle fd, ParsedRequest & req,
+                                     bool count_only) {
+    json & body = req.raw_body;
+    const std::string requested = body.value("model", std::string());
+    const bool unnamed = requested.empty() || requested == "auto";
+    if (count_only && unnamed) {
+        send_error(fd, 400, "token counting requires an explicit model name");
+        return true;
+    }
+    // Generation always follows operator priority. Only token counting needs
+    // an explicit tokenizer, since no generating model has been selected yet.
+    const bool automatic = !count_only;
+
+    // A routing reservation owns a backend slot through retirement and output
+    // draining. Engine admission, on its worker, remains the KV authority.
+    struct Reservation {
+        HttpServer & owner;
+        RoutedModel * model;
+        RoutingAdmission admission = RoutingAdmission::handled;
+        ~Reservation() {
+            if (!model) return;
+            std::lock_guard<std::mutex> lock(owner.routing_mu_);
+            --model->in_flight;
+            // Busy/unfit probes released no engine capacity. Waking peers
+            // here makes waiting clients repeatedly trigger each other.
+            if (admission == RoutingAdmission::handled) owner.routing_cv_.notify_all();
+        }
+    };
+    struct Waiting {
+        HttpServer & owner;
+        bool active = false;
+        ~Waiting() {
+            if (!active) return;
+            std::lock_guard<std::mutex> lock(owner.routing_mu_);
+            --owner.routing_waiters_;
+        }
+    } waiting{*this};
+
+    std::unordered_set<HttpServer *> unfit;
+    for (;;) {
+        if (http_detail::inspect_peer_socket(fd) ==
+                http_detail::PeerSocketState::Disconnected) return true;
+        bool known = automatic;
+        for (auto & model : models_) {
+            if (!automatic && requested != model.server->config_.model_name) continue;
+            known = true;
+            if (unfit.count(model.server)) continue;
+            {
+                std::lock_guard<std::mutex> lock(routing_mu_);
+                if (stopping_.load()) break;
+                if (!count_only && model.in_flight >= model.capacity) continue;
+                if (!count_only) ++model.in_flight;
+                if (waiting.active) {
+                    --routing_waiters_;
+                    waiting.active = false;
+                }
+            }
+            Reservation reservation{*this, count_only ? nullptr : &model};
+            // Always restart from the endpoint parse, before any model-specific
+            // template, tokenizer, reasoning or sampler defaults were applied.
+            ParsedRequest attempt = req;
+            attempt.raw_body["model"] = model.server->config_.model_name;
+            model.server->handle_model_request(fd, attempt, count_only,
+                                               &reservation.admission);
+            if (reservation.admission == RoutingAdmission::handled) return true;
+            if (reservation.admission == RoutingAdmission::unfit) {
+                if (!automatic) {
+                    send_error(fd, 400, "request exceeds model context or KV pool capacity");
+                    return true;
+                }
+                unfit.insert(model.server);
+            }
+        }
+        if (unfit.size() == models_.size()) {
+            send_error(fd, 400, "request exceeds the context or KV pool capacity of every model");
+            return true;
+        }
+        if (!known) {
+            send_error(fd, 404, "unknown model '" + requested + "'");
+            return true;
+        }
+        if (!automatic || stopping_.load()) {
+            send_error(fd, 503, "no available model capacity or server stopping");
+            return true;
+        }
+        std::unique_lock<std::mutex> lock(routing_mu_);
+        if (!waiting.active) {
+            if (routing_waiters_ >= config_.routing_queue_limit) {
+                lock.unlock();
+                send_error(fd, 503, "model routing waiting queue is full");
+                return true;
+            }
+            ++routing_waiters_;
+            waiting.active = true;
+        }
+        // Capacity can also change inside an engine without HTTP retirement.
+        // A bounded retry probes that state on its owning worker and observes
+        // cancellation/shutdown even when all model reservations stay occupied.
+        routing_cv_.wait_for(lock, kClientMonitorInterval);
+        lock.unlock();
+        if (http_detail::inspect_peer_socket(fd) ==
+                http_detail::PeerSocketState::Disconnected) return true;
+    }
+}
+
+json HttpServer::model_routing_status() {
+    json models = json::array();
+    std::lock_guard<std::mutex> lock(routing_mu_);
+    for (const auto & model : models_) {
+        HttpServer & server = *model.server;
+        models.push_back({{"id", server.config_.model_name},
+            {"capacity", model.capacity}, {"in_flight", model.in_flight},
+            {"execution_mode", server.backend_.seq_engine() ? "batched" : "single-request"},
+            {"target_device", server.config_.target_device},
+            {"draft_device", server.config_.draft_device},
+            {"max_context", server.config_.max_ctx},
+            {"props", build_props_body(server.config_, server.prefix_cache_, server.tool_memory_)},
+            {"status", server.status_.to_json()}});
+    }
+    return {{"routing", "primary-first"}, {"waiting", routing_waiters_},
+            {"queue_limit", config_.routing_queue_limit}, {"models", models}};
+}
+
 // ─── Request parsing ────────────────────────────────────────────────────
 
 // Fields shared by every endpoint: stream/model/max-tokens, sampler,
@@ -1701,7 +1883,7 @@ void HttpServer::handle_client(SocketHandle fd) {
 bool HttpServer::parse_common_request_fields(
         SocketHandle fd, const json & body, ParsedRequest & req) {
     req.stream = body.value("stream", false);
-    req.model = body.value("model", config_.model_name);
+    req.model = config_.model_name;
     req.disk_cache_policy = config_.disk_cache_policy;
 
     // Accept the output-token names used by each supported API dialect.
@@ -2058,7 +2240,7 @@ bool HttpServer::render_and_tokenize_request(
 // Context-length gate. Oversized prompts pass through when compression
 // (pflash) will run — the post-compress check is the real gate.
 bool HttpServer::validate_request_context(
-        SocketHandle fd, const ParsedRequest & req) {
+        SocketHandle fd, const ParsedRequest & req, bool send_failure) {
     const int prompt_tokens = (int) req.prompt_tokens.size();
     const bool pflash_will_run =
         config_.pflash_mode != ServerConfig::PflashMode::OFF &&
@@ -2069,7 +2251,7 @@ bool HttpServer::validate_request_context(
             prompt_tokens, req.max_output, config_.max_ctx, pflash_will_run)) {
         return true;
     }
-    send_error(fd, 400,
+    if (send_failure) send_error(fd, 400,
                context_overflow_message(
                    config_.max_ctx, prompt_tokens, req.max_output));
     return false;
@@ -2092,13 +2274,15 @@ void HttpServer::log_parsed_request(const ParsedRequest & req) const {
         req.stop_sequences.size(), req.model.c_str());
 }
 
-void HttpServer::enqueue_request_and_wait(SocketHandle fd, ParsedRequest req) {
+RoutingAdmission HttpServer::enqueue_request_and_wait(SocketHandle fd, ParsedRequest req,
+                                           bool report_admission) {
     // Set socket non-blocking for send() stall detection during streaming.
     sock_set_nonblock(fd);
 
     ServerJob job;
     job.fd = fd;
     job.req = std::move(req);
+    job.report_admission = report_admission;
     enqueue(&job);
 
     // The worker can spend minutes in prefill before its first token. Keep the
@@ -2122,6 +2306,7 @@ void HttpServer::enqueue_request_and_wait(SocketHandle fd, ParsedRequest req) {
         }
         lock.lock();
     }
+    return job.admission;
 }
 
 bool HttpServer::route_request(SocketHandle fd, const HttpRequest & hr) {
@@ -2133,12 +2318,24 @@ bool HttpServer::route_request(SocketHandle fd, const HttpRequest & hr) {
     ParsedRequest req;
     bool count_tokens_only = false;
     try {
-        const json body = json::parse(hr.body);
-        req.raw_body = body;
-        if (!parse_common_request_fields(fd, body, req)) return true;
+        req.raw_body = json::parse(hr.body);
         if (!parse_endpoint_request(
-                hr.path, body, req, count_tokens_only)) return false;
+                hr.path, req.raw_body, req, count_tokens_only)) return false;
+        return models_.empty()
+            ? handle_model_request(fd, req, count_tokens_only)
+            : route_model_request(fd, req, count_tokens_only);
+    } catch (const std::exception & e) {
+        send_error(fd, 400, std::string("JSON parse error: ") + e.what());
+        return true;
+    }
+}
 
+bool HttpServer::handle_model_request(SocketHandle fd, ParsedRequest & req,
+                                      bool count_tokens_only,
+                                      RoutingAdmission * admission) {
+    try {
+        const json & body = req.raw_body;
+        if (!parse_common_request_fields(fd, body, req)) return true;
         const std::vector<ChatMessage> chat_messages =
             normalize_chat_messages(req.messages, req.format, tool_memory_);
         // Reasoning must be applied BEFORE rendering: the template injects
@@ -2187,9 +2384,13 @@ bool HttpServer::route_request(SocketHandle fd, const HttpRequest & hr) {
         return true;
     }
 
-    if (!validate_request_context(fd, req)) return true;
+    if (!validate_request_context(fd, req, admission == nullptr)) {
+        if (admission) *admission = RoutingAdmission::unfit;
+        return true;
+    }
     log_parsed_request(req);
-    enqueue_request_and_wait(fd, std::move(req));
+    const auto outcome = enqueue_request_and_wait(fd, std::move(req), admission != nullptr);
+    if (admission) *admission = outcome;
     return true;
 }
 
@@ -4255,8 +4456,9 @@ void HttpServer::process_job(ServerJob * job) {
 void HttpServer::enqueue(ServerJob * job) {
     std::lock_guard<std::mutex> lk(queue_mu_);
     if (stopping_.load()) {
-        // Server is shutting down — immediately signal job as done.
+        // Return routed requests to the listener for a shutdown response.
         std::lock_guard<std::mutex> jlk(job->mu);
+        job->admission = RoutingAdmission::busy;
         job->done = true;
         job->cv.notify_one();
         return;
@@ -4322,11 +4524,20 @@ ServerJob * HttpServer::dequeue_for(
 // ─── HTTP I/O ───────────────────────────────────────────────────────────
 
 bool HttpServer::read_http_request(SocketHandle fd, HttpRequest & out) {
-#if defined(_WIN32)
-    // On Windows, accept() may return a socket that inherits the non-blocking
-    // mode of the listen socket. Force blocking mode for reliable recv().
-    sock_set_block(fd);
-#endif
+    sock_set_nonblock(fd);
+    auto receive = [&](char * data, size_t size) -> ssize_t {
+        while (!stopping_.load()) {
+            struct pollfd pfd{fd, POLLIN, 0};
+            const int ready = poll(&pfd, 1, 100);
+            if (ready < 0 && sock_is_eintr(sock_errno())) continue;
+            if (ready < 0 || (pfd.revents & (POLLERR | POLLNVAL))) return -1;
+            if (ready == 0) continue;
+            const ssize_t n = recv(fd, data, size, 0);
+            if (n < 0 && (sock_is_eintr(sock_errno()) || sock_is_eagain(sock_errno()))) continue;
+            return n;
+        }
+        return -1;
+    };
     std::string buf;
     buf.reserve(8192);
     char tmp[4096];
@@ -4334,15 +4545,7 @@ bool HttpServer::read_http_request(SocketHandle fd, HttpRequest & out) {
     // Read until we find the header/body boundary (\r\n\r\n or \n\n).
     ssize_t hend = -1;
     while (hend < 0 && buf.size() < 65536) {
-        ssize_t n = recv(fd, tmp, sizeof(tmp), 0);
-        if (n < 0 && sock_is_eintr(sock_errno())) continue;
-#if defined(_WIN32)
-        if (n < 0 && sock_is_eagain(sock_errno())) {
-            struct pollfd pfd{fd, POLLIN, 0};
-            poll(&pfd, 1, 1000);
-            continue;
-        }
-#endif
+        ssize_t n = receive(tmp, sizeof(tmp));
         if (n <= 0) return false;
         buf.append(tmp, n);
 
@@ -4407,15 +4610,7 @@ bool HttpServer::read_http_request(SocketHandle fd, HttpRequest & out) {
 
     // Read body.
     while ((ssize_t)buf.size() < hend + content_length) {
-        ssize_t n = recv(fd, tmp, sizeof(tmp), 0);
-        if (n < 0 && sock_is_eintr(sock_errno())) continue;
-#if defined(_WIN32)
-        if (n < 0 && sock_is_eagain(sock_errno())) {
-            struct pollfd pfd{fd, POLLIN, 0};
-            poll(&pfd, 1, 1000);
-            continue;
-        }
-#endif
+        ssize_t n = receive(tmp, sizeof(tmp));
         if (n <= 0) return false;
         buf.append(tmp, n);
     }
@@ -4564,6 +4759,15 @@ bool HttpServer::send_response(
         const std::string & body) {
     const std::string payload =
         format_http_response(status, content_type, body);
+    if (status == 503 && stopping_.load()) {
+        // Reject unstarted requests without delaying shutdown for a stalled
+        // reader. Active native requests keep the normal send/drain path;
+        // the socket closes when its handler returns.
+        sock_set_nonblock(fd);
+        ClientSendBuffer pending;
+        pending.append(payload);
+        return pending.flush(fd) && pending.empty();
+    }
     return send_all(fd, payload.data(), payload.size());
 }
 

--- a/server/src/server/http_server.h
+++ b/server/src/server/http_server.h
@@ -56,6 +56,9 @@ using json = nlohmann::json;
 // ─── Forward declarations ───────────────────────────────────────────────
 struct ServerJob;
 
+// Admission feedback is returned before any response bytes or model compute.
+enum class RoutingAdmission { handled, busy, unfit };
+
 namespace http_detail {
 // Non-consuming peer-state probe used by the client-thread job monitor.
 // A read half-close is not a disconnect: HTTP clients may finish writing a
@@ -88,6 +91,7 @@ struct ServerConfig {
     std::string host        = "0.0.0.0";
     int         port        = 8080;
     int         max_tokens  = 4096;     // default max output tokens (legacy alias for default_max_tokens)
+    int         routing_queue_limit = 32; // waiting auto requests across the listener
     int         max_ctx     = 0;        // 0 = use backend's DevicePlacement default (8192)
     bool        enable_cors = true;
     std::string model_name  = "dflash";
@@ -360,10 +364,13 @@ public:
     // Set the chat template format (detected from model arch).
     void set_chat_format(ChatFormat fmt) { chat_format_ = fmt; }
 
-    // Start listening. Blocks until shutdown() is called.
-    int run();
+    // Start one listener. Optional model contexts are borrowed until run()
+    // returns and must include this first. Model names must be explicit and unique.
+    // Each context gets its existing scheduler or single-request worker, never another socket.
+    int run(const std::vector<HttpServer *> & models = {});
 
-    // Signal the server to stop accepting new connections and drain.
+    // Finalize after run() returns; also called by the destructor.
+    // Use request_stop() to stop a running listener from another thread.
     void shutdown();
 
     // Async-signal-safe: only sets the stopping flag. The accept loop polls
@@ -378,6 +385,13 @@ public:
 private:
     // Client thread: read HTTP request, parse, enqueue job, wait.
     void handle_client(SocketHandle fd);
+
+    struct HttpRequest;
+    void start_worker();
+    bool route_model_request(SocketHandle fd, ParsedRequest & req, bool count_only);
+    bool handle_model_request(SocketHandle fd, ParsedRequest & req, bool count_only,
+                              RoutingAdmission * admission = nullptr);
+    json model_routing_status();
 
     // Worker thread: process jobs sequentially. process_job owns the
     // lifecycle of one dequeued request, including signaling completion.
@@ -516,9 +530,11 @@ private:
         const std::vector<ChatMessage> & chat_messages,
         const ParsedRequest & req, bool add_generation_prompt,
         std::string & rendered, std::string & error);
-    bool validate_request_context(SocketHandle fd, const ParsedRequest & req);
+    bool validate_request_context(SocketHandle fd, const ParsedRequest & req,
+                                  bool send_failure = true);
     void log_parsed_request(const ParsedRequest & req) const;
-    void enqueue_request_and_wait(SocketHandle fd, ParsedRequest req);
+    RoutingAdmission enqueue_request_and_wait(SocketHandle fd, ParsedRequest req,
+                                  bool report_admission = false);
 
     // Send HTTP response helpers.
     bool send_response(SocketHandle fd, int status, const std::string & content_type,
@@ -599,6 +615,19 @@ private:
     std::unordered_map<PrefixHash, std::string,
                        PrefixHashHasher, PrefixHashEqual> frozen_content_cache_;
 
+    // Immutable model table after run() starts; only reservations mutate under
+    // routing_mu_. A reservation spans parsing through job retirement/output
+    // draining, so disconnects never make still-running engine work invisible.
+    struct RoutedModel {
+        HttpServer * server;
+        int capacity;
+        int in_flight = 0;
+    };
+    std::vector<RoutedModel> models_;
+    std::mutex routing_mu_;
+    std::condition_variable routing_cv_;
+    int routing_waiters_ = 0;
+
     // Worker thread.
     std::thread                     worker_thread_;
     std::mutex                      queue_mu_;
@@ -635,12 +664,12 @@ struct ServerJob {
 
     // Concurrent-scheduler state that survives a pool-full admission retry.
     // The classic worker leaves these fields untouched.
+    bool          report_admission = false; // return busy before committing a response
+    RoutingAdmission admission = RoutingAdmission::handled; // published with done
     bool          announced = false;
-    bool          sse_started = false;
     // First concurrent-scheduler attempt; retained across busy deferrals so
     // server-side prefill/elapsed telemetry does not erase queueing delay.
     std::chrono::steady_clock::time_point parallel_started_at{};
-    std::unique_ptr<SseEmitter> emitter;
 };
 
 // ─── Parse session_id from a chat-completion JSON body ──────────────────

--- a/server/src/server/scheduler.cpp
+++ b/server/src/server/scheduler.cpp
@@ -417,22 +417,46 @@ void HttpServer::scheduler_loop(SeqEngine & engine) {
                 req.max_output, live_slots);
         }
 
-        // Commit the SSE preamble BEFORE the (multi-second) prefill so
-        // streaming clients see the 200 immediately — and so a dead client
-        // is detected before its prefill is paid for. The socket is fresh
-        // (nothing sent yet), so these few hundred bytes cannot stall.
-        // sse_started survives a busy deferral: retries do not resend.
-        if (!job->emitter) {
-            job->emitter = std::make_unique<SseEmitter>(
-                req.format, req.response_id, req.model,
-                (int)req.prompt_tokens.size(), req.tools, &tool_memory_,
-                req.stop_sequences, req.started_in_thinking);
+        // Admission only claims the slot and queues the prompt. Prefill
+        // advances one chunk per engine step alongside live decode.
+        auto ar = engine.admit(next_request_id, req.prompt_tokens,
+                               req.sampler);
+        if (ar.status == SeqEngine::AdmitResult::Status::capacity_exceeded) {
+            if (job->report_admission) {
+                job->admission = RoutingAdmission::unfit;
+            } else {
+                send_error(job->fd, 400, "admission failed: " + ar.error);
+            }
+            finish_job(job);
+            return AdmissionDisposition::Retired;
         }
-        if (req.stream && !job->sse_started) {
-            job->sse_started = true;
+        if (ar.status == SeqEngine::AdmitResult::Status::busy) {
+            if (job->report_admission) {
+                job->admission = RoutingAdmission::busy;
+                finish_job(job);
+                return AdmissionDisposition::Retired;
+            }
+            return AdmissionDisposition::Deferred;
+        }
+        if (ar.status != SeqEngine::AdmitResult::Status::admitted) {
+            std::fprintf(stderr, "[server] admit failed: %s\n",
+                         ar.error.c_str());
+            send_error(job->fd, 500, "admission failed: " + ar.error);
+            finish_job(job);
+            return AdmissionDisposition::Retired;
+        }
+        next_request_id++;
+
+        // Commit response bytes only after admission. A busy routed request
+        // can still try another model; no tokenizer/model identity is on wire.
+        auto emitter = std::make_unique<SseEmitter>(
+            req.format, req.response_id, req.model,
+            (int)req.prompt_tokens.size(), req.tools, &tool_memory_,
+            req.stop_sequences, req.started_in_thinking);
+        if (req.stream) {
             bool ok = send_sse_headers(job);
             if (ok) {
-                for (const auto & c : job->emitter->emit_start()) {
+                for (const auto & c : emitter->emit_start()) {
                     if (!send_job_bytes(job, c.data(), c.size())) {
                         ok = false;
                         break;
@@ -440,36 +464,13 @@ void HttpServer::scheduler_loop(SeqEngine & engine) {
                 }
             }
             if (!ok) {
+                engine.retire(ar.slot);
                 finish_job(job);
                 return AdmissionDisposition::Retired;
             }
             start_job_stream(job);
         }
 
-        // Admission only claims the slot and queues the prompt. Prefill
-        // advances one chunk per engine step alongside live decode.
-        auto ar = engine.admit(next_request_id, req.prompt_tokens,
-                               req.sampler);
-        if (ar.status == SeqEngine::AdmitResult::Status::busy)
-            return AdmissionDisposition::Deferred;
-        if (ar.status != SeqEngine::AdmitResult::Status::admitted) {
-            std::fprintf(stderr, "[server] admit failed: %s\n",
-                         ar.error.c_str());
-            if (req.stream && job->sse_started) {
-                stop_job_stream(job);
-                // Headers are already on the wire: report in-stream, like
-                // the classic worker's fail_request after SSE start.
-                for (const std::string & chunk : sse_error_close_chunks(
-                         "admission failed: " + ar.error)) {
-                    send_job_bytes(job, chunk.data(), chunk.size());
-                }
-            } else {
-                send_error(job->fd, 500, "admission failed: " + ar.error);
-            }
-            finish_job(job);
-            return AdmissionDisposition::Retired;
-        }
-        next_request_id++;
 
         SchedSlot & s = slots[(size_t)ar.slot];
         s = SchedSlot{};
@@ -482,7 +483,7 @@ void HttpServer::scheduler_loop(SeqEngine & engine) {
         s.n_gen_cap = std::min(
             n_gen_cap,
             engine.max_context() - (int)req.prompt_tokens.size() + 1);
-        s.emitter = std::move(job->emitter);
+        s.emitter = std::move(emitter);
         s.send_buffer.mark_progress(std::chrono::steady_clock::now());
         if (budget_active && !config_.think_close_token_ids.empty() &&
             config_.hard_limit_reply_budget > 0) {
@@ -749,19 +750,8 @@ void HttpServer::scheduler_loop(SeqEngine & engine) {
     for (DrainJob & d : drains) finish_job(d.job);
     drains.clear();
     if (deferred) {
-        // admit_job() sends the SSE headers and opening event before asking
-        // the engine for a slot, so a pool-full deferred stream is already
-        // live on the wire. Close that protocol cleanly on shutdown instead
-        // of waking the client thread and letting it truncate the response.
-        const ParsedRequest & req = deferred->req;
-        if (req.stream && deferred->sse_started) {
-            for (const std::string & chunk :
-                 sse_error_close_chunks("server shutting down")) {
-                send_all(deferred->fd, chunk.data(), chunk.size());
-            }
-        } else {
-            send_error(deferred->fd, 503, "server shutting down");
-        }
+        // No response has been committed for a deferred admission.
+        send_error(deferred->fd, 503, "server shutting down");
         finish_job(deferred);
     }
     // Jobs that never reached admission are still parked in their client

--- a/server/src/server/server_main.cpp
+++ b/server/src/server/server_main.cpp
@@ -26,6 +26,7 @@
 #include "placement/pflash_placement.h"
 #include "placement/draft_residency.h"
 #include "kvflash_pager.h"
+#include "kv_quant.h"
 
 #include <algorithm>
 #include <cerrno>
@@ -36,6 +37,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <memory>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -74,6 +76,11 @@ static void print_usage(const char * prog) {
         "Usage: %s <model.gguf> [options]\n"
         "\n"
         "Options:\n"
+        "  --model <path>      Begin a model block; set placement with --target-device.\n"
+        "  --load-balancing    Enable primary-first fallback (disabled by default).\n"
+        "  --load-balancing-primary-gpu <backend:gpu> Select the primary model by its target device.\n"
+        "                      Defaults to the first block; request model names\n"
+        "                      do not change generation routing.\n"
         "  --draft <path>       Draft model for speculative decode\n"
         "  --port <N>           Listen port (default: 8080)\n"
         "  --host <addr>        Bind address (default: 0.0.0.0)\n"
@@ -117,8 +124,9 @@ static void print_usage(const char * prog) {
         "  --paged-attention   Use paged autoregressive decode for dense Qwen3.5 and\n"
         "                       Qwen3.6 targets with 16-token blocks, or DeepSeek4\n"
         "                       targets with 128-token blocks. This mode is experimental.\n"
+        "  --routing-queue-limit <N> Maximum waiting auto requests (default: 32)\n"
         "  --max-concurrency <N>  Maximum concurrent decode sequences\n"
-        "                         (enables paged attention; default: 1)\n"
+        "                         (N > 1 enables paged attention; default: 1)\n"
         "  --admission-coalesce-ms <N>  Idle-to-busy batching window\n"
         "                               (default: 20; 0 disables)\n"
         "  --kv-pool-tokens <N> Total paged K/V pool shared by all\n"
@@ -232,23 +240,42 @@ static void print_usage(const char * prog) {
         "\n", prog);
 }
 
-int main(int argc, char ** argv) {
-    if (argc < 2 || argv[1][0] == '-') {
-        print_usage(argv[0]);
-        return 2;
-    }
+// Own everything borrowed by a model's HTTP/scheduler context. Shutdown must
+// join the worker and client users before releasing backend or tokenizer state.
+struct LoadedModel {
+    Tokenizer tokenizer;
+    Tokenizer drafter_tokenizer;
+    std::unique_ptr<ModelBackend> backend;
+    MoeRoutingCollector routing_collector;
+    std::unique_ptr<HttpServer> server;
+    bool freq_tracking = false;
 
-    // Parse arguments.
+    ~LoadedModel() {
+        server.reset();
+        if (!backend) return;
+        if (freq_tracking) {
+            if (const auto * stats = backend->get_routing_stats()) {
+                stats->print_freq_analysis();
+            } else {
+                std::fprintf(stderr, "[server] --freq: no routing stats available (model may not be MoE)\n");
+            }
+        }
+        if (routing_collector.is_open()) {
+            backend->set_routing_collector(nullptr);
+            routing_collector.close();
+        }
+        backend->shutdown();
+    }
+};
+
+struct ModelOptions {
     BackendArgs bargs;
     ServerConfig sconfig;
-    bargs.model_path = argv[1];
     bool   spark_autotune = false; // --spark: self-tuning hot/cold MoE residency
     int    spark_slots = -1;       // --spark-slots: explicit cache slots/layer (-1=auto)
     double spark_vram_gib = 0.0;   // --spark-vram: total VRAM target in GiB (0=use card)
     std::string cache_type_k;  // explicit --cache-type-k override
     std::string cache_type_v;  // explicit --cache-type-v override
-    bool target_device_seen = false;
-    bool target_devices_seen = false;
     bool fast_rollback_forced_off = false;
     bool target_split_fast_rollback_cli = false;
     bool adaptive_experts_set = false;  // --adaptive-experts (MoE architectures only)
@@ -271,6 +298,10 @@ int main(int argc, char ** argv) {
         bool effort_max              = false;
     } cli_set;
 
+    // Keep process-wide options inert until the selected model is loaded.
+    std::string adaptive_experts_tau;
+    std::string kvflash_pool, kvflash_policy, kvflash_tau;
+
     // Track whether the operator passed the legacy --max-tokens alias.
     // When set and --default-max-tokens is NOT also passed, --max-tokens
     // wins over the model card for default_max_tokens (it was a documented
@@ -279,7 +310,49 @@ int main(int argc, char ** argv) {
     bool legacy_max_tokens_set = false;
     int  legacy_max_tokens_val = 0;
 
+};
+
+static int parse_model_options(int argc, char ** argv, ModelOptions & model,
+                               bool load_balancing, bool first_model) {
+    if (argc < 2 || argv[1][0] == '-') {
+        print_usage(argv[0]);
+        return 2;
+    }
+    auto & bargs = model.bargs;
+    auto & sconfig = model.sconfig;
+    auto & spark_autotune = model.spark_autotune;
+    auto & spark_slots = model.spark_slots;
+    auto & spark_vram_gib = model.spark_vram_gib;
+    auto & cache_type_k = model.cache_type_k;
+    auto & cache_type_v = model.cache_type_v;
+    auto & fast_rollback_forced_off = model.fast_rollback_forced_off;
+    auto & target_split_fast_rollback_cli = model.target_split_fast_rollback_cli;
+    auto & adaptive_experts_set = model.adaptive_experts_set;
+    auto & ddtree_tau_set = model.ddtree_tau_set;
+    auto & specla_top_k_set = model.specla_top_k_set;
+    auto & specla_top_k = model.specla_top_k;
+    auto & cli_set = model.cli_set;
+    auto & legacy_max_tokens_set = model.legacy_max_tokens_set;
+    auto & legacy_max_tokens_val = model.legacy_max_tokens_val;
+    bool target_device_seen = false;
+    bool target_devices_seen = false;
+    bargs.model_path = argv[1];
+
     for (int i = 2; i < argc; i++) {
+        const std::string option = argv[i];
+        if (!first_model &&
+            (option == "--host" || option == "--port" || option == "--no-cors" || option == "--routing-queue-limit")) {
+            std::fprintf(stderr, "[server] %s belongs in the first model block: there is one listener\n", argv[i]);
+            return 2;
+        }
+        if (load_balancing && (option == "--peer-access" ||
+            option == "--no-fast-rollback" || option == "--target-split-fast-rollback" ||
+            option == "--adaptive-experts" || option == "--specla" ||
+            option == "--specla-top-k" || option.rfind("--kvflash", 0) == 0 ||
+            option.rfind("--spark", 0) == 0)) {
+            std::fprintf(stderr, "[server] %s changes process-wide policy and cannot be scoped to a model\n", argv[i]);
+            return 2;
+        }
         if (std::strcmp(argv[i], "--draft") == 0 && i + 1 < argc) {
             bargs.draft_path = argv[++i];
         } else if (std::strcmp(argv[i], "--port") == 0 && i + 1 < argc) {
@@ -396,6 +469,14 @@ int main(int argc, char ** argv) {
             bargs.fa_window = std::atoi(argv[++i]);
         } else if (std::strcmp(argv[i], "--paged-attention") == 0) {
             bargs.paged_attention = true;
+        } else if (std::strcmp(argv[i], "--routing-queue-limit") == 0 && i + 1 < argc) {
+            const char * value = argv[++i];
+            const char * end = value + std::strlen(value);
+            const auto parsed = std::from_chars(value, end, sconfig.routing_queue_limit);
+            if (parsed.ec != std::errc{} || parsed.ptr != end || sconfig.routing_queue_limit < 0) {
+                std::fprintf(stderr, "[server] --routing-queue-limit must be a nonnegative integer\n");
+                return 2;
+            }
         } else if (std::strcmp(argv[i], "--max-concurrency") == 0 && i + 1 < argc) {
             const char * value = argv[++i];
             const char * end = value + std::strlen(value);
@@ -487,7 +568,7 @@ int main(int argc, char ** argv) {
                     "--adaptive-experts: tau must be a float in (0,1], got \"%s\"\n", tau);
                 return 1;
             }
-            set_environment_variable("DFLASH_ADAPTIVE_K_TAU", tau, false);  // explicit env still wins
+            if (model.adaptive_experts_tau.empty()) model.adaptive_experts_tau = tau;
             adaptive_experts_set = true;
         } else if (std::strcmp(argv[i], "--verify-width") == 0 && i + 1 < argc) {
             bargs.verify_width = std::atoi(argv[++i]);
@@ -505,7 +586,7 @@ int main(int argc, char ** argv) {
                                      "'auto', got '%s'\n", argv[i]);
                 return 1;
             }
-            set_environment_variable("DFLASH_KVFLASH", argv[i], true);
+            model.kvflash_pool = argv[i];
         } else if (std::strcmp(argv[i], "--kvflash-policy") == 0 && i + 1 < argc) {
             ++i;
             if (std::strcmp(argv[i], "drafter") != 0 && std::strcmp(argv[i], "lru") != 0 &&
@@ -514,14 +595,14 @@ int main(int argc, char ** argv) {
                              argv[i]);
                 return 1;
             }
-            set_environment_variable("DFLASH_KVFLASH_POLICY", argv[i], true);
+            model.kvflash_policy = argv[i];
         } else if (std::strcmp(argv[i], "--kvflash-tau") == 0 && i + 1 < argc) {
             if (std::atoi(argv[++i]) <= 0) {
                 std::fprintf(stderr, "--kvflash-tau expects a positive interval, got '%s'\n",
                              argv[i]);
                 return 1;
             }
-            set_environment_variable("DFLASH_KVFLASH_TAU", argv[i], true);
+            model.kvflash_tau = argv[i];
         } else if (std::strcmp(argv[i], "--spark") == 0) {
             spark_autotune = true;
         } else if (std::strcmp(argv[i], "--spark-slots") == 0 && i + 1 < argc) {
@@ -573,9 +654,6 @@ int main(int argc, char ** argv) {
             sconfig.pflash_keep_ratio = (float)std::atof(argv[++i]);
         } else if (std::strcmp(argv[i], "--prefill-drafter") == 0 && i + 1 < argc) {
             sconfig.pflash_drafter_path = argv[++i];
-            // kvflash reads this to lazy-attach the drafter as its
-            // residency scorer even when prefill compression is off.
-            set_environment_variable("DFLASH_KVFLASH_DRAFTER", argv[i], true);
         } else if (std::strcmp(argv[i], "--prefill-skip-park") == 0) {
             sconfig.pflash_skip_park = true;
         } else if (std::strcmp(argv[i], "--prefill-upstream-base") == 0 && i + 1 < argc) {
@@ -692,6 +770,58 @@ int main(int argc, char ** argv) {
         bargs.ddtree_tau = 6.0f;
     }
 
+    for (const auto * type : {&cache_type_k, &cache_type_v}) {
+        if (!type->empty() && dflash::parse_kv_type(type->c_str()) == GGML_TYPE_COUNT) {
+            std::fprintf(stderr, "[server] invalid KV cache type '%s' (use f16, bf16, q4_0, q4_1, q5_0, q5_1, q8_0 or tq3_0)\n", type->c_str());
+            return 2;
+        }
+    }
+    // Validate every block before model files or GPU resources are loaded.
+    if (load_balancing && bargs.max_concurrency < 1) {
+        std::fprintf(stderr, "[server] --max-concurrency must be positive for model '%s'\n",
+            sconfig.model_name.c_str());
+        return 2;
+    }
+    if (bargs.max_concurrency > 1) bargs.paged_attention = true;
+    if (load_balancing && (bargs.device.is_multi_device() ||
+            bargs.remote_draft.enabled() || bargs.remote_target_shard.enabled() ||
+            sconfig.pflash_mode != ServerConfig::PflashMode::OFF ||
+            !sconfig.pflash_upstream_base.empty() || sconfig.lazy_draft ||
+            sconfig.freq_tracking || !sconfig.collect_routing_path.empty())) {
+        std::fprintf(stderr, "[server] model '%s' requires local serving; compression, sharding, request-scoped drafts and routing collection are unsupported with load balancing\n", sconfig.model_name.c_str());
+        return 2;
+    }
+    return 0;
+}
+
+static int load_model(ModelOptions & model, LoadedModel & loaded, bool multi_model) {
+    if (!model.adaptive_experts_tau.empty())
+        set_environment_variable("DFLASH_ADAPTIVE_K_TAU", model.adaptive_experts_tau.c_str(), false);
+    if (!model.kvflash_pool.empty())
+        set_environment_variable("DFLASH_KVFLASH", model.kvflash_pool.c_str(), true);
+    if (!model.kvflash_policy.empty())
+        set_environment_variable("DFLASH_KVFLASH_POLICY", model.kvflash_policy.c_str(), true);
+    if (!model.kvflash_tau.empty())
+        set_environment_variable("DFLASH_KVFLASH_TAU", model.kvflash_tau.c_str(), true);
+    // KVFlash can use this drafter even when prefill compression is off.
+    if (!model.sconfig.pflash_drafter_path.empty())
+        set_environment_variable("DFLASH_KVFLASH_DRAFTER", model.sconfig.pflash_drafter_path.c_str(), true);
+    auto & bargs = model.bargs;
+    auto & sconfig = model.sconfig;
+    auto & spark_autotune = model.spark_autotune;
+    auto & spark_slots = model.spark_slots;
+    auto & spark_vram_gib = model.spark_vram_gib;
+    auto & cache_type_k = model.cache_type_k;
+    auto & cache_type_v = model.cache_type_v;
+    auto & fast_rollback_forced_off = model.fast_rollback_forced_off;
+    auto & target_split_fast_rollback_cli = model.target_split_fast_rollback_cli;
+    auto & adaptive_experts_set = model.adaptive_experts_set;
+    auto & ddtree_tau_set = model.ddtree_tau_set;
+    auto & specla_top_k_set = model.specla_top_k_set;
+    auto & specla_top_k = model.specla_top_k;
+    auto & cli_set = model.cli_set;
+    auto & legacy_max_tokens_set = model.legacy_max_tokens_set;
+    auto & legacy_max_tokens_val = model.legacy_max_tokens_val;
     if (fast_rollback_forced_off) {
         bargs.fast_rollback = false;
         target_split_fast_rollback_cli = false;
@@ -722,13 +852,6 @@ int main(int argc, char ** argv) {
         if (const char * e = std::getenv("DFLASH27B_DRAFT_SWA")) {
             bargs.draft_swa_window = std::atoi(e);
         }
-    }
-
-    // Concurrent serving is implemented by the paged engine, so one user-facing
-    // concurrency flag selects the complete serving mode. Keep the feature gate
-    // strict for non-CLI callers that construct BackendArgs directly.
-    if (bargs.max_concurrency > 1) {
-        bargs.paged_attention = true;
     }
 
     // Ask the factory to resolve model/placement facts and apply its feature
@@ -765,6 +888,12 @@ int main(int argc, char ** argv) {
     }
     const ResolvedBackendPlan & backend_plan = backend_preparation.plan;
     const std::string & arch = backend_plan.arch();
+    if (multi_model && !bargs.paged_attention && arch != "deepseek4" && arch != "qwen35") {
+        std::fprintf(stderr,
+            "[server] model '%s': single-request routing currently supports Qwen and DeepSeek4; "
+            "use --max-concurrency for a supported batched model\n", sconfig.model_name.c_str());
+        return 2;
+    }
     const bool kvflash_requested =
         kvflash_pool_requested(std::getenv("DFLASH_KVFLASH"));
     if (target_split_fast_rollback_cli && arch != "qwen35") {
@@ -874,12 +1003,25 @@ int main(int argc, char ** argv) {
         ensure_stats_env("DFLASH_LAGUNA_NEXT_PLACEMENT_OUT", "/dev/null");
     }
 
-    // Explicit --cache-type-k/v override via env vars.
-    if (!cache_type_k.empty()) {
-        set_environment_variable("DFLASH27B_KV_K", cache_type_k.c_str(), true);
-    }
-    if (!cache_type_v.empty()) {
-        set_environment_variable("DFLASH27B_KV_V", cache_type_v.c_str(), true);
+    // Monolithic Qwen owns its KV overrides, including allocation/budgeting.
+    // DS4 has a family-specific cache layout and never consumed these flags.
+    if (arch == "qwen35" && !bargs.device.is_multi_device()) {
+        if (!cache_type_k.empty()) bargs.cache_type_k = dflash::parse_kv_type(cache_type_k.c_str());
+        if (!cache_type_v.empty()) bargs.cache_type_v = dflash::parse_kv_type(cache_type_v.c_str());
+        dflash::resolve_kv_types(bargs.cache_type_k, bargs.cache_type_v,
+                                bargs.cache_type_k, bargs.cache_type_v);
+        cache_type_k = dflash::kv_type_name(bargs.cache_type_k);
+        cache_type_v = dflash::kv_type_name(bargs.cache_type_v);
+    } else if (arch == "deepseek4") {
+        if (!cache_type_k.empty() || !cache_type_v.empty()) {
+            std::fprintf(stderr, "[server] model '%s': --cache-type-k/v are ignored by DeepSeek4's fixed cache layout\n", sconfig.model_name.c_str());
+        }
+        cache_type_k = cache_type_v = "fixed (deepseek4)";
+    } else {
+        // Preserve existing single-model architectures and remote-shard launches.
+        // These paths cannot participate in multi-model paged serving.
+        if (!cache_type_k.empty()) set_environment_variable("DFLASH27B_KV_K", cache_type_k.c_str(), true);
+        if (!cache_type_v.empty()) set_environment_variable("DFLASH27B_KV_V", cache_type_v.c_str(), true);
     }
 
     // TQ3_0 KV auto-selection was removed (2026-07): tq3_0 saved ~40% VRAM on
@@ -906,14 +1048,14 @@ int main(int argc, char ** argv) {
 
     // Load tokenizer.
     std::fprintf(stderr, "[server] loading tokenizer from %s\n", bargs.model_path);
-    Tokenizer tokenizer;
+    Tokenizer & tokenizer = loaded.tokenizer;
     if (!tokenizer.load_from_gguf(bargs.model_path)) {
         std::fprintf(stderr, "[server] tokenizer load failed\n");
         return 1;
     }
 
     // Load pflash drafter tokenizer (if pflash enabled).
-    Tokenizer drafter_tokenizer;
+    Tokenizer & drafter_tokenizer = loaded.drafter_tokenizer;
     if (pflash_enabled) {
         std::fprintf(stderr, "[server] loading pflash drafter tokenizer from %s\n",
                      sconfig.pflash_drafter_path.c_str());
@@ -991,7 +1133,8 @@ int main(int argc, char ** argv) {
                 arch.c_str());
         }
     }
-    auto backend = create_backend(bargs, backend_plan);
+    auto & backend = loaded.backend;
+    backend = create_backend(bargs, backend_plan);
     if (!backend) {
         std::fprintf(stderr, "[server] backend creation failed\n");
         return 1;
@@ -1260,17 +1403,9 @@ int main(int argc, char ** argv) {
     std::fprintf(stderr, "[server] │  prefill_cache   = %d slots\n", sconfig.prefill_cache_cap);
     std::fprintf(stderr, "[server] │  cors            = %s\n", sconfig.enable_cors ? "ON" : "off");
     std::fprintf(stderr, "[server] │  cache_type_k    = %s\n",
-#ifdef GGML_USE_HIP
-        cache_type_k.empty() ? "q4_0 (default, HIP)" : cache_type_k.c_str());
-#else
         cache_type_k.empty() ? "family default" : cache_type_k.c_str());
-#endif
     std::fprintf(stderr, "[server] │  cache_type_v    = %s\n",
-#ifdef GGML_USE_HIP
-        cache_type_v.empty() ? "q4_0 (default, HIP)" : cache_type_v.c_str());
-#else
         cache_type_v.empty() ? "family default" : cache_type_v.c_str());
-#endif
     std::fprintf(stderr, "[server] │  pflash          = %s\n",
         sconfig.pflash_mode == ServerConfig::PflashMode::AUTO ? "auto" :
         sconfig.pflash_mode == ServerConfig::PflashMode::ALWAYS ? "always" : "off");
@@ -1373,11 +1508,10 @@ int main(int argc, char ** argv) {
         }
     }
 
-    HttpServer server(*backend, tokenizer, sconfig);
+    loaded.server = std::make_unique<HttpServer>(*backend, tokenizer, sconfig);
+    HttpServer & server = *loaded.server;
     server.set_chat_format(chat_format_for_arch(arch));
-    g_server = &server;
-    std::signal(SIGTERM, signal_handler);
-    std::signal(SIGINT, signal_handler);
+    loaded.freq_tracking = sconfig.freq_tracking;
     if (pflash_enabled) {
         server.set_drafter_tokenizer(&drafter_tokenizer);
     }
@@ -1388,7 +1522,7 @@ int main(int argc, char ** argv) {
     }
 
     // Set up routing data collector (--collect-routing)
-    MoeRoutingCollector routing_collector;
+    auto & routing_collector = loaded.routing_collector;
     if (!sconfig.collect_routing_path.empty()) {
         if (!routing_collector.open(sconfig.collect_routing_path)) {
             std::fprintf(stderr, "[server] failed to open routing collector output\n");
@@ -1402,26 +1536,122 @@ int main(int argc, char ** argv) {
         }
     }
 
-    int ret = server.run();
+    return 0;
+}
 
-    // Print frequency analysis at shutdown (--freq)
-    if (sconfig.freq_tracking) {
-        const auto * stats = backend->get_routing_stats();
-        if (stats) {
-            stats->print_freq_analysis();
+int main(int argc, char ** argv) {
+    // Reuse the existing per-model CLI and loader. Argument strings belong to
+    // main's argv and outlive every backend, including factories borrowing paths.
+    std::vector<std::vector<char *>> model_args(1, {argv[0]});
+    bool load_balancing = false;
+    std::string primary_gpu;
+    for (int i = 1; i < argc; ++i) {
+        if (std::strcmp(argv[i], "--load-balancing") == 0) {
+            load_balancing = true;
+        } else if (std::strcmp(argv[i], "--load-balancing-primary-gpu") == 0) {
+            DevicePlacement device;
+            if (!primary_gpu.empty() || i + 1 >= argc ||
+                !parse_placement_device(argv[i + 1], device) ||
+                device.backend == PlacementBackend::Auto) {
+                std::fprintf(stderr, "[server] --load-balancing-primary-gpu requires one explicit backend:gpu value\n");
+                return 2;
+            }
+            primary_gpu = placement_device_name(device);
+            ++i;
+        } else if (std::strcmp(argv[i], "--model") == 0) {
+            if (i + 1 >= argc || argv[i + 1][0] == '-') {
+                std::fprintf(stderr, "[server] --model requires a model path\n");
+                return 2;
+            }
+            if (model_args.back().size() > 1) model_args.push_back({argv[0]});
+            model_args.back().push_back(argv[++i]);
         } else {
-            std::fprintf(stderr, "[server] --freq: no routing stats available "
-                                 "(model may not be MoE)\n");
+            model_args.back().push_back(argv[i]);
+        }
+    }
+    const bool multi_model = model_args.size() > 1;
+    if (load_balancing && !multi_model) {
+        std::fprintf(stderr, "[server] --load-balancing requires at least two model blocks\n");
+        return 2;
+    }
+    std::vector<ModelOptions> options(model_args.size());
+    std::set<std::string> names;
+    for (size_t m = 0; m < model_args.size(); ++m) {
+        auto & args = model_args[m];
+        const int count = (int)args.size();
+        args.push_back(nullptr);
+        const int ret = parse_model_options(count, args.data(), options[m], load_balancing, m == 0);
+        if (ret != 0) {
+            std::fprintf(stderr, "[server] invalid model block %zu (%s)\n", m + 1,
+                options[m].sconfig.model_name.c_str());
+            return ret;
+        }
+        const auto & name = options[m].sconfig.model_name;
+        if (load_balancing && (name.empty() || name == "auto" || !names.insert(name).second)) {
+            std::fprintf(stderr, "[server] model block %zu: --model-name must be unique, nonempty and different from auto (got '%s')\n", m + 1, name.c_str());
+            return 2;
         }
     }
 
-    // Close routing collector (prints summary)
-    if (routing_collector.is_open()) {
-        backend->set_routing_collector(nullptr);
-        routing_collector.close();
+    // Listener policy belongs to the first CLI block, independently of priority.
+    const ServerConfig listener_config = options.front().sconfig;
+    if (!primary_gpu.empty()) {
+        size_t selected = options.size();
+        for (size_t m = 0; m < options.size(); ++m) {
+            if (placement_device_name(options[m].bargs.device) != primary_gpu) continue;
+            if (selected != options.size()) {
+                std::fprintf(stderr, "[server] --load-balancing-primary-gpu matches multiple model blocks\n");
+                return 2;
+            }
+            selected = m;
+        }
+        if (selected == options.size()) {
+            std::fprintf(stderr, "[server] --load-balancing-primary-gpu must match a configured --target-device\n");
+            return 2;
+        }
+        std::rotate(options.begin(), options.begin() + selected, options.begin() + selected + 1);
+    }
+    // Disabled balancing loads only the selected primary, regardless of how
+    // many placements were configured. No unused GPU worker is started.
+    if (!load_balancing) options.resize(1);
+    for (auto & option : options) {
+        option.sconfig.host = listener_config.host;
+        option.sconfig.port = listener_config.port;
+        option.sconfig.enable_cors = listener_config.enable_cors;
+        option.sconfig.routing_queue_limit = listener_config.routing_queue_limit;
+    }
+    std::fprintf(stderr, "[server] load balancing %s; primary=%s target=%s\n",
+        load_balancing ? "enabled" : "disabled", options.front().sconfig.model_name.c_str(),
+        placement_device_name(options.front().bargs.device).c_str());
+
+    if (load_balancing) {
+        const auto & listener = options.front().sconfig;
+        std::fprintf(stderr, "[server] one listener at %s:%d; %zu independent models (environment settings are shared)\n",
+            listener.host.c_str(), listener.port, options.size());
+        for (size_t m = 0; m < options.size(); ++m) {
+            auto & option = options[m];
+            std::fprintf(stderr, "[server] model %zu: %s target=%s slots=%d execution=%s\n",
+                m + 1, option.sconfig.model_name.c_str(),
+                placement_device_name(option.bargs.device).c_str(), option.bargs.max_concurrency,
+                option.bargs.paged_attention ? "batched" : "single-request");
+        }
     }
 
-    // Cleanup.
-    backend->shutdown();
+    std::vector<std::unique_ptr<LoadedModel>> loaded;
+    std::vector<HttpServer *> servers;
+    // All initialization (including backend environment defaults) finishes
+    // before starting any scheduler. No worker observes model-loading mutations.
+    for (auto & option : options) {
+        auto model = std::make_unique<LoadedModel>();
+        const int ret = load_model(option, *model, load_balancing);
+        if (ret != 0) return ret;
+        servers.push_back(model->server.get());
+        loaded.push_back(std::move(model));
+    }
+    g_server = servers.front();
+    std::signal(SIGTERM, signal_handler);
+    std::signal(SIGINT, signal_handler);
+    const int ret = load_balancing ? g_server->run(servers) : g_server->run();
+    g_server = nullptr;
     return ret;
 }

--- a/server/test/test_draft_topk_cuda.cpp
+++ b/server/test/test_draft_topk_cuda.cpp
@@ -22,6 +22,8 @@
 
 #include <cuda_runtime.h>
 
+#include <atomic>
+#include <thread>
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
@@ -209,4 +211,41 @@ TEST_CASE(DraftTopkCudaFixture, draft_topk_cuda_suite) {
     }
     REQUIRE(failures == 0);
     printf("\nALL PASS: %d/%d cases\n", idx, idx);
+}
+
+// Workers overlap different logits and allocation sizes. With two devices,
+// alternate ownership as well, so replacement must free on the old device.
+TEST_CASE(DraftTopkCudaFixture, draft_topk_concurrent_workers_and_device_changes) {
+    int devices = 0;
+    if (cudaGetDeviceCount(&devices) != cudaSuccess || devices == 0) {
+        printf("SKIP: no CUDA device available\n");
+        return;
+    }
+    const int used_devices = devices > 1 ? 2 : 1;
+    std::atomic<int> ready{0};
+    std::atomic<bool> go{false};
+    bool ok[2] = {true, true};
+    auto worker = [&](int id) {
+        ++ready;
+        while (!go.load()) std::this_thread::yield();
+        for (int i = 0; i < 8; ++i) {
+            const int device = (i + id) % used_devices;
+            if (cudaSetDevice(device) != cudaSuccess ||
+                !run_case({1 + (i % 3) * 7, 4096, 8, 0.7f},
+                          1000u + id * 100u + i)) {
+                ok[id] = false;
+                break;
+            }
+            int current = -1;
+            if (cudaGetDevice(&current) != cudaSuccess || current != device)
+                ok[id] = false;
+        }
+    };
+    std::thread a(worker, 0), b(worker, 1);
+    while (ready.load() != 2) std::this_thread::yield();
+    go = true;
+    a.join();
+    b.join(); // Worker-owned GPU scratch is destroyed here.
+    CHECK(ok[0]);
+    CHECK(ok[1]);
 }

--- a/server/test/test_gpu_sampler_cuda.cpp
+++ b/server/test/test_gpu_sampler_cuda.cpp
@@ -12,6 +12,8 @@
 
 #include <cuda_runtime.h>
 
+#include <atomic>
+#include <thread>
 #include <algorithm>
 #include <chrono>
 #include <cmath>
@@ -335,4 +337,44 @@ TEST_CASE(GpuSamplerCudaFixture, gpu_sampler_microbench_when_enabled) {
         gpu_sampler_microbench();
     }
     CHECK(true);
+}
+
+TEST_CASE(GpuSamplerCudaFixture, independent_workers_sample_distinct_logits) {
+    if (!gpu_sampler_test_available()) return;
+    int devices = 0;
+    CHECK(cudaGetDeviceCount(&devices) == cudaSuccess);
+    std::atomic<int> ready{0};
+    std::atomic<bool> go{false};
+    bool ok[2] = {true, true};
+    auto worker = [&](int id) {
+        ++ready;
+        while (!go.load()) std::this_thread::yield();
+        for (int i = 0; i < 32; ++i) {
+            const int device = (i + id) % (devices > 1 ? 2 : 1);
+            if (cudaSetDevice(device) != cudaSuccess) { ok[id] = false; break; }
+            const int vocab = 1024 + (i % 3) * 1024;
+            const int expected = id * 100 + i;
+            std::vector<float> logits(vocab, -100.0f);
+            logits[expected] = 100.0f;
+            SamplerCfg cfg;
+            cfg.temp = 0.0f;
+            cfg.top_k = 0;
+            cfg.top_p = 1.0f;
+            const int token = geometric_sample_logits_cuda(
+                logits.data(), vocab, cfg, {}, 0.5, false);
+            if (token != expected) ok[id] = false;
+            cfg.temp = 1.0f;
+            std::vector<float> probs(vocab);
+            if (!geometric_compute_probs_cuda(logits.data(), vocab, cfg, {},
+                                              probs.data(), false) || probs[expected] < 0.999f)
+                ok[id] = false;
+        }
+    };
+    std::thread a(worker, 0), b(worker, 1);
+    while (ready.load() != 2) std::this_thread::yield();
+    go = true;
+    a.join();
+    b.join();
+    CHECK(ok[0]);
+    CHECK(ok[1]);
 }

--- a/server/test/test_kv_quant.cpp
+++ b/server/test/test_kv_quant.cpp
@@ -115,6 +115,25 @@ static void t2_resolve_kv_types() {
     assert(k == GGML_TYPE_TQ3_0 && v == GGML_TYPE_Q8_0);
     clear_kv_env();
 
+    // Two model overrides coexist; neither changes the shared default.
+    setenv("DFLASH27B_KV_K", "f16", 1);
+    setenv("DFLASH27B_KV_V", "f16", 1);
+    dflash::resolve_kv_types(k, v, GGML_TYPE_Q8_0, GGML_TYPE_Q8_0);
+    assert(k == GGML_TYPE_Q8_0 && v == GGML_TYPE_Q8_0);
+    dflash::resolve_kv_types(k, v, GGML_TYPE_Q4_0, GGML_TYPE_Q4_0);
+    assert(k == GGML_TYPE_Q4_0 && v == GGML_TYPE_Q4_0);
+    dflash::resolve_kv_types(k, v);
+    assert(k == GGML_TYPE_F16 && v == GGML_TYPE_F16);
+    assert(std::strcmp(std::getenv("DFLASH27B_KV_K"), "f16") == 0);
+    assert(std::strcmp(std::getenv("DFLASH27B_KV_V"), "f16") == 0);
+    // Explicit CLI values also supersede malformed inherited defaults, as
+    // the old CLI's environment overwrite did for single-model launches.
+    setenv("DFLASH27B_KV_K", "invalid", 1);
+    setenv("DFLASH27B_KV_V", "invalid", 1);
+    dflash::resolve_kv_types(k, v, GGML_TYPE_Q8_0, GGML_TYPE_Q8_0);
+    assert(k == GGML_TYPE_Q8_0 && v == GGML_TYPE_Q8_0);
+    clear_kv_env();
+
     std::puts("T2 PASS");
 }
 

--- a/server/test/test_model_names.cmake
+++ b/server/test/test_model_names.cmake
@@ -1,0 +1,46 @@
+# Exercise the actual CLI before model loading. HTTP routing tests construct
+# ServerConfig directly, so cannot detect rejection of unused CLI model names.
+set(primary "${CMAKE_CURRENT_BINARY_DIR}/model-name-test-missing-primary.gguf")
+set(secondary "${CMAKE_CURRENT_BINARY_DIR}/model-name-test-missing-secondary.gguf")
+if(EXISTS "${primary}" OR EXISTS "${secondary}")
+    message(FATAL_ERROR "CLI test requires missing model paths")
+endif()
+
+function(check_launch name expected_code expected_text)
+    execute_process(COMMAND "${SERVER}" ${ARGN}
+        RESULT_VARIABLE result OUTPUT_VARIABLE output ERROR_VARIABLE error
+        TIMEOUT 10)
+    string(FIND "${error}" "${expected_text}" found)
+    if(NOT "${result}" STREQUAL "${expected_code}" OR found EQUAL -1)
+        message(FATAL_ERROR "${name}: exit=${result}\n${output}\n${error}")
+    endif()
+endfunction()
+
+# Disabled balancing must reach loading with default names, including when
+# the selected primary is the second block. No GPU/model assets are needed.
+check_launch(default_primary 1 "failed to detect architecture from ${primary}"
+    "${primary}" --target-device ${BACKEND}:0 --model "${secondary}" --target-device ${BACKEND}:1)
+check_launch(selected_primary 1 "failed to detect architecture from ${secondary}"
+    "${primary}" --target-device ${BACKEND}:0 --model "${secondary}" --target-device ${BACKEND}:1
+    --load-balancing-primary-gpu ${BACKEND}:1)
+check_launch(unused_reserved_name 1 "failed to detect architecture from ${primary}"
+    "${primary}" --model "${secondary}" --model-name auto)
+check_launch(balanced_duplicate 2 "--model-name must be unique"
+    "${primary}" --model "${secondary}" --load-balancing)
+check_launch(balanced_reserved 2 "--model-name must be unique"
+    "${primary}" --model-name qwen --model "${secondary}" --model-name auto --load-balancing)
+check_launch(balanced_unique 1 "failed to detect architecture from ${primary}"
+    "${primary}" --model-name qwen --model "${secondary}" --model-name ds4 --load-balancing)
+
+# Shared policy belongs only to loaded models. Disabled balancing preserves
+# one-model CLI features even when an unused block contains other policies.
+check_launch(disabled_selected_policy 1 "failed to detect architecture from ${primary}"
+    "${primary}" --no-fast-rollback --kvflash 1024
+    --model "${secondary}" --spark)
+check_launch(disabled_second_policy 1 "failed to detect architecture from ${secondary}"
+    "${primary}" --target-device ${BACKEND}:0 --kvflash 1024
+    --model "${secondary}" --target-device ${BACKEND}:1 --no-fast-rollback
+    --load-balancing-primary-gpu ${BACKEND}:1)
+check_launch(balanced_policy_rejected 2 "changes process-wide policy"
+    "${primary}" --model-name qwen --no-fast-rollback
+    --model "${secondary}" --model-name ds4 --load-balancing)

--- a/server/test/test_model_routing.cpp
+++ b/server/test/test_model_routing.cpp
@@ -1,0 +1,812 @@
+// Real HTTP + existing batch schedulers, with deterministic host-only engines.
+// Protects cross-model admission, tokenization, retirement and worker ownership.
+#include "CppUnitTestFramework.hpp"
+#include "server/http_server.h"
+#include "common/concurrency/seq_engine.h"
+#include "gguf.h"
+
+#if !defined(_WIN32)
+#include <arpa/inet.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <filesystem>
+#include <mutex>
+#include <stdexcept>
+#include <thread>
+
+namespace {
+using namespace dflash::common;
+using Clock = std::chrono::steady_clock;
+using namespace std::chrono_literals;
+struct ModelRoutingFixture {};
+#define ROUTING_CHECK(expression) do { \
+    if (!(expression)) throw std::runtime_error( \
+        std::string("routing check at line ") + std::to_string(__LINE__) + ": " #expression); \
+} while (false)
+
+class Socket {
+public:
+    explicit Socket(int fd) : fd_(fd) { ROUTING_CHECK(fd >= 0); }
+    ~Socket() { close(); }
+    Socket(Socket && other) noexcept : fd_(other.fd_) { other.fd_ = -1; }
+    Socket(const Socket &) = delete;
+    int get() const { return fd_; }
+    void close() { if (fd_ >= 0) ::close(fd_); fd_ = -1; }
+    void send(const std::string & data) {
+        size_t offset = 0;
+        while (offset < data.size()) {
+            const auto n = ::send(fd_, data.data() + offset, data.size() - offset, MSG_NOSIGNAL);
+            ROUTING_CHECK(n > 0);
+            offset += (size_t)n;
+        }
+    }
+    std::string read() {
+        std::string response;
+        const auto deadline = Clock::now() + 5s;
+        for (;;) {
+            ROUTING_CHECK(Clock::now() < deadline);
+            pollfd pfd{fd_, POLLIN, 0};
+            const int ready = poll(&pfd, 1, 100);
+            ROUTING_CHECK(ready >= 0);
+            if (!ready) continue;
+            char bytes[4096];
+            const auto n = recv(fd_, bytes, sizeof(bytes), 0);
+            ROUTING_CHECK(n >= 0);
+            if (n == 0) return response;
+            response.append(bytes, (size_t)n);
+        }
+    }
+private:
+    int fd_;
+};
+
+json response_body(const std::string & response, int status = 200) {
+    ROUTING_CHECK(response.rfind("HTTP/1.1 " + std::to_string(status) + " ", 0) == 0);
+    const auto boundary = response.find("\r\n\r\n");
+    ROUTING_CHECK(boundary != std::string::npos);
+    return json::parse(response.substr(boundary + 4));
+}
+
+class HeldEngine final : public SeqEngine {
+public:
+    int slot_count() const override { return 2; }
+    int max_context() const override { return 64; }
+    bool token_is_eos(int32_t token) const override { return token == 2; }
+    StepPlanLimits step_plan_limits(int) const override { return {2, 64, 128}; }
+    AdmitResult admit(uint64_t, const std::vector<int32_t> & prompt,
+                      const SamplerCfg & sampler) override {
+        std::lock_guard<std::mutex> lock(mu);
+        ++attempts;
+        cv.notify_all();
+        if (prompt.size() > prompt_capacity) return {AdmitResult::Status::capacity_exceeded, -1, "prompt exceeds pool"};
+        if (capacity_busy) return {AdmitResult::Status::busy, -1, "KV headroom occupied"};
+        if (fail_next) {
+            fail_next = false;
+            return {AdmitResult::Status::failed, -1, "injected admission failure"};
+        }
+        for (int i = 0; i < 2; ++i) {
+            if (active[i]) continue;
+            active[i] = true;
+            prompts.push_back(prompt);
+            temperatures.push_back(sampler.temp);
+            ++admissions;
+            cv.notify_all();
+            return {AdmitResult::Status::admitted, i, {}};
+        }
+        return {AdmitResult::Status::busy, -1, {}};
+    }
+    StepResult step(const StepPlan & plan) override {
+        std::unique_lock<std::mutex> lock(mu);
+        if (block_step) {
+            inside_block = true;
+            cv.notify_all();
+            cv.wait(lock, [&] { return !block_step; });
+        }
+        StepResult result;
+        for (const auto & slice : plan.prefills) {
+            result.prefills.push_back({slice.slot,
+                release ? PrefillOutput::Status::completed : PrefillOutput::Status::advanced,
+                release ? 0 : -1, {}});
+        }
+        for (const auto & input : plan.decode) result.decode.push_back({input.slot, 2, false, {}});
+        // An unfinished fake prefill yields control to the real scheduler,
+        // allowing admission and cancellation without timing-based completion.
+        lock.unlock();
+        std::this_thread::yield();
+        return result;
+    }
+    void retire(int slot) override {
+        std::lock_guard<std::mutex> lock(mu);
+        active.at((size_t)slot) = false;
+        ++retirements;
+        cv.notify_all();
+    }
+    void wait_admissions(int count) {
+        std::unique_lock<std::mutex> lock(mu);
+        ROUTING_CHECK(cv.wait_for(lock, 5s, [&] { return admissions >= count; }));
+    }
+    void wait_retirements(int count) {
+        std::unique_lock<std::mutex> lock(mu);
+        ROUTING_CHECK(cv.wait_for(lock, 5s, [&] { return retirements >= count; }));
+    }
+    void finish() {
+        std::lock_guard<std::mutex> lock(mu);
+        release = true;
+        block_step = false;
+        cv.notify_all();
+    }
+    std::mutex mu;
+    std::condition_variable cv;
+    std::array<bool, 2> active{};
+    size_t prompt_capacity = 64;
+    bool capacity_busy = false;
+    bool release = false, fail_next = false, block_step = false, inside_block = false;
+    int attempts = 0;
+    int admissions = 0, retirements = 0;
+    std::vector<std::vector<int32_t>> prompts;
+    std::vector<float> temperatures;
+};
+
+struct RoutedBackend : ModelBackend {
+    HeldEngine engine;
+    SeqEngine * seq_engine() override { return &engine; }
+    void print_ready_banner() const override {}
+    bool park(ParkTarget) override { return true; }
+    bool unpark(ParkTarget) override { return true; }
+    bool is_target_parked() const override { return false; }
+    GenerateResult generate_impl(const GenerateRequest &, const DaemonIO &) override { return {}; }
+    bool snapshot_save(int) override { return false; }
+    void snapshot_free(int) override {}
+    bool snapshot_used(int) const override { return false; }
+    int snapshot_cur_pos(int) const override { return 0; }
+    GenerateResult restore_and_generate_impl(int, const GenerateRequest &, const DaemonIO &) override { return {}; }
+    bool handle_compress(const std::string &, const DaemonIO &) override { return false; }
+    void free_drafter() override {}
+    void shutdown() override {}
+};
+
+// Exercises the existing ModelBackend::generate path without a SeqEngine.
+// The gate models work boundaries where real backends poll DaemonIO cancellation.
+struct HeldSingleBackend final : RoutedBackend {
+    SeqEngine * seq_engine() override { return nullptr; }
+    GenerateResult generate_impl(const GenerateRequest & req, const DaemonIO & io) override {
+        std::unique_lock<std::mutex> lock(mu);
+        ++calls;
+        prompts.push_back(req.prompt);
+        temperatures.push_back(req.sampler.temp);
+        cv.notify_all();
+        const auto deadline = Clock::now() + 5s;
+        while (!released && !io.is_cancelled() && Clock::now() < deadline) {
+            cv.wait_for(lock, 10ms);
+        }
+        GenerateResult result;
+        if (io.is_cancelled()) {
+            ++cancellations;
+            cv.notify_all();
+        } else if (!released) {
+            return result; // Bounded failure if the server never cancels or releases us.
+        } else {
+            result.tokens = {0, 2};
+            for (int32_t token : result.tokens) io.emit(token);
+        }
+        result.succeed();
+        return result;
+    }
+    void wait_calls(int count) {
+        std::unique_lock<std::mutex> lock(mu);
+        ROUTING_CHECK(cv.wait_for(lock, 5s, [&] { return calls >= count; }));
+    }
+    void wait_cancellations(int count) {
+        std::unique_lock<std::mutex> lock(mu);
+        ROUTING_CHECK(cv.wait_for(lock, 5s, [&] { return cancellations >= count; }));
+    }
+    void finish() {
+        std::lock_guard<std::mutex> lock(mu);
+        released = true;
+        cv.notify_all();
+    }
+    std::mutex mu;
+    std::condition_variable cv;
+    bool released = false;
+    int calls = 0, cancellations = 0;
+    std::vector<std::vector<int32_t>> prompts;
+    std::vector<float> temperatures;
+};
+
+void load_tokenizer(Tokenizer & tokenizer, bool second) {
+    gguf_context * ctx = gguf_init_empty();
+    const char * first[] = {"q", "x", "<eos>", "y", "s"};
+    const char * other[] = {"s", "y", "<eos>", "x", "q"};
+    const uint32_t types[] = {1, 1, 3, 1, 1};
+    gguf_set_arr_str(ctx, "tokenizer.ggml.tokens", second ? other : first, 5);
+    gguf_set_arr_data(ctx, "tokenizer.ggml.token_type", GGUF_TYPE_UINT32, types, 5);
+    gguf_set_val_str(ctx, "tokenizer.ggml.model", "gpt2");
+    gguf_set_val_u32(ctx, "tokenizer.ggml.eos_token_id", 2);
+    const auto path = std::filesystem::temp_directory_path() /
+        ("luce-routing-" + std::to_string(getpid()) + (second ? "-b.gguf" : "-a.gguf"));
+    gguf_write_to_file(ctx, path.c_str(), false);
+    gguf_free(ctx);
+    const bool loaded = tokenizer.load_from_gguf(path.c_str());
+    std::filesystem::remove(path);
+    ROUTING_CHECK(loaded);
+}
+
+class RunningModels {
+public:
+    RoutedBackend first, second;
+    HeldSingleBackend single;
+    HeldSingleBackend first_single;
+    Tokenizer first_tok, second_tok;
+    std::unique_ptr<HttpServer> listener, peer;
+    std::thread runner;
+    int port = 0;
+    std::atomic<int> result{-1};
+
+    explicit RunningModels(bool single_peer = false, bool single_listener = false,
+                           bool load_balancing = true, int queue_limit = 0,
+                           bool reverse_priority = false) {
+        load_tokenizer(first_tok, false);
+        load_tokenizer(second_tok, true);
+        // Obtain a loopback test port from the OS, then hand it to HttpServer.
+        Socket reservation(socket(AF_INET, SOCK_STREAM, 0));
+        sockaddr_in address{};
+        address.sin_family = AF_INET;
+        address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        ROUTING_CHECK(bind(reservation.get(), (sockaddr *)&address, sizeof(address)) == 0);
+        socklen_t length = sizeof(address);
+        ROUTING_CHECK(getsockname(reservation.get(), (sockaddr *)&address, &length) == 0);
+        port = ntohs(address.sin_port);
+        ServerConfig config;
+        config.host = "127.0.0.1";
+        config.port = port;
+        config.model_name = "qwen";
+        config.max_ctx = 64;
+        config.routing_queue_limit = queue_limit;
+        config.default_max_tokens = 4;
+        config.prefix_cache_cap = 0;
+        config.ppp_enabled = false;
+        config.admission_coalesce_ms = 0;
+        config.chat_template_src = "{{ messages[0]['content'] }}";
+        config.sampler_defaults.has_temperature = true;
+        config.sampler_defaults.temperature = 0.2f;
+        ModelBackend & first_backend = single_listener ? static_cast<ModelBackend &>(first_single) : first;
+        listener = std::make_unique<HttpServer>(first_backend, first_tok, config);
+        config.model_name = "ds4";
+        config.chat_template_src = "y{{ messages[0]['content'] }}";
+        config.sampler_defaults.temperature = 0.7f;
+        ModelBackend & peer_backend = single_peer ? static_cast<ModelBackend &>(single) : second;
+        peer = std::make_unique<HttpServer>(peer_backend, second_tok, config);
+        if (reverse_priority) std::swap(listener, peer);
+        reservation.close();
+        runner = std::thread([this, load_balancing] {
+            result = load_balancing ? listener->run({listener.get(), peer.get()})
+                                    : listener->run();
+        });
+        try {
+            // Wait on actual listener readiness, not a fixed startup sleep.
+            const auto deadline = Clock::now() + 5s;
+            for (;;) {
+                ROUTING_CHECK(result.load() == -1);
+                Socket probe(socket(AF_INET, SOCK_STREAM, 0));
+                address.sin_port = htons(port);
+                if (connect(probe.get(), (sockaddr *)&address, sizeof(address)) == 0) break;
+                ROUTING_CHECK(Clock::now() < deadline);
+                std::this_thread::yield();
+            }
+        } catch (...) { stop(); throw; }
+    }
+    ~RunningModels() { stop(); }
+    void stop() {
+        listener->request_stop();
+        first.engine.finish();
+        second.engine.finish();
+        single.finish();
+        first_single.finish();
+        if (runner.joinable()) runner.join();
+    }
+    Socket connect_client() {
+        Socket client(socket(AF_INET, SOCK_STREAM, 0));
+        sockaddr_in address{};
+        address.sin_family = AF_INET;
+        address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        address.sin_port = htons(port);
+        ROUTING_CHECK(connect(client.get(), (sockaddr *)&address, sizeof(address)) == 0);
+        return client;
+    }
+    Socket post(json body, const std::string & path = "/v1/chat/completions") {
+        auto client = connect_client();
+        const auto text = body.dump();
+        client.send("POST " + path + " HTTP/1.1\r\nHost: localhost\r\nContent-Length: " +
+                    std::to_string(text.size()) + "\r\n\r\n" + text);
+        return client;
+    }
+    json get(const std::string & path) {
+        auto client = connect_client();
+        client.send("GET " + path + " HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        return response_body(client.read());
+    }
+    void wait_load(int first_count, int second_count) {
+        const auto deadline = Clock::now() + 5s;
+        for (;;) {
+            const auto status = get("/status/json")["models"];
+            if (status[0]["in_flight"] == first_count && status[1]["in_flight"] == second_count) return;
+            ROUTING_CHECK(Clock::now() < deadline);
+            std::this_thread::yield();
+        }
+    }
+};
+
+json chat(const char * model = "qwen", bool stream = false) {
+    return {{"model", model}, {"stream", stream}, {"max_tokens", 4},
+            {"messages", {{{"role", "user"}, {"content", "x"}}}}};
+}
+} // namespace
+
+TEST_CASE(ModelRoutingFixture, test_two_plus_two_preserves_batching_and_independent_progress) {
+    RunningModels models;
+    std::vector<Socket> clients;
+    for (int i = 0; i < 4; ++i) {
+        clients.push_back(models.post(chat(i % 2 ? "ds4" : "qwen")));
+        (i < 2 ? models.first : models.second).engine.wait_admissions(i % 2 + 1);
+    }
+    models.wait_load(2, 2);
+    response_body(models.post(chat("ds4")).read(), 503);
+    models.first.engine.finish();
+    for (int i : {0, 1}) {
+        const auto body = response_body(clients[i].read());
+        ROUTING_CHECK(body["model"] == "qwen");
+        ROUTING_CHECK(body["choices"][0]["message"]["content"] == "q");
+    }
+    models.wait_load(0, 2); // DS4 cannot stall Qwen's worker or response path.
+    models.second.engine.finish();
+    for (int i : {2, 3}) {
+        const auto body = response_body(clients[i].read());
+        ROUTING_CHECK(body["model"] == "ds4");
+        ROUTING_CHECK(body["choices"][0]["message"]["content"] == "s");
+    }
+    models.wait_load(0, 0);
+    ROUTING_CHECK(models.first.engine.prompts[0] == std::vector<int32_t>({1}));
+    ROUTING_CHECK(models.second.engine.prompts[0] == std::vector<int32_t>({1, 3}));
+    ROUTING_CHECK(models.first.engine.temperatures[0] == 0.2f);
+    ROUTING_CHECK(models.second.engine.temperatures[0] == 0.7f);
+    const auto list = models.get("/v1/models")["data"];
+    ROUTING_CHECK(list.size() == 2);
+    ROUTING_CHECK(list[0]["id"] == "qwen" && list[1]["id"] == "ds4");
+    const auto codex = models.get("/v1/models?client_version=test")["models"];
+    ROUTING_CHECK(codex.size() == 2 && codex[1]["slug"] == "ds4");
+    const auto props = models.get("/props");
+    ROUTING_CHECK(props["server"]["props_schema"] == 2);
+    ROUTING_CHECK(props["models"][1]["props"]["model_alias"] == "ds4");
+}
+
+TEST_CASE(ModelRoutingFixture, test_rejected_requests_and_engine_failure_release_capacity) {
+    RunningModels models;
+    response_body(models.post(chat("missing"), "/v1/messages/count_tokens").read(), 404);
+    auto invalid = chat(); invalid.erase("messages");
+    response_body(models.post(invalid).read(), 400);
+    invalid = chat(); invalid["model"] = 42;
+    response_body(models.post(invalid).read(), 400);
+    invalid = chat(); invalid["messages"][0]["content"] = std::string(100, 'x');
+    response_body(models.post(invalid).read(), 400);
+    response_body(models.post(chat("auto"), "/v1/messages/count_tokens").read(), 400);
+    ROUTING_CHECK(response_body(models.post(chat("ds4"), "/v1/messages/count_tokens").read())["input_tokens"] == 2);
+    ROUTING_CHECK(response_body(models.post(chat("qwen"), "/v1/messages/count_tokens").read())["input_tokens"] == 1);
+    {
+        std::lock_guard<std::mutex> lock(models.first.engine.mu);
+        models.first.engine.fail_next = true;
+    }
+    response_body(models.post(chat("qwen")).read(), 500);
+    models.wait_load(0, 0);
+    models.first.engine.finish();
+    ROUTING_CHECK(response_body(models.post(chat("qwen")).read())["model"] == "qwen");
+}
+
+TEST_CASE(ModelRoutingFixture, test_disconnect_holds_capacity_until_engine_retirement) {
+    RunningModels models;
+    auto a = models.post(chat("qwen"));
+    auto b = models.post(chat("qwen"));
+    models.first.engine.wait_admissions(2);
+    {
+        std::unique_lock<std::mutex> lock(models.first.engine.mu);
+        models.first.engine.block_step = true;
+        ROUTING_CHECK(models.first.engine.cv.wait_for(lock, 5s, [&] { return models.first.engine.inside_block; }));
+    }
+    // A TCP reset is an unambiguous disconnect. FIN alone also represents a
+    // legitimate HTTP client that half-closes its write side and keeps reading.
+    linger reset{1, 0};
+    ROUTING_CHECK(setsockopt(a.get(), SOL_SOCKET, SO_LINGER, &reset, sizeof(reset)) == 0);
+    a.close(); // A running step still owns this request's state.
+    models.second.engine.finish();
+    ROUTING_CHECK(response_body(models.post(chat("qwen")).read())["model"] == "ds4");
+    models.wait_load(2, 0); // Fallback did not reclaim a primary slot mid-step.
+    {
+        std::lock_guard<std::mutex> lock(models.first.engine.mu);
+        models.first.engine.block_step = false;
+        models.first.engine.cv.notify_all();
+    }
+    models.first.engine.wait_retirements(1);
+    models.wait_load(1, 0);
+    auto replacement = models.post(chat("qwen"));
+    models.first.engine.wait_admissions(3);
+    models.first.engine.finish();
+    ROUTING_CHECK(response_body(b.read())["model"] == "qwen");
+    ROUTING_CHECK(response_body(replacement.read())["model"] == "qwen");
+    models.wait_load(0, 0);
+}
+
+TEST_CASE(ModelRoutingFixture, test_response_protocols_use_selected_model_and_terminal_event) {
+    RunningModels models;
+    {
+        std::lock_guard<std::mutex> lock(models.first.engine.mu);
+        models.first.engine.capacity_busy = true;
+    }
+    models.second.engine.finish();
+    const auto stream = models.post(chat("ds4", true)).read();
+    ROUTING_CHECK(stream.rfind("HTTP/1.1 200 ", 0) == 0);
+    ROUTING_CHECK(stream.find("\"model\":\"ds4\"") != std::string::npos);
+    ROUTING_CHECK(stream.find("\"content\":\"s\"") != std::string::npos);
+    ROUTING_CHECK(stream.find("data: [DONE]") != std::string::npos);
+    const auto message = response_body(models.post(chat("ds4"), "/v1/messages").read());
+    ROUTING_CHECK(message["model"] == "ds4");
+    ROUTING_CHECK(message["content"][0]["text"] == "s");
+    json request = {{"model", "ds4"}, {"input", {{{"role", "user"}, {"content", "x"}}}},
+                    {"max_output_tokens", 4}};
+    const auto response = response_body(models.post(request, "/v1/responses").read());
+    ROUTING_CHECK(response["model"] == "ds4");
+    ROUTING_CHECK(response["output"][0]["content"][0]["text"] == "s");
+    models.wait_load(0, 0);
+}
+
+TEST_CASE(ModelRoutingFixture, test_shutdown_drains_both_models_and_incomplete_upload) {
+    RunningModels models;
+    auto a = models.post(chat("qwen"));
+    models.first.engine.wait_admissions(1);
+    auto extra = models.post(chat("auto"));
+    models.first.engine.wait_admissions(2);
+    auto b = models.post(chat("ds4"));
+    auto incomplete = models.connect_client();
+    incomplete.send("POST /v1/chat/completions HTTP/1.1\r\nContent-Length: 100\r\n\r\n{");
+    models.first.engine.wait_admissions(1);
+    models.second.engine.wait_admissions(1);
+    models.listener->request_stop();
+    models.runner.join();
+    ROUTING_CHECK(models.result == 0);
+    ROUTING_CHECK(models.first.engine.retirements == 2);
+    ROUTING_CHECK(models.second.engine.retirements == 1);
+}
+
+TEST_CASE(ModelRoutingFixture, test_hybrid_admission_uses_single_capacity_and_independent_workers) {
+    RunningModels models(true);
+    const auto props = models.get("/props")["models"];
+    ROUTING_CHECK(props[0]["capacity"] == 2 && props[0]["execution_mode"] == "batched");
+    ROUTING_CHECK(props[1]["capacity"] == 1 && props[1]["execution_mode"] == "single-request");
+    auto first = models.post(chat());
+    models.first.engine.wait_admissions(1);
+    auto third = models.post(chat());
+    models.first.engine.wait_admissions(2);
+    auto second = models.post(chat("ds4"));
+    models.single.wait_calls(1);
+    models.wait_load(2, 1);
+    response_body(models.post(chat("ds4")).read(), 503);
+    models.first.engine.finish();
+    ROUTING_CHECK(response_body(first.read())["model"] == "qwen");
+    ROUTING_CHECK(response_body(third.read())["model"] == "qwen");
+    models.wait_load(0, 1);
+    models.single.finish();
+    const auto body = response_body(second.read());
+    ROUTING_CHECK(body["model"] == "ds4");
+    ROUTING_CHECK(body["choices"][0]["message"]["content"] == "s");
+    models.wait_load(0, 0);
+    ROUTING_CHECK(models.single.prompts[0] == std::vector<int32_t>({1, 3}));
+    ROUTING_CHECK(models.single.temperatures[0] == 0.7f);
+}
+
+TEST_CASE(ModelRoutingFixture, test_hybrid_disconnect_cancels_single_worker_and_reuses_capacity) {
+    RunningModels models(true);
+    {
+        std::lock_guard<std::mutex> lock(models.first.engine.mu);
+        models.first.engine.capacity_busy = true;
+    }
+    auto client = models.post(chat("ds4", true));
+    models.single.wait_calls(1);
+    linger reset{1, 0};
+    ROUTING_CHECK(setsockopt(client.get(), SOL_SOCKET, SO_LINGER, &reset, sizeof(reset)) == 0);
+    client.close();
+    models.single.wait_cancellations(1);
+    models.wait_load(0, 0);
+    models.single.finish();
+    const auto stream = models.post(chat("ds4", true)).read();
+    ROUTING_CHECK(stream.find("\"model\":\"ds4\"") != std::string::npos);
+    ROUTING_CHECK(stream.find("\"content\":\"s\"") != std::string::npos);
+    ROUTING_CHECK(stream.find("data: [DONE]") != std::string::npos);
+}
+
+TEST_CASE(ModelRoutingFixture, test_hybrid_shutdown_drains_single_worker_before_destroying_contexts) {
+    RunningModels models(true);
+    auto first = models.post(chat("qwen"));
+    models.first.engine.wait_admissions(1);
+    auto extra = models.post(chat("auto"));
+    models.first.engine.wait_admissions(2);
+    auto second = models.post(chat("ds4", true));
+    models.single.wait_calls(1);
+    models.listener->request_stop();
+    models.single.finish();
+    models.runner.join();
+    ROUTING_CHECK(models.result == 0);
+    ROUTING_CHECK(models.single.cancellations == 0);
+    const auto stream = second.read();
+    ROUTING_CHECK(stream.find("data: [DONE]") != std::string::npos);
+    ROUTING_CHECK(stream.find("\"content\":\"s\"") != std::string::npos);
+    ROUTING_CHECK(models.first.engine.retirements == 2);
+}
+
+// The prior fixtures cover batched/batched and batched/native. These protect
+// the pilot's native/native ownership, including the listener's own worker.
+TEST_CASE(ModelRoutingFixture, test_two_native_workers_preserve_priority_and_capacity) {
+    RunningModels models(true, true);
+    const auto props = models.get("/props");
+    ROUTING_CHECK(props["routing"] == "primary-first");
+    for (const auto & model : props["models"]) {
+        ROUTING_CHECK(model["capacity"] == 1);
+        ROUTING_CHECK(model["execution_mode"] == "single-request");
+    }
+    auto first = models.post(chat("qwen"));
+    models.first_single.wait_calls(1);
+    auto second = models.post(chat("ds4"));
+    models.single.wait_calls(1);
+    models.wait_load(1, 1);
+    response_body(models.post(chat("ds4")).read(), 503);
+    models.first_single.finish();
+    const auto qwen = response_body(first.read());
+    ROUTING_CHECK(qwen["model"] == "qwen");
+    ROUTING_CHECK(qwen["choices"][0]["message"]["content"] == "q");
+    models.wait_load(0, 1);
+    models.single.finish();
+    const auto ds4 = response_body(second.read());
+    ROUTING_CHECK(ds4["model"] == "ds4");
+    ROUTING_CHECK(ds4["choices"][0]["message"]["content"] == "s");
+    models.wait_load(0, 0);
+    ROUTING_CHECK(models.first_single.prompts[0] == std::vector<int32_t>({1}));
+    ROUTING_CHECK(models.single.prompts[0] == std::vector<int32_t>({1, 3}));
+    ROUTING_CHECK(response_body(models.post(chat("auto")).read())["model"] == "qwen");
+}
+
+TEST_CASE(ModelRoutingFixture, test_two_native_workers_finish_before_shutdown_returns) {
+    RunningModels models(true, true);
+    auto first = models.post(chat("qwen", true));
+    models.first_single.wait_calls(1);
+    auto second = models.post(chat("ds4"));
+    models.single.wait_calls(1);
+    models.listener->request_stop();
+    models.first_single.finish();
+    models.single.finish();
+    models.runner.join();
+    ROUTING_CHECK(models.result == 0);
+    ROUTING_CHECK(models.first_single.cancellations == 0);
+    ROUTING_CHECK(models.single.cancellations == 0);
+    const auto stream = first.read();
+    ROUTING_CHECK(stream.find("data: [DONE]") != std::string::npos);
+    ROUTING_CHECK(stream.find("\"content\":\"q\"") != std::string::npos);
+    ROUTING_CHECK(response_body(second.read())["choices"][0]["message"]["content"] == "s");
+}
+
+TEST_CASE(ModelRoutingFixture, test_default_native_worker_finishes_active_response_on_shutdown) {
+    for (bool stream : {false, true}) {
+        RunningModels models(false, true, false);
+        auto client = models.post(chat("alias", stream));
+        models.first_single.wait_calls(1);
+        models.listener->request_stop();
+        models.first_single.finish();
+        models.runner.join();
+        ROUTING_CHECK(models.result == 0);
+        ROUTING_CHECK(models.first_single.cancellations == 0);
+        const auto response = client.read();
+        if (stream) {
+            ROUTING_CHECK(response.find("data: [DONE]") != std::string::npos);
+            ROUTING_CHECK(response.find("\"content\":\"q\"") != std::string::npos);
+        } else {
+            ROUTING_CHECK(response_body(response)["choices"][0]["message"]["content"] == "q");
+        }
+    }
+}
+
+// Exercise primary preference, engine KV pressure below slot capacity, and
+// listener-owned waiting/cancellation independently of request model names.
+TEST_CASE(ModelRoutingFixture, test_model_names_and_auto_fill_primary_then_secondary_and_drain_waiter) {
+    RunningModels models(false, false, true, 1);
+    auto omitted = chat(); omitted.erase("model");
+    auto a = models.post(omitted);
+    models.first.engine.wait_admissions(1);
+    auto b = models.post(chat("ds4"));
+    models.first.engine.wait_admissions(2);
+    auto c = models.post(chat("auto"));
+    models.second.engine.wait_admissions(1);
+    auto d = models.post(chat("qwen"));
+    models.second.engine.wait_admissions(2);
+    auto waiting = models.post(chat("unrecognized-client-alias"));
+    const auto deadline = Clock::now() + 5s;
+    while (models.get("/status/json")["waiting"] != 1) {
+        ROUTING_CHECK(Clock::now() < deadline);
+        std::this_thread::yield();
+    }
+    response_body(models.post(chat("qwen")).read(), 503);
+    models.first.engine.finish();
+    ROUTING_CHECK(response_body(a.read())["model"] == "qwen");
+    ROUTING_CHECK(response_body(b.read())["model"] == "qwen");
+    ROUTING_CHECK(response_body(waiting.read())["model"] == "qwen");
+    models.wait_load(0, 2);
+    models.second.engine.finish();
+    ROUTING_CHECK(response_body(c.read())["model"] == "ds4");
+    ROUTING_CHECK(response_body(d.read())["model"] == "ds4");
+}
+
+TEST_CASE(ModelRoutingFixture, test_kv_busy_falls_back_before_stream_headers_and_retokenizes) {
+    RunningModels models;
+    {
+        std::lock_guard<std::mutex> lock(models.first.engine.mu);
+        models.first.engine.capacity_busy = true;
+    }
+    models.second.engine.finish();
+    ROUTING_CHECK(response_body(models.post(chat("qwen")).read())["model"] == "ds4");
+    const auto stream = models.post(chat("auto", true)).read();
+    ROUTING_CHECK(stream.find("HTTP/1.1 200 ") == 0);
+    ROUTING_CHECK(stream.find("HTTP/1.1", 1) == std::string::npos);
+    ROUTING_CHECK(stream.find("\"model\":\"qwen\"") == std::string::npos);
+    ROUTING_CHECK(stream.find("\"model\":\"ds4\"") != std::string::npos);
+    ROUTING_CHECK(stream.find("data: [DONE]") != std::string::npos);
+    models.wait_load(0, 0);
+    ROUTING_CHECK(models.first.engine.admissions == 0);
+    ROUTING_CHECK(models.second.engine.prompts[0] == std::vector<int32_t>({1, 3}));
+    ROUTING_CHECK(models.second.engine.temperatures[0] == 0.7f);
+}
+
+TEST_CASE(ModelRoutingFixture, test_permanent_capacity_falls_back_or_rejects_without_waiting) {
+    RunningModels models;
+    {
+        std::lock_guard<std::mutex> lock(models.first.engine.mu);
+        models.first.engine.prompt_capacity = 0;
+    }
+    models.second.engine.finish();
+    ROUTING_CHECK(response_body(models.post(chat("auto")).read())["model"] == "ds4");
+    models.wait_load(0, 0);
+    {
+        std::lock_guard<std::mutex> lock(models.second.engine.mu);
+        models.second.engine.prompt_capacity = 0;
+    }
+    response_body(models.post(chat("auto")).read(), 400);
+    ROUTING_CHECK(models.get("/status/json")["waiting"] == 0);
+    auto oversized = chat("auto");
+    oversized["messages"][0]["content"] = std::string(100, 'x');
+    response_body(models.post(oversized).read(), 400);
+    ROUTING_CHECK(models.get("/status/json")["waiting"] == 0);
+}
+
+TEST_CASE(ModelRoutingFixture, test_busy_engines_retry_without_retirement_notification) {
+    RunningModels models(false, false, true, 1);
+    {
+        std::scoped_lock lock(models.first.engine.mu, models.second.engine.mu);
+        models.first.engine.capacity_busy = true;
+        models.second.engine.capacity_busy = true;
+    }
+    auto waiting = models.post(chat("auto"));
+    const auto deadline = Clock::now() + 5s;
+    while (models.get("/status/json")["waiting"] != 1) {
+        ROUTING_CHECK(Clock::now() < deadline);
+        std::this_thread::yield();
+    }
+    {
+        std::lock_guard<std::mutex> lock(models.second.engine.mu);
+        models.second.engine.capacity_busy = false;
+    }
+    models.second.engine.wait_admissions(1);
+    ROUTING_CHECK(models.get("/status/json")["waiting"] == 0);
+    models.second.engine.finish();
+    ROUTING_CHECK(response_body(waiting.read())["model"] == "ds4");
+}
+
+TEST_CASE(ModelRoutingFixture, test_waiting_disconnect_and_shutdown_release_requests) {
+    RunningModels models(true, true, true, 1);
+    auto a = models.post(chat("auto"));
+    models.first_single.wait_calls(1);
+    auto b = models.post(chat("auto"));
+    models.single.wait_calls(1);
+    auto waiting = models.post(chat("auto"));
+    auto wait_count = [&](int count) {
+        const auto deadline = Clock::now() + 5s;
+        while (models.get("/status/json")["waiting"] != count) {
+            ROUTING_CHECK(Clock::now() < deadline);
+            std::this_thread::yield();
+        }
+    };
+    wait_count(1);
+    linger reset{1, 0};
+    ROUTING_CHECK(setsockopt(waiting.get(), SOL_SOCKET, SO_LINGER, &reset, sizeof(reset)) == 0);
+    waiting.close();
+    wait_count(0);
+    auto replacement = models.post(chat("auto"));
+    wait_count(1);
+    models.listener->request_stop();
+    models.first_single.finish();
+    models.single.finish();
+    models.runner.join();
+    ROUTING_CHECK(models.result == 0);
+    response_body(replacement.read(), 503);
+}
+
+// Busy probes must not wake each other into an unbounded admission loop.
+// Existing retry coverage has only one waiter, so it cannot expose that loop.
+TEST_CASE(ModelRoutingFixture, test_busy_waiters_do_not_trigger_each_others_retries) {
+    RunningModels models(false, false, true, 2);
+    {
+        std::scoped_lock lock(models.first.engine.mu, models.second.engine.mu);
+        models.first.engine.capacity_busy = true;
+        models.second.engine.capacity_busy = true;
+    }
+    auto a = models.post(chat());
+    auto b = models.post(chat());
+    {
+        std::unique_lock<std::mutex> lock(models.first.engine.mu);
+        // Over one 250 ms retry interval, two clients should make only a
+        // handful of attempts. Allow ample scheduling/spurious-wakeup slack.
+        ROUTING_CHECK(!models.first.engine.cv.wait_for(lock, 250ms, [&] {
+            return models.first.engine.attempts >= 32;
+        }));
+    }
+    models.listener->request_stop();
+    models.runner.join();
+    response_body(a.read(), 503);
+    response_body(b.read(), 503);
+}
+
+// The routed test covers this error only with admission feedback enabled.
+TEST_CASE(ModelRoutingFixture, test_single_model_permanent_capacity_is_client_error) {
+    RunningModels models(false, false, false);
+    {
+        std::lock_guard<std::mutex> lock(models.first.engine.mu);
+        models.first.engine.prompt_capacity = 0;
+    }
+    for (bool stream : {false, true}) {
+        response_body(models.post(chat("qwen", stream)).read(), 400);
+    }
+    ROUTING_CHECK(models.first.engine.admissions == 0);
+}
+
+// Disabled balancing must not start a peer or let a client alias change identity.
+TEST_CASE(ModelRoutingFixture, test_single_model_run_does_not_enable_balancing) {
+    RunningModels models(false, false, false);
+    ROUTING_CHECK(!models.get("/props").contains("routing"));
+    ROUTING_CHECK(models.get("/v1/models")["data"].size() == 1);
+    models.first.engine.finish();
+    auto request = chat(); request.erase("model");
+    ROUTING_CHECK(response_body(models.post(request).read())["model"] == "qwen");
+    ROUTING_CHECK(response_body(models.post(chat("ds4")).read())["model"] == "qwen");
+    ROUTING_CHECK(models.second.engine.admissions == 0);
+}
+
+// Protect priority reversal and removal of secondary-name pinning. The old
+// suite only selected the first registered model when both had capacity.
+TEST_CASE(ModelRoutingFixture, test_reversed_priority_ignores_generation_model_names) {
+    RunningModels models(false, false, true, 0, true);
+    models.first.engine.finish();
+    models.second.engine.finish();
+    for (const char * name : {"qwen", "ds4", "auto", "", "client-alias"}) {
+        ROUTING_CHECK(response_body(models.post(chat(name)).read())["model"] == "ds4");
+    }
+    ROUTING_CHECK(models.first.engine.admissions == 0);
+    ROUTING_CHECK(response_body(models.post(chat("qwen"), "/v1/messages/count_tokens").read())["input_tokens"] == 1);
+    {
+        std::lock_guard<std::mutex> lock(models.second.engine.mu);
+        models.second.engine.capacity_busy = true;
+    }
+    ROUTING_CHECK(response_body(models.post(chat("ds4")).read())["model"] == "qwen");
+}
+
+#undef ROUTING_CHECK
+#endif

--- a/server/test/test_seq_slot_manager.cpp
+++ b/server/test/test_seq_slot_manager.cpp
@@ -192,7 +192,7 @@ int main() {
         PagedKvPool pool(4, 2, /*block_size=*/16);
         Qwen35SlotManager mgr(pool, /*max_ctx=*/128);
         auto never = admit(mgr, 1, prompt_tokens(100), greedy_sampler());
-        CHECK(!is_admitted(never) && !is_busy(never));   // prompt 100 > pool 64
+        CHECK(never.status == SeqEngine::AdmitResult::Status::capacity_exceeded); // prompt 100 > pool 64
         CHECK(pool.active_sequence_count() == 0);
 
         // Impossibility wins over temporary slot pressure: do not queue an

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -120,6 +120,19 @@ struct ServerUnitFixture {};
     } \
 } while (0)
 
+// Device ordinals must not wrap when matching routing priority to placement.
+TEST_CASE(ServerUnitFixture, test_placement_device_rejects_gpu_index_overflow) {
+    DevicePlacement device;
+    TEST_ASSERT(parse_placement_device("hip:0", device));
+    TEST_ASSERT(parse_placement_device(
+        "hip:" + std::to_string(std::numeric_limits<int>::max()), device));
+    for (const char * value : {"hip:2147483648", "hip:4294967296",
+                              "hip:999999999999999999999999999999", "hip:-1"}) {
+        TEST_ASSERT(!parse_placement_device(value, device));
+    }
+    TEST_ASSERT(!parse_placement_device_list("hip:0,hip:4294967296", device));
+}
+
 TEST_CASE(ServerUnitFixture, test_api_format_names_are_total) {
     CHECK(std::string(api_format_name(ApiFormat::OPENAI_CHAT)) == "chat");
     CHECK(std::string(api_format_name(ApiFormat::ANTHROPIC)) == "anthropic");


### PR DESCRIPTION
This PR lets one `dflash_server` process serve several models through one HTTP address. You choose where each model loads, which model gets requests first, and whether requests may fall back to another model when the preferred model is busy.

For example, Qwen can stay on the R9700 and DeepSeek4 on Strix Halo. Changing the primary GPU reverses request priority while keeping both model placements unchanged.

### Request behavior

| Situation | What happens |
| --- | --- |
| Load balancing is disabled (the default) | Only the selected primary model loads and serves. Other configured model blocks are unused. |
| Load balancing is enabled and the primary has capacity | The primary serves the request. |
| The primary has no free slot or enough available KV-cache capacity | The server tries the other loaded models in their configured order. |
| Every eligible model is busy | The request waits in memory, subject to `--routing-queue-limit`. A full waiting queue returns HTTP 503. |
| A request cannot fit a model's context or total KV capacity | That model is skipped. When no model can fit, the request returns HTTP 400. |
| A request has already started generating | It stays on that model until completion, cancellation, or failure. |

**The generation request's `model` field does not select or pin a model.** Omitted names, `auto`, configured names, and other client aliases all follow the operator's priority. The response identifies the model that actually answered. This applies to Chat Completions, Messages, and Responses.

Fallback happens before response headers or prefill. Each attempt renders and tokenizes the original request with the selected model's own template, tokenizer, and defaults. Validation errors and backend failures other than admission-capacity rejection terminate the request without fallback.

### Launch options

Each `--model <path>` starts a model block. Model-specific options following it apply to that model until the next `--model`.

| Option | Scope | Meaning / default |
| --- | --- | --- |
| `--model <path>` | Per model | Starts a block and selects its GGUF file. The first path may also be positional for existing single-model commands. |
| `--load-balancing-primary-gpu <backend:gpu>` | Whole launch | Selects the primary by matching exactly one block's target device. If omitted, the first block is primary. Does not change model placement or enable balancing. |
| `--load-balancing` | Whole launch | Enables primary-first capacity fallback and loads all configured models. Off by default; requires at least two model blocks. |
| `--routing-queue-limit <N>` | Listener; first block | Maximum waiting routing requests. Default **32**; **0** returns 503 immediately when every eligible model is busy. |

The old `--primary-gpu`, `--load-balancing-next-model`, and `--next-model` spellings are rejected.

### Example: Qwen on R9700, DeepSeek4 on Strix Halo

This example assumes R9700 is `hip:0` and Strix Halo is `hip:1`. Replace the paths and device IDs with those on the host.

```bash
dflash_server --load-balancing --load-balancing-primary-gpu hip:0 \
  --model /models/qwen38-27b.gguf \
  --model-name qwen --target-device hip:0 \
  --draft /models/qwen38-dflash2.gguf --draft-device hip:0 \
  --max-ctx 4096 --max-concurrency 4 --kv-pool-tokens 16384 \
  --cache-type-k q8_0 --cache-type-v q8_0 --fa-window 0 \
  --default-max-tokens 2048 --hard-limit-reply-budget 1024 \
  --host 127.0.0.1 --port 8080 --routing-queue-limit 32 \
  --model /models/deepseek-v4-flash.gguf \
  --model-name ds4 --target-device hip:1 \
  --max-ctx 8192 --max-concurrency 1 \
  --default-max-tokens 2048 --hard-limit-reply-budget 1024 \
  --prefix-cache-slots 0 --prefill-cache-slots 0 --disk-prefix-cache off \
  --ds4-fused-decode --ds4-expert-top-k 6 --ds4-prefill exact
```

Here Qwen can hold up to four active reservations, and DS4 one. KV pressure can trigger fallback before all four Qwen slots are occupied. Change only the primary flag to `--load-balancing-primary-gpu hip:1` to try DS4 first. Remove `--load-balancing` to load and serve only that selected primary.

### Ownership and observability

The listener reuses the existing model loaders and workers. Each model owns its tokenizer, defaults, backend, and scheduler. A listener reservation lasts through engine retirement and output draining, so a disconnect cannot expose capacity while GPU work is still running. The scheduler owns actual KV admission. GPU draft top-K and CUDA sampling scratch are owned by each worker thread and released on their allocation device when the worker exits. Native single-request workers finish active requests during SIGTERM, including terminal response events; genuine client disconnects still cancel generation, and routing waiters receive 503.

`/v1/models` lists the loaded models. `/props` and `/status/json` expose their placement, priority order, capacity, in-flight reservations, and waiting counts. In multi-model serving, token counting requires an explicit model name and uses that model's tokenizer without fallback.

### Limits

Waiting is in memory, without a server queue deadline or FIFO guarantee. Capacity release wakes waiters; a 250 ms retry also observes engine capacity changes, disconnects, and shutdown. Slow readers can retain reservations while output drains.

This change selects a model before generation. It does not migrate active streams, suspend requests to SSD, or recover universally from GPU OOM. Admission protects the prompt and rolling decode headroom; later cache exhaustion keeps the existing error/retirement behavior. Cross-model continuation would require text replay because KV/recurrent states are incompatible.

Environment settings remain process-wide. With balancing enabled, startup rejects unsupported shared-policy combinations, including KVFlash/Spark CLI controls, compression, remote drafts, and target splitting. With balancing disabled, the selected primary retains single-model CLI features; unused blocks do not apply environment policy. No throughput or latency improvement is claimed.

### Validation

- 500 server unit tests passed, including native streaming/non-streaming shutdown completion, routed native/hybrid draining, disconnect cancellation, and waiter cleanup. All nine CLI model-name/policy cases passed.
- All 13 native CUDA sampler/top-K fixture tests passed on DGX GB10 (sm_121), including both concurrent-worker tests; the full NVIDIA GPU CI job passed. CI now explicitly runs these fixtures and the three HIP top-K cases on AMD.
- HIP top-K parity and concurrent-worker/device-switch tests passed. The deterministic interleaving that previously returned another worker's candidate IDs now returns each caller's correct IDs.
- Qwen3.8-27B + DFlash2 on R9700 and native DS4 on Strix each finish all 400 requested tokens with `[DONE]` after SIGTERM. Their complete outputs match the clean pre-PR reference exactly; the prior head stopped at 104 and 101 generated tokens respectively.
- Final real-model qualification passed 76 assertions: native Qwen + DS4 and batched Qwen + DS4 routing, fallback across all three APIs, queue overflow, waiter abandonment, disconnect cleanup, capacity reuse, and shutdown 503 responses. Native active requests drain normally; batched slots retain their existing cancellation/finalization behavior.
- Three concurrent two-Qwen DDTree/DFlash2 request pairs completed cleanly and matched the earlier CPU top-K control. A disabled-balancing launch with an unused KVFlash-configured DS4 block successfully served through the selected paged Qwen model. All test processes exited.

The server was rebuilt with the clean PR dependencies for both `gfx1201` and `gfx1151`. Native NVIDIA execution passed on DGX GB10 in [CI](https://github.com/Luce-Org/lucebox/actions/runs/34472272385); all 10 local sampler checks also passed using a disposable HIP adaptation. Tests use the repository-converted GGUF DFlash2 draft because the existing safetensors loader does not load its selector.

Usage and detailed boundaries: [MODEL_LOAD_BALANCING.md](https://github.com/Graffioh/lucebox-hub/blob/codex/primary-capacity-routing/server/docs/MODEL_LOAD_BALANCING.md). The loader is adapted from commit `63151ff8`, preserved behind [luce_box#103](https://github.com/Luce-Org/luce_box/pull/103) and [luce_box#105](https://github.com/Luce-Org/luce_box/pull/105).

