### PR TITLE
fix(ci) pause the RTX 3090 jobs while the runner is offline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,12 +159,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - job_name: GPU tests (self-hosted RTX 3090, sm_86)
-            runner: lucebox-rtx3090
-            arch: "86"
-            compute_cap: "8.6"
-            concurrency_group: lucebox-rtx3090-gpu-runner
-            sparse_attention: "true"
+          # TEMPORARY (2026-09-09): the lucebox-rtx3090 runner is offline
+          # (NVIDIA driver not responding since 2026-09-07), so every run of
+          # this entry fails before the checkout step. Restore the entry once
+          # the runner is back. The sparse-attention smoke is 3090-only and
+          # does not run while this is commented out.
+          # - job_name: GPU tests (self-hosted RTX 3090, sm_86)
+          #   runner: lucebox-rtx3090
+          #   arch: "86"
+          #   compute_cap: "8.6"
+          #   concurrency_group: lucebox-rtx3090-gpu-runner
+          #   sparse_attention: "true"
           - job_name: GPU tests (self-hosted DGX GB10, sm_121 verifier)
             runner: dgx-gb10
             arch: "121"

--- a/.github/workflows/speed-profile.yml
+++ b/.github/workflows/speed-profile.yml
@@ -29,6 +29,10 @@ concurrency:
 jobs:
   speed-profile:
     name: Speed profile (self-hosted RTX 3090, sm_86)
+    # TEMPORARY (2026-09-09): the lucebox-rtx3090 runner is offline, so PR
+    # runs fail at the GPU-info step. Only manual dispatch runs until the
+    # runner is back; drop this condition to restore automatic PR profiling.
+    if: github.event_name == 'workflow_dispatch'
     runs-on: [self-hosted, lucebox-rtx3090]
     timeout-minutes: 30
     # Keep automatic PR profiling advisory, but make a manual promotion check honest:


### PR DESCRIPTION
The lucebox-rtx3090 runner has been offline since 2026-09-07 (NVIDIA driver not responding), so the 3090 GPU-tests matrix entry and the PR speed profile fail on every run.

This comments out the 3090 matrix entry in CI (the GB10 entry is unchanged) and limits the speed profile to manual dispatch. Both changes are marked TEMPORARY in the workflow files; revert this commit once the runner is repaired.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

