### PR TITLE
feat(pflash): Qwen3.5-0.8B hybrid drafter with block-15 LongAttnComp scorer

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -453,6 +453,7 @@ add_library(dflash_common STATIC
     src/draft/draft_safetensors_loader.cpp
     src/draft/draft_graph.cpp
     src/qwen3/anchor_scan.cpp
+    src/qwen3/pflash_selection.cpp
     src/qwen3/qwen3_drafter.cpp
     src/qwen3/qwen3_kvflash_scorer.cpp
     src/qwen3/qwen3_loader.cpp
@@ -1671,6 +1672,8 @@ if(DFLASH27B_TESTS)
             test/test_drafter_tail_capture_guard.cpp
             test/test_drafter_warm_path_regression.cpp
             test/test_qwen3_buffer_plan.cpp
+            test/test_pflash_drafter_ipc.cpp
+            test/test_pflash_selection.cpp
             test/test_model_test_paths.cpp
             test/test_gguf_mmap.cpp
             test/test_kv_quant.cpp

--- a/server/README.md
+++ b/server/README.md
@@ -319,11 +319,23 @@ See the [current six-expert Strix Halo profile](https://www.lucebox.com/blog/dee
 | `--prefill-threshold <N>` | `32000` | Token threshold used by auto mode. |
 | `--prefill-keep-ratio <F>` | `0.05` | Fraction of source tokens kept. |
 | `--prefill-curve T:R [T:R ...]` | none | Piecewise keep-ratio curve; overrides the flat ratio. |
-| `--prefill-drafter <path>` | none | PFlash drafter GGUF. |
+| `--prefill-drafter <path>` | none | PFlash drafter GGUF: Qwen3-0.6B, or Qwen3.5-0.8B when the file name contains `qwen3.5`/`qwen35`. |
 | `--prefill-skip-park` | off | Keep target and decode draft resident while PFlash runs. |
 | `--prefill-upstream-base <URL>` | none | Enable compression-proxy mode. |
 | `--prefill-upstream-key <KEY>` | none | Bearer token for the upstream. |
 | `--prefill-upstream-model <NAME>` | none | Model name forwarded upstream. |
+
+With a Qwen3.5-0.8B drafter and strict LongAttnComp selection
+(`PFLASH_LONGATTNCOMP_MODE=budget_only`, `PFLASH_LONGATTNCOMP_CHUNK_SIZE`,
+`PFLASH_LONGATTNCOMP_QUERY_TOKENS`), the drafter runs only its first fifteen
+blocks and scores the context with block 15's NoPE Q/K projections, the same
+attention-mass scorer the Qwen3-0.6B block-13 head uses. Its 262K native
+context covers inputs the Qwen3-0.6B drafter cannot score within its 32K
+window. `PFLASH_LONGATTNCOMP_HEAD_GGUF` accepts a trained block-15 head
+(schema `qwen3_5_0_8b_nope_qk_mass_v1`); `PFLASH_QWEN35_LEGACY_SCORER=1`
+restores the previous all-layer running-max scorer. The Qwen3.5 attention
+runs dense (`ggml_flash_attn_ext`); the block-sparse FlashPrefill kernels
+still dispatch head dimension 128 only.
 
 ### Reasoning and MoE controls
 

--- a/server/README.md
+++ b/server/README.md
@@ -337,6 +337,18 @@ restores the previous all-layer running-max scorer. The Qwen3.5 attention
 runs dense (`ggml_flash_attn_ext`); the block-sparse FlashPrefill kernels
 still dispatch head dimension 128 only.
 
+The per-session adaptive keep ratio applies to this path unchanged: a request
+carrying a `session_id` retains the session's ratio, the strict selector fills
+its token budget from it, and the ratio is updated from the smoothed DFlash
+acceptance rate after every turn where speculative decoding ran (below 75%
+acceptance retain more, above 85% retain less, 0.5-1 point per turn, bounded
+to 2.5-20%; `server/src/server/adaptive_keep_ratio.h`). A new session starts
+from the configured ratio for its prompt length (`--prefill-keep-ratio` or
+`--prefill-curve`), so the controller adapts around the real-use budget
+instead of a fixed 10%. Acceptance is a proxy for compression quality: it
+does not detect a dropped answer document directly, so the ratio curve and
+the retention benchmarks remain the quality reference.
+
 ### Reasoning and MoE controls
 
 | Option | Default | Purpose |

--- a/server/src/common/model_backend.h
+++ b/server/src/common/model_backend.h
@@ -423,6 +423,12 @@ struct ModelBackend {
     struct CompressRequest {
         std::vector<int32_t> input_ids;      // drafter-tokenized prompt
         float                keep_ratio;      // fraction to keep (0.0–1.0)
+        // Exclusive end and width of the user-query token window inside
+        // input_ids. Negative end preserves the legacy trailing-token window.
+        // Keeping this separate from DFLASH_COMPRESS_QUERY_TOKENS matters:
+        // that knob controls lexical anchors, not neural scorer Q rows.
+        int                  score_query_end = -1;
+        int                  score_query_tokens = 8;
         std::string          drafter_path;    // GGUF path (for lazy-load)
         int                  drafter_gpu = 0;  // backend-local GPU for PFlash drafter
         bool                 skip_park = false; // true on >=32GB GPUs

--- a/server/src/common/model_backend.h
+++ b/server/src/common/model_backend.h
@@ -438,6 +438,14 @@ struct ModelBackend {
     struct CompressResult {
         bool                 ok = false;
         std::vector<int32_t> compressed_ids;  // surviving token IDs
+
+        static CompressResult from_compressed_ids(
+                std::vector<int32_t> ids) {
+            CompressResult result;
+            result.compressed_ids = std::move(ids);
+            result.ok = !result.compressed_ids.empty();
+            return result;
+        }
     };
 
     // Typed compress API (preferred for in-process callers).

--- a/server/src/common/model_backend.h
+++ b/server/src/common/model_backend.h
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include "pflash_types.h"
+
 #include <algorithm>
 #include <cstdint>
 #include <cstdio>
@@ -429,6 +431,9 @@ struct ModelBackend {
         // that knob controls lexical anchors, not neural scorer Q rows.
         int                  score_query_end = -1;
         int                  score_query_tokens = 8;
+        // Role-derived instruction structure in drafter-token coordinates.
+        // Empty is a valid instruction-free or legacy request.
+        std::vector<PFlashTokenSpan> required_instruction_spans;
         std::string          drafter_path;    // GGUF path (for lazy-load)
         int                  drafter_gpu = 0;  // backend-local GPU for PFlash drafter
         bool                 skip_park = false; // true on >=32GB GPUs

--- a/server/src/common/pflash_drafter_ipc.cpp
+++ b/server/src/common/pflash_drafter_ipc.cpp
@@ -3,10 +3,138 @@
 #include "pflash_drafter_ipc.h"
 
 #include <algorithm>
+#include <cerrno>
+#include <climits>
 #include <cmath>
 #include <cstdio>
+#include <cstdlib>
+#include <sstream>
 
 namespace dflash::common {
+
+namespace {
+
+bool parse_int_token(const std::string & raw, int & out) {
+    if (raw.empty()) return false;
+    errno = 0;
+    char * end = nullptr;
+    const long value = std::strtol(raw.c_str(), &end, 10);
+    if (errno == ERANGE || end == raw.c_str() || *end != '\0' ||
+        value < INT_MIN || value > INT_MAX) {
+        return false;
+    }
+    out = (int) value;
+    return true;
+}
+
+bool parse_float_token(const std::string & raw, float & out) {
+    if (raw.empty()) return false;
+    errno = 0;
+    char * end = nullptr;
+    const float value = std::strtof(raw.c_str(), &end);
+    if (errno == ERANGE || end == raw.c_str() || *end != '\0' ||
+        !std::isfinite(value)) {
+        return false;
+    }
+    out = value;
+    return true;
+}
+
+bool validate_request_fields(
+        float keep_ratio,
+        int score_query_tokens,
+        const std::string & path,
+        std::string & error) {
+    if (!std::isfinite(keep_ratio) || keep_ratio < 0.0f || keep_ratio > 1.0f) {
+        error = "PFlash IPC keep_ratio must be finite and in [0, 1]";
+        return false;
+    }
+    if (score_query_tokens < 1) {
+        error = "PFlash IPC score_query_tokens must be positive";
+        return false;
+    }
+    if (path.empty()) {
+        error = "PFlash IPC token path must not be empty";
+        return false;
+    }
+    return true;
+}
+
+} // namespace
+
+bool format_pflash_drafter_ipc_compress_command(
+        float keep_ratio,
+        int score_query_end,
+        int score_query_tokens,
+        const std::string & path,
+        std::string & out,
+        std::string & error) {
+    out.clear();
+    error.clear();
+    if (!validate_request_fields(keep_ratio, score_query_tokens, path, error)) {
+        return false;
+    }
+
+    char keep_text[64];
+    std::snprintf(keep_text, sizeof(keep_text), "%.9g", keep_ratio);
+
+    std::ostringstream line;
+    line << "compress2 " << keep_text << ' ' << score_query_end << ' '
+         << score_query_tokens << ' ' << path;
+    out = line.str();
+    return true;
+}
+
+bool parse_pflash_drafter_ipc_compress_command(
+        const std::string & line,
+        PFlashDrafterIpcCompressCommand & out,
+        std::string & error) {
+    out = {};
+    error.clear();
+
+    std::istringstream iss(line);
+    std::string command;
+    if (!(iss >> command)) {
+        error = "PFlash IPC command is empty";
+        return false;
+    }
+
+    std::string keep_raw;
+    std::string query_end_raw;
+    std::string query_tokens_raw;
+    if (!(iss >> keep_raw >> query_end_raw >> query_tokens_raw)) {
+        error = "PFlash IPC compress command is missing fields";
+        return false;
+    }
+    if (!parse_int_token(query_end_raw, out.score_query_end) ||
+        !parse_int_token(query_tokens_raw, out.score_query_tokens)) {
+        error = "PFlash IPC query fields must be integers";
+        return false;
+    }
+    out.path = read_line_tail(iss);
+
+    if (command == "compress2") {
+        if (!parse_float_token(keep_raw, out.keep_ratio)) {
+            error = "PFlash IPC keep_ratio must be a float";
+            return false;
+        }
+    } else if (command == "compress") {
+        int keep_x1000 = 0;
+        if (!parse_int_token(keep_raw, keep_x1000) ||
+            keep_x1000 < 0 || keep_x1000 > 1000) {
+            error = "PFlash IPC legacy keep_x1000 must be in [0, 1000]";
+            return false;
+        }
+        out.legacy_quantized_ratio = true;
+        out.keep_ratio = (float) keep_x1000 / 1000.0f;
+    } else {
+        error = "unknown PFlash IPC command";
+        return false;
+    }
+
+    return validate_request_fields(
+        out.keep_ratio, out.score_query_tokens, out.path, error);
+}
 
 bool PFlashDrafterIpcClient::start(
         const std::string & bin,
@@ -58,12 +186,15 @@ bool PFlashDrafterIpcClient::compress(
         std::fprintf(stderr, "pflash-ipc write tokens failed: %s\n", path.c_str());
         return false;
     }
-    int keep_x1000 = (int)std::lround(std::max(0.0f, keep_ratio) * 1000.0f);
-    keep_x1000 = std::max(0, std::min(1000, keep_x1000));
-
-    std::fprintf(cmd, "compress %d %d %d %s\n",
-                 keep_x1000, score_query_end, score_query_tokens,
-                 path.c_str());
+    std::string line;
+    std::string error;
+    if (!format_pflash_drafter_ipc_compress_command(
+            keep_ratio, score_query_end, score_query_tokens, path, line, error)) {
+        std::fprintf(stderr, "pflash-ipc bad compress request: %s\n", error.c_str());
+        std::remove(path.c_str());
+        return false;
+    }
+    std::fprintf(cmd, "%s\n", line.c_str());
     std::fflush(cmd);
 
     int32_t status = -1;

--- a/server/src/common/pflash_drafter_ipc.cpp
+++ b/server/src/common/pflash_drafter_ipc.cpp
@@ -40,9 +40,12 @@ bool PFlashDrafterIpcClient::start(
 bool PFlashDrafterIpcClient::compress(
         const std::vector<int32_t> & input_ids,
         float keep_ratio,
-        std::vector<int32_t> & compressed_ids) {
+        std::vector<int32_t> & compressed_ids,
+        int score_query_end,
+        int score_query_tokens) {
 #if defined(_WIN32)
     (void)input_ids; (void)keep_ratio; (void)compressed_ids;
+    (void)score_query_end; (void)score_query_tokens;
     return false;
 #else
     compressed_ids.clear();
@@ -58,7 +61,9 @@ bool PFlashDrafterIpcClient::compress(
     int keep_x1000 = (int)std::lround(std::max(0.0f, keep_ratio) * 1000.0f);
     keep_x1000 = std::max(0, std::min(1000, keep_x1000));
 
-    std::fprintf(cmd, "compress %d %s\n", keep_x1000, path.c_str());
+    std::fprintf(cmd, "compress %d %d %d %s\n",
+                 keep_x1000, score_query_end, score_query_tokens,
+                 path.c_str());
     std::fflush(cmd);
 
     int32_t status = -1;

--- a/server/src/common/pflash_drafter_ipc.cpp
+++ b/server/src/common/pflash_drafter_ipc.cpp
@@ -43,6 +43,7 @@ bool parse_float_token(const std::string & raw, float & out) {
 bool validate_request_fields(
         float keep_ratio,
         int score_query_tokens,
+        const std::vector<PFlashTokenSpan> & instruction_spans,
         const std::string & path,
         std::string & error) {
     if (!std::isfinite(keep_ratio) || keep_ratio < 0.0f || keep_ratio > 1.0f) {
@@ -52,6 +53,22 @@ bool validate_request_fields(
     if (score_query_tokens < 1) {
         error = "PFlash IPC score_query_tokens must be positive";
         return false;
+    }
+    if (instruction_spans.size() > kPFlashMaxInstructionSpans) {
+        error = "PFlash IPC has too many instruction spans";
+        return false;
+    }
+    int previous_end = 0;
+    for (const auto & span : instruction_spans) {
+        if (span.begin < 0 || span.end <= span.begin) {
+            error = "PFlash IPC instruction span is invalid";
+            return false;
+        }
+        if (span.begin < previous_end) {
+            error = "PFlash IPC instruction spans must be ordered and non-overlapping";
+            return false;
+        }
+        previous_end = span.end;
     }
     if (path.empty()) {
         error = "PFlash IPC token path must not be empty";
@@ -71,7 +88,8 @@ bool format_pflash_drafter_ipc_compress_command(
         std::string & error) {
     out.clear();
     error.clear();
-    if (!validate_request_fields(keep_ratio, score_query_tokens, path, error)) {
+    if (!validate_request_fields(
+            keep_ratio, score_query_tokens, {}, path, error)) {
         return false;
     }
 
@@ -81,6 +99,40 @@ bool format_pflash_drafter_ipc_compress_command(
     std::ostringstream line;
     line << "compress2 " << keep_text << ' ' << score_query_end << ' '
          << score_query_tokens << ' ' << path;
+    out = line.str();
+    return true;
+}
+
+bool format_pflash_drafter_ipc_compress_command(
+        float keep_ratio,
+        int score_query_end,
+        int score_query_tokens,
+        const std::vector<PFlashTokenSpan> & required_instruction_spans,
+        const std::string & path,
+        std::string & out,
+        std::string & error) {
+    out.clear();
+    error.clear();
+    if (required_instruction_spans.empty()) {
+        return format_pflash_drafter_ipc_compress_command(
+            keep_ratio, score_query_end, score_query_tokens,
+            path, out, error);
+    }
+    if (!validate_request_fields(
+            keep_ratio, score_query_tokens,
+            required_instruction_spans, path, error)) {
+        return false;
+    }
+
+    char keep_text[64];
+    std::snprintf(keep_text, sizeof(keep_text), "%.9g", keep_ratio);
+    std::ostringstream line;
+    line << "compress3 " << keep_text << ' ' << score_query_end << ' '
+         << score_query_tokens << ' ' << required_instruction_spans.size();
+    for (const auto & span : required_instruction_spans) {
+        line << ' ' << span.begin << ' ' << span.end;
+    }
+    line << ' ' << path;
     out = line.str();
     return true;
 }
@@ -111,13 +163,39 @@ bool parse_pflash_drafter_ipc_compress_command(
         error = "PFlash IPC query fields must be integers";
         return false;
     }
-    out.path = read_line_tail(iss);
-
-    if (command == "compress2") {
+    if (command == "compress3") {
         if (!parse_float_token(keep_raw, out.keep_ratio)) {
             error = "PFlash IPC keep_ratio must be a float";
             return false;
         }
+        std::string count_raw;
+        int span_count = -1;
+        if (!(iss >> count_raw) || !parse_int_token(count_raw, span_count) ||
+            span_count < 0 ||
+            (size_t) span_count > kPFlashMaxInstructionSpans) {
+            error = "PFlash IPC instruction span count is invalid";
+            return false;
+        }
+        out.required_instruction_spans.reserve((size_t) span_count);
+        for (int index = 0; index < span_count; ++index) {
+            std::string begin_raw;
+            std::string end_raw;
+            PFlashTokenSpan span;
+            if (!(iss >> begin_raw >> end_raw) ||
+                !parse_int_token(begin_raw, span.begin) ||
+                !parse_int_token(end_raw, span.end)) {
+                error = "PFlash IPC instruction span fields must be integers";
+                return false;
+            }
+            out.required_instruction_spans.push_back(span);
+        }
+        out.path = read_line_tail(iss);
+    } else if (command == "compress2") {
+        if (!parse_float_token(keep_raw, out.keep_ratio)) {
+            error = "PFlash IPC keep_ratio must be a float";
+            return false;
+        }
+        out.path = read_line_tail(iss);
     } else if (command == "compress") {
         int keep_x1000 = 0;
         if (!parse_int_token(keep_raw, keep_x1000) ||
@@ -127,13 +205,15 @@ bool parse_pflash_drafter_ipc_compress_command(
         }
         out.legacy_quantized_ratio = true;
         out.keep_ratio = (float) keep_x1000 / 1000.0f;
+        out.path = read_line_tail(iss);
     } else {
         error = "unknown PFlash IPC command";
         return false;
     }
 
     return validate_request_fields(
-        out.keep_ratio, out.score_query_tokens, out.path, error);
+        out.keep_ratio, out.score_query_tokens,
+        out.required_instruction_spans, out.path, error);
 }
 
 bool PFlashDrafterIpcClient::start(
@@ -170,10 +250,12 @@ bool PFlashDrafterIpcClient::compress(
         float keep_ratio,
         std::vector<int32_t> & compressed_ids,
         int score_query_end,
-        int score_query_tokens) {
+        int score_query_tokens,
+        const std::vector<PFlashTokenSpan> & required_instruction_spans) {
 #if defined(_WIN32)
     (void)input_ids; (void)keep_ratio; (void)compressed_ids;
     (void)score_query_end; (void)score_query_tokens;
+    (void)required_instruction_spans;
     return false;
 #else
     compressed_ids.clear();
@@ -189,7 +271,8 @@ bool PFlashDrafterIpcClient::compress(
     std::string line;
     std::string error;
     if (!format_pflash_drafter_ipc_compress_command(
-            keep_ratio, score_query_end, score_query_tokens, path, line, error)) {
+            keep_ratio, score_query_end, score_query_tokens,
+            required_instruction_spans, path, line, error)) {
         std::fprintf(stderr, "pflash-ipc bad compress request: %s\n", error.c_str());
         std::remove(path.c_str());
         return false;

--- a/server/src/common/pflash_drafter_ipc.h
+++ b/server/src/common/pflash_drafter_ipc.h
@@ -16,6 +16,27 @@
 
 namespace dflash::common {
 
+struct PFlashDrafterIpcCompressCommand {
+    bool legacy_quantized_ratio = false;
+    float keep_ratio = 0.0f;
+    int score_query_end = -1;
+    int score_query_tokens = 8;
+    std::string path;
+};
+
+bool format_pflash_drafter_ipc_compress_command(
+    float keep_ratio,
+    int score_query_end,
+    int score_query_tokens,
+    const std::string & path,
+    std::string & out,
+    std::string & error);
+
+bool parse_pflash_drafter_ipc_compress_command(
+    const std::string & line,
+    PFlashDrafterIpcCompressCommand & out,
+    std::string & error);
+
 class PFlashDrafterIpcClient {
 public:
     PFlashDrafterIpcClient() = default;

--- a/server/src/common/pflash_drafter_ipc.h
+++ b/server/src/common/pflash_drafter_ipc.h
@@ -30,7 +30,9 @@ public:
 
     bool compress(const std::vector<int32_t> & input_ids,
                   float keep_ratio,
-                  std::vector<int32_t> & compressed_ids);
+                  std::vector<int32_t> & compressed_ids,
+                  int score_query_end = -1,
+                  int score_query_tokens = 8);
 
     bool active() const { return active_; }
     void close();

--- a/server/src/common/pflash_drafter_ipc.h
+++ b/server/src/common/pflash_drafter_ipc.h
@@ -8,6 +8,7 @@
 
 #include "backend_ipc.h"
 #include "io_utils.h"
+#include "pflash_types.h"
 
 #include <cstdint>
 #include <cstdio>
@@ -21,6 +22,7 @@ struct PFlashDrafterIpcCompressCommand {
     float keep_ratio = 0.0f;
     int score_query_end = -1;
     int score_query_tokens = 8;
+    std::vector<PFlashTokenSpan> required_instruction_spans;
     std::string path;
 };
 
@@ -28,6 +30,15 @@ bool format_pflash_drafter_ipc_compress_command(
     float keep_ratio,
     int score_query_end,
     int score_query_tokens,
+    const std::string & path,
+    std::string & out,
+    std::string & error);
+
+bool format_pflash_drafter_ipc_compress_command(
+    float keep_ratio,
+    int score_query_end,
+    int score_query_tokens,
+    const std::vector<PFlashTokenSpan> & required_instruction_spans,
     const std::string & path,
     std::string & out,
     std::string & error);
@@ -53,7 +64,9 @@ public:
                   float keep_ratio,
                   std::vector<int32_t> & compressed_ids,
                   int score_query_end = -1,
-                  int score_query_tokens = 8);
+                  int score_query_tokens = 8,
+                  const std::vector<PFlashTokenSpan> &
+                      required_instruction_spans = {});
 
     bool active() const { return active_; }
     void close();

--- a/server/src/common/pflash_drafter_ipc_daemon.cpp
+++ b/server/src/common/pflash_drafter_ipc_daemon.cpp
@@ -47,9 +47,12 @@ int run_pflash_drafter_ipc_daemon(const char * drafter_path,
         if (cmd == "quit" || cmd == "exit") break;
         if (cmd == "compress") {
             int keep_x1000 = 0;
-            iss >> keep_x1000;
+            int score_query_end = -1;
+            int score_query_tokens = 8;
+            iss >> keep_x1000 >> score_query_end >> score_query_tokens;
             std::string path = read_line_tail(iss);
-            if (keep_x1000 < 0 || keep_x1000 > 1000 || path.empty()) {
+            if (keep_x1000 < 0 || keep_x1000 > 1000 ||
+                score_query_tokens < 1 || path.empty()) {
                 std::fprintf(stderr, "[pflash-ipc-daemon] bad compress: %s\n",
                              line.c_str());
                 stream_status(stream_fd, -1);
@@ -63,7 +66,9 @@ int run_pflash_drafter_ipc_daemon(const char * drafter_path,
                 continue;
             }
             const float keep = (float)keep_x1000 / 1000.0f;
-            auto compressed = drafter_score_and_compress(ctx, input_ids, keep);
+            auto compressed = drafter_score_and_compress(
+                ctx, input_ids, keep, /*chunk_size=*/32, score_query_tokens,
+                /*pool_kernel=*/13, score_query_end);
             if (compressed.empty()) {
                 std::fprintf(stderr, "[pflash-ipc-daemon] compress returned empty\n");
                 stream_status(stream_fd, -1);

--- a/server/src/common/pflash_drafter_ipc_daemon.cpp
+++ b/server/src/common/pflash_drafter_ipc_daemon.cpp
@@ -45,30 +45,26 @@ int run_pflash_drafter_ipc_daemon(const char * drafter_path,
         std::string cmd;
         iss >> cmd;
         if (cmd == "quit" || cmd == "exit") break;
-        if (cmd == "compress") {
-            int keep_x1000 = 0;
-            int score_query_end = -1;
-            int score_query_tokens = 8;
-            iss >> keep_x1000 >> score_query_end >> score_query_tokens;
-            std::string path = read_line_tail(iss);
-            if (keep_x1000 < 0 || keep_x1000 > 1000 ||
-                score_query_tokens < 1 || path.empty()) {
-                std::fprintf(stderr, "[pflash-ipc-daemon] bad compress: %s\n",
-                             line.c_str());
+        if (cmd == "compress" || cmd == "compress2") {
+            PFlashDrafterIpcCompressCommand request;
+            std::string parse_error;
+            if (!parse_pflash_drafter_ipc_compress_command(line, request, parse_error)) {
+                std::fprintf(stderr, "[pflash-ipc-daemon] bad compress: %s (%s)\n",
+                             line.c_str(), parse_error.c_str());
                 stream_status(stream_fd, -1);
                 continue;
             }
-            auto input_ids = read_int32_file(path);
+            auto input_ids = read_int32_file(request.path);
             if (input_ids.empty()) {
                 std::fprintf(stderr, "[pflash-ipc-daemon] read tokens failed: %s\n",
-                             path.c_str());
+                             request.path.c_str());
                 stream_status(stream_fd, -1);
                 continue;
             }
-            const float keep = (float)keep_x1000 / 1000.0f;
             auto compressed = drafter_score_and_compress(
-                ctx, input_ids, keep, /*chunk_size=*/32, score_query_tokens,
-                /*pool_kernel=*/13, score_query_end);
+                ctx, input_ids, request.keep_ratio, /*chunk_size=*/32,
+                request.score_query_tokens, /*pool_kernel=*/13,
+                request.score_query_end);
             if (compressed.empty()) {
                 std::fprintf(stderr, "[pflash-ipc-daemon] compress returned empty\n");
                 stream_status(stream_fd, -1);

--- a/server/src/common/pflash_drafter_ipc_daemon.cpp
+++ b/server/src/common/pflash_drafter_ipc_daemon.cpp
@@ -45,7 +45,7 @@ int run_pflash_drafter_ipc_daemon(const char * drafter_path,
         std::string cmd;
         iss >> cmd;
         if (cmd == "quit" || cmd == "exit") break;
-        if (cmd == "compress" || cmd == "compress2") {
+        if (cmd == "compress" || cmd == "compress2" || cmd == "compress3") {
             PFlashDrafterIpcCompressCommand request;
             std::string parse_error;
             if (!parse_pflash_drafter_ipc_compress_command(line, request, parse_error)) {
@@ -64,7 +64,8 @@ int run_pflash_drafter_ipc_daemon(const char * drafter_path,
             auto compressed = drafter_score_and_compress(
                 ctx, input_ids, request.keep_ratio, /*chunk_size=*/32,
                 request.score_query_tokens, /*pool_kernel=*/13,
-                request.score_query_end);
+                request.score_query_end,
+                request.required_instruction_spans);
             if (compressed.empty()) {
                 std::fprintf(stderr, "[pflash-ipc-daemon] compress returned empty\n");
                 stream_status(stream_fd, -1);

--- a/server/src/common/pflash_types.h
+++ b/server/src/common/pflash_types.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cstddef>
+
+namespace dflash::common {
+
+inline constexpr size_t kPFlashMaxInstructionSpans = 64;
+
+// Half-open token range in the drafter-tokenized prompt.
+struct PFlashTokenSpan {
+    int begin = 0;
+    int end = 0;
+};
+
+inline bool operator==(
+        const PFlashTokenSpan & left,
+        const PFlashTokenSpan & right) noexcept {
+    return left.begin == right.begin && left.end == right.end;
+}
+
+inline bool operator!=(
+        const PFlashTokenSpan & left,
+        const PFlashTokenSpan & right) noexcept {
+    return !(left == right);
+}
+
+} // namespace dflash::common

--- a/server/src/flashprefill_q8.cpp
+++ b/server/src/flashprefill_q8.cpp
@@ -156,7 +156,16 @@ int flash_prefill_forward_q8(
                                     (size_t)kv_len * cl * sizeof(uint16_t));
         }
 
-        ggml_backend_graph_compute(backend, gf);
+        const ggml_status compute_status =
+            ggml_backend_graph_compute(backend, gf);
+        if (compute_status != GGML_STATUS_SUCCESS) {
+            std::fprintf(stderr,
+                         "[flashprefill_q8] graph compute failed at cs=%d: %s\n",
+                         cs, ggml_status_to_string(compute_status));
+            ggml_free(ctx);
+            ggml_gallocr_free(galloc);
+            return -1;
+        }
         ggml_backend_synchronize(backend);
         ggml_free(ctx);
     }

--- a/server/src/qwen3/pflash_selection.cpp
+++ b/server/src/qwen3/pflash_selection.cpp
@@ -1,0 +1,315 @@
+#include "pflash_selection.h"
+
+#include <algorithm>
+#include <cerrno>
+#include <climits>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace dflash::qwen3 {
+
+namespace {
+
+constexpr const char * kModeEnv = "PFLASH_LONGATTNCOMP_MODE";
+constexpr const char * kChunkEnv = "PFLASH_LONGATTNCOMP_CHUNK_SIZE";
+constexpr const char * kQueryEnv = "PFLASH_LONGATTNCOMP_QUERY_TOKENS";
+constexpr const char * kQueryParserEnv = "PFLASH_LONGATTNCOMP_QUERY_PARSER";
+constexpr const char * kTopPEnv = "PFLASH_LONGATTNCOMP_TOP_P";
+
+PFlashSelectionResult invalid_result(std::string error) {
+    PFlashSelectionResult result;
+    result.error = std::move(error);
+    return result;
+}
+
+bool parse_int(const char * raw, int & out) {
+    if (!raw || !*raw) return false;
+    errno = 0;
+    char * end = nullptr;
+    const long value = std::strtol(raw, &end, 10);
+    if (errno == ERANGE || end == raw || *end != '\0' ||
+        value < INT_MIN || value > INT_MAX) {
+        return false;
+    }
+    out = static_cast<int>(value);
+    return true;
+}
+
+bool parse_double(const char * raw, double & out) {
+    if (!raw || !*raw) return false;
+    errno = 0;
+    char * end = nullptr;
+    const double value = std::strtod(raw, &end);
+    if (errno == ERANGE || end == raw || *end != '\0' ||
+        !std::isfinite(value)) {
+        return false;
+    }
+    out = value;
+    return true;
+}
+
+int scheduled_chunk_size(int input_tokens) {
+    if (input_tokens < 500) return 128;
+    if (input_tokens < 3000) return 512;
+    return 1024;
+}
+
+} // namespace
+
+bool has_pflash_longattncomp_environment() noexcept {
+    return std::getenv(kModeEnv) != nullptr ||
+           std::getenv(kChunkEnv) != nullptr ||
+           std::getenv(kQueryEnv) != nullptr ||
+           std::getenv(kQueryParserEnv) != nullptr ||
+           std::getenv(kTopPEnv) != nullptr;
+}
+
+bool pflash_chunk_is_structurally_required(
+        int begin,
+        int end,
+        int query_begin,
+        int query_end,
+        int input_tokens) noexcept {
+    if (begin < 0 || end <= begin || query_begin < 0 ||
+        query_end < query_begin || input_tokens < query_end ||
+        end > input_tokens) {
+        return false;
+    }
+    const bool query_chunk = begin < query_end && end > query_begin;
+    const bool structural_suffix_chunk =
+        begin < input_tokens && end > query_end;
+    return query_chunk || structural_suffix_chunk;
+}
+
+PFlashSelectionResult select_pflash_candidates(
+        const std::vector<PFlashSelectionCandidate> & candidates,
+        const PFlashSelectionPolicy & policy,
+        PFlashSelectionMode mode) {
+    if (mode == PFlashSelectionMode::Legacy) {
+        return invalid_result("legacy mode does not use strict PFlash selection");
+    }
+    if (policy.token_budget <= 0) {
+        return invalid_result("PFlash token budget must be positive");
+    }
+    if (!std::isfinite(policy.top_p) || policy.top_p <= 0.0 || policy.top_p > 1.0) {
+        return invalid_result("PFlash top_p must be finite and in (0, 1]");
+    }
+
+    std::vector<const PFlashSelectionCandidate *> source_ranges;
+    source_ranges.reserve(candidates.size());
+    std::vector<size_t> ordinals;
+    ordinals.reserve(candidates.size());
+    for (const auto & candidate : candidates) {
+        if (candidate.begin < 0 || candidate.end <= candidate.begin) {
+            return invalid_result("PFlash candidate range is invalid");
+        }
+        if (!std::isfinite(candidate.score)) {
+            return invalid_result("PFlash candidate score must be finite");
+        }
+        source_ranges.push_back(&candidate);
+        ordinals.push_back(candidate.ordinal);
+    }
+
+    std::sort(ordinals.begin(), ordinals.end());
+    if (std::adjacent_find(ordinals.begin(), ordinals.end()) != ordinals.end()) {
+        return invalid_result("PFlash candidate ordinals must be unique");
+    }
+    std::sort(source_ranges.begin(), source_ranges.end(),
+        [](const auto * left, const auto * right) {
+            if (left->begin != right->begin) return left->begin < right->begin;
+            return left->end < right->end;
+        });
+    for (size_t index = 1; index < source_ranges.size(); ++index) {
+        if (source_ranges[index - 1]->end > source_ranges[index]->begin) {
+            return invalid_result("PFlash candidate ranges must not overlap");
+        }
+    }
+
+    PFlashSelectionResult result;
+    result.ok = true;
+    result.stop = PFlashSelectionStop::CandidatesExhausted;
+    std::vector<const PFlashSelectionCandidate *> selected_candidates;
+    selected_candidates.reserve(candidates.size());
+
+    std::vector<const PFlashSelectionCandidate *> optional;
+    optional.reserve(candidates.size());
+    for (const auto & candidate : candidates) {
+        if (candidate.mandatory) {
+            const int length = candidate.end - candidate.begin;
+            if (length > policy.token_budget - result.retained_tokens) {
+                result = {};
+                result.stop = PFlashSelectionStop::MandatoryQueryExceedsBudget;
+                result.error = "mandatory PFlash query tokens exceed the token budget";
+                return result;
+            }
+            selected_candidates.push_back(&candidate);
+            result.retained_tokens += length;
+        } else {
+            optional.push_back(&candidate);
+        }
+    }
+
+    std::sort(optional.begin(), optional.end(),
+        [](const auto * left, const auto * right) {
+            const double left_score = std::max(0.0, left->score);
+            const double right_score = std::max(0.0, right->score);
+            if (left_score != right_score) return left_score > right_score;
+            return left->ordinal < right->ordinal;
+        });
+
+    double max_score = 0.0;
+    for (const auto * candidate : optional) {
+        max_score = std::max(max_score, std::max(0.0, candidate->score));
+    }
+    double scaled_total = 0.0;
+    if (max_score > 0.0) {
+        for (const auto * candidate : optional) {
+            scaled_total += std::max(0.0, candidate->score) / max_score;
+        }
+    }
+
+    for (const auto * candidate : optional) {
+        if (mode == PFlashSelectionMode::CumulativeTopP &&
+            result.retained_mass >= policy.top_p) {
+            result.stop = PFlashSelectionStop::TopPReached;
+            break;
+        }
+
+        const int length = candidate->end - candidate->begin;
+        if (length > policy.token_budget - result.retained_tokens) {
+            result.stop = PFlashSelectionStop::BudgetReached;
+            break;
+        }
+
+        selected_candidates.push_back(candidate);
+        result.retained_tokens += length;
+        if (!optional.empty()) {
+            result.retained_mass += max_score > 0.0
+                ? (std::max(0.0, candidate->score) / max_score) / scaled_total
+                : 1.0 / static_cast<double>(optional.size());
+        }
+    }
+
+    std::sort(selected_candidates.begin(), selected_candidates.end(),
+        [](const auto * left, const auto * right) {
+            if (left->begin != right->begin) return left->begin < right->begin;
+            return left->end < right->end;
+        });
+    result.ordinals.reserve(selected_candidates.size());
+    for (const auto * candidate : selected_candidates) {
+        result.ordinals.push_back(candidate->ordinal);
+    }
+    return result;
+}
+
+const char * pflash_selection_mode_name(PFlashSelectionMode mode) noexcept {
+    switch (mode) {
+        case PFlashSelectionMode::Legacy: return "legacy";
+        case PFlashSelectionMode::BudgetOnly: return "budget_only";
+        case PFlashSelectionMode::CumulativeTopP: return "top_p";
+    }
+    return "unknown";
+}
+
+const char * pflash_selection_stop_name(PFlashSelectionStop stop) noexcept {
+    switch (stop) {
+        case PFlashSelectionStop::TopPReached: return "top_p_reached";
+        case PFlashSelectionStop::BudgetReached: return "budget_reached";
+        case PFlashSelectionStop::CandidatesExhausted: return "candidates_exhausted";
+        case PFlashSelectionStop::InvalidInput: return "invalid_input";
+        case PFlashSelectionStop::MandatoryQueryExceedsBudget:
+            return "mandatory_query_exceeds_budget";
+    }
+    return "unknown";
+}
+
+const char * pflash_query_parser_name(PFlashQueryParser parser) noexcept {
+    switch (parser) {
+        case PFlashQueryParser::SemanticUser: return "latest_user";
+        case PFlashQueryParser::ArbitraryTail: return "arbitrary_tail";
+    }
+    return "unknown";
+}
+
+bool resolve_pflash_longattncomp(
+        int input_tokens,
+        int legacy_chunk_size,
+        PFlashLongAttnCompConfig & out,
+        std::string & error) {
+    error.clear();
+    if (input_tokens < 0) {
+        error = "PFlash input token count must not be negative";
+        return false;
+    }
+    if (legacy_chunk_size <= 0) {
+        error = "PFlash legacy chunk size must be positive";
+        return false;
+    }
+
+    const char * mode_raw = std::getenv(kModeEnv);
+    const char * chunk_raw = std::getenv(kChunkEnv);
+    const char * query_raw = std::getenv(kQueryEnv);
+    const char * query_parser_raw = std::getenv(kQueryParserEnv);
+    const char * top_p_raw = std::getenv(kTopPEnv);
+
+    PFlashLongAttnCompConfig config;
+    config.configured = mode_raw || chunk_raw || query_raw ||
+        query_parser_raw || top_p_raw;
+    config.chunk_size = legacy_chunk_size;
+
+    if (mode_raw) {
+        if (std::strcmp(mode_raw, "budget_only") == 0) {
+            config.mode = PFlashSelectionMode::BudgetOnly;
+        } else if (std::strcmp(mode_raw, "top_p") == 0) {
+            config.mode = PFlashSelectionMode::CumulativeTopP;
+        } else {
+            error = std::string(kModeEnv) + " must be budget_only or top_p";
+            return false;
+        }
+    }
+    config.selection_active = config.mode != PFlashSelectionMode::Legacy;
+
+    if (chunk_raw) {
+        if (!parse_int(chunk_raw, config.chunk_size) || config.chunk_size <= 0) {
+            error = std::string(kChunkEnv) + " must be a positive integer";
+            return false;
+        }
+    } else if (config.selection_active) {
+        config.chunk_size = scheduled_chunk_size(input_tokens);
+    }
+
+    if (query_raw &&
+        (!parse_int(query_raw, config.query_tokens) ||
+         config.query_tokens < 1 || config.query_tokens > 512)) {
+        error = std::string(kQueryEnv) + " must be an integer in [1, 512]";
+        return false;
+    }
+
+    if (query_parser_raw) {
+        if (std::strcmp(query_parser_raw, "latest_user") == 0) {
+            config.query_parser = PFlashQueryParser::SemanticUser;
+        } else if (std::strcmp(query_parser_raw, "arbitrary_tail") == 0) {
+            config.query_parser = PFlashQueryParser::ArbitraryTail;
+        } else {
+            error = std::string(kQueryParserEnv) +
+                " must be latest_user or arbitrary_tail";
+            return false;
+        }
+    }
+
+    if (top_p_raw &&
+        (!parse_double(top_p_raw, config.top_p) ||
+         config.top_p <= 0.0 || config.top_p > 1.0)) {
+        error = std::string(kTopPEnv) + " must be finite and in (0, 1]";
+        return false;
+    }
+
+    out = config;
+    return true;
+}
+
+} // namespace dflash::qwen3

--- a/server/src/qwen3/pflash_selection.cpp
+++ b/server/src/qwen3/pflash_selection.cpp
@@ -73,7 +73,9 @@ bool pflash_chunk_is_structurally_required(
         int end,
         int query_begin,
         int query_end,
-        int input_tokens) noexcept {
+        int input_tokens,
+        const std::vector<dflash::common::PFlashTokenSpan> &
+            required_instruction_spans) noexcept {
     if (begin < 0 || end <= begin || query_begin < 0 ||
         query_end < query_begin || input_tokens < query_end ||
         end > input_tokens) {
@@ -82,7 +84,40 @@ bool pflash_chunk_is_structurally_required(
     const bool query_chunk = begin < query_end && end > query_begin;
     const bool structural_suffix_chunk =
         begin < input_tokens && end > query_end;
-    return query_chunk || structural_suffix_chunk;
+    if (query_chunk || structural_suffix_chunk) return true;
+    for (const auto & span : required_instruction_spans) {
+        if (begin < span.end && end > span.begin) return true;
+    }
+    return false;
+}
+
+bool validate_pflash_instruction_spans(
+        const std::vector<dflash::common::PFlashTokenSpan> & spans,
+        int input_tokens,
+        std::string & error) noexcept {
+    error.clear();
+    if (input_tokens < 0) {
+        error = "PFlash input token count must not be negative";
+        return false;
+    }
+    if (spans.size() > dflash::common::kPFlashMaxInstructionSpans) {
+        error = "PFlash has too many instruction spans";
+        return false;
+    }
+    int previous_end = 0;
+    for (const auto & span : spans) {
+        if (span.begin < 0 || span.end <= span.begin ||
+            span.end > input_tokens) {
+            error = "PFlash instruction span is outside the input";
+            return false;
+        }
+        if (span.begin < previous_end) {
+            error = "PFlash instruction spans must be ordered and non-overlapping";
+            return false;
+        }
+        previous_end = span.end;
+    }
+    return true;
 }
 
 PFlashSelectionResult select_pflash_candidates(
@@ -143,7 +178,7 @@ PFlashSelectionResult select_pflash_candidates(
             if (length > policy.token_budget - result.retained_tokens) {
                 result = {};
                 result.stop = PFlashSelectionStop::MandatoryQueryExceedsBudget;
-                result.error = "mandatory PFlash query tokens exceed the token budget";
+                result.error = "mandatory PFlash retention tokens exceed the token budget";
                 return result;
             }
             selected_candidates.push_back(&candidate);

--- a/server/src/qwen3/pflash_selection.h
+++ b/server/src/qwen3/pflash_selection.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace dflash::qwen3 {
+
+enum class PFlashSelectionMode {
+    Legacy,
+    BudgetOnly,
+    CumulativeTopP,
+};
+
+enum class PFlashQueryParser {
+    SemanticUser,
+    ArbitraryTail,
+};
+
+enum class PFlashSelectionStop {
+    TopPReached,
+    BudgetReached,
+    CandidatesExhausted,
+    InvalidInput,
+    MandatoryQueryExceedsBudget,
+};
+
+struct PFlashSelectionCandidate {
+    size_t ordinal = 0;
+    int begin = 0;
+    int end = 0;
+    double score = 0.0;
+    bool mandatory = false;
+};
+
+struct PFlashSelectionPolicy {
+    int token_budget = 0;
+    double top_p = 0.95;
+};
+
+struct PFlashSelectionResult {
+    bool ok = false;
+    std::vector<size_t> ordinals;
+    int retained_tokens = 0;
+    double retained_mass = 0.0;
+    PFlashSelectionStop stop = PFlashSelectionStop::InvalidInput;
+    std::string error;
+};
+
+bool pflash_chunk_is_structurally_required(
+    int begin,
+    int end,
+    int query_begin,
+    int query_end,
+    int input_tokens) noexcept;
+
+PFlashSelectionResult select_pflash_candidates(
+    const std::vector<PFlashSelectionCandidate> & candidates,
+    const PFlashSelectionPolicy & policy,
+    PFlashSelectionMode mode);
+
+const char * pflash_selection_mode_name(PFlashSelectionMode mode) noexcept;
+const char * pflash_selection_stop_name(PFlashSelectionStop stop) noexcept;
+const char * pflash_query_parser_name(PFlashQueryParser parser) noexcept;
+
+struct PFlashLongAttnCompConfig {
+    PFlashSelectionMode mode = PFlashSelectionMode::Legacy;
+    PFlashQueryParser query_parser = PFlashQueryParser::SemanticUser;
+    int chunk_size = 0;
+    int query_tokens = 8;
+    double top_p = 0.95;
+    bool configured = false;
+    bool selection_active = false;
+};
+
+// Presence, rather than validity, gates cache and continuation policy so an
+// empty or invalid experiment variable cannot silently fall back to legacy.
+bool has_pflash_longattncomp_environment() noexcept;
+
+bool resolve_pflash_longattncomp(
+    int input_tokens,
+    int legacy_chunk_size,
+    PFlashLongAttnCompConfig & out,
+    std::string & error);
+
+} // namespace dflash::qwen3

--- a/server/src/qwen3/pflash_selection.h
+++ b/server/src/qwen3/pflash_selection.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "common/pflash_types.h"
+
 #include <cstddef>
 #include <string>
 #include <vector>
@@ -52,7 +54,14 @@ bool pflash_chunk_is_structurally_required(
     int end,
     int query_begin,
     int query_end,
-    int input_tokens) noexcept;
+    int input_tokens,
+    const std::vector<dflash::common::PFlashTokenSpan> &
+        required_instruction_spans = {}) noexcept;
+
+bool validate_pflash_instruction_spans(
+    const std::vector<dflash::common::PFlashTokenSpan> & spans,
+    int input_tokens,
+    std::string & error) noexcept;
 
 PFlashSelectionResult select_pflash_candidates(
     const std::vector<PFlashSelectionCandidate> & candidates,

--- a/server/src/qwen3/qwen3_backend.cpp
+++ b/server/src/qwen3/qwen3_backend.cpp
@@ -967,11 +967,10 @@ ModelBackend::CompressResult Qwen3Backend::compress(const CompressRequest & req)
         drafter_loaded_ = true;
     }
 
-    result.compressed_ids = drafter_score_and_compress(
+    result = CompressResult::from_compressed_ids(drafter_score_and_compress(
         drafter_ctx_, req.input_ids, req.keep_ratio,
         /*chunk_size=*/32, req.score_query_tokens, /*pool_kernel=*/13,
-        req.score_query_end);
-    result.ok = true;
+        req.score_query_end));
 
     if (req.residency_action == DraftResidencyAction::ReleaseAfterUse) {
         free_drafter();
@@ -1036,7 +1035,7 @@ bool Qwen3Backend::handle_compress(const std::string & line, const DaemonIO & io
 
     for (int32_t t : compressed) io.emit(t);
     io.emit(-1);
-    return true;
+    return !compressed.empty();
 }
 
 void Qwen3Backend::free_drafter() {

--- a/server/src/qwen3/qwen3_backend.cpp
+++ b/server/src/qwen3/qwen3_backend.cpp
@@ -968,7 +968,9 @@ ModelBackend::CompressResult Qwen3Backend::compress(const CompressRequest & req)
     }
 
     result.compressed_ids = drafter_score_and_compress(
-        drafter_ctx_, req.input_ids, req.keep_ratio);
+        drafter_ctx_, req.input_ids, req.keep_ratio,
+        /*chunk_size=*/32, req.score_query_tokens, /*pool_kernel=*/13,
+        req.score_query_end);
     result.ok = true;
 
     if (req.residency_action == DraftResidencyAction::ReleaseAfterUse) {

--- a/server/src/qwen3/qwen3_backend.cpp
+++ b/server/src/qwen3/qwen3_backend.cpp
@@ -970,7 +970,7 @@ ModelBackend::CompressResult Qwen3Backend::compress(const CompressRequest & req)
     result = CompressResult::from_compressed_ids(drafter_score_and_compress(
         drafter_ctx_, req.input_ids, req.keep_ratio,
         /*chunk_size=*/32, req.score_query_tokens, /*pool_kernel=*/13,
-        req.score_query_end));
+        req.score_query_end, req.required_instruction_spans));
 
     if (req.residency_action == DraftResidencyAction::ReleaseAfterUse) {
         free_drafter();

--- a/server/src/qwen3/qwen3_drafter.cpp
+++ b/server/src/qwen3/qwen3_drafter.cpp
@@ -15,6 +15,7 @@
 
 #include "qwen3_drafter.h"
 #include "qwen3_drafter_model.h"
+#include "pflash_selection.h"
 #include "qwen3/anchor_params.h"
 #include "common/backend_precision.h"
 #include "internal.h"
@@ -80,6 +81,22 @@ static void force_chunk_neighborhood(std::vector<uint8_t> & forced, int n_chunks
     for (int c = lo; c <= hi; ++c) forced[(size_t)c] = 1;
 }
 
+struct PFlashTraceFields {
+    const std::vector<int32_t> * input_ids = nullptr;
+    int query_begin = -1;
+    int query_end = -1;
+    dflash::qwen3::PFlashSelectionMode selector_mode =
+        dflash::qwen3::PFlashSelectionMode::Legacy;
+    dflash::qwen3::PFlashQueryParser query_parser =
+        dflash::qwen3::PFlashQueryParser::SemanticUser;
+    int token_budget = 0;
+    dflash::qwen3::PFlashSelectionStop stop =
+        dflash::qwen3::PFlashSelectionStop::InvalidInput;
+    int retained_tokens = 0;
+    double retained_mass = 0.0;
+    const std::vector<double> * exact_chunk_scores = nullptr;
+};
+
 static void write_compression_trace(
         int input_tokens,
         float keep_ratio,
@@ -90,7 +107,8 @@ static void write_compression_trace(
         const std::vector<std::pair<float, int>> & chunk_means,
         const std::vector<uint8_t> & selected,
         const std::vector<uint8_t> & forced,
-        const std::vector<int32_t> & compressed_ids) {
+        const std::vector<int32_t> & compressed_ids,
+        const PFlashTraceFields * trace_fields = nullptr) {
     const char * path = std::getenv("DFLASH_PFLASH_TRACE_PATH");
     if (!path || !*path) return;
 
@@ -104,16 +122,58 @@ static void write_compression_trace(
     for (const auto & chunk : chunk_means) {
         scores[(size_t)chunk.second] = chunk.first;
     }
+    const bool has_exact_scores = trace_fields &&
+        trace_fields->exact_chunk_scores &&
+        trace_fields->exact_chunk_scores->size() == scores.size();
+    if (trace_fields &&
+        trace_fields->selector_mode !=
+            dflash::qwen3::PFlashSelectionMode::Legacy &&
+        !has_exact_scores) {
+        std::fclose(file);
+        std::fprintf(stderr, "[pflash-trace] exact strict scores unavailable\n");
+        return;
+    }
 
     std::fprintf(file,
-        "{\"schema_version\":1,\"input_tokens\":%d,\"keep_ratio\":%.9g,"
-        "\"chunk_size\":%d,\"n_lookahead\":%d,\"pool_kernel\":%d,"
+        "{\"schema_version\":%d,\"input_tokens\":%d,\"keep_ratio\":%.9g",
+        trace_fields ? 2 : 1, input_tokens, keep_ratio);
+    if (trace_fields) {
+        std::fputs(",\"input_ids\":[", file);
+        for (size_t index = 0; index < trace_fields->input_ids->size(); ++index) {
+            if (index) std::fputc(',', file);
+            std::fprintf(file, "%d", (*trace_fields->input_ids)[index]);
+        }
+        std::fprintf(file,
+            "],\"query_begin\":%d,\"query_end\":%d,"
+            "\"selector_mode\":\"%s\",\"query_parser\":\"%s\","
+            "\"token_budget\":%d,"
+            "\"retained_tokens\":%d",
+            trace_fields->query_begin, trace_fields->query_end,
+            dflash::qwen3::pflash_selection_mode_name(
+                trace_fields->selector_mode),
+            dflash::qwen3::pflash_query_parser_name(trace_fields->query_parser),
+            trace_fields->token_budget, trace_fields->retained_tokens);
+        if (trace_fields->selector_mode ==
+            dflash::qwen3::PFlashSelectionMode::Legacy) {
+            std::fputs(",\"stop_reason\":null,\"retained_mass\":null", file);
+        } else {
+            std::fprintf(file,
+                ",\"stop_reason\":\"%s\",\"retained_mass\":%.17g",
+                dflash::qwen3::pflash_selection_stop_name(trace_fields->stop),
+                trace_fields->retained_mass);
+        }
+    }
+    std::fprintf(file,
+        ",\"chunk_size\":%d,\"n_lookahead\":%d,\"pool_kernel\":%d,"
         "\"n_keep\":%d,\"chunk_scores\":[",
-        input_tokens, keep_ratio, chunk_size, n_lookahead, pool_kernel, n_keep);
+        chunk_size, n_lookahead, pool_kernel, n_keep);
     for (size_t index = 0; index < scores.size(); ++index) {
         if (index) std::fputc(',', file);
-        if (std::isfinite(scores[index])) {
-            std::fprintf(file, "%.9g", scores[index]);
+        const double score = has_exact_scores
+            ? (*trace_fields->exact_chunk_scores)[index]
+            : (double) scores[index];
+        if (std::isfinite(score)) {
+            std::fprintf(file, has_exact_scores ? "%.17g" : "%.9g", score);
         } else {
             std::fputs("null", file);
         }
@@ -141,6 +201,110 @@ static void write_compression_trace(
     }
     std::fputs("]}\n", file);
     std::fclose(file);
+}
+
+static std::vector<int32_t> select_longattncomp_chunks(
+        const std::vector<int32_t> & ids,
+        const std::vector<float> & token_scores,
+        float keep_ratio,
+        int n_lookahead,
+        int score_query_end,
+        int pool_kernel,
+        const dflash::qwen3::PFlashLongAttnCompConfig & config,
+        bool write_trace) {
+    const int input_tokens = (int) ids.size();
+    const int query_end = score_query_end < 0 ? input_tokens : score_query_end;
+    const int query_tokens = std::min(n_lookahead, query_end);
+    const int query_begin = query_end - query_tokens;
+    const int selector_budget = (int) std::floor(
+        (double) input_tokens * (double) keep_ratio);
+    const int n_chunks =
+        (input_tokens + config.chunk_size - 1) / config.chunk_size;
+
+    std::vector<dflash::qwen3::PFlashSelectionCandidate> candidates;
+    std::vector<std::pair<float, int>> chunk_means;
+    std::vector<double> exact_chunk_scores;
+    candidates.reserve((size_t) n_chunks);
+    chunk_means.reserve((size_t) n_chunks);
+    exact_chunk_scores.reserve((size_t) n_chunks);
+    for (int chunk = 0; chunk < n_chunks; ++chunk) {
+        const int begin = chunk * config.chunk_size;
+        const int end = std::min(input_tokens, begin + config.chunk_size);
+        double score = 0.0;
+        for (int token = begin; token < end; ++token) {
+            score += token_scores[(size_t) token];
+        }
+        score /= (double) std::max(1, end - begin);
+        const bool mandatory =
+            dflash::qwen3::pflash_chunk_is_structurally_required(
+                begin, end, query_begin, query_end, input_tokens);
+        candidates.push_back({(size_t) chunk, begin, end, score, mandatory});
+        chunk_means.push_back({(float) score, chunk});
+        exact_chunk_scores.push_back(score);
+    }
+
+    const auto selected = dflash::qwen3::select_pflash_candidates(
+        candidates,
+        dflash::qwen3::PFlashSelectionPolicy{selector_budget, config.top_p},
+        config.mode);
+    if (!selected.ok) {
+        set_last_error("PFlash LongAttnComp selection failed: " + selected.error);
+        std::fprintf(stderr,
+            "[pflash-longattncomp] ERROR mode=%s budget=%d stop=%s: %s\n",
+            dflash::qwen3::pflash_selection_mode_name(config.mode),
+            selector_budget,
+            dflash::qwen3::pflash_selection_stop_name(selected.stop),
+            selected.error.c_str());
+        std::fflush(stderr);
+        return {};
+    }
+
+    std::vector<uint8_t> selected_mask((size_t) n_chunks, 0);
+    std::vector<uint8_t> mandatory_mask((size_t) n_chunks, 0);
+    for (const auto & candidate : candidates) {
+        if (candidate.mandatory) mandatory_mask[candidate.ordinal] = 1;
+    }
+    for (size_t ordinal : selected.ordinals) {
+        if (ordinal >= selected_mask.size()) {
+            set_last_error("PFlash LongAttnComp selector returned an invalid ordinal");
+            return {};
+        }
+        selected_mask[ordinal] = 1;
+    }
+
+    std::vector<int32_t> output;
+    output.reserve((size_t) selected.retained_tokens);
+    for (const auto & candidate : candidates) {
+        if (!selected_mask[candidate.ordinal]) continue;
+        output.insert(output.end(),
+                      ids.begin() + candidate.begin,
+                      ids.begin() + candidate.end);
+    }
+
+    std::fprintf(stderr,
+        "[pflash-longattncomp] selected mode=%s chunk=%d query=%d "
+        "budget=%d selected_tokens=%zu chunks=%zu/%d stop=%s mass=%.9g\n",
+        dflash::qwen3::pflash_selection_mode_name(config.mode),
+        config.chunk_size, query_tokens, selector_budget, output.size(),
+        selected.ordinals.size(), n_chunks,
+        dflash::qwen3::pflash_selection_stop_name(selected.stop),
+        selected.retained_mass);
+    std::fflush(stderr);
+
+    if (write_trace) {
+        const int n_keep_approx = std::max(
+            1, (selector_budget + config.chunk_size - 1) / config.chunk_size);
+        const PFlashTraceFields strict_fields{
+            &ids, query_begin, query_end, config.mode, config.query_parser,
+            selector_budget,
+            selected.stop, selected.retained_tokens, selected.retained_mass,
+            &exact_chunk_scores};
+        write_compression_trace(
+            input_tokens, keep_ratio, config.chunk_size, query_tokens,
+            pool_kernel, n_keep_approx, chunk_means, selected_mask,
+            mandatory_mask, output, &strict_fields);
+    }
+    return output;
 }
 
 #if defined(DFLASH27B_BACKEND_HIP)
@@ -336,7 +500,8 @@ static std::vector<int32_t> qwen35_score_and_compress(
     int chunk_size,
     int n_lookahead,
     int pool_kernel,
-    int score_query_end) {
+    int score_query_end,
+    const dflash::qwen3::PFlashLongAttnCompConfig & experiment) {
 
     const int S = (int)ids.size();
     const int hidden = w.n_embd;
@@ -625,6 +790,12 @@ static std::vector<int32_t> qwen35_score_and_compress(
         smoothed[(size_t)j] = (n > 0) ? (s / (float)n) : 0.0f;
     }
     smooth_score.swap(smoothed);
+
+    if (experiment.selection_active) {
+        return select_longattncomp_chunks(
+            ids, smooth_score, keep_ratio, n_lookahead, score_query_end,
+            pk, experiment, true);
+    }
     
     std::vector<std::pair<float, int>> chunk_means;
     for (int c = 0; c < n_chunks; ++c) {
@@ -775,6 +946,29 @@ std::vector<int32_t> drafter_score_and_compress(
         set_last_error("drafter not loaded");
         return {};
     }
+
+    dflash::qwen3::PFlashLongAttnCompConfig experiment;
+    std::string experiment_error;
+    if (!dflash::qwen3::resolve_pflash_longattncomp(
+            (int) ids.size(), chunk_size, experiment, experiment_error)) {
+        set_last_error("invalid PFlash LongAttnComp config: " + experiment_error);
+        std::fprintf(stderr, "[pflash-longattncomp] ERROR config: %s\n",
+                     experiment_error.c_str());
+        std::fflush(stderr);
+        return {};
+    }
+    chunk_size = experiment.chunk_size;
+    if (experiment.configured) {
+        std::fprintf(stderr,
+            "[pflash-longattncomp] config mode=%s active=%d chunk=%d "
+            "query_parser=%s query_cap=%d query_actual=%d top_p=%.9g "
+            "input=%zu\n",
+            dflash::qwen3::pflash_selection_mode_name(experiment.mode),
+            (int) experiment.selection_active, experiment.chunk_size,
+            dflash::qwen3::pflash_query_parser_name(experiment.query_parser),
+            experiment.query_tokens, n_lookahead, experiment.top_p, ids.size());
+        std::fflush(stderr);
+    }
     if (ctx.arch == DrafterArch::Qwen35_0p8b) {
         if (!ctx.arch_state) {
             set_last_error("qwen35 drafter state missing");
@@ -782,7 +976,8 @@ std::vector<int32_t> drafter_score_and_compress(
         }
         auto * st = static_cast<Qwen35DrafterState *>(ctx.arch_state);
         return qwen35_score_and_compress(st->weights, ids, keep_ratio, chunk_size,
-                                         n_lookahead, pool_kernel, score_query_end);
+                                         n_lookahead, pool_kernel, score_query_end,
+                                         experiment);
     }
     const int S = (int)ids.size();
     if (S < n_lookahead + 1) {
@@ -822,6 +1017,12 @@ std::vector<int32_t> drafter_score_and_compress(
         int n = 0;
         for (int k = lo; k <= hi; ++k) { s += score[k]; ++n; }
         smooth[j] = (n > 0) ? (s / (float)n) : 0.0f;
+    }
+
+    if (experiment.selection_active) {
+        return select_longattncomp_chunks(
+            ids, smooth, keep_ratio, n_lookahead, score_query_end,
+            pool_kernel, experiment, true);
     }
 
     // ── 4. Chunk-top-K + span merge ───────────────────────────────────
@@ -938,8 +1139,18 @@ std::vector<int32_t> drafter_score_and_compress(
         S, out.size(), (int)selected.size(), n_chunks, forced_count);
     std::fflush(stderr);
 
+    const int query_end = score_query_end < 0 ? S : score_query_end;
+    const int query_begin = query_end - n_lookahead;
+    const int token_budget = (int) std::floor(
+        (double) S * (double) keep_ratio);
+    const PFlashTraceFields trace_fields{
+        &ids, query_begin, query_end, experiment.mode,
+        experiment.query_parser, token_budget,
+        dflash::qwen3::PFlashSelectionStop::InvalidInput, (int) out.size(),
+        0.0, nullptr};
     write_compression_trace(S, keep_ratio, chunk_size, n_lookahead,
-        pool_kernel, n_keep, chunk_means, selected_mask, forced, out);
+        pool_kernel, n_keep, chunk_means, selected_mask, forced, out,
+        &trace_fields);
 
     return out;
 }

--- a/server/src/qwen3/qwen3_drafter.cpp
+++ b/server/src/qwen3/qwen3_drafter.cpp
@@ -80,6 +80,69 @@ static void force_chunk_neighborhood(std::vector<uint8_t> & forced, int n_chunks
     for (int c = lo; c <= hi; ++c) forced[(size_t)c] = 1;
 }
 
+static void write_compression_trace(
+        int input_tokens,
+        float keep_ratio,
+        int chunk_size,
+        int n_lookahead,
+        int pool_kernel,
+        int n_keep,
+        const std::vector<std::pair<float, int>> & chunk_means,
+        const std::vector<uint8_t> & selected,
+        const std::vector<uint8_t> & forced,
+        const std::vector<int32_t> & compressed_ids) {
+    const char * path = std::getenv("DFLASH_PFLASH_TRACE_PATH");
+    if (!path || !*path) return;
+
+    FILE * file = std::fopen(path, "a");
+    if (!file) {
+        std::fprintf(stderr, "[pflash-trace] cannot append %s\n", path);
+        return;
+    }
+
+    std::vector<float> scores(selected.size(), 0.0f);
+    for (const auto & chunk : chunk_means) {
+        scores[(size_t)chunk.second] = chunk.first;
+    }
+
+    std::fprintf(file,
+        "{\"schema_version\":1,\"input_tokens\":%d,\"keep_ratio\":%.9g,"
+        "\"chunk_size\":%d,\"n_lookahead\":%d,\"pool_kernel\":%d,"
+        "\"n_keep\":%d,\"chunk_scores\":[",
+        input_tokens, keep_ratio, chunk_size, n_lookahead, pool_kernel, n_keep);
+    for (size_t index = 0; index < scores.size(); ++index) {
+        if (index) std::fputc(',', file);
+        if (std::isfinite(scores[index])) {
+            std::fprintf(file, "%.9g", scores[index]);
+        } else {
+            std::fputs("null", file);
+        }
+    }
+    std::fputs("],\"selected_chunks\":[", file);
+    bool first = true;
+    for (size_t index = 0; index < selected.size(); ++index) {
+        if (!selected[index]) continue;
+        if (!first) std::fputc(',', file);
+        std::fprintf(file, "%zu", index);
+        first = false;
+    }
+    std::fputs("],\"forced_chunks\":[", file);
+    first = true;
+    for (size_t index = 0; index < forced.size(); ++index) {
+        if (!forced[index]) continue;
+        if (!first) std::fputc(',', file);
+        std::fprintf(file, "%zu", index);
+        first = false;
+    }
+    std::fputs("],\"compressed_ids\":[", file);
+    for (size_t index = 0; index < compressed_ids.size(); ++index) {
+        if (index) std::fputc(',', file);
+        std::fprintf(file, "%d", compressed_ids[index]);
+    }
+    std::fputs("]}\n", file);
+    std::fclose(file);
+}
+
 #if defined(DFLASH27B_BACKEND_HIP)
 bool prewarm_drafter_once(const Qwen3DrafterWeights & w) {
     static bool warmed = false;
@@ -874,6 +937,9 @@ std::vector<int32_t> drafter_score_and_compress(
         std::chrono::duration<double>(t2 - t0).count(),
         S, out.size(), (int)selected.size(), n_chunks, forced_count);
     std::fflush(stderr);
+
+    write_compression_trace(S, keep_ratio, chunk_size, n_lookahead,
+        pool_kernel, n_keep, chunk_means, selected_mask, forced, out);
 
     return out;
 }

--- a/server/src/qwen3/qwen3_drafter.cpp
+++ b/server/src/qwen3/qwen3_drafter.cpp
@@ -272,11 +272,18 @@ static std::vector<int32_t> qwen35_score_and_compress(
     float keep_ratio,
     int chunk_size,
     int n_lookahead,
-    int pool_kernel) {
+    int pool_kernel,
+    int score_query_end) {
 
     const int S = (int)ids.size();
     const int hidden = w.n_embd;
     if (S < n_lookahead + 1) return ids;
+    const int query_end = score_query_end < 0 ? S : score_query_end;
+    if (n_lookahead < 1 || query_end < n_lookahead || query_end > S) {
+        set_last_error("qwen35 scorer query window out of range");
+        return {};
+    }
+    const int query_start = query_end - n_lookahead;
 
     auto t0 = std::chrono::steady_clock::now();
     std::vector<float> running_max((size_t)n_lookahead * S, -INFINITY);
@@ -441,7 +448,7 @@ static std::vector<int32_t> qwen35_score_and_compress(
             }
             const TargetLayer & L = w.layers[il];
             ggml_tensor * inp_tail = ggml_view_2d(sctx, act_in, hidden, n_lookahead,
-                act_in->nb[1], (size_t)(S - n_lookahead) * act_in->nb[1]);
+                act_in->nb[1], (size_t)query_start * act_in->nb[1]);
             ggml_tensor * q_cur = ggml_rms_norm(sctx, inp_tail, w.rms_eps);
             q_cur = ggml_mul(sctx, q_cur, L.attn_norm);
             ggml_tensor * QG = ggml_mul_mat(sctx, L.wq, q_cur);
@@ -473,7 +480,7 @@ static std::vector<int32_t> qwen35_score_and_compress(
             }
             std::vector<int32_t> pos4((size_t)4 * n_lookahead, 0);
             for (int i = 0; i < n_lookahead; ++i) {
-                int p = S - n_lookahead + i;
+                const int p = query_start + i;
                 pos4[(size_t)0 * n_lookahead + i] = p;
                 pos4[(size_t)1 * n_lookahead + i] = p;
                 pos4[(size_t)2 * n_lookahead + i] = p;
@@ -481,7 +488,7 @@ static std::vector<int32_t> qwen35_score_and_compress(
             ggml_backend_tensor_set(pos_tail, pos4.data(), 0, pos4.size() * sizeof(int32_t));
             std::vector<float> mask((size_t)n_lookahead * K_len, 0.0f);
             for (int t = 0; t < n_lookahead; ++t) {
-                const int visible_end = S - n_lookahead + t + 1;
+                const int visible_end = query_start + t + 1;
                 for (int j = 0; j < K_len; ++j) {
                     mask[(size_t)t * K_len + j] = (j < visible_end) ? 0.0f : -INFINITY;
                 }
@@ -495,6 +502,21 @@ static std::vector<int32_t> qwen35_score_and_compress(
             }
             std::vector<float> tmp((size_t)K_len * n_lookahead * w.n_head);
             ggml_backend_tensor_get(probs, tmp.data(), 0, tmp.size() * sizeof(float));
+            const size_t nonfinite =
+                count_nonfinite_scores(tmp.data(), tmp.size());
+            if (nonfinite != 0) {
+                const std::string message =
+                    "non-finite Qwen3.5 PFlash scores at layer " +
+                    std::to_string(il) + ": " + std::to_string(nonfinite) +
+                    "/" + std::to_string(tmp.size());
+                std::fprintf(stderr, "[pflash] ERROR: %s\n", message.c_str());
+                std::fflush(stderr);
+                ggml_gallocr_free(salloc); ggml_free(sctx);
+                ggml_gallocr_free(alloc); ggml_backend_buffer_free(act_buf);
+                ggml_free(act_ctx); free_target_cache(cache);
+                set_last_error(message);
+                return {};
+            }
             for (int h = 0; h < w.n_head; ++h) {
                 for (int t = 0; t < n_lookahead; ++t) {
                     for (int j = 0; j < S; ++j) {
@@ -684,7 +706,8 @@ std::vector<int32_t> drafter_score_and_compress(
     float keep_ratio,
     int chunk_size,
     int n_lookahead,
-    int pool_kernel) {
+    int pool_kernel,
+    int score_query_end) {
     if (!ctx.loaded) {
         set_last_error("drafter not loaded");
         return {};
@@ -695,7 +718,8 @@ std::vector<int32_t> drafter_score_and_compress(
             return {};
         }
         auto * st = static_cast<Qwen35DrafterState *>(ctx.arch_state);
-        return qwen35_score_and_compress(st->weights, ids, keep_ratio, chunk_size, n_lookahead, pool_kernel);
+        return qwen35_score_and_compress(st->weights, ids, keep_ratio, chunk_size,
+                                         n_lookahead, pool_kernel, score_query_end);
     }
     const int S = (int)ids.size();
     if (S < n_lookahead + 1) {
@@ -706,7 +730,8 @@ std::vector<int32_t> drafter_score_and_compress(
     // ── 1. Custom forward + GPU tail-attention scoring ────────────────
     auto t0 = std::chrono::steady_clock::now();
     std::vector<float> running_max;
-    if (!forward_qwen3_drafter_model(ctx.weights, ids, n_lookahead, running_max)) {
+    if (!forward_qwen3_drafter_model(
+            ctx.weights, ids, n_lookahead, running_max, score_query_end)) {
         return {};
     }
     auto t1 = std::chrono::steady_clock::now();

--- a/server/src/qwen3/qwen3_drafter.cpp
+++ b/server/src/qwen3/qwen3_drafter.cpp
@@ -95,6 +95,7 @@ struct PFlashTraceFields {
     int retained_tokens = 0;
     double retained_mass = 0.0;
     const std::vector<double> * exact_chunk_scores = nullptr;
+    const std::vector<PFlashTokenSpan> * required_instruction_spans = nullptr;
 };
 
 static void write_compression_trace(
@@ -136,7 +137,7 @@ static void write_compression_trace(
 
     std::fprintf(file,
         "{\"schema_version\":%d,\"input_tokens\":%d,\"keep_ratio\":%.9g",
-        trace_fields ? 2 : 1, input_tokens, keep_ratio);
+        trace_fields ? 3 : 1, input_tokens, keep_ratio);
     if (trace_fields) {
         std::fputs(",\"input_ids\":[", file);
         for (size_t index = 0; index < trace_fields->input_ids->size(); ++index) {
@@ -153,6 +154,18 @@ static void write_compression_trace(
                 trace_fields->selector_mode),
             dflash::qwen3::pflash_query_parser_name(trace_fields->query_parser),
             trace_fields->token_budget, trace_fields->retained_tokens);
+        std::fputs(",\"required_instruction_spans\":[", file);
+        if (trace_fields->required_instruction_spans) {
+            for (size_t index = 0;
+                 index < trace_fields->required_instruction_spans->size();
+                 ++index) {
+                if (index) std::fputc(',', file);
+                const auto & span =
+                    (*trace_fields->required_instruction_spans)[index];
+                std::fprintf(file, "[%d,%d]", span.begin, span.end);
+            }
+        }
+        std::fputc(']', file);
         if (trace_fields->selector_mode ==
             dflash::qwen3::PFlashSelectionMode::Legacy) {
             std::fputs(",\"stop_reason\":null,\"retained_mass\":null", file);
@@ -211,6 +224,8 @@ static std::vector<int32_t> select_longattncomp_chunks(
         int score_query_end,
         int pool_kernel,
         const dflash::qwen3::PFlashLongAttnCompConfig & config,
+        const std::vector<PFlashTokenSpan> & required_instruction_spans,
+        bool direct_mass,
         bool write_trace) {
     const int input_tokens = (int) ids.size();
     const int query_end = score_query_end < 0 ? input_tokens : score_query_end;
@@ -234,10 +249,13 @@ static std::vector<int32_t> select_longattncomp_chunks(
         for (int token = begin; token < end; ++token) {
             score += token_scores[(size_t) token];
         }
-        score /= (double) std::max(1, end - begin);
+        if (!direct_mass) {
+            score /= (double) std::max(1, end - begin);
+        }
         const bool mandatory =
             dflash::qwen3::pflash_chunk_is_structurally_required(
-                begin, end, query_begin, query_end, input_tokens);
+                begin, end, query_begin, query_end, input_tokens,
+                required_instruction_spans);
         candidates.push_back({(size_t) chunk, begin, end, score, mandatory});
         chunk_means.push_back({(float) score, chunk});
         exact_chunk_scores.push_back(score);
@@ -298,7 +316,7 @@ static std::vector<int32_t> select_longattncomp_chunks(
             &ids, query_begin, query_end, config.mode, config.query_parser,
             selector_budget,
             selected.stop, selected.retained_tokens, selected.retained_mass,
-            &exact_chunk_scores};
+            &exact_chunk_scores, &required_instruction_spans};
         write_compression_trace(
             input_tokens, keep_ratio, config.chunk_size, query_tokens,
             pool_kernel, n_keep_approx, chunk_means, selected_mask,
@@ -501,7 +519,8 @@ static std::vector<int32_t> qwen35_score_and_compress(
     int n_lookahead,
     int pool_kernel,
     int score_query_end,
-    const dflash::qwen3::PFlashLongAttnCompConfig & experiment) {
+    const dflash::qwen3::PFlashLongAttnCompConfig & experiment,
+    const std::vector<PFlashTokenSpan> & required_instruction_spans) {
 
     const int S = (int)ids.size();
     const int hidden = w.n_embd;
@@ -794,7 +813,7 @@ static std::vector<int32_t> qwen35_score_and_compress(
     if (experiment.selection_active) {
         return select_longattncomp_chunks(
             ids, smooth_score, keep_ratio, n_lookahead, score_query_end,
-            pk, experiment, true);
+            pk, experiment, required_instruction_spans, false, true);
     }
     
     std::vector<std::pair<float, int>> chunk_means;
@@ -941,7 +960,8 @@ std::vector<int32_t> drafter_score_and_compress(
     int chunk_size,
     int n_lookahead,
     int pool_kernel,
-    int score_query_end) {
+    int score_query_end,
+    const std::vector<PFlashTokenSpan> & required_instruction_spans) {
     if (!ctx.loaded) {
         set_last_error("drafter not loaded");
         return {};
@@ -958,6 +978,26 @@ std::vector<int32_t> drafter_score_and_compress(
         return {};
     }
     chunk_size = experiment.chunk_size;
+    if (!experiment.selection_active && !required_instruction_spans.empty()) {
+        set_last_error(
+            "PFlash instruction spans require strict LongAttnComp selection");
+        std::fprintf(stderr,
+            "[pflash-longattncomp] ERROR instruction spans require strict selection\n");
+        std::fflush(stderr);
+        return {};
+    }
+    if (experiment.selection_active) {
+        std::string span_error;
+        if (!dflash::qwen3::validate_pflash_instruction_spans(
+                required_instruction_spans, (int) ids.size(), span_error)) {
+            set_last_error("invalid PFlash instruction spans: " + span_error);
+            std::fprintf(stderr,
+                "[pflash-longattncomp] ERROR instruction spans: %s\n",
+                span_error.c_str());
+            std::fflush(stderr);
+            return {};
+        }
+    }
     if (experiment.configured) {
         std::fprintf(stderr,
             "[pflash-longattncomp] config mode=%s active=%d chunk=%d "
@@ -977,7 +1017,8 @@ std::vector<int32_t> drafter_score_and_compress(
         auto * st = static_cast<Qwen35DrafterState *>(ctx.arch_state);
         return qwen35_score_and_compress(st->weights, ids, keep_ratio, chunk_size,
                                          n_lookahead, pool_kernel, score_query_end,
-                                         experiment);
+                                         experiment,
+                                         required_instruction_spans);
     }
     const int S = (int)ids.size();
     if (S < n_lookahead + 1) {
@@ -1021,8 +1062,11 @@ std::vector<int32_t> drafter_score_and_compress(
 
     if (experiment.selection_active) {
         return select_longattncomp_chunks(
-            ids, smooth, keep_ratio, n_lookahead, score_query_end,
-            pool_kernel, experiment, true);
+            ids, ctx.weights.longattncomp_head_loaded ? score : smooth,
+            keep_ratio, n_lookahead, score_query_end,
+            ctx.weights.longattncomp_head_loaded ? 1 : pool_kernel,
+            experiment, required_instruction_spans,
+            ctx.weights.longattncomp_head_loaded, true);
     }
 
     // ── 4. Chunk-top-K + span merge ───────────────────────────────────

--- a/server/src/qwen3/qwen3_drafter.cpp
+++ b/server/src/qwen3/qwen3_drafter.cpp
@@ -18,12 +18,14 @@
 #include "pflash_selection.h"
 #include "qwen3/anchor_params.h"
 #include "common/backend_precision.h"
+#include "common/gguf_inspect.h"
 #include "internal.h"
 #include "anchor_scan.h"
 
 #include "ggml.h"
 #include "ggml-alloc.h"
 #include "ggml-backend.h"
+#include "gguf.h"
 
 #include <algorithm>
 #include <chrono>
@@ -31,6 +33,7 @@
 #include <cstdio>
 #include <cstring>
 #include <cstdlib>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -47,17 +50,172 @@ static void build_causal_mask_f16(std::vector<uint16_t> & out, int kv_len, int n
     const int kv_pad = align_up_i(kv_len, 32);
     const int q_pad = align_up_i(n_tokens, 32);
     out.assign((size_t)kv_pad * q_pad, F16_NEG_INF);
+    static_assert(F16_ZERO == 0, "visible mask entries are zero-filled with memset");
     for (int q = 0; q < n_tokens; ++q) {
-        const int abs_q = kv_start + q;
-        for (int k = 0; k <= abs_q && k < kv_len; ++k) {
-            out[(size_t)q * kv_pad + k] = F16_ZERO;
+        const int visible = std::min(kv_len, kv_start + q + 1);
+        if (visible > 0) {
+            std::memset(out.data() + (size_t)q * kv_pad, 0, (size_t)visible * sizeof(uint16_t));
         }
     }
 }
 
+// Qwen3.5-0.8B LongAttnComp scorer. Features are the residual entering
+// full-attention block 15 after the first 15 blocks (twelve GatedDeltaNet and
+// three full-attention blocks). Block 15's own Q/K projections score the
+// context without RoPE, exactly like the Qwen3-0.6B block-13 head; an
+// optional trained head replaces those two projections.
+static constexpr int kQwen35HeadBlock = 15;
+static constexpr const char * kQwen35HeadSchema = "qwen3_5_0_8b_nope_qk_mass_v1";
+static constexpr const char * kQwen35HeadBaseModel = "Qwen/Qwen3.5-0.8B";
+static constexpr const char * kQwen35HeadFeatureTap =
+    "post_block14_residual_before_block15";
+
+// create_target_cache honours DFLASH27B_KV_TQ3; the drafter cache never wants
+// the TurboQuant rotation, so force it off while the cache is created.
+struct ScopedKvTq3Off {
+    ScopedKvTq3Off() {
+#if defined(_WIN32)
+        char * raw = nullptr;
+        size_t len = 0;
+        _dupenv_s(&raw, &len, "DFLASH27B_KV_TQ3");
+        had_ = raw != nullptr;
+        old_ = had_ ? raw : "";
+        free(raw);
+        _putenv_s("DFLASH27B_KV_TQ3", "0");
+#else
+        const char * raw = std::getenv("DFLASH27B_KV_TQ3");
+        had_ = raw != nullptr;
+        old_ = had_ ? raw : "";
+        setenv("DFLASH27B_KV_TQ3", "0", 1);
+#endif
+    }
+    ~ScopedKvTq3Off() {
+#if defined(_WIN32)
+        // _putenv_s with empty value removes the variable on MSVCRT.
+        _putenv_s("DFLASH27B_KV_TQ3", had_ ? old_.c_str() : "");
+#else
+        if (had_) setenv("DFLASH27B_KV_TQ3", old_.c_str(), 1);
+        else unsetenv("DFLASH27B_KV_TQ3");
+#endif
+    }
+    bool had_ = false;
+    std::string old_;
+};
+
 struct Qwen35DrafterState {
     TargetWeights weights;
+    std::string gguf_sha256;
+    ggml_context *        head_ctx = nullptr;
+    ggml_backend_buffer_t head_buf = nullptr;
+    ggml_tensor *         head_wq  = nullptr;  // [hidden, n_head * head_dim], query rows only
+    ggml_tensor *         head_wk  = nullptr;  // [hidden, n_head_kv * head_dim]
+    bool                  head_loaded = false;
 };
+
+static void free_qwen35_head(Qwen35DrafterState & st) {
+    if (st.head_buf) { ggml_backend_buffer_free(st.head_buf); st.head_buf = nullptr; }
+    if (st.head_ctx) { ggml_free(st.head_ctx); st.head_ctx = nullptr; }
+    st.head_wq = st.head_wk = nullptr;
+    st.head_loaded = false;
+}
+
+static bool qwen35_metadata_equals(gguf_context * g, const char * key,
+                                   const std::string & expected) {
+    const int id = gguf_find_key(g, key);
+    return id >= 0 && gguf_get_kv_type(g, id) == GGUF_TYPE_STRING &&
+           expected == gguf_get_val_str(g, id);
+}
+
+static bool qwen35_head_block_available(const TargetWeights & w, std::string & error) {
+    if (w.n_layer <= kQwen35HeadBlock || (size_t)kQwen35HeadBlock >= w.layers.size()) {
+        error = "qwen35 LongAttnComp scorer needs at least 16 blocks";
+        return false;
+    }
+    const TargetLayer & L = w.layers[(size_t)kQwen35HeadBlock];
+    if (((kQwen35HeadBlock + 1) % w.full_attention_interval) != 0 ||
+        !L.wq || !L.wk || !L.attn_norm || !L.q_norm || !L.k_norm) {
+        error = "qwen35 LongAttnComp scorer block 15 is not a full-attention block";
+        return false;
+    }
+    return true;
+}
+
+// Optional trained head for the block-15 tap. Fails closed on any contract
+// mismatch, mirroring the Qwen3-0.6B head loader.
+static bool load_qwen35_longattncomp_head(const std::string & path,
+                                          Qwen35DrafterState & st) {
+    const TargetWeights & w = st.weights;
+    std::string block_error;
+    if (!qwen35_head_block_available(w, block_error)) {
+        set_last_error(block_error);
+        return false;
+    }
+    if (st.gguf_sha256.empty()) {
+        set_last_error("LongAttnComp head requires the drafter GGUF identity hash");
+        return false;
+    }
+    ggml_context * data_ctx = nullptr;
+    gguf_init_params params{ /*no_alloc=*/ false, /*ctx=*/ &data_ctx };
+    gguf_context * g = gguf_init_from_file(path.c_str(), params);
+    if (!g) {
+        set_last_error("LongAttnComp head GGUF could not be opened: " + path);
+        return false;
+    }
+    auto fail = [&](const std::string & message) {
+        free_qwen35_head(st);
+        gguf_free(g);
+        if (data_ctx) ggml_free(data_ctx);
+        set_last_error(message);
+        return false;
+    };
+    if (!qwen35_metadata_equals(g, "general.architecture", "longattncomp") ||
+        !qwen35_metadata_equals(g, "longattncomp.schema", kQwen35HeadSchema) ||
+        !qwen35_metadata_equals(g, "longattncomp.base_model", kQwen35HeadBaseModel) ||
+        !qwen35_metadata_equals(g, "longattncomp.runtime_gguf_sha256", st.gguf_sha256) ||
+        !qwen35_metadata_equals(g, "longattncomp.feature_tap", kQwen35HeadFeatureTap)) {
+        return fail("LongAttnComp head metadata does not match the loaded Qwen3.5-0.8B drafter");
+    }
+    struct Contract {
+        const char * name;
+        int64_t ne0;
+        int64_t ne1;
+        ggml_tensor ** destination;
+    };
+    const Contract contracts[] = {
+        {"longattncomp.attn_q.weight", (int64_t)w.n_embd,
+         (int64_t)w.n_head * w.n_embd_head_k, &st.head_wq},
+        {"longattncomp.attn_k.weight", (int64_t)w.n_embd,
+         (int64_t)w.n_head_kv * w.n_embd_head_k, &st.head_wk},
+    };
+    ggml_init_params head_params{};
+    head_params.mem_size = 4 * ggml_tensor_overhead();
+    head_params.no_alloc = true;
+    st.head_ctx = ggml_init(head_params);
+    if (!st.head_ctx) return fail("LongAttnComp head context allocation failed");
+    for (const auto & contract : contracts) {
+        ggml_tensor * source = data_ctx ? ggml_get_tensor(data_ctx, contract.name) : nullptr;
+        if (!source || source->type != GGML_TYPE_F32 || ggml_n_dims(source) != 2 ||
+            source->ne[0] != contract.ne0 || source->ne[1] != contract.ne1) {
+            return fail(std::string("LongAttnComp head tensor contract mismatch: ") +
+                        contract.name);
+        }
+        *contract.destination =
+            ggml_new_tensor_2d(st.head_ctx, GGML_TYPE_F32, contract.ne0, contract.ne1);
+        ggml_set_name(*contract.destination, contract.name);
+    }
+    st.head_buf = ggml_backend_alloc_ctx_tensors(st.head_ctx, w.backend);
+    if (!st.head_buf) return fail("LongAttnComp head buffer allocation failed");
+    for (const auto & contract : contracts) {
+        ggml_tensor * source = ggml_get_tensor(data_ctx, contract.name);
+        ggml_backend_tensor_set(*contract.destination, source->data, 0, ggml_nbytes(source));
+    }
+    gguf_free(g);
+    ggml_free(data_ctx);
+    st.head_loaded = true;
+    std::fprintf(stderr, "[qwen35-drafter] loaded LongAttnComp head: %s\n", path.c_str());
+    std::fflush(stderr);
+    return true;
+}
 
 static int env_int(const char * name, int fallback) {
     if (const char * v = std::getenv(name)) {
@@ -441,9 +599,29 @@ bool load_drafter(const std::string & gguf_path, int /*gpu_layers*/,
 
     if (arch == DrafterArch::Qwen35_0p8b) {
         auto * st = new Qwen35DrafterState();
-        if (!load_target_gguf(gguf_path, out.backend, st->weights)) {
+        // The scorer never needs logits, and tied-embedding Qwen3.5-0.8B
+        // exports omit output.weight, so skip the lm_head entirely.
+        TargetLoadPlan plan;
+        plan.load_output = false;
+        if (!load_target_gguf_partial(gguf_path, out.backend, plan, st->weights)) {
             delete st;
             return false;
+        }
+        if (const char * head_path = std::getenv("PFLASH_LONGATTNCOMP_HEAD_GGUF")) {
+            const auto identity = read_gguf_metadata(gguf_path, /*compute_sha256=*/ true);
+            st->gguf_sha256 = identity.ok ? identity.sha256 : std::string();
+            if (!*head_path || !load_qwen35_longattncomp_head(head_path, *st)) {
+                if (!*head_path) {
+                    set_last_error("PFLASH_LONGATTNCOMP_HEAD_GGUF is empty");
+                }
+                std::fprintf(stderr,
+                    "[qwen35-drafter] ERROR: LongAttnComp head load failed, "
+                    "refusing to serve without it\n");
+                std::fflush(stderr);
+                free_target_weights(st->weights);
+                delete st;
+                return false;
+            }
         }
         out.arch_state = st;
         out.loaded = true;
@@ -499,6 +677,7 @@ void free_drafter(DrafterContext & ctx) {
 void free_drafter_weights(DrafterContext & ctx) {
     if (ctx.arch == DrafterArch::Qwen35_0p8b && ctx.arch_state) {
         auto * st = static_cast<Qwen35DrafterState *>(ctx.arch_state);
+        free_qwen35_head(*st);
         free_target_weights(st->weights);
         delete st;
         ctx.arch_state = nullptr;
@@ -536,33 +715,12 @@ static std::vector<int32_t> qwen35_score_and_compress(
     std::vector<float> running_max((size_t)n_lookahead * S, -INFINITY);
 
     TargetCache cache;
-#if defined(_WIN32)
-    char *  old_tq3_raw = nullptr;
-    size_t  old_tq3_len = 0;
-    _dupenv_s(&old_tq3_raw, &old_tq3_len, "DFLASH27B_KV_TQ3");
-    const bool had_old_tq3 = (old_tq3_raw != nullptr);
-    std::string old_tq3_s  = had_old_tq3 ? old_tq3_raw : "";
-    free(old_tq3_raw);
-    _putenv_s("DFLASH27B_KV_TQ3", "0");
-    auto restore_tq3 = [&]() {
-        // _putenv_s with empty value removes the variable on MSVCRT.
-        _putenv_s("DFLASH27B_KV_TQ3", had_old_tq3 ? old_tq3_s.c_str() : "");
-    };
-#else
-    const char * old_tq3 = std::getenv("DFLASH27B_KV_TQ3");
-    std::string old_tq3_s = old_tq3 ? old_tq3 : "";
-    const bool had_old_tq3 = (old_tq3 != nullptr);
-    setenv("DFLASH27B_KV_TQ3", "0", 1);
-    auto restore_tq3 = [&]() {
-        if (had_old_tq3) setenv("DFLASH27B_KV_TQ3", old_tq3_s.c_str(), 1);
-        else unsetenv("DFLASH27B_KV_TQ3");
-    };
-#endif
-    if (!create_target_cache(w, S, 0, w.backend, cache, true)) {
-        restore_tq3();
-        return {};
+    {
+        ScopedKvTq3Off tq3_off;
+        if (!create_target_cache(w, S, 0, w.backend, cache, true)) {
+            return {};
+        }
     }
-    restore_tq3();
 
     ggml_init_params act_ip{};
     act_ip.mem_size = (size_t)8 * ggml_tensor_overhead() + 4096;
@@ -953,6 +1111,293 @@ static std::vector<int32_t> qwen35_score_and_compress(
     return out_ids;
 }
 
+// LongAttnComp scoring for the Qwen3.5-0.8B drafter: run blocks 0..14, then
+// score every context token against the query window with block 15's NoPE
+// Q/K (or a trained replacement) and select chunks by attention mass. This
+// is the runtime counterpart of the Python retention screen (trial 0075).
+static std::vector<int32_t> qwen35_longattncomp_score_and_compress(
+    Qwen35DrafterState & st,
+    const std::vector<int32_t> & ids,
+    float keep_ratio,
+    int n_lookahead,
+    int score_query_end,
+    const dflash::qwen3::PFlashLongAttnCompConfig & experiment,
+    const std::vector<PFlashTokenSpan> & required_instruction_spans) {
+
+    TargetWeights & w = st.weights;
+    const int S = (int)ids.size();
+    const int hidden = w.n_embd;
+    const int H = w.n_head;
+    const int Hk = w.n_head_kv;
+    const int D = w.n_embd_head_k;
+    std::string block_error;
+    if (!qwen35_head_block_available(w, block_error)) {
+        set_last_error(block_error);
+        return {};
+    }
+    if (n_lookahead < 1 || S < n_lookahead + 1) {
+        set_last_error("qwen35 LongAttnComp scorer input is too short");
+        return {};
+    }
+    const int query_end = score_query_end < 0 ? S : score_query_end;
+    if (query_end < n_lookahead || query_end > S) {
+        set_last_error("qwen35 LongAttnComp scorer query window out of range");
+        return {};
+    }
+    const int query_start = query_end - n_lookahead;
+    const TargetLayer & L = w.layers[(size_t)kQwen35HeadBlock];
+
+    auto t0 = std::chrono::steady_clock::now();
+    TargetCache cache;
+    {
+        ScopedKvTq3Off tq3_off;
+        if (!create_target_cache(w, S, 0, w.backend, cache, true)) {
+            return {};
+        }
+    }
+
+    ggml_init_params act_ip{};
+    act_ip.mem_size = (size_t)8 * ggml_tensor_overhead() + 4096;
+    act_ip.no_alloc = true;
+    ggml_context * act_ctx = ggml_init(act_ip);
+    if (!act_ctx) {
+        free_target_cache(cache);
+        set_last_error("qwen35 drafter activation ctx init failed");
+        return {};
+    }
+    ggml_tensor * act_in = ggml_new_tensor_2d(act_ctx, GGML_TYPE_F32, hidden, S);
+    ggml_tensor * act_out = ggml_new_tensor_2d(act_ctx, GGML_TYPE_F32, hidden, S);
+    ggml_backend_buffer_t act_buf = ggml_backend_alloc_ctx_tensors(act_ctx, w.backend);
+    if (!act_buf) {
+        ggml_free(act_ctx);
+        free_target_cache(cache);
+        set_last_error("qwen35 drafter activation allocation failed");
+        return {};
+    }
+    auto cleanup = [&]() {
+        ggml_backend_buffer_free(act_buf);
+        ggml_free(act_ctx);
+        free_target_cache(cache);
+    };
+
+    {
+        const int batch = 2048;
+        std::vector<float> emb((size_t)hidden * batch);
+        for (int i = 0; i < S; i += batch) {
+            const int n = std::min(batch, S - i);
+            if (!w.embedder.embed(ids.data() + i, n, emb.data())) {
+                cleanup();
+                set_last_error("qwen35 drafter embedding failed");
+                return {};
+            }
+            ggml_backend_tensor_set(act_in, emb.data(), (size_t)i * act_in->nb[1],
+                                    (size_t)hidden * n * sizeof(float));
+        }
+    }
+
+    ggml_gallocr_t alloc = ggml_gallocr_new(ggml_backend_get_default_buffer_type(w.backend));
+    const int ubatch = 1024;
+    std::vector<uint16_t> mask_bits;
+    for (int il = 0; il < kQwen35HeadBlock; ++il) {
+        const bool is_attn = (((il + 1) % w.full_attention_interval) == 0);
+        for (int start = 0; start < S; start += ubatch) {
+            const int n = std::min(ubatch, S - start);
+            const int kv_len = start + n;
+            ggml_init_params ip{};
+            ip.mem_size = 512 * 1024 * 1024;
+            ip.no_alloc = true;
+            ggml_context * ctx = ggml_init(ip);
+            if (!ctx) {
+                ggml_gallocr_free(alloc); cleanup();
+                set_last_error("qwen35 drafter layer graph ctx init failed");
+                return {};
+            }
+            ggml_cgraph * gf = ggml_new_graph_custom(ctx, 16384, false);
+            ggml_tensor * inp = ggml_view_2d(ctx, act_in, hidden, n, act_in->nb[1],
+                                             (size_t)start * act_in->nb[1]);
+            ggml_tensor * pos = nullptr;
+            ggml_tensor * mask = nullptr;
+            if (is_attn) {
+                pos = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, 4 * n);
+                ggml_set_input(pos);
+                mask = ggml_new_tensor_2d(ctx, GGML_TYPE_F16,
+                                          align_up_i(kv_len, 32), align_up_i(n, 32));
+                ggml_set_input(mask);
+            }
+            ggml_tensor * out = build_qwen35_layer(ctx, gf, w, cache, il, inp, pos, mask,
+                                                   start, n, false, 0);
+            ggml_tensor * dst = ggml_view_2d(ctx, act_out, hidden, n, act_out->nb[1],
+                                             (size_t)start * act_out->nb[1]);
+            if (ggml_nelements(out) != ggml_nelements(dst)) {
+                ggml_free(ctx); ggml_gallocr_free(alloc); cleanup();
+                set_last_error("qwen35 layer output shape mismatch");
+                return {};
+            }
+            ggml_build_forward_expand(gf, ggml_cpy(ctx, out, dst));
+            if (!ggml_gallocr_alloc_graph(alloc, gf)) {
+                ggml_free(ctx); ggml_gallocr_free(alloc); cleanup();
+                set_last_error("qwen35 drafter graph allocation failed");
+                return {};
+            }
+            if (is_attn) {
+                std::vector<int32_t> p4((size_t)4 * n, 0);
+                for (int i = 0; i < n; ++i) {
+                    const int p = start + i;
+                    p4[(size_t)0 * n + i] = p;
+                    p4[(size_t)1 * n + i] = p;
+                    p4[(size_t)2 * n + i] = p;
+                }
+                ggml_backend_tensor_set(pos, p4.data(), 0, p4.size() * sizeof(int32_t));
+                build_causal_mask_f16(mask_bits, kv_len, n, start);
+                ggml_backend_tensor_set(mask, mask_bits.data(), 0,
+                                        mask_bits.size() * sizeof(uint16_t));
+            }
+            const auto status = ggml_backend_graph_compute(w.backend, gf);
+            ggml_free(ctx);
+            if (status != GGML_STATUS_SUCCESS) {
+                ggml_gallocr_free(alloc); cleanup();
+                set_last_error("qwen35 drafter graph compute failed");
+                return {};
+            }
+        }
+        std::swap(act_in, act_out);
+    }
+    ggml_gallocr_free(alloc);
+    auto t1 = std::chrono::steady_clock::now();
+
+    // Block-15 NoPE Q/K scoring: softmax over keys before the query window,
+    // then mean over heads and query tokens. The query never scores itself.
+    // Keys are projected in chunks so no intermediate tensor puts the
+    // sequence length into a HIP grid y/z dimension (65,535 limit); the
+    // logits land in one [S, n_lookahead, H] buffer for a single softmax.
+    const int key_chunk = 8192;
+    const int n_key_chunks = (S + key_chunk - 1) / key_chunk;
+    ggml_init_params lip{};
+    lip.mem_size = (size_t)8 * ggml_tensor_overhead() + 4096;
+    lip.no_alloc = true;
+    ggml_context * lctx = ggml_init(lip);
+    if (!lctx) {
+        cleanup();
+        set_last_error("qwen35 score buffer ctx allocation failed");
+        return {};
+    }
+    ggml_tensor * logits = ggml_new_tensor_3d(lctx, GGML_TYPE_F32, S, n_lookahead, H);
+    ggml_tensor * mask = ggml_new_tensor_2d(lctx, GGML_TYPE_F32, S, n_lookahead);
+    ggml_backend_buffer_t lbuf = ggml_backend_alloc_ctx_tensors(lctx, w.backend);
+    if (!lbuf) {
+        ggml_free(lctx); cleanup();
+        set_last_error("qwen35 score buffer allocation failed");
+        return {};
+    }
+    {
+        std::vector<float> m((size_t)n_lookahead * S, -INFINITY);
+        for (int t = 0; t < n_lookahead; ++t) {
+            std::fill_n(m.begin() + (size_t)t * S, (size_t)query_start, 0.0f);
+        }
+        ggml_backend_tensor_set(mask, m.data(), 0, m.size() * sizeof(float));
+    }
+    ggml_init_params sip{};
+    sip.mem_size = ggml_tensor_overhead() * (size_t)(64 + 24 * n_key_chunks) +
+                   ggml_graph_overhead_custom(4096, false) + 64 * 1024;
+    sip.no_alloc = true;
+    ggml_context * sctx = ggml_init(sip);
+    if (!sctx) {
+        ggml_backend_buffer_free(lbuf); ggml_free(lctx); cleanup();
+        set_last_error("qwen35 score graph ctx allocation failed");
+        return {};
+    }
+    ggml_cgraph * sgf = ggml_new_graph_custom(sctx, 4096, false);
+    ggml_tensor * wk_src = st.head_loaded ? st.head_wk : L.wk;
+    ggml_tensor * x_q = ggml_view_2d(sctx, act_in, hidden, n_lookahead, act_in->nb[1],
+                                     (size_t)query_start * act_in->nb[1]);
+    ggml_tensor * q_in = ggml_mul(sctx, ggml_rms_norm(sctx, x_q, w.rms_eps), L.attn_norm);
+    ggml_tensor * Q = nullptr;
+    if (st.head_loaded) {
+        Q = ggml_reshape_3d(sctx, ggml_mul_mat(sctx, st.head_wq, q_in), D, H, n_lookahead);
+    } else {
+        // Native block 15 packs query and gate rows per head; keep the query half.
+        ggml_tensor * QG = ggml_reshape_3d(sctx, ggml_mul_mat(sctx, L.wq, q_in),
+                                           D * 2, H, n_lookahead);
+        Q = ggml_view_3d(sctx, QG, D, H, n_lookahead,
+                         ggml_element_size(QG) * D * 2,
+                         ggml_element_size(QG) * D * 2 * H, 0);
+    }
+    Q = ggml_mul(sctx, ggml_rms_norm(sctx, Q, w.rms_eps), L.q_norm);
+    ggml_tensor * Q_perm = ggml_cont(sctx, ggml_permute(sctx, Q, 0, 2, 1, 3));  // [D, n_lookahead, H]
+    for (int b = 0; b < S; b += key_chunk) {
+        const int n = std::min(key_chunk, S - b);
+        ggml_tensor * x_c = ggml_view_2d(sctx, act_in, hidden, n, act_in->nb[1],
+                                         (size_t)b * act_in->nb[1]);
+        ggml_tensor * x_norm = ggml_mul(sctx, ggml_rms_norm(sctx, x_c, w.rms_eps), L.attn_norm);
+        ggml_tensor * K = ggml_reshape_3d(sctx, ggml_mul_mat(sctx, wk_src, x_norm), D, Hk, n);
+        K = ggml_mul(sctx, ggml_rms_norm(sctx, K, w.rms_eps), L.k_norm);
+        K = ggml_cont(sctx, ggml_permute(sctx, K, 0, 2, 1, 3));  // [D, n, Hk]
+        ggml_tensor * K_score = K;
+        if (H != Hk) {
+            const int gqa = H / Hk;
+            ggml_tensor * K_4d = ggml_reshape_4d(sctx, K, D, n, 1, Hk);
+            ggml_tensor * K_tpl = ggml_new_tensor_4d(sctx, GGML_TYPE_F32, D, n, gqa, Hk);
+            K_score = ggml_reshape_3d(sctx, ggml_repeat(sctx, K_4d, K_tpl), D, n, H);
+        }
+        ggml_tensor * part = ggml_mul_mat(sctx, K_score, Q_perm);  // [n, n_lookahead, H]
+        ggml_tensor * dst = ggml_view_3d(sctx, logits, n, n_lookahead, H,
+                                         logits->nb[1], logits->nb[2],
+                                         (size_t)b * logits->nb[0]);
+        ggml_build_forward_expand(sgf, ggml_cpy(sctx, part, dst));
+    }
+    ggml_tensor * probs = ggml_soft_max_ext(sctx, logits, mask,
+                                            1.0f / std::sqrt((float)D), 0.0f);
+    ggml_set_output(probs);
+    ggml_build_forward_expand(sgf, probs);
+    ggml_gallocr_t salloc = ggml_gallocr_new(ggml_backend_get_default_buffer_type(w.backend));
+    if (!ggml_gallocr_alloc_graph(salloc, sgf)) {
+        ggml_gallocr_free(salloc); ggml_free(sctx);
+        ggml_backend_buffer_free(lbuf); ggml_free(lctx); cleanup();
+        set_last_error("qwen35 score graph allocation failed");
+        return {};
+    }
+    const auto score_status = ggml_backend_graph_compute(w.backend, sgf);
+    if (score_status != GGML_STATUS_SUCCESS) {
+        ggml_gallocr_free(salloc); ggml_free(sctx);
+        ggml_backend_buffer_free(lbuf); ggml_free(lctx); cleanup();
+        set_last_error("qwen35 score graph compute failed");
+        return {};
+    }
+    std::vector<float> probs_h((size_t)S * n_lookahead * H);
+    ggml_backend_tensor_get(probs, probs_h.data(), 0, probs_h.size() * sizeof(float));
+    ggml_gallocr_free(salloc);
+    ggml_free(sctx);
+    ggml_backend_buffer_free(lbuf);
+    ggml_free(lctx);
+    cleanup();
+    const size_t nonfinite = count_nonfinite_scores(probs_h.data(), probs_h.size());
+    if (nonfinite != 0) {
+        const std::string message =
+            "non-finite Qwen3.5 LongAttnComp scores: " + std::to_string(nonfinite) +
+            "/" + std::to_string(probs_h.size());
+        std::fprintf(stderr, "[pflash] ERROR: %s\n", message.c_str());
+        std::fflush(stderr);
+        set_last_error(message);
+        return {};
+    }
+    std::vector<float> token_mass;
+    longattncomp_mean_token_mass(probs_h.data(), S, n_lookahead, H, token_mass);
+    auto t2 = std::chrono::steady_clock::now();
+    std::fprintf(stderr,
+        "[qwen35-longattncomp] forward %.2fs (blocks 0-%d, S=%d) score %.2fs "
+        "total %.2fs head=%s\n",
+        std::chrono::duration<double>(t1 - t0).count(), kQwen35HeadBlock - 1, S,
+        std::chrono::duration<double>(t2 - t1).count(),
+        std::chrono::duration<double>(t2 - t0).count(),
+        st.head_loaded ? "trained" : "native-block15");
+    std::fflush(stderr);
+
+    return select_longattncomp_chunks(
+        ids, token_mass, keep_ratio, n_lookahead, score_query_end,
+        /*pool_kernel=*/1, experiment, required_instruction_spans,
+        /*direct_mass=*/true, /*write_trace=*/true);
+}
+
 std::vector<int32_t> drafter_score_and_compress(
     DrafterContext & ctx,
     const std::vector<int32_t> & ids,
@@ -1015,6 +1460,20 @@ std::vector<int32_t> drafter_score_and_compress(
             return {};
         }
         auto * st = static_cast<Qwen35DrafterState *>(ctx.arch_state);
+        // Strict LongAttnComp selection scores with the block-15 head; the
+        // legacy all-layer running-max scorer stays available for legacy
+        // selection or when PFLASH_QWEN35_LEGACY_SCORER=1 forces it.
+        const char * legacy_scorer = std::getenv("PFLASH_QWEN35_LEGACY_SCORER");
+        const bool force_legacy = legacy_scorer && std::string(legacy_scorer) == "1";
+        if (experiment.selection_active && !force_legacy) {
+            return qwen35_longattncomp_score_and_compress(
+                *st, ids, keep_ratio, n_lookahead, score_query_end, experiment,
+                required_instruction_spans);
+        }
+        if (st->head_loaded) {
+            set_last_error("Qwen3.5 LongAttnComp head requires strict selection");
+            return {};
+        }
         return qwen35_score_and_compress(st->weights, ids, keep_ratio, chunk_size,
                                          n_lookahead, pool_kernel, score_query_end,
                                          experiment,

--- a/server/src/qwen3/qwen3_drafter.h
+++ b/server/src/qwen3/qwen3_drafter.h
@@ -69,8 +69,9 @@ void free_drafter_weights(DrafterContext & ctx);
 //   ids          input token IDs of length S
 //   keep_ratio   fraction of `chunk_size`-token chunks to keep
 //   chunk_size   span granularity (default 32)
-//   n_lookahead  trailing Q tokens used for tail attention (default 8)
+//   n_lookahead  Q tokens used for scorer attention (default 8)
 //   pool_kernel  AvgPool kernel for score smoothing (default 13)
+//   score_query_end  exclusive end of Q window in ids; negative means tail
 //
 // On failure returns empty vector + sets last_error.
 std::vector<int32_t> drafter_score_and_compress(
@@ -79,6 +80,7 @@ std::vector<int32_t> drafter_score_and_compress(
     float  keep_ratio,
     int    chunk_size  = 32,
     int    n_lookahead = 8,
-    int    pool_kernel = 13);
+    int    pool_kernel = 13,
+    int    score_query_end = -1);
 
 } // namespace dflash::common

--- a/server/src/qwen3/qwen3_drafter.h
+++ b/server/src/qwen3/qwen3_drafter.h
@@ -13,6 +13,8 @@
 
 #pragma once
 
+#include "common/pflash_types.h"
+
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -81,6 +83,8 @@ std::vector<int32_t> drafter_score_and_compress(
     int    chunk_size  = 32,
     int    n_lookahead = 8,
     int    pool_kernel = 13,
-    int    score_query_end = -1);
+    int    score_query_end = -1,
+    const std::vector<PFlashTokenSpan> &
+        required_instruction_spans = {});
 
 } // namespace dflash::common

--- a/server/src/qwen3/qwen3_drafter_model.h
+++ b/server/src/qwen3/qwen3_drafter_model.h
@@ -94,6 +94,30 @@ bool forward_qwen3_drafter_model(
     std::vector<float> & running_max,
     int score_query_end = -1);
 
+struct QueryCaptureSlice {
+    int chunk_offset = 0;
+    int query_offset = 0;
+    int tokens = 0;
+
+    bool valid() const { return tokens > 0; }
+};
+
+inline QueryCaptureSlice query_capture_slice(
+        int query_start,
+        int query_end,
+        int chunk_start,
+        int chunk_tokens) {
+    const int chunk_end = chunk_start + chunk_tokens;
+    const int overlap_start = query_start > chunk_start ? query_start : chunk_start;
+    const int overlap_end = query_end < chunk_end ? query_end : chunk_end;
+    if (overlap_start >= overlap_end) return {};
+    return {
+        overlap_start - chunk_start,
+        overlap_start - query_start,
+        overlap_end - overlap_start,
+    };
+}
+
 inline size_t count_nonfinite_scores(const float * values, size_t count) {
     size_t nonfinite = 0;
     for (size_t index = 0; index < count; ++index) {

--- a/server/src/qwen3/qwen3_drafter_model.h
+++ b/server/src/qwen3/qwen3_drafter_model.h
@@ -13,6 +13,8 @@
 
 #include "ggml.h"
 
+#include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -76,11 +78,12 @@ void free_qwen3_drafter_model(Qwen3DrafterWeights & w);
 // Inputs:
 //   w           — loaded weights (must be on the selected GPU backend)
 //   ids         — input token IDs of length S (drafter vocab)
-//   n_lookahead — number of trailing query tokens for tail attention (=8)
+//   n_lookahead — number of query tokens for scorer attention (=8)
+//   score_query_end — exclusive end of query window; negative selects the tail
 //
 // Outputs:
 //   running_max — flat [n_lookahead, S] f32, max-over-heads-and-layers of
-//                 softmax(Q_tail @ K^T / sqrt(D)) per (lookahead, key) pair.
+//                 softmax(Q_query @ K^T / sqrt(D)) per (lookahead, key) pair.
 //                 Caller does AvgPool + chunk-top-K + span merge.
 //
 // Returns true on success. On failure sets last_error and returns false.
@@ -88,6 +91,15 @@ bool forward_qwen3_drafter_model(
     const Qwen3DrafterWeights & w,
     const std::vector<int32_t> & ids,
     int n_lookahead,
-    std::vector<float> & running_max);
+    std::vector<float> & running_max,
+    int score_query_end = -1);
+
+inline size_t count_nonfinite_scores(const float * values, size_t count) {
+    size_t nonfinite = 0;
+    for (size_t index = 0; index < count; ++index) {
+        if (!std::isfinite(values[index])) ++nonfinite;
+    }
+    return nonfinite;
+}
 
 } // namespace dflash::common

--- a/server/src/qwen3/qwen3_drafter_model.h
+++ b/server/src/qwen3/qwen3_drafter_model.h
@@ -65,6 +65,7 @@ struct Qwen3DrafterWeights {
     int n_vocab    = 151936;
     int n_ctx_max  = 40960;
     float rope_theta = 1000000.0f;
+    bool longattncomp_head_loaded = false;
 };
 
 bool load_qwen3_drafter_model(const std::string & gguf_path,

--- a/server/src/qwen3/qwen3_drafter_model.h
+++ b/server/src/qwen3/qwen3_drafter_model.h
@@ -127,4 +127,25 @@ inline size_t count_nonfinite_scores(const float * values, size_t count) {
     return nonfinite;
 }
 
+// LongAttnComp token mass: mean over heads and query tokens of softmax
+// probabilities laid out as ggml [n_keys, n_queries, n_heads] (ne0 fastest).
+inline void longattncomp_mean_token_mass(
+        const float * probs,
+        int n_keys,
+        int n_queries,
+        int n_heads,
+        std::vector<float> & out) {
+    out.assign((size_t) n_keys, 0.0f);
+    if (n_keys <= 0 || n_queries <= 0 || n_heads <= 0) return;
+    std::vector<double> sum((size_t) n_keys, 0.0);
+    for (int h = 0; h < n_heads; ++h) {
+        for (int t = 0; t < n_queries; ++t) {
+            const float * row = probs + ((size_t) h * n_queries + t) * n_keys;
+            for (int j = 0; j < n_keys; ++j) sum[(size_t) j] += row[j];
+        }
+    }
+    const double denominator = (double) n_heads * (double) n_queries;
+    for (int j = 0; j < n_keys; ++j) out[(size_t) j] = (float) (sum[(size_t) j] / denominator);
+}
+
 } // namespace dflash::common

--- a/server/src/qwen3/qwen3_graph.cpp
+++ b/server/src/qwen3/qwen3_graph.cpp
@@ -224,7 +224,8 @@ bool forward_qwen3_drafter_model(
     const Qwen3DrafterWeights & w,
     const std::vector<int32_t> & ids,
     int n_lookahead,
-    std::vector<float> & running_max)
+    std::vector<float> & running_max,
+    int score_query_end)
 {
     if (!w.backend || !w.tok_embd) {
         set_last_error("forward_qwen3_drafter_model: weights not loaded");
@@ -250,10 +251,17 @@ bool forward_qwen3_drafter_model(
         return e == nullptr || std::string(e) != "0";
     }();
 
-    if (S < n_lookahead + 1) {
+    if (n_lookahead < 1 || S < n_lookahead + 1) {
         set_last_error("forward_qwen3_drafter_model: S too small");
         return false;
     }
+    const int query_end = score_query_end < 0 ? S : score_query_end;
+    if (query_end < n_lookahead || query_end > S) {
+        set_last_error(
+            "forward_qwen3_drafter_model: scorer query window out of range");
+        return false;
+    }
+    const int query_start = query_end - n_lookahead;
     running_max.assign((size_t)n_lookahead * S, -INFINITY);
 
     // Read scoring/early-exit env vars once; compute alloc range before buffers are created.
@@ -353,7 +361,7 @@ bool forward_qwen3_drafter_model(
     {
         std::vector<float> m((size_t)n_lookahead * S, 0.0f);
         for (int t = 0; t < n_lookahead; ++t) {
-            int visible_end = S - n_lookahead + t + 1;
+            const int visible_end = query_start + t + 1;
             for (int j = 0; j < S; ++j) {
                 m[(size_t)t * S + j] = (j < visible_end) ? 0.0f : -INFINITY;
             }
@@ -463,9 +471,8 @@ bool forward_qwen3_drafter_model(
             // NoPE: capture pre-RoPE Q tail (only for layers that will be scored).
             if (nope_tail && il >= score_layer_start_pre) {
                 const int si = il - score_layer_start_pre;
-                const int tail_lo_nr = S - n_lookahead;
-                if (tail_lo_nr >= cs && tail_lo_nr + n_lookahead <= cs + cl) {
-                    const int local_lo_nr = tail_lo_nr - cs;
+                if (query_start >= cs && query_end <= cs + cl) {
+                    const int local_lo_nr = query_start - cs;
                     ggml_tensor * Q_prenrope_tail = ggml_view_3d(
                         gA, Q, D, H, n_lookahead,
                         Q->nb[1], Q->nb[2],
@@ -516,9 +523,8 @@ bool forward_qwen3_drafter_model(
             ggml_build_forward_expand(gfA, ggml_cpy(gA, V, V_dst));
 
             // Copy Q tail to Q_last_v[il] in the chunk that contains the tail.
-            const int tail_lo = S - n_lookahead;
-            if (!nope_tail && tail_lo >= cs && tail_lo + n_lookahead <= cs + cl) {
-                int local_lo = tail_lo - cs;
+            if (!nope_tail && query_start >= cs && query_end <= cs + cl) {
+                const int local_lo = query_start - cs;
                 ggml_tensor * Q_tail_local = ggml_view_3d(
                     gA, Q, D, H, n_lookahead,
                     Q->nb[1], Q->nb[2],
@@ -827,12 +833,33 @@ bool forward_qwen3_drafter_model(
             cleanup_all();
             return false;
         }
-        ggml_backend_graph_compute(w.backend, gf);
-        ggml_backend_tensor_get(probs, probs_h.data(), 0,
-                                probs_h.size() * sizeof(float));
+        const auto score_status = ggml_backend_graph_compute(w.backend, gf);
+        size_t nonfinite = 0;
+        if (score_status == GGML_STATUS_SUCCESS) {
+            ggml_backend_tensor_get(probs, probs_h.data(), 0,
+                                    probs_h.size() * sizeof(float));
+            nonfinite = count_nonfinite_scores(probs_h.data(), probs_h.size());
+        }
         ggml_gallocr_free(s_galloc);
         if (in_buf) ggml_backend_buffer_free(in_buf);
         ggml_free(gctx);
+        if (score_status != GGML_STATUS_SUCCESS) {
+            set_last_error("tail score graph compute failed at layer " +
+                           std::to_string(il));
+            cleanup_all();
+            return false;
+        }
+        if (nonfinite != 0) {
+            const std::string message =
+                "non-finite PFlash tail scores at layer " +
+                std::to_string(il) + ": " + std::to_string(nonfinite) +
+                "/" + std::to_string(probs_h.size());
+            std::fprintf(stderr, "[pflash] ERROR: %s\n", message.c_str());
+            std::fflush(stderr);
+            set_last_error(message);
+            cleanup_all();
+            return false;
+        }
 
         for (int t = 0; t < n_lookahead; ++t) {
             for (int j = 0; j < S; ++j) {

--- a/server/src/qwen3/qwen3_graph.cpp
+++ b/server/src/qwen3/qwen3_graph.cpp
@@ -650,6 +650,16 @@ bool forward_qwen3_drafter_model(
                 free_hip_chunk_graph_b(gb);
                 ggml_gallocr_free(galloc); cleanup_all(); return false;
             }
+            // HIP D2D hipMemcpy can return before its null-stream copy finishes.
+            // GGML uses a nonblocking stream, so make the copy-in dependency explicit.
+            cudaError_t copy_in_sync_e = cudaStreamSynchronize(nullptr);
+            if (copy_in_sync_e != cudaSuccess) {
+                set_last_error(std::string("graph B copy-in synchronization failed at layer ") +
+                               std::to_string(il) + " chunk " + std::to_string(cs) + ": " +
+                               cudaGetErrorString(copy_in_sync_e));
+                free_hip_chunk_graph_b(gb);
+                ggml_gallocr_free(galloc); cleanup_all(); return false;
+            }
             auto tB_copy_in1 = std::chrono::steady_clock::now();
             t_b_copy_in += std::chrono::duration<double>(tB_copy_in1 - tB_copy_in0).count();
             if (debug_first_layer) {

--- a/server/src/qwen3/qwen3_graph.cpp
+++ b/server/src/qwen3/qwen3_graph.cpp
@@ -471,14 +471,21 @@ bool forward_qwen3_drafter_model(
             // NoPE: capture pre-RoPE Q tail (only for layers that will be scored).
             if (nope_tail && il >= score_layer_start_pre) {
                 const int si = il - score_layer_start_pre;
-                if (query_start >= cs && query_end <= cs + cl) {
-                    const int local_lo_nr = query_start - cs;
+                const auto capture = query_capture_slice(
+                    query_start, query_end, cs, cl);
+                if (capture.valid()) {
                     ggml_tensor * Q_prenrope_tail = ggml_view_3d(
-                        gA, Q, D, H, n_lookahead,
+                        gA, Q, D, H, capture.tokens,
                         Q->nb[1], Q->nb[2],
-                        (size_t)local_lo_nr * Q->nb[2]);
+                        (size_t)capture.chunk_offset * Q->nb[2]);
+                    Q_prenrope_tail = ggml_cont(gA, Q_prenrope_tail);
+                    Q_prenrope_tail = ggml_reshape_1d(
+                        gA, Q_prenrope_tail, D * H * capture.tokens);
+                    ggml_tensor * Q_prenrope_dst = ggml_view_1d(
+                        gA, Q_norope_v[si].t, D * H * capture.tokens,
+                        (size_t)capture.query_offset * Q_norope_v[si].t->nb[2]);
                     ggml_build_forward_expand(gfA,
-                        ggml_cpy(gA, Q_prenrope_tail, Q_norope_v[si].t));
+                        ggml_cpy(gA, Q_prenrope_tail, Q_prenrope_dst));
                 }
             }
             Q = ggml_rope_ext(gA, Q, pos_chunk, nullptr, D,
@@ -522,15 +529,22 @@ bool forward_qwen3_drafter_model(
             ggml_build_forward_expand(gfA, ggml_cpy(gA, K, K_dst));
             ggml_build_forward_expand(gfA, ggml_cpy(gA, V, V_dst));
 
-            // Copy Q tail to Q_last_v[il] in the chunk that contains the tail.
-            if (!nope_tail && query_start >= cs && query_end <= cs + cl) {
-                const int local_lo = query_start - cs;
+            // Copy the overlapping Q-query slice; a query can straddle chunks.
+            const auto capture = query_capture_slice(
+                query_start, query_end, cs, cl);
+            if (!nope_tail && capture.valid()) {
                 ggml_tensor * Q_tail_local = ggml_view_3d(
-                    gA, Q, D, H, n_lookahead,
+                    gA, Q, D, H, capture.tokens,
                     Q->nb[1], Q->nb[2],
-                    (size_t)local_lo * Q->nb[2]);
+                    (size_t)capture.chunk_offset * Q->nb[2]);
+                Q_tail_local = ggml_cont(gA, Q_tail_local);
+                Q_tail_local = ggml_reshape_1d(
+                    gA, Q_tail_local, D * H * capture.tokens);
+                ggml_tensor * Q_tail_dst = ggml_view_1d(
+                    gA, Q_last_v[layer_cache_idx].t, D * H * capture.tokens,
+                    (size_t)capture.query_offset * Q_last_v[layer_cache_idx].t->nb[2]);
                 ggml_build_forward_expand(gfA,
-                    ggml_cpy(gA, Q_tail_local, Q_last_v[layer_cache_idx].t));
+                    ggml_cpy(gA, Q_tail_local, Q_tail_dst));
             }
 
             auto tA_setup1 = std::chrono::steady_clock::now();

--- a/server/src/qwen3/qwen3_graph.cpp
+++ b/server/src/qwen3/qwen3_graph.cpp
@@ -478,11 +478,10 @@ bool forward_qwen3_drafter_model(
                         gA, Q, D, H, capture.tokens,
                         Q->nb[1], Q->nb[2],
                         (size_t)capture.chunk_offset * Q->nb[2]);
-                    Q_prenrope_tail = ggml_cont(gA, Q_prenrope_tail);
-                    Q_prenrope_tail = ggml_reshape_1d(
-                        gA, Q_prenrope_tail, D * H * capture.tokens);
-                    ggml_tensor * Q_prenrope_dst = ggml_view_1d(
-                        gA, Q_norope_v[si].t, D * H * capture.tokens,
+                    ggml_tensor * Q_prenrope_dst = ggml_view_3d(
+                        gA, Q_norope_v[si].t, D, H, capture.tokens,
+                        Q_norope_v[si].t->nb[1],
+                        Q_norope_v[si].t->nb[2],
                         (size_t)capture.query_offset * Q_norope_v[si].t->nb[2]);
                     ggml_build_forward_expand(gfA,
                         ggml_cpy(gA, Q_prenrope_tail, Q_prenrope_dst));
@@ -537,11 +536,10 @@ bool forward_qwen3_drafter_model(
                     gA, Q, D, H, capture.tokens,
                     Q->nb[1], Q->nb[2],
                     (size_t)capture.chunk_offset * Q->nb[2]);
-                Q_tail_local = ggml_cont(gA, Q_tail_local);
-                Q_tail_local = ggml_reshape_1d(
-                    gA, Q_tail_local, D * H * capture.tokens);
-                ggml_tensor * Q_tail_dst = ggml_view_1d(
-                    gA, Q_last_v[layer_cache_idx].t, D * H * capture.tokens,
+                ggml_tensor * Q_tail_dst = ggml_view_3d(
+                    gA, Q_last_v[layer_cache_idx].t, D, H, capture.tokens,
+                    Q_last_v[layer_cache_idx].t->nb[1],
+                    Q_last_v[layer_cache_idx].t->nb[2],
                     (size_t)capture.query_offset * Q_last_v[layer_cache_idx].t->nb[2]);
                 ggml_build_forward_expand(gfA,
                     ggml_cpy(gA, Q_tail_local, Q_tail_dst));

--- a/server/src/qwen3/qwen3_graph.cpp
+++ b/server/src/qwen3/qwen3_graph.cpp
@@ -178,10 +178,12 @@ bool build_hip_chunk_graph_b(const Qwen3DrafterLayer & L,
     return true;
 }
 
-void warm_hip_chunk_graph_b_once(ggml_backend_t backend, HipChunkGraphB & out) {
+bool warm_hip_chunk_graph_b_once(ggml_backend_t backend,
+                                 HipChunkGraphB & out,
+                                 std::string & error) {
     static bool warmed = false;
     if (warmed) {
-        return;
+        return true;
     }
 
     struct ggml_tensor * warm_tensors[] = {
@@ -190,13 +192,27 @@ void warm_hip_chunk_graph_b_once(ggml_backend_t backend, HipChunkGraphB & out) {
     for (ggml_tensor * t : warm_tensors) {
         cudaError_t e = cudaMemset(t->data, 0, ggml_nbytes(t));
         if (e != cudaSuccess) {
-            return;
+            error = std::string("memset failed: ") + cudaGetErrorString(e);
+            return false;
         }
     }
 
-    ggml_backend_graph_compute(backend, out.gf_proj_add);
-    ggml_backend_graph_compute(backend, out.gf_ffn);
+    const ggml_status proj_status =
+        ggml_backend_graph_compute(backend, out.gf_proj_add);
+    if (proj_status != GGML_STATUS_SUCCESS) {
+        error = std::string("projection graph failed: ") +
+                ggml_status_to_string(proj_status);
+        return false;
+    }
+    const ggml_status ffn_status =
+        ggml_backend_graph_compute(backend, out.gf_ffn);
+    if (ffn_status != GGML_STATUS_SUCCESS) {
+        error = std::string("FFN graph failed: ") +
+                ggml_status_to_string(ffn_status);
+        return false;
+    }
     warmed = true;
+    return true;
 }
 #endif
 
@@ -393,7 +409,17 @@ bool forward_qwen3_drafter_model(
             return false;
         }
         ggml_backend_tensor_set(t_ids, ids.data(), 0, (size_t)S * sizeof(int32_t));
-        ggml_backend_graph_compute(w.backend, gf);
+        const ggml_status embed_status =
+            ggml_backend_graph_compute(w.backend, gf);
+        if (embed_status != GGML_STATUS_SUCCESS) {
+            set_last_error(std::string("embed graph compute failed: ") +
+                           ggml_status_to_string(embed_status));
+            ggml_gallocr_free(galloc);
+            if (in_buf) ggml_backend_buffer_free(in_buf);
+            ggml_free(gctx);
+            cleanup_all();
+            return false;
+        }
         ggml_gallocr_free(galloc);
         if (in_buf) ggml_backend_buffer_free(in_buf);
         ggml_free(gctx);
@@ -556,10 +582,19 @@ bool forward_qwen3_drafter_model(
             auto tA_alloc1 = std::chrono::steady_clock::now();
             t_a_alloc += std::chrono::duration<double>(tA_alloc1 - tA_alloc0).count();
             auto tA0 = std::chrono::steady_clock::now();
-            ggml_backend_graph_compute(w.backend, gfA);
+            const ggml_status graph_a_status =
+                ggml_backend_graph_compute(w.backend, gfA);
             ggml_backend_synchronize(w.backend);
             auto tA1 = std::chrono::steady_clock::now();
             t_compute_a += std::chrono::duration<double>(tA1 - tA0).count();
+            if (graph_a_status != GGML_STATUS_SUCCESS) {
+                set_last_error(std::string("graph A compute failed at layer ") +
+                               std::to_string(il) + " chunk " +
+                               std::to_string(cs) + ": " +
+                               ggml_status_to_string(graph_a_status));
+                ggml_free(gA);
+                ggml_gallocr_free(galloc); cleanup_all(); return false;
+            }
             if (debug_first_layer) {
                 std::fprintf(stderr,
                              "[qwen3-0.6b-fp dbg] layer0 chunk A done setup=%.3fs alloc=%.3fs compute=%.3fs\n",
@@ -586,7 +621,20 @@ bool forward_qwen3_drafter_model(
             set_last_error("flash_prefill_forward failed at layer " + std::to_string(il));
             ggml_gallocr_free(galloc); cleanup_all(); return false;
         }
-        cudaDeviceSynchronize();
+        cudaError_t fp_launch_e = cudaGetLastError();
+        if (fp_launch_e != cudaSuccess) {
+            set_last_error(std::string("flash_prefill launch failed at layer ") +
+                           std::to_string(il) + ": " +
+                           cudaGetErrorString(fp_launch_e));
+            ggml_gallocr_free(galloc); cleanup_all(); return false;
+        }
+        cudaError_t fp_sync_e = cudaDeviceSynchronize();
+        if (fp_sync_e != cudaSuccess) {
+            set_last_error(std::string("flash_prefill synchronization failed at layer ") +
+                           std::to_string(il) + ": " +
+                           cudaGetErrorString(fp_sync_e));
+            ggml_gallocr_free(galloc); cleanup_all(); return false;
+        }
         auto tF1 = std::chrono::steady_clock::now();
         t_fp += std::chrono::duration<double>(tF1 - tF0).count();
         if (debug_first_layer) {
@@ -613,7 +661,13 @@ bool forward_qwen3_drafter_model(
         }
 
         auto tB_warm0 = std::chrono::steady_clock::now();
-        warm_hip_chunk_graph_b_once(w.backend, gb);
+        std::string warm_error;
+        if (!warm_hip_chunk_graph_b_once(w.backend, gb, warm_error)) {
+            set_last_error(std::string("graph B warmup failed at layer ") +
+                           std::to_string(il) + ": " + warm_error);
+            free_hip_chunk_graph_b(gb);
+            ggml_gallocr_free(galloc); cleanup_all(); return false;
+        }
         auto tB_warm1 = std::chrono::steady_clock::now();
         t_b_warm += std::chrono::duration<double>(tB_warm1 - tB_warm0).count();
         if (debug_first_layer) {
@@ -697,11 +751,21 @@ bool forward_qwen3_drafter_model(
             double proj_s = 0, ffn_s = 0;
             auto one = [&](ggml_cgraph * gf, double & acc) {
                 auto ts0 = std::chrono::steady_clock::now();
-                ggml_backend_graph_compute(w.backend, gf);
+                const ggml_status status =
+                    ggml_backend_graph_compute(w.backend, gf);
                 auto ts1 = std::chrono::steady_clock::now();
                 acc = std::chrono::duration<double>(ts1 - ts0).count();
+                return status;
             };
-            one(gb.gf_proj_add, proj_s);
+            const ggml_status proj_status = one(gb.gf_proj_add, proj_s);
+            if (proj_status != GGML_STATUS_SUCCESS) {
+                set_last_error(std::string("graph B projection compute failed at layer ") +
+                               std::to_string(il) + " chunk " +
+                               std::to_string(cs) + ": " +
+                               ggml_status_to_string(proj_status));
+                free_hip_chunk_graph_b(gb);
+                ggml_gallocr_free(galloc); cleanup_all(); return false;
+            }
 
             auto tB_norm0 = std::chrono::steady_clock::now();
             launch_rms_norm_mul_w_f32(
@@ -710,11 +774,36 @@ bool forward_qwen3_drafter_model(
                 (float *)gb.hf->data,
                 cl, hidden, eps,
                 /*stream=*/nullptr);
-            cudaDeviceSynchronize();
+            cudaError_t rms_launch_e = cudaGetLastError();
+            if (rms_launch_e != cudaSuccess) {
+                set_last_error(std::string("graph B RMSNorm launch failed at layer ") +
+                               std::to_string(il) + " chunk " +
+                               std::to_string(cs) + ": " +
+                               cudaGetErrorString(rms_launch_e));
+                free_hip_chunk_graph_b(gb);
+                ggml_gallocr_free(galloc); cleanup_all(); return false;
+            }
+            cudaError_t rms_sync_e = cudaDeviceSynchronize();
+            if (rms_sync_e != cudaSuccess) {
+                set_last_error(std::string("graph B RMSNorm synchronization failed at layer ") +
+                               std::to_string(il) + " chunk " +
+                               std::to_string(cs) + ": " +
+                               cudaGetErrorString(rms_sync_e));
+                free_hip_chunk_graph_b(gb);
+                ggml_gallocr_free(galloc); cleanup_all(); return false;
+            }
             auto tB_norm1 = std::chrono::steady_clock::now();
             t_b_norm += std::chrono::duration<double>(tB_norm1 - tB_norm0).count();
 
-            one(gb.gf_ffn, ffn_s);
+            const ggml_status ffn_status = one(gb.gf_ffn, ffn_s);
+            if (ffn_status != GGML_STATUS_SUCCESS) {
+                set_last_error(std::string("graph B FFN compute failed at layer ") +
+                               std::to_string(il) + " chunk " +
+                               std::to_string(cs) + ": " +
+                               ggml_status_to_string(ffn_status));
+                free_hip_chunk_graph_b(gb);
+                ggml_gallocr_free(galloc); cleanup_all(); return false;
+            }
             auto tB1 = std::chrono::steady_clock::now();
             t_compute_b += std::chrono::duration<double>(tB1 - tB0).count();
 

--- a/server/src/qwen3/qwen3_graph.cpp
+++ b/server/src/qwen3/qwen3_graph.cpp
@@ -262,10 +262,11 @@ bool forward_qwen3_drafter_model(
     const float rope_b = w.rope_theta;
     // Pre-RoPE tail scoring: removes RoPE distance decay from the score signal.
     // Default ON; set DFLASH_FP_NOPE_TAIL=0 to disable (saves ~K_curr_v memory).
-    static const bool nope_tail = []() -> bool {
+    static const bool configured_nope_tail = []() -> bool {
         const char * e = std::getenv("DFLASH_FP_NOPE_TAIL");
         return e == nullptr || std::string(e) != "0";
     }();
+    const bool nope_tail = w.longattncomp_head_loaded || configured_nope_tail;
 
     if (n_lookahead < 1 || S < n_lookahead + 1) {
         set_last_error("forward_qwen3_drafter_model: S too small");
@@ -291,9 +292,13 @@ bool forward_qwen3_drafter_model(
         if (e) { int v = std::atoi(e); if (v > 0) return v; }
         return -1;
     }();
-    const int fwd_layer_limit_pre = (early_exit_pre > 0 && early_exit_pre < w.n_layer)
-        ? early_exit_pre : w.n_layer;
-    const ScoreRange pre_range = compute_score_range(w.n_layer, score_layers_pre, fwd_layer_limit_pre);
+    const int fwd_layer_limit_pre = w.longattncomp_head_loaded
+        ? 14
+        : ((early_exit_pre > 0 && early_exit_pre < w.n_layer)
+            ? early_exit_pre : w.n_layer);
+    const ScoreRange pre_range = w.longattncomp_head_loaded
+        ? ScoreRange{13, 14}
+        : compute_score_range(w.n_layer, score_layers_pre, fwd_layer_limit_pre);
     const int score_layer_start_pre = pre_range.start;
     const int n_score_layers = pre_range.count(); // K_norope/Q_norope sized to this, not n_layer
 
@@ -377,7 +382,9 @@ bool forward_qwen3_drafter_model(
     {
         std::vector<float> m((size_t)n_lookahead * S, 0.0f);
         for (int t = 0; t < n_lookahead; ++t) {
-            const int visible_end = query_start + t + 1;
+            const int visible_end = w.longattncomp_head_loaded
+                ? query_start
+                : query_start + t + 1;
             for (int j = 0; j < S; ++j) {
                 m[(size_t)t * S + j] = (j < visible_end) ? 0.0f : -INFINITY;
             }
@@ -425,8 +432,6 @@ bool forward_qwen3_drafter_model(
         ggml_free(gctx);
     }
 
-    const int & early_exit_n = early_exit_pre;  // alias for readability in loop below
-
     // Per-layer A→FA→B loop.
     ggml_gallocr_t galloc = ggml_gallocr_new(
         ggml_backend_get_default_buffer_type(w.backend));
@@ -447,8 +452,7 @@ bool forward_qwen3_drafter_model(
     double t_b_warm = 0.0, t_b_setup = 0.0, t_b_alloc = 0.0, t_b_copy_in = 0.0, t_b_norm = 0.0, t_compute_b = 0.0, t_b_copy_out = 0.0;
     double t_fp = 0.0;
 
-    const int fwd_layer_limit = (early_exit_n > 0 && early_exit_n < w.n_layer)
-        ? early_exit_n : w.n_layer;
+    const int fwd_layer_limit = fwd_layer_limit_pre;
 
     for (int il = 0; il < fwd_layer_limit; ++il) {
         const auto & L = w.layers[il];
@@ -604,6 +608,10 @@ bool forward_qwen3_drafter_model(
                 std::fflush(stderr);
             }
             ggml_free(gA);
+        }
+
+        if (w.longattncomp_head_loaded && il == 13) {
+            continue;
         }
 
         // ── Attention dispatch ──
@@ -974,15 +982,25 @@ bool forward_qwen3_drafter_model(
 
         for (int t = 0; t < n_lookahead; ++t) {
             for (int j = 0; j < S; ++j) {
-                float m = -INFINITY;
-                for (int h = 0; h < H; ++h) {
-                    float v = probs_h[(size_t)j
-                                      + (size_t)t * S
-                                      + (size_t)h * S * n_lookahead];
-                    if (v > m) m = v;
-                }
                 size_t idx = (size_t)t * S + j;
-                if (m > running_max[idx]) running_max[idx] = m;
+                if (w.longattncomp_head_loaded) {
+                    float sum = 0.0f;
+                    for (int h = 0; h < H; ++h) {
+                        sum += probs_h[(size_t)j
+                                       + (size_t)t * S
+                                       + (size_t)h * S * n_lookahead];
+                    }
+                    running_max[idx] = sum / (float)H;
+                } else {
+                    float m = -INFINITY;
+                    for (int h = 0; h < H; ++h) {
+                        float v = probs_h[(size_t)j
+                                          + (size_t)t * S
+                                          + (size_t)h * S * n_lookahead];
+                        if (v > m) m = v;
+                    }
+                    if (m > running_max[idx]) running_max[idx] = m;
+                }
             }
         }
     }

--- a/server/src/qwen3/qwen3_loader.cpp
+++ b/server/src/qwen3/qwen3_loader.cpp
@@ -24,6 +24,7 @@
 
 #include "qwen3_drafter_model.h"
 #include "common/backend_precision.h"
+#include "common/gguf_inspect.h"
 #include "common/gguf_mmap.h"
 #include "internal.h"
 
@@ -91,6 +92,20 @@ bool copy_tensor_from_file(gguf_context * gctx, const char * name,
         return true;
     }
 
+    if (src_type == GGML_TYPE_F32 && dst_type == GGML_TYPE_BF16) {
+        std::vector<ggml_bf16_t> tmp_bf16((size_t)n);
+        ggml_fp32_to_bf16_row((const float *)src, tmp_bf16.data(), n);
+        ggml_backend_tensor_set(dst, tmp_bf16.data(), 0, ggml_nbytes(dst));
+        return true;
+    }
+
+    if (src_type == GGML_TYPE_F32 && dst_type == GGML_TYPE_F16) {
+        std::vector<ggml_fp16_t> tmp_f16((size_t)n);
+        ggml_fp32_to_fp16_row((const float *)src, tmp_f16.data(), n);
+        ggml_backend_tensor_set(dst, tmp_f16.data(), 0, ggml_nbytes(dst));
+        return true;
+    }
+
     std::fprintf(stderr, "[qwen3-0.6b] unsupported tensor conversion for %s: %s -> %s\n",
                  name, ggml_type_name(src_type), ggml_type_name(dst_type));
     return false;
@@ -106,6 +121,89 @@ float get_f32(gguf_context * g, const char * key, float def) {
     int k = gguf_find_key(g, key);
     if (k < 0) return def;
     return gguf_get_val_f32(g, k);
+}
+
+bool metadata_equals(gguf_context * g, const char * key, const char * expected) {
+    const int id = gguf_find_key(g, key);
+    return id >= 0 && std::string(gguf_get_val_str(g, id)) == expected;
+}
+
+bool load_longattncomp_head(
+        const std::string & path,
+        const std::string & drafter_sha256,
+        Qwen3DrafterWeights & out) {
+    ggml_context * tensor_ctx = nullptr;
+    gguf_init_params iparams{ /*no_alloc=*/ true, /*ctx=*/ &tensor_ctx };
+    gguf_context * gctx = gguf_init_from_file(path.c_str(), iparams);
+    if (!gctx) {
+        set_last_error("LongAttnComp head GGUF could not be opened: " + path);
+        return false;
+    }
+    auto fail = [&](const std::string & message) {
+        gguf_free(gctx);
+        if (tensor_ctx) ggml_free(tensor_ctx);
+        set_last_error(message);
+        return false;
+    };
+    const bool metadata_ok =
+        metadata_equals(gctx, "general.architecture", "longattncomp") &&
+        metadata_equals(gctx, "longattncomp.schema", "qwen3_0_6b_nope_qk_mass_v1") &&
+        metadata_equals(gctx, "longattncomp.base_model", "Qwen/Qwen3-0.6B") &&
+        metadata_equals(
+            gctx,
+            "longattncomp.runtime_gguf_sha256",
+            drafter_sha256.c_str()) &&
+        metadata_equals(
+            gctx,
+            "longattncomp.feature_tap",
+            "post_block12_residual_before_block13");
+    if (!metadata_ok) {
+        return fail("LongAttnComp head metadata does not match the loaded Qwen3-0.6B drafter");
+    }
+    struct TensorContract {
+        const char * name;
+        ggml_tensor * destination;
+    };
+    const TensorContract contracts[] = {
+        {"longattncomp.attn_q.weight", out.layers[13].wq},
+        {"longattncomp.attn_k.weight", out.layers[13].wk},
+    };
+    for (const auto & contract : contracts) {
+        const int64_t id = gguf_find_tensor(gctx, contract.name);
+        ggml_tensor * source = tensor_ctx
+            ? ggml_get_tensor(tensor_ctx, contract.name)
+            : nullptr;
+        if (id < 0 || gguf_get_tensor_type(gctx, id) != GGML_TYPE_F32 ||
+            !source || !ggml_are_same_shape(source, contract.destination) ||
+            gguf_get_tensor_size(gctx, id) !=
+                (size_t)ggml_nelements(contract.destination) * sizeof(float)) {
+            return fail(std::string("LongAttnComp head tensor contract mismatch: ") +
+                        contract.name);
+        }
+    }
+    const size_t data_offset = gguf_get_data_offset(gctx);
+    GgufMmap mmap;
+    std::string mmap_error;
+    if (!mmap.open(path, mmap_error)) {
+        return fail(mmap_error);
+    }
+    for (const auto & contract : contracts) {
+        const int64_t id = gguf_find_tensor(gctx, contract.name);
+        const size_t offset = gguf_get_tensor_offset(gctx, id);
+        const size_t size = gguf_get_tensor_size(gctx, id);
+        if (data_offset > mmap.size() || offset > mmap.size() - data_offset ||
+            size > mmap.size() - data_offset - offset ||
+            !copy_tensor_from_file(
+                gctx, contract.name, mmap.data(), data_offset, contract.destination)) {
+            return fail(std::string("LongAttnComp head tensor load failed: ") +
+                        contract.name);
+        }
+    }
+    gguf_free(gctx);
+    if (tensor_ctx) ggml_free(tensor_ctx);
+    out.longattncomp_head_loaded = true;
+    std::fprintf(stderr, "[qwen3-0.6b] loaded LongAttnComp head: %s\n", path.c_str());
+    return true;
 }
 
 } // namespace
@@ -287,6 +385,23 @@ bool load_qwen3_drafter_model(const std::string & path,
         out.ctx = nullptr;
         return false;
     }
+    if (const char * head_path = std::getenv("PFLASH_LONGATTNCOMP_HEAD_GGUF")) {
+        constexpr const char * expected_drafter_sha256 =
+            "f9c9f1d3c1e21755b82d4e165f88dbbbd4355646d632fb5d6cef7c66ed4ee04e";
+        const auto drafter_identity = read_gguf_metadata(path, true);
+        if (!*head_path || out.n_layer < 14 || !drafter_identity.ok ||
+            drafter_identity.sha256 != expected_drafter_sha256 ||
+            !load_longattncomp_head(head_path, drafter_identity.sha256, out)) {
+            if (drafter_identity.sha256 != expected_drafter_sha256) {
+                set_last_error("LongAttnComp head requires the pinned Qwen3-0.6B drafter GGUF");
+            }
+            ggml_backend_buffer_free(out.buf);
+            ggml_free(out.ctx);
+            out.buf = nullptr;
+            out.ctx = nullptr;
+            return false;
+        }
+    }
     return true;
 }
 
@@ -294,6 +409,7 @@ void free_qwen3_drafter_model(Qwen3DrafterWeights & w) {
     if (w.buf) { ggml_backend_buffer_free(w.buf); w.buf = nullptr; }
     if (w.ctx) { ggml_free(w.ctx); w.ctx = nullptr; }
     w.layers.clear();
+    w.longattncomp_head_loaded = false;
     w.tok_embd = w.out_norm = w.output = nullptr;
     w.backend = nullptr;
 }

--- a/server/src/qwen35/gguf_target_loader.cpp
+++ b/server/src/qwen35/gguf_target_loader.cpp
@@ -562,7 +562,9 @@ bool load_target_gguf_partial(const std::string & path,
     out.tok_embd = g("token_embd.weight");
     out.out_norm = g("output_norm.weight");
     out.output   = g("output.weight");
-    if (!out.tok_embd || !out.out_norm || !out.output) {
+    // Tied-embedding exports omit output.weight; that is only fatal when the
+    // load plan needs the lm_head (the PFlash drafter never computes logits).
+    if (!out.tok_embd || !out.out_norm || (!out.output && plan.load_output)) {
         set_last_error("missing top-level tensors (token_embd/output_norm/output)");
         gguf_free(gctx);
         return false;

--- a/server/src/qwen35/qwen35_backend.cpp
+++ b/server/src/qwen35/qwen35_backend.cpp
@@ -1187,7 +1187,9 @@ std::vector<ModelBackend::CompressResult> Qwen35Backend::compress_batch(
 
         auto & result = results[index];
         result.compressed_ids = drafter_score_and_compress(
-            drafter_ctx_, request.input_ids, request.keep_ratio);
+            drafter_ctx_, request.input_ids, request.keep_ratio,
+            /*chunk_size=*/32, request.score_query_tokens, /*pool_kernel=*/13,
+            request.score_query_end);
         result.ok = !result.compressed_ids.empty();
         if (result.ok) {
             std::fprintf(stderr, "[compress] %zu -> %zu tokens\n",

--- a/server/src/qwen35/qwen35_backend.cpp
+++ b/server/src/qwen35/qwen35_backend.cpp
@@ -1189,7 +1189,7 @@ std::vector<ModelBackend::CompressResult> Qwen35Backend::compress_batch(
         result.compressed_ids = drafter_score_and_compress(
             drafter_ctx_, request.input_ids, request.keep_ratio,
             /*chunk_size=*/32, request.score_query_tokens, /*pool_kernel=*/13,
-            request.score_query_end);
+            request.score_query_end, request.required_instruction_spans);
         result.ok = !result.compressed_ids.empty();
         if (result.ok) {
             std::fprintf(stderr, "[compress] %zu -> %zu tokens\n",

--- a/server/src/qwen35/qwen35_layer_split_adapter.cpp
+++ b/server/src/qwen35/qwen35_layer_split_adapter.cpp
@@ -1384,7 +1384,9 @@ Qwen35LayerSplitAdapter::compress(const ModelBackend::CompressRequest & req) {
     }
 
     result.compressed_ids = drafter_score_and_compress(
-        pflash_drafter_, req.input_ids, req.keep_ratio);
+        pflash_drafter_, req.input_ids, req.keep_ratio,
+        /*chunk_size=*/32, req.score_query_tokens, /*pool_kernel=*/13,
+        req.score_query_end);
     result.ok = !result.compressed_ids.empty();
     if (result.ok) {
         std::fprintf(stderr, "[target-split][compress] %zu -> %zu tokens\n",

--- a/server/src/qwen35/qwen35_layer_split_adapter.cpp
+++ b/server/src/qwen35/qwen35_layer_split_adapter.cpp
@@ -1386,7 +1386,7 @@ Qwen35LayerSplitAdapter::compress(const ModelBackend::CompressRequest & req) {
     result.compressed_ids = drafter_score_and_compress(
         pflash_drafter_, req.input_ids, req.keep_ratio,
         /*chunk_size=*/32, req.score_query_tokens, /*pool_kernel=*/13,
-        req.score_query_end);
+        req.score_query_end, req.required_instruction_spans);
     result.ok = !result.compressed_ids.empty();
     if (result.ok) {
         std::fprintf(stderr, "[target-split][compress] %zu -> %zu tokens\n",

--- a/server/src/server/adaptive_keep_ratio.h
+++ b/server/src/server/adaptive_keep_ratio.h
@@ -53,23 +53,32 @@ inline AdaptiveKeepRatioState step_adaptive_keep_ratio(
 // Prevents memory exhaustion from unbounded unique-session insertion.
 class HttpServerSessions {
 public:
-    void update(const std::string& session_id, float observed_accept) {
+    // ``seed_keep`` is the ratio a brand-new session adapts from: the server
+    // passes the configured (curve) ratio so a session starts at the real-use
+    // budget for its prompt length rather than the fixed default, and the
+    // controller then moves it by acceptance feedback within the same bounds.
+    void update(const std::string& session_id, float observed_accept,
+                float seed_keep = AdaptiveKeepRatioState{}.last_keep) {
         std::lock_guard<std::mutex> lock(mu_);
         auto it = map_.find(session_id);
         if (it == map_.end()) {
             evict_if_full_locked();
             lru_.push_front(session_id);
-            map_.emplace(session_id, Entry{step_adaptive_keep_ratio({}, observed_accept), lru_.begin()});
+            AdaptiveKeepRatioState seed;
+            seed.last_keep = std::clamp(seed_keep, kBanditKeepMin, kBanditKeepMax);
+            map_.emplace(session_id, Entry{step_adaptive_keep_ratio(seed, observed_accept), lru_.begin()});
         } else {
             it->second.state = step_adaptive_keep_ratio(it->second.state, observed_accept);
             lru_.splice(lru_.begin(), lru_, it->second.lru_it);
         }
     }
 
-    float get_keep_ratio(const std::string& session_id) const {
+    // A session with no feedback yet reports ``fallback`` (the configured ratio).
+    float get_keep_ratio(const std::string& session_id,
+                         float fallback = AdaptiveKeepRatioState{}.last_keep) const {
         std::lock_guard<std::mutex> lock(mu_);
         auto it = map_.find(session_id);
-        if (it == map_.end()) return AdaptiveKeepRatioState{}.last_keep;
+        if (it == map_.end()) return fallback;
         lru_.splice(lru_.begin(), lru_, it->second.lru_it);
         return it->second.state.last_keep;
     }

--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -2904,7 +2904,8 @@ std::string HttpServer::apply_pflash_compression(
             compress_request.input_ids.size() - (size_t) query_window.end);
     } else {
         std::fprintf(stderr,
-            "[pflash] scorer query mapping failed — using rendered prompt tail\n");
+            "[pflash] ERROR: scorer query mapping failed; refusing compression\n");
+        return "PFlash scorer query mapping failed";
     }
     compress_request.drafter_path = config_.pflash_drafter_path;
     compress_request.drafter_gpu = config_.pflash_drafter_gpu;

--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -24,6 +24,7 @@
 #include "pin_friendly_prompt.h"
 #include "common/kv_rotation.h"
 #include "common/sha1.h"
+#include "qwen3/pflash_selection.h"
 #include "freeze_history.h"
 
 #ifdef DFLASH_HAS_CURL
@@ -34,6 +35,7 @@
 #include <array>
 #include <cerrno>
 #include <chrono>
+#include <climits>
 #include <cctype>
 #include <cmath>
 #include <cstdint>
@@ -189,18 +191,40 @@ HeartbeatSendResult try_send_sse_heartbeat(
 PflashQueryWindow find_pflash_query_window(
         const std::vector<int32_t> & prompt,
         const std::vector<int32_t> & query,
-        int max_tokens) {
+        int max_tokens,
+        int search_end,
+        int search_begin) {
     PflashQueryWindow result;
     if (prompt.empty() || query.empty() || max_tokens < 1) return result;
 
+    const int limit = search_end < 0
+        ? (int) prompt.size()
+        : (std::min)((int) prompt.size(), search_end);
+    if (limit < 1 || search_begin < 0 || search_begin >= limit) return result;
     const int widest = (std::min)(max_tokens, (int) query.size());
     // For a short query, require all available tokens. For a normal query,
     // four matching suffix tokens are enough to tolerate a BPE boundary
     // difference without accidentally selecting a lone punctuation token.
     const int narrowest = (std::min)(4, widest);
+    // A configured semantic boundary is the exact content end. Shorten only
+    // the suffix width there; accepting an earlier occurrence would silently
+    // turn a failed latest-user mapping into preceding context.
+    if (search_end >= 0) {
+        const int bounded_widest = (std::min)(widest, limit - search_begin);
+        for (int width = bounded_widest; width >= narrowest; --width) {
+            const auto query_begin = query.end() - width;
+            if (std::equal(query_begin, query.end(),
+                           prompt.begin() + limit - width)) {
+                result.end = limit;
+                result.tokens = width;
+                return result;
+            }
+        }
+        return result;
+    }
     for (int width = widest; width >= narrowest; --width) {
         const auto query_begin = query.end() - width;
-        for (int end = (int) prompt.size(); end >= width; --end) {
+        for (int end = limit; end >= width; --end) {
             if (std::equal(query_begin, query.end(),
                            prompt.begin() + end - width)) {
                 result.end = end;
@@ -210,6 +234,94 @@ PflashQueryWindow find_pflash_query_window(
         }
     }
     return result;
+}
+
+PflashQueryWindow pflash_tail_query_window(
+        const std::vector<int32_t> & prompt,
+        int max_tokens,
+        int query_end,
+        int query_begin) noexcept {
+    PflashQueryWindow result;
+    if (prompt.empty() || max_tokens < 1) return result;
+    result.end = query_end < 0
+        ? static_cast<int>(prompt.size())
+        : query_end;
+    if (result.end < 1 || result.end > static_cast<int>(prompt.size()) ||
+        query_begin < 0 || query_begin >= result.end) {
+        return {};
+    }
+    result.tokens = (std::min)(max_tokens, result.end - query_begin);
+    return result;
+}
+
+int pflash_query_search_end_from_sentinel(
+        const std::vector<int32_t> & original,
+        const std::vector<int32_t> & sentinel) noexcept {
+    size_t common_suffix = 0;
+    while (common_suffix < original.size() &&
+           common_suffix < sentinel.size() &&
+           original[original.size() - common_suffix - 1] ==
+               sentinel[sentinel.size() - common_suffix - 1]) {
+        ++common_suffix;
+    }
+    if (common_suffix == 0 || common_suffix >= original.size()) {
+        return -1;
+    }
+    return static_cast<int>(original.size() - common_suffix);
+}
+int pflash_query_search_begin_from_sentinel(
+        const std::vector<int32_t> & original,
+        const std::vector<int32_t> & sentinel) noexcept {
+    size_t common_prefix = 0;
+    while (common_prefix < original.size() &&
+           common_prefix < sentinel.size() &&
+           original[common_prefix] == sentinel[common_prefix]) {
+        ++common_prefix;
+    }
+    if (common_prefix >= original.size()) return -1;
+    return static_cast<int>(common_prefix);
+}
+
+std::string pflash_token_fingerprint(
+        const std::vector<int32_t> & ids) {
+    uint64_t hash = UINT64_C(14695981039346656037);
+    for (int32_t token : ids) {
+        const uint32_t value = static_cast<uint32_t>(token);
+        for (int shift = 0; shift < 32; shift += 8) {
+            hash ^= static_cast<uint8_t>(value >> shift);
+            hash *= UINT64_C(1099511628211);
+        }
+    }
+
+    char encoded[17];
+    std::snprintf(encoded, sizeof(encoded), "%016llx",
+                  static_cast<unsigned long long>(hash));
+    return encoded;
+}
+
+
+bool pflash_full_cache_restore_allowed(
+        bool longattncomp_environment_present) noexcept {
+    return !longattncomp_environment_present;
+}
+
+bool pflash_continuation_must_fail_closed(
+        bool longattncomp_environment_present) noexcept {
+    return longattncomp_environment_present;
+}
+
+int pflash_target_token_ceiling(
+        int original_target_tokens, double keep_ratio) noexcept {
+    if (original_target_tokens < 0 || !std::isfinite(keep_ratio) ||
+        keep_ratio <= 0.0) {
+        return -1;
+    }
+    const double ceiling = std::floor(
+        static_cast<double>(original_target_tokens) * keep_ratio);
+    if (!std::isfinite(ceiling) || ceiling < 0.0 || ceiling > INT_MAX) {
+        return -1;
+    }
+    return static_cast<int>(ceiling);
 }
 
 }  // namespace http_detail
@@ -2844,8 +2956,11 @@ void HttpServer::apply_flowkv_compression(
 
 std::string HttpServer::apply_pflash_compression(
         const ParsedRequest & req, PreparedPrompt & prepared) {
+    const bool longattncomp_environment =
+        dflash::qwen3::has_pflash_longattncomp_environment();
     auto [full_slot, full_len] = prefix_cache_.lookup_full(req.prompt_tokens);
-    if (full_slot >= 0) {
+    if (http_detail::pflash_full_cache_restore_allowed(
+            longattncomp_environment) && full_slot >= 0) {
         std::fprintf(stderr,
             "[pflash] full-cache hit slot=%d — skipping compress\n",
             full_slot);
@@ -2862,8 +2977,109 @@ std::string HttpServer::apply_pflash_compression(
     const std::string prompt_text = tokenizer_.decode(req.prompt_tokens);
     auto drafter_ids = drafter_tokenizer_->encode(prompt_text);
 
+    if (drafter_ids.empty()) {
+        return "PFlash drafter tokenizer produced an empty prompt";
+    }
+
+    dflash::qwen3::PFlashLongAttnCompConfig experiment;
+    std::string experiment_error;
+    if (!dflash::qwen3::resolve_pflash_longattncomp(
+            (int) drafter_ids.size(), 32, experiment, experiment_error)) {
+        return "invalid PFlash LongAttnComp config: " + experiment_error;
+    }
+
+    const bool messages_input =
+        req.messages.is_array() && !req.messages.empty();
+    const bool raw_text_input = req.messages.is_string();
+    const char * parser_input_kind = messages_input
+        ? "messages" : (raw_text_input ? "raw_text" : "unsupported");
+    std::string parser_selection_rule;
     std::string last_user_text;
-    if (req.messages.is_array()) {
+    int query_content_begin = -1;
+    int query_content_end = -1;
+    if (experiment.configured) {
+        if (!messages_input && !raw_text_input) {
+            return "PFlash LongAttnComp input has no parseable text";
+        }
+        try {
+            auto messages =
+                normalize_chat_messages(req.messages, req.format, tool_memory_);
+            if (messages.empty()) {
+                return "PFlash LongAttnComp normalized messages are empty";
+            }
+
+            int last_user_index = -1;
+            for (int index = (int) messages.size() - 1; index >= 0; --index) {
+                if (messages[(size_t) index].role == "user") {
+                    last_user_index = index;
+                    break;
+                }
+            }
+            if (last_user_index >= 0) {
+                last_user_text = messages[(size_t) last_user_index].content;
+            }
+
+            int boundary_index = (int) messages.size() - 1;
+            if (!raw_text_input &&
+                experiment.query_parser ==
+                    dflash::qwen3::PFlashQueryParser::SemanticUser) {
+                boundary_index = last_user_index;
+            }
+            if (boundary_index < 0 ||
+                (experiment.query_parser ==
+                     dflash::qwen3::PFlashQueryParser::SemanticUser &&
+                 !raw_text_input && last_user_text.empty())) {
+                return "PFlash LongAttnComp latest-user boundary is unavailable";
+            }
+
+            static constexpr const char * kContentBegin =
+                "__DFLASH_PFLASH_CONTENT_BEGIN_02C47F91__";
+            static constexpr const char * kContentEnd =
+                "__DFLASH_PFLASH_CONTENT_END_6E6B61A8__";
+            auto begin_messages = messages;
+            begin_messages[(size_t) boundary_index].content =
+                std::string(kContentBegin) +
+                begin_messages[(size_t) boundary_index].content;
+            auto end_messages = messages;
+            end_messages[(size_t) boundary_index].content += kContentEnd;
+
+            std::string begin_rendered;
+            std::string end_rendered;
+            std::string boundary_error;
+            if (!render_messages_to_text(
+                    begin_messages, req, /*add_generation_prompt=*/true,
+                    begin_rendered, boundary_error)) {
+                return "PFlash LongAttnComp content-start render failed: " +
+                    boundary_error;
+            }
+            boundary_error.clear();
+            if (!render_messages_to_text(
+                    end_messages, req, /*add_generation_prompt=*/true,
+                    end_rendered, boundary_error)) {
+                return "PFlash LongAttnComp content-end render failed: " +
+                    boundary_error;
+            }
+
+            const auto begin_ids = drafter_tokenizer_->encode(
+                tokenizer_.decode(tokenizer_.encode(begin_rendered)));
+            const auto end_ids = drafter_tokenizer_->encode(
+                tokenizer_.decode(tokenizer_.encode(end_rendered)));
+            query_content_begin =
+                http_detail::pflash_query_search_begin_from_sentinel(
+                    drafter_ids, begin_ids);
+            query_content_end =
+                http_detail::pflash_query_search_end_from_sentinel(
+                    drafter_ids, end_ids);
+            if (query_content_begin < 0 ||
+                query_content_end <= query_content_begin ||
+                query_content_end >= (int) drafter_ids.size()) {
+                return "PFlash LongAttnComp content boundary mapping failed";
+            }
+        } catch (const std::exception & error) {
+            return std::string("PFlash user-query normalization failed: ") +
+                   error.what();
+        }
+    } else if (req.messages.is_array()) {
         for (int index = (int) req.messages.size() - 1; index >= 0; --index) {
             if (req.messages[index].value("role", "") != "user") continue;
             const auto & content = req.messages[index]["content"];
@@ -2881,13 +3097,36 @@ std::string HttpServer::apply_pflash_compression(
             break;
         }
     }
-    const auto query_ids = last_user_text.empty()
-        ? std::vector<int32_t>{}
-        : drafter_tokenizer_->encode(last_user_text);
-    const auto query_window = http_detail::find_pflash_query_window(
-        drafter_ids, query_ids);
-    if (drafter_ids.empty()) {
-        return "PFlash drafter tokenizer produced an empty prompt";
+
+    std::vector<int32_t> semantic_query_ids;
+    std::vector<int32_t> expected_query_ids;
+    http_detail::PflashQueryWindow query_window;
+    if (!last_user_text.empty()) {
+        semantic_query_ids = drafter_tokenizer_->encode(last_user_text);
+    }
+    if (experiment.configured && raw_text_input) {
+        parser_selection_rule = "content_tail";
+        query_window = http_detail::pflash_tail_query_window(
+            drafter_ids, experiment.query_tokens,
+            query_content_end, query_content_begin);
+    } else if (experiment.configured &&
+               experiment.query_parser ==
+                   dflash::qwen3::PFlashQueryParser::ArbitraryTail) {
+        parser_selection_rule = "prompt_tail";
+        query_window = http_detail::pflash_tail_query_window(
+            drafter_ids, experiment.query_tokens, query_content_end);
+    } else if (!semantic_query_ids.empty()) {
+        if (experiment.configured) parser_selection_rule = "semantic_suffix";
+        query_window = http_detail::find_pflash_query_window(
+            drafter_ids, semantic_query_ids,
+            experiment.configured ? experiment.query_tokens : 8,
+            query_content_end,
+            experiment.configured ? query_content_begin : 0);
+        if (experiment.configured && query_window.valid()) {
+            expected_query_ids.assign(
+                semantic_query_ids.end() - query_window.tokens,
+                semantic_query_ids.end());
+        }
     }
 
     ModelBackend::CompressRequest compress_request;
@@ -2897,6 +3136,30 @@ std::string HttpServer::apply_pflash_compression(
     if (query_window.valid()) {
         compress_request.score_query_end = query_window.end;
         compress_request.score_query_tokens = query_window.tokens;
+        if (experiment.configured) {
+            const int query_begin = query_window.end - query_window.tokens;
+            const json provenance = {
+                {"schema_version", 1},
+                {"input_kind", parser_input_kind},
+                {"selection_rule", parser_selection_rule},
+                {"query_parser",
+                 dflash::qwen3::pflash_query_parser_name(
+                     experiment.query_parser)},
+                {"input_tokens", (int) compress_request.input_ids.size()},
+                {"input_fingerprint_fnv1a64",
+                 http_detail::pflash_token_fingerprint(
+                     compress_request.input_ids)},
+                {"content_begin", query_content_begin},
+                {"content_end", query_content_end},
+                {"query_begin", query_begin},
+                {"query_end", query_window.end},
+                {"requested_query_tokens", experiment.query_tokens},
+                {"expected_query_ids", expected_query_ids},
+            };
+            std::fprintf(stderr, "[pflash-parser] %s\n",
+                         provenance.dump().c_str());
+            std::fflush(stderr);
+        }
         std::fprintf(stderr,
             "[pflash] scorer query mapped to drafter tokens [%d,%d); "
             "rendered suffix=%zu tokens\n",
@@ -2951,36 +3214,53 @@ std::string HttpServer::apply_pflash_compression(
 
     // Compression is allowed to be lossy, but the active user query must
     // survive. Re-append short queries when fewer than 80% of their tokens do.
-    if (!last_user_text.empty()) {
+    if (!experiment.selection_active && !last_user_text.empty()) {
         int query_kept = 0;
-        if (!query_ids.empty()) {
-            int query_index = (int) query_ids.size() - 1;
+        if (!semantic_query_ids.empty()) {
+            int query_index = (int) semantic_query_ids.size() - 1;
             for (int kept_index = (int) result.compressed_ids.size() - 1;
                  kept_index >= 0 && query_index >= 0; --kept_index) {
-                if (result.compressed_ids[kept_index] == query_ids[query_index]) {
+                if (result.compressed_ids[kept_index] == semantic_query_ids[query_index]) {
                     ++query_kept;
                     --query_index;
                 }
             }
         }
         const float survival = (float) query_kept /
-            (std::max)(1, (int) query_ids.size());
+            (std::max)(1, (int) semantic_query_ids.size());
         std::fprintf(stderr,
             "[pflash] query survival: %d/%d (%.0f%%)\n",
-            query_kept, (int) query_ids.size(), survival * 100.0f);
-        if (survival < 0.80f && (int) query_ids.size() < 1000) {
+            query_kept, (int) semantic_query_ids.size(), survival * 100.0f);
+        if (survival < 0.80f && (int) semantic_query_ids.size() < 1000) {
             compressed_text += "\n" + last_user_text;
             std::fprintf(stderr,
                 "[pflash] query below 80%% — re-appended full query (%d tokens)\n",
-                (int) query_ids.size());
+                (int) semantic_query_ids.size());
         } else if (survival < 0.80f) {
             std::fprintf(stderr,
                 "[pflash] query below 80%% but too large to re-append (%d tokens)\n",
-                (int) query_ids.size());
+                (int) semantic_query_ids.size());
         }
     }
 
-    prepared.tokens = tokenizer_.encode(compressed_text);
+    auto final_tokens = tokenizer_.encode(compressed_text);
+    if (experiment.selection_active) {
+        const int target_ceiling = http_detail::pflash_target_token_ceiling(
+            prompt_tokens, compress_request.keep_ratio);
+        if (target_ceiling < 0) {
+            return "PFlash LongAttnComp target-token ceiling is invalid";
+        }
+        std::fprintf(stderr,
+            "[pflash-longattncomp] final target tokens=%zu ceiling=%d\n",
+            final_tokens.size(), target_ceiling);
+        std::fflush(stderr);
+        if ((int) final_tokens.size() > target_ceiling) {
+            return "PFlash LongAttnComp final prompt exceeds target-token ceiling "
+                "(" + std::to_string(final_tokens.size()) + " > " +
+                std::to_string(target_ceiling) + ")";
+        }
+    }
+    prepared.tokens = std::move(final_tokens);
     prepared.compressed = true;
     std::fprintf(stderr,
         "[pflash] %d -> %d -> %d tokens (%.1f%% kept)\n",
@@ -3004,6 +3284,27 @@ HttpServer::PreparedPrompt HttpServer::prepare_prompt(
              prompt_tokens >= config_.pflash_threshold);
         const bool continuation = should_compress &&
             is_continuation_request(req.messages);
+        const bool longattncomp_environment =
+            dflash::qwen3::has_pflash_longattncomp_environment();
+        if (should_compress && longattncomp_environment) {
+            dflash::qwen3::PFlashLongAttnCompConfig experiment;
+            std::string experiment_error;
+            if (!dflash::qwen3::resolve_pflash_longattncomp(
+                    0, 32, experiment, experiment_error)) {
+                prepared.error_status = 500;
+                prepared.error = "invalid PFlash LongAttnComp config: " +
+                    experiment_error;
+                return prepared;
+            }
+            if (http_detail::pflash_continuation_must_fail_closed(
+                    longattncomp_environment) &&
+                (continuation || req.disk_cache_policy.compress)) {
+                prepared.error_status = 500;
+                prepared.error =
+                    "PFlash LongAttnComp does not support continuation or FlowKV compression";
+                return prepared;
+            }
+        }
 
         if (should_compress && continuation && req.messages.is_array()) {
             // FlowKV owns continuation compression automatically. Falling

--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -3079,6 +3079,8 @@ std::string HttpServer::apply_pflash_compression(
             return std::string("PFlash user-query normalization failed: ") +
                    error.what();
         }
+    } else if (raw_text_input) {
+        last_user_text = req.messages.get<std::string>();
     } else if (req.messages.is_array()) {
         for (int index = (int) req.messages.size() - 1; index >= 0; --index) {
             if (req.messages[index].value("role", "") != "user") continue;

--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -186,6 +186,32 @@ HeartbeatSendResult try_send_sse_heartbeat(
     return HeartbeatSendResult::Complete;
 }
 
+PflashQueryWindow find_pflash_query_window(
+        const std::vector<int32_t> & prompt,
+        const std::vector<int32_t> & query,
+        int max_tokens) {
+    PflashQueryWindow result;
+    if (prompt.empty() || query.empty() || max_tokens < 1) return result;
+
+    const int widest = (std::min)(max_tokens, (int) query.size());
+    // For a short query, require all available tokens. For a normal query,
+    // four matching suffix tokens are enough to tolerate a BPE boundary
+    // difference without accidentally selecting a lone punctuation token.
+    const int narrowest = (std::min)(4, widest);
+    for (int width = widest; width >= narrowest; --width) {
+        const auto query_begin = query.end() - width;
+        for (int end = (int) prompt.size(); end >= width; --end) {
+            if (std::equal(query_begin, query.end(),
+                           prompt.begin() + end - width)) {
+                result.end = end;
+                result.tokens = width;
+                return result;
+            }
+        }
+    }
+    return result;
+}
+
 }  // namespace http_detail
 
 static std::string context_overflow_message(int max_ctx, int prompt_tokens, int max_output) {
@@ -2835,6 +2861,31 @@ std::string HttpServer::apply_pflash_compression(
     const int prompt_tokens = (int) req.prompt_tokens.size();
     const std::string prompt_text = tokenizer_.decode(req.prompt_tokens);
     auto drafter_ids = drafter_tokenizer_->encode(prompt_text);
+
+    std::string last_user_text;
+    if (req.messages.is_array()) {
+        for (int index = (int) req.messages.size() - 1; index >= 0; --index) {
+            if (req.messages[index].value("role", "") != "user") continue;
+            const auto & content = req.messages[index]["content"];
+            if (content.is_string()) {
+                last_user_text = content.get<std::string>();
+            } else if (content.is_array()) {
+                for (const auto & part : content) {
+                    const std::string type = part.value("type", "");
+                    if (type == "text" || type == "input_text" ||
+                        type == "output_text") {
+                        last_user_text += part.value("text", "");
+                    }
+                }
+            }
+            break;
+        }
+    }
+    const auto query_ids = last_user_text.empty()
+        ? std::vector<int32_t>{}
+        : drafter_tokenizer_->encode(last_user_text);
+    const auto query_window = http_detail::find_pflash_query_window(
+        drafter_ids, query_ids);
     if (drafter_ids.empty()) {
         return "PFlash drafter tokenizer produced an empty prompt";
     }
@@ -2843,6 +2894,18 @@ std::string HttpServer::apply_pflash_compression(
     compress_request.input_ids = std::move(drafter_ids);
     compress_request.keep_ratio = http_detail::resolve_pflash_keep_ratio(
         pflash_keep_ratio(config_, prompt_tokens), req.session_id, sessions_);
+    if (query_window.valid()) {
+        compress_request.score_query_end = query_window.end;
+        compress_request.score_query_tokens = query_window.tokens;
+        std::fprintf(stderr,
+            "[pflash] scorer query mapped to drafter tokens [%d,%d); "
+            "rendered suffix=%zu tokens\n",
+            query_window.end - query_window.tokens, query_window.end,
+            compress_request.input_ids.size() - (size_t) query_window.end);
+    } else {
+        std::fprintf(stderr,
+            "[pflash] scorer query mapping failed — using rendered prompt tail\n");
+    }
     compress_request.drafter_path = config_.pflash_drafter_path;
     compress_request.drafter_gpu = config_.pflash_drafter_gpu;
     compress_request.skip_park = config_.pflash_skip_park;
@@ -2866,7 +2929,9 @@ std::string HttpServer::apply_pflash_compression(
         }
         result.ok = pflash_remote_.compress(
             compress_request.input_ids, compress_request.keep_ratio,
-            result.compressed_ids);
+            result.compressed_ids,
+            compress_request.score_query_end,
+            compress_request.score_query_tokens);
         if (residency == DraftResidencyAction::ReleaseAfterUse) {
             pflash_remote_.close();
         }
@@ -2885,28 +2950,7 @@ std::string HttpServer::apply_pflash_compression(
 
     // Compression is allowed to be lossy, but the active user query must
     // survive. Re-append short queries when fewer than 80% of their tokens do.
-    std::string last_user_text;
-    if (req.messages.is_array()) {
-        for (int index = (int) req.messages.size() - 1; index >= 0; --index) {
-            if (req.messages[index].value("role", "") != "user") continue;
-            const auto & content = req.messages[index]["content"];
-            if (content.is_string()) {
-                last_user_text = content.get<std::string>();
-            } else if (content.is_array()) {
-                for (const auto & part : content) {
-                    const std::string type = part.value("type", "");
-                    if (type == "text" || type == "input_text" ||
-                        type == "output_text") {
-                        last_user_text += part.value("text", "");
-                    }
-                }
-            }
-            break;
-        }
-    }
-
     if (!last_user_text.empty()) {
-        const auto query_ids = drafter_tokenizer_->encode(last_user_text);
         int query_kept = 0;
         if (!query_ids.empty()) {
             int query_index = (int) query_ids.size() - 1;

--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -226,15 +226,25 @@ PflashQueryWindow find_pflash_query_window(
     // Unanchored: the latest occurrence of the (suffix-trimmed) query inside
     // [search_begin, limit). An explicit query may sit before trailing
     // instructions, so it is not required to end at the content boundary.
+    // Its last token may also merge with what follows it in the prompt
+    // (trailing whitespace before a newline), so up to two trailing query
+    // tokens may be dropped; the untrimmed query is always preferred.
     const int floor = (std::max)(0, search_begin);
-    for (int width = widest; width >= narrowest; --width) {
-        const auto query_begin = query.end() - width;
-        for (int end = limit; end - width >= floor; --end) {
-            if (std::equal(query_begin, query.end(),
-                           prompt.begin() + end - width)) {
-                result.end = end;
-                result.tokens = width;
-                return result;
+    const int max_trailing = (std::min)(2, (int) query.size() - narrowest);
+    for (int drop = 0; drop <= max_trailing; ++drop) {
+        const auto query_end = query.end() - drop;
+        const int available = (int) query.size() - drop;
+        const int drop_widest = (std::min)(max_tokens, available);
+        for (int width = drop_widest; width >= narrowest; --width) {
+            const auto query_begin = query_end - width;
+            for (int end = limit; end - width >= floor; --end) {
+                if (std::equal(query_begin, query_end,
+                               prompt.begin() + end - width)) {
+                    result.end = end;
+                    result.tokens = width;
+                    result.trailing_trimmed = drop;
+                    return result;
+                }
             }
         }
     }
@@ -3296,9 +3306,10 @@ std::string HttpServer::apply_pflash_compression(
             experiment.configured ? query_content_begin : 0,
             /*anchored=*/ req.pflash_query.empty());
         if (experiment.configured && query_window.valid()) {
+            const auto matched_end =
+                semantic_query_ids.end() - query_window.trailing_trimmed;
             expected_query_ids.assign(
-                semantic_query_ids.end() - query_window.tokens,
-                semantic_query_ids.end());
+                matched_end - query_window.tokens, matched_end);
         }
     }
 

--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -193,7 +193,8 @@ PflashQueryWindow find_pflash_query_window(
         const std::vector<int32_t> & query,
         int max_tokens,
         int search_end,
-        int search_begin) {
+        int search_begin,
+        bool anchored) {
     PflashQueryWindow result;
     if (prompt.empty() || query.empty() || max_tokens < 1) return result;
 
@@ -209,7 +210,7 @@ PflashQueryWindow find_pflash_query_window(
     // A configured semantic boundary is the exact content end. Shorten only
     // the suffix width there; accepting an earlier occurrence would silently
     // turn a failed latest-user mapping into preceding context.
-    if (search_end >= 0) {
+    if (search_end >= 0 && anchored) {
         const int bounded_widest = (std::min)(widest, limit - search_begin);
         for (int width = bounded_widest; width >= narrowest; --width) {
             const auto query_begin = query.end() - width;
@@ -222,9 +223,13 @@ PflashQueryWindow find_pflash_query_window(
         }
         return result;
     }
+    // Unanchored: the latest occurrence of the (suffix-trimmed) query inside
+    // [search_begin, limit). An explicit query may sit before trailing
+    // instructions, so it is not required to end at the content boundary.
+    const int floor = (std::max)(0, search_begin);
     for (int width = widest; width >= narrowest; --width) {
         const auto query_begin = query.end() - width;
-        for (int end = limit; end >= width; --end) {
+        for (int end = limit; end - width >= floor; --end) {
             if (std::equal(query_begin, query.end(),
                            prompt.begin() + end - width)) {
                 result.end = end;
@@ -3288,7 +3293,8 @@ std::string HttpServer::apply_pflash_compression(
             drafter_ids, semantic_query_ids,
             experiment.configured ? experiment.query_tokens : 8,
             query_content_end,
-            experiment.configured ? query_content_begin : 0);
+            experiment.configured ? query_content_begin : 0,
+            /*anchored=*/ req.pflash_query.empty());
         if (experiment.configured && query_window.valid()) {
             expected_query_ids.assign(
                 semantic_query_ids.end() - query_window.tokens,

--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -282,6 +282,63 @@ int pflash_query_search_begin_from_sentinel(
     return static_cast<int>(common_prefix);
 }
 
+PflashInstructionMessagePlan plan_pflash_instruction_messages(
+        const std::vector<ChatMessage> & messages) {
+    PflashInstructionMessagePlan plan;
+    for (size_t index = 0; index < messages.size(); ++index) {
+        const auto & message = messages[index];
+        const bool instruction_role =
+            message.role == "system" || message.role == "developer";
+        if (instruction_role && !message.content.empty()) {
+            plan.instruction_messages.push_back(index);
+        }
+    }
+    return plan;
+}
+
+PFlashTokenSpan pflash_changed_token_span(
+        const std::vector<int32_t> & original,
+        const std::vector<int32_t> & variant) noexcept {
+    size_t common_prefix = 0;
+    while (common_prefix < original.size() &&
+           common_prefix < variant.size() &&
+           original[common_prefix] == variant[common_prefix]) {
+        ++common_prefix;
+    }
+
+    size_t common_suffix = 0;
+    while (common_suffix < original.size() - common_prefix &&
+           common_suffix < variant.size() - common_prefix &&
+           original[original.size() - common_suffix - 1] ==
+               variant[variant.size() - common_suffix - 1]) {
+        ++common_suffix;
+    }
+
+    const int begin = static_cast<int>(common_prefix);
+    const int end = static_cast<int>(original.size() - common_suffix);
+    return end > begin ? PFlashTokenSpan{begin, end}
+                       : PFlashTokenSpan{-1, -1};
+}
+
+std::vector<PFlashTokenSpan> canonicalize_pflash_token_spans(
+        std::vector<PFlashTokenSpan> spans) {
+    std::sort(spans.begin(), spans.end(), [] (
+            const PFlashTokenSpan & left,
+            const PFlashTokenSpan & right) {
+        return left.begin < right.begin ||
+            (left.begin == right.begin && left.end < right.end);
+    });
+    std::vector<PFlashTokenSpan> result;
+    for (const PFlashTokenSpan & span : spans) {
+        if (!result.empty() && span.begin <= result.back().end) {
+            result.back().end = std::max(result.back().end, span.end);
+        } else {
+            result.push_back(span);
+        }
+    }
+    return result;
+}
+
 std::string pflash_token_fingerprint(
         const std::vector<int32_t> & ids) {
     uint64_t hash = UINT64_C(14695981039346656037);
@@ -2997,6 +3054,7 @@ std::string HttpServer::apply_pflash_compression(
     std::string last_user_text;
     int query_content_begin = -1;
     int query_content_end = -1;
+    std::vector<PFlashTokenSpan> required_instruction_spans;
     if (experiment.configured) {
         if (!messages_input && !raw_text_input) {
             return "PFlash LongAttnComp input has no parseable text";
@@ -3036,47 +3094,147 @@ std::string HttpServer::apply_pflash_compression(
                 "__DFLASH_PFLASH_CONTENT_BEGIN_02C47F91__";
             static constexpr const char * kContentEnd =
                 "__DFLASH_PFLASH_CONTENT_END_6E6B61A8__";
-            auto begin_messages = messages;
-            begin_messages[(size_t) boundary_index].content =
-                std::string(kContentBegin) +
-                begin_messages[(size_t) boundary_index].content;
-            auto end_messages = messages;
-            end_messages[(size_t) boundary_index].content += kContentEnd;
+            const auto map_message_content = [&] (
+                    size_t message_index,
+                    int & content_begin,
+                    int & content_end,
+                    std::string & boundary_error) -> bool {
+                auto begin_messages = messages;
+                begin_messages[message_index].content =
+                    std::string(kContentBegin) +
+                    begin_messages[message_index].content;
+                auto end_messages = messages;
+                end_messages[message_index].content += kContentEnd;
 
-            std::string begin_rendered;
-            std::string end_rendered;
+                std::string begin_rendered;
+                std::string end_rendered;
+                if (!render_messages_to_text(
+                        begin_messages, req, /*add_generation_prompt=*/true,
+                        begin_rendered, boundary_error)) {
+                    boundary_error = "content-start render failed: " +
+                        boundary_error;
+                    return false;
+                }
+                boundary_error.clear();
+                if (!render_messages_to_text(
+                        end_messages, req, /*add_generation_prompt=*/true,
+                        end_rendered, boundary_error)) {
+                    boundary_error = "content-end render failed: " +
+                        boundary_error;
+                    return false;
+                }
+
+                const auto begin_ids = drafter_tokenizer_->encode(
+                    tokenizer_.decode(tokenizer_.encode(begin_rendered)));
+                const auto end_ids = drafter_tokenizer_->encode(
+                    tokenizer_.decode(tokenizer_.encode(end_rendered)));
+                content_begin =
+                    http_detail::pflash_query_search_begin_from_sentinel(
+                        drafter_ids, begin_ids);
+                content_end =
+                    http_detail::pflash_query_search_end_from_sentinel(
+                        drafter_ids, end_ids);
+                if (content_begin < 0 || content_end <= content_begin ||
+                    content_end >= (int) drafter_ids.size()) {
+                    boundary_error = "content boundary mapping failed";
+                    return false;
+                }
+                return true;
+            };
+            const auto map_rendered_message = [&] (
+                    size_t message_index,
+                    PFlashTokenSpan & message_span,
+                    std::string & boundary_error) -> bool {
+                auto without_message = messages;
+                without_message.erase(without_message.begin() + message_index);
+
+                std::string without_message_rendered;
+                if (!render_messages_to_text(
+                        without_message, req, /*add_generation_prompt=*/true,
+                        without_message_rendered, boundary_error)) {
+                    boundary_error = "message-removal render failed: " +
+                        boundary_error;
+                    return false;
+                }
+                const auto without_message_ids = drafter_tokenizer_->encode(
+                    tokenizer_.decode(tokenizer_.encode(
+                        without_message_rendered)));
+                message_span = http_detail::pflash_changed_token_span(
+                    drafter_ids, without_message_ids);
+                if (message_span.begin < 0) {
+                    boundary_error =
+                        "complete rendered message did not map to a prompt span";
+                    return false;
+                }
+                return true;
+            };
+
             std::string boundary_error;
-            if (!render_messages_to_text(
-                    begin_messages, req, /*add_generation_prompt=*/true,
-                    begin_rendered, boundary_error)) {
-                return "PFlash LongAttnComp content-start render failed: " +
-                    boundary_error;
+            if (!map_message_content(
+                    (size_t) boundary_index,
+                    query_content_begin, query_content_end,
+                    boundary_error)) {
+                return "PFlash LongAttnComp " + boundary_error;
             }
-            boundary_error.clear();
-            if (!render_messages_to_text(
-                    end_messages, req, /*add_generation_prompt=*/true,
-                    end_rendered, boundary_error)) {
-                return "PFlash LongAttnComp content-end render failed: " +
-                    boundary_error;
-            }
-
-            const auto begin_ids = drafter_tokenizer_->encode(
-                tokenizer_.decode(tokenizer_.encode(begin_rendered)));
-            const auto end_ids = drafter_tokenizer_->encode(
-                tokenizer_.decode(tokenizer_.encode(end_rendered)));
-            query_content_begin =
-                http_detail::pflash_query_search_begin_from_sentinel(
-                    drafter_ids, begin_ids);
-            query_content_end =
-                http_detail::pflash_query_search_end_from_sentinel(
-                    drafter_ids, end_ids);
             if (query_content_begin < 0 ||
                 query_content_end <= query_content_begin ||
                 query_content_end >= (int) drafter_ids.size()) {
                 return "PFlash LongAttnComp content boundary mapping failed";
             }
+
+            if (experiment.selection_active) {
+                const auto instruction_plan =
+                    http_detail::plan_pflash_instruction_messages(messages);
+                for (size_t instruction_index :
+                        instruction_plan.instruction_messages) {
+                    PFlashTokenSpan instruction_span;
+                    boundary_error.clear();
+                    if (!map_rendered_message(
+                            instruction_index, instruction_span,
+                            boundary_error)) {
+                        return "PFlash LongAttnComp instruction mapping failed: " +
+                            boundary_error;
+                    }
+                    required_instruction_spans.push_back(instruction_span);
+                }
+
+                if (!req.tools.is_null() && !req.tools.empty()) {
+                    ParsedRequest tool_free_req = req;
+                    tool_free_req.tools = json::array();
+                    std::string tool_free_rendered;
+                    boundary_error.clear();
+                    if (!render_messages_to_text(
+                            messages, tool_free_req,
+                            /*add_generation_prompt=*/true,
+                            tool_free_rendered, boundary_error)) {
+                        return "PFlash LongAttnComp tool mapping failed: " +
+                            boundary_error;
+                    }
+                    const auto tool_free_ids = drafter_tokenizer_->encode(
+                        tokenizer_.decode(tokenizer_.encode(tool_free_rendered)));
+                    const PFlashTokenSpan tool_span =
+                        http_detail::pflash_changed_token_span(
+                            drafter_ids, tool_free_ids);
+                    if (tool_span.begin < 0) {
+                        return "PFlash LongAttnComp tool mapping failed: "
+                            "tools did not produce a retained prompt span";
+                    }
+                    required_instruction_spans.push_back(tool_span);
+                }
+
+                required_instruction_spans =
+                    http_detail::canonicalize_pflash_token_spans(
+                        std::move(required_instruction_spans));
+                std::string instruction_error;
+                if (!dflash::qwen3::validate_pflash_instruction_spans(
+                        required_instruction_spans,
+                        (int) drafter_ids.size(), instruction_error)) {
+                    return "PFlash LongAttnComp instruction mapping failed: " +
+                        instruction_error;
+                }
+            }
         } catch (const std::exception & error) {
-            return std::string("PFlash user-query normalization failed: ") +
+            return std::string("PFlash retention normalization failed: ") +
                    error.what();
         }
     } else if (raw_text_input) {
@@ -3133,6 +3291,8 @@ std::string HttpServer::apply_pflash_compression(
 
     ModelBackend::CompressRequest compress_request;
     compress_request.input_ids = std::move(drafter_ids);
+    compress_request.required_instruction_spans =
+        std::move(required_instruction_spans);
     compress_request.keep_ratio = http_detail::resolve_pflash_keep_ratio(
         pflash_keep_ratio(config_, prompt_tokens), req.session_id, sessions_);
     if (query_window.valid()) {
@@ -3140,6 +3300,11 @@ std::string HttpServer::apply_pflash_compression(
         compress_request.score_query_tokens = query_window.tokens;
         if (experiment.configured) {
             const int query_begin = query_window.end - query_window.tokens;
+            json instruction_spans = json::array();
+            for (const auto & span :
+                    compress_request.required_instruction_spans) {
+                instruction_spans.push_back({span.begin, span.end});
+            }
             const json provenance = {
                 {"schema_version", 1},
                 {"input_kind", parser_input_kind},
@@ -3157,6 +3322,7 @@ std::string HttpServer::apply_pflash_compression(
                 {"query_end", query_window.end},
                 {"requested_query_tokens", experiment.query_tokens},
                 {"expected_query_ids", expected_query_ids},
+                {"required_instruction_spans", instruction_spans},
             };
             std::fprintf(stderr, "[pflash-parser] %s\n",
                          provenance.dump().c_str());
@@ -3197,7 +3363,8 @@ std::string HttpServer::apply_pflash_compression(
             compress_request.input_ids, compress_request.keep_ratio,
             result.compressed_ids,
             compress_request.score_query_end,
-            compress_request.score_query_tokens);
+            compress_request.score_query_tokens,
+            compress_request.required_instruction_spans);
         if (residency == DraftResidencyAction::ReleaseAfterUse) {
             pflash_remote_.close();
         }

--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -453,9 +453,11 @@ bool flowkv_should_activate(const ServerConfig & config,
 float resolve_pflash_keep_ratio(float configured_ratio,
                                 const std::string & session_id,
                                 const HttpServerSessions & sessions) {
+    // A session adapts from the configured (curve) ratio: until its first
+    // acceptance feedback it keeps that ratio, afterwards the controller's.
     return session_id.empty()
         ? configured_ratio
-        : sessions.get_keep_ratio(session_id);
+        : sessions.get_keep_ratio(session_id, configured_ratio);
 }
 
 bool should_clamp_flowkv_disk_cache(
@@ -4636,9 +4638,11 @@ void HttpServer::process_job(ServerJob * job) {
     // Bandit: update when spec decode actually ran — including 0-accept case,
     // which signals the current keep_ratio is too low.
     if (!req.session_id.empty() && result.spec_decode_ran) {
-        float old_keep = sessions_.get_keep_ratio(req.session_id);
+        const float configured_keep =
+            pflash_keep_ratio(config_, (int) req.prompt_tokens.size());
+        float old_keep = sessions_.get_keep_ratio(req.session_id, configured_keep);
         int   old_turn = sessions_.turn_count(req.session_id);
-        sessions_.update(req.session_id, result.accept_rate);
+        sessions_.update(req.session_id, result.accept_rate, configured_keep);
         float new_keep = sessions_.get_keep_ratio(req.session_id);
         float ema      = sessions_.get_ema(req.session_id);
         std::fprintf(stderr,

--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -2341,6 +2341,7 @@ bool HttpServer::route_request(SocketHandle fd, const HttpRequest & hr) {
         apply_request_reasoning(body, config_, req);
         // Bandit: parse session_id from extra_body (opt-in adaptive keep_ratio).
         req.session_id = parse_session_id_from_body(body);
+        req.pflash_query = parse_pflash_query_from_body(body);
 
         // PPP rearrange (optional): peel ephemeral system banners into a
         // following system message so the first chat boundary is stable.
@@ -3261,6 +3262,12 @@ std::string HttpServer::apply_pflash_compression(
     std::vector<int32_t> semantic_query_ids;
     std::vector<int32_t> expected_query_ids;
     http_detail::PflashQueryWindow query_window;
+    if (!req.pflash_query.empty()) {
+        // An explicit query replaces the message-tail heuristic; it must occur
+        // inside the latest user content so the window maps onto real tokens.
+        last_user_text = req.pflash_query;
+        parser_selection_rule = "explicit_query";
+    }
     if (!last_user_text.empty()) {
         semantic_query_ids = drafter_tokenizer_->encode(last_user_text);
     }

--- a/server/src/server/http_server.h
+++ b/server/src/server/http_server.h
@@ -274,7 +274,39 @@ struct PflashQueryWindow {
 PflashQueryWindow find_pflash_query_window(
     const std::vector<int32_t> & prompt,
     const std::vector<int32_t> & query,
-    int max_tokens = 8);
+    int max_tokens = 8,
+    int search_end = -1,
+    int search_begin = 0);
+
+PflashQueryWindow pflash_tail_query_window(
+    const std::vector<int32_t> & prompt,
+    int max_tokens,
+    int query_end = -1,
+    int query_begin = 0) noexcept;
+
+// Return the original prompt offset immediately before the stable trailing
+// suffix shared with a version whose latest user message carries a sentinel.
+// Invalid when no such bounded suffix can establish the semantic boundary.
+int pflash_query_search_end_from_sentinel(
+    const std::vector<int32_t> & original,
+    const std::vector<int32_t> & sentinel) noexcept;
+
+// Return the first token offset affected by a version whose selected message
+// content carries a leading sentinel. This is a conservative lower bound for
+// the selected content in the original rendered prompt.
+int pflash_query_search_begin_from_sentinel(
+    const std::vector<int32_t> & original,
+    const std::vector<int32_t> & sentinel) noexcept;
+
+std::string pflash_token_fingerprint(
+    const std::vector<int32_t> & ids);
+
+bool pflash_full_cache_restore_allowed(
+    bool longattncomp_environment_present) noexcept;
+bool pflash_continuation_must_fail_closed(
+    bool longattncomp_environment_present) noexcept;
+int pflash_target_token_ceiling(
+    int original_target_tokens, double keep_ratio) noexcept;
 
 }  // namespace http_detail
 

--- a/server/src/server/http_server.h
+++ b/server/src/server/http_server.h
@@ -422,6 +422,8 @@ public:
     }
 
 private:
+    friend struct HttpServerTestAccess;
+
     // Client thread: read HTTP request, parse, enqueue job, wait.
     void handle_client(SocketHandle fd);
 

--- a/server/src/server/http_server.h
+++ b/server/src/server/http_server.h
@@ -262,6 +262,20 @@ bool canonical_assistant_content(
     const std::string & generated_text,
     std::string & content);
 
+struct PflashQueryWindow {
+    int end = -1;       // exclusive token offset in the rendered prompt
+    int tokens = 0;     // width of the matching query suffix
+
+    bool valid() const { return end >= tokens && tokens > 0; }
+};
+
+// Find the last sufficiently-specific suffix of the user query inside the
+// rendered drafter-tokenized prompt. Public for model-free regression tests.
+PflashQueryWindow find_pflash_query_window(
+    const std::vector<int32_t> & prompt,
+    const std::vector<int32_t> & query,
+    int max_tokens = 8);
+
 }  // namespace http_detail
 
 // ─── Parsed request ─────────────────────────────────────────────────────

--- a/server/src/server/http_server.h
+++ b/server/src/server/http_server.h
@@ -371,6 +371,7 @@ struct ParsedRequest {
     std::vector<std::string>  stop_sequences;
     // Bandit: per-session adaptive keep_ratio opt-in
     std::string               session_id;
+    std::string               pflash_query;   // explicit scorer query text (optional request field)
     DiskPrefixCachePolicy     disk_cache_policy;
     // PPP: stable pin cut for tool-heavy requests (0 = use default boundary).
     int                       pin_end_token = 0;
@@ -712,6 +713,23 @@ struct ServerJob {
 // ─── Parse session_id from a chat-completion JSON body ──────────────────
 // Returns empty string when session_id is absent or not a string (int/null/array).
 // Checks extra_body.session_id first, then top-level session_id.
+// PFlash: an explicit scorer query. The compressor scores context against
+// this text instead of the last user message's tail, so a caller that knows
+// its question (a benchmark, a RAG layer) can hand it over. Accepted at the top
+// level or under extra_body, like session_id.
+inline std::string parse_pflash_query_from_body(const json & body) {
+    if (body.contains("extra_body")) {
+        const auto & eb = body["extra_body"];
+        if (eb.is_object() && eb.contains("pflash_query") && eb["pflash_query"].is_string()) {
+            return eb["pflash_query"].get<std::string>();
+        }
+    }
+    if (body.contains("pflash_query") && body["pflash_query"].is_string()) {
+        return body["pflash_query"].get<std::string>();
+    }
+    return {};
+}
+
 inline std::string parse_session_id_from_body(const json & body) {
     if (body.contains("extra_body")) {
         const auto & eb = body["extra_body"];

--- a/server/src/server/http_server.h
+++ b/server/src/server/http_server.h
@@ -294,7 +294,8 @@ PflashQueryWindow find_pflash_query_window(
     const std::vector<int32_t> & query,
     int max_tokens = 8,
     int search_end = -1,
-    int search_begin = 0);
+    int search_begin = 0,
+    bool anchored = true);
 
 PflashQueryWindow pflash_tail_query_window(
     const std::vector<int32_t> & prompt,

--- a/server/src/server/http_server.h
+++ b/server/src/server/http_server.h
@@ -269,6 +269,24 @@ struct PflashQueryWindow {
     bool valid() const { return end >= tokens && tokens > 0; }
 };
 
+struct PflashInstructionMessagePlan {
+    std::vector<size_t> instruction_messages;
+};
+
+PflashInstructionMessagePlan plan_pflash_instruction_messages(
+    const std::vector<ChatMessage> & messages);
+
+// Return the conservative token interval in `original` changed by rendering
+// a request variant. Used to retain tool definitions independently of where
+// an arbitrary chat template places them.
+PFlashTokenSpan pflash_changed_token_span(
+    const std::vector<int32_t> & original,
+    const std::vector<int32_t> & variant) noexcept;
+
+// Sort and merge overlapping/adjacent mapped spans before selector validation.
+std::vector<PFlashTokenSpan> canonicalize_pflash_token_spans(
+    std::vector<PFlashTokenSpan> spans);
+
 // Find the last sufficiently-specific suffix of the user query inside the
 // rendered drafter-tokenized prompt. Public for model-free regression tests.
 PflashQueryWindow find_pflash_query_window(

--- a/server/src/server/http_server.h
+++ b/server/src/server/http_server.h
@@ -265,6 +265,7 @@ bool canonical_assistant_content(
 struct PflashQueryWindow {
     int end = -1;       // exclusive token offset in the rendered prompt
     int tokens = 0;     // width of the matching query suffix
+    int trailing_trimmed = 0;  // query tokens dropped from its end to match
 
     bool valid() const { return end >= tokens && tokens > 0; }
 };

--- a/server/test/test_bandit_integration.cpp
+++ b/server/test/test_bandit_integration.cpp
@@ -101,3 +101,14 @@ TEST_CASE(BanditIntegrationFixture, non_string_session_id_array_extra_body) {
     std::string sid = parse_session_id_from_body(body);
     CHECK(sid.empty());
 }
+
+TEST_CASE(BanditIntegrationFixture, pflash_query_top_level_and_extra_body) {
+    json top = {{"pflash_query", "Which function has the deliberate error?"}};
+    CHECK(parse_pflash_query_from_body(top) == "Which function has the deliberate error?");
+    json nested = {{"extra_body", {{"pflash_query", "What is the major tributary of the Rhine?"}}}};
+    CHECK(parse_pflash_query_from_body(nested) == "What is the major tributary of the Rhine?");
+    json absent = {{"messages", json::array()}};
+    CHECK(parse_pflash_query_from_body(absent).empty());
+    json wrong_type = {{"pflash_query", 7}};
+    CHECK(parse_pflash_query_from_body(wrong_type).empty());
+}

--- a/server/test/test_pflash_drafter_ipc.cpp
+++ b/server/test/test_pflash_drafter_ipc.cpp
@@ -1,0 +1,98 @@
+#include "CppUnitTestFramework.hpp"
+
+#include "common/pflash_drafter_ipc.h"
+
+#include <cmath>
+#include <string>
+
+using namespace dflash::common;
+
+namespace {
+
+struct PFlashDrafterIpcFixture : CppUnitTestFramework::CommonFixture {
+    using CppUnitTestFramework::CommonFixture::CommonFixture;
+};
+
+} // namespace
+
+TEST_CASE(PFlashDrafterIpcFixture, compress2_round_trips_paper_ratio_budget) {
+    const float keep = 16384.0f / 120000.0f;
+    std::string line;
+    std::string error;
+
+    REQUIRE(format_pflash_drafter_ipc_compress_command(
+        keep, 119900, 128, "/tmp/pflash ids.bin", line, error));
+    REQUIRE(error.empty());
+
+    PFlashDrafterIpcCompressCommand parsed;
+    REQUIRE(parse_pflash_drafter_ipc_compress_command(line, parsed, error));
+    REQUIRE(error.empty());
+    REQUIRE(!parsed.legacy_quantized_ratio);
+    REQUIRE(parsed.keep_ratio == keep);
+    REQUIRE((int) std::floor(120000.0 * (double) parsed.keep_ratio) == 16384);
+    REQUIRE(parsed.score_query_end == 119900);
+    REQUIRE(parsed.score_query_tokens == 128);
+    REQUIRE(parsed.path == "/tmp/pflash ids.bin");
+}
+
+TEST_CASE(PFlashDrafterIpcFixture, legacy_x1000_parser_is_supported_but_quantized) {
+    PFlashDrafterIpcCompressCommand parsed;
+    std::string error;
+
+    REQUIRE(parse_pflash_drafter_ipc_compress_command(
+        "compress 137 119900 128 /tmp/pflash_ids.bin", parsed, error));
+    REQUIRE(error.empty());
+    REQUIRE(parsed.legacy_quantized_ratio);
+    REQUIRE(parsed.keep_ratio == 0.137f);
+    REQUIRE((int) std::floor(120000.0 * (double) parsed.keep_ratio) > 16384);
+    REQUIRE(parsed.score_query_end == 119900);
+    REQUIRE(parsed.score_query_tokens == 128);
+    REQUIRE(parsed.path == "/tmp/pflash_ids.bin");
+}
+
+TEST_CASE(PFlashDrafterIpcFixture, parser_rejects_malformed_values) {
+    const char * bad_lines[] = {
+        "compress2 nan 10 8 /tmp/ids.bin",
+        "compress2 inf 10 8 /tmp/ids.bin",
+        "compress2 -0.1 10 8 /tmp/ids.bin",
+        "compress2 1.1 10 8 /tmp/ids.bin",
+        "compress2 0.5 10 0 /tmp/ids.bin",
+        "compress2 0.5 10 8",
+        "compress 1001 10 8 /tmp/ids.bin",
+        "compress -1 10 8 /tmp/ids.bin",
+        "compress 500 10 0 /tmp/ids.bin",
+        "unknown 0.5 10 8 /tmp/ids.bin",
+    };
+
+    for (const char * line : bad_lines) {
+        PFlashDrafterIpcCompressCommand parsed;
+        std::string error;
+        REQUIRE(!parse_pflash_drafter_ipc_compress_command(
+            line, parsed, error));
+        REQUIRE(!error.empty());
+    }
+}
+
+TEST_CASE(PFlashDrafterIpcFixture, formatter_fails_closed_on_invalid_values) {
+    struct BadFormatInput {
+        float keep_ratio;
+        int score_query_tokens;
+        const char * path;
+    };
+    const BadFormatInput bad_inputs[] = {
+        {-0.1f, 8, "/tmp/ids.bin"},
+        {1.1f, 8, "/tmp/ids.bin"},
+        {0.5f, 0, "/tmp/ids.bin"},
+        {0.5f, 8, ""},
+    };
+
+    for (const auto & input : bad_inputs) {
+        std::string line;
+        std::string error;
+        REQUIRE(!format_pflash_drafter_ipc_compress_command(
+            input.keep_ratio, 10, input.score_query_tokens,
+            input.path, line, error));
+        REQUIRE(line.empty());
+        REQUIRE(!error.empty());
+    }
+}

--- a/server/test/test_pflash_drafter_ipc.cpp
+++ b/server/test/test_pflash_drafter_ipc.cpp
@@ -1,6 +1,8 @@
 #include "CppUnitTestFramework.hpp"
 
 #include "common/pflash_drafter_ipc.h"
+#include "common/model_backend.h"
+#include "qwen3/pflash_selection.h"
 
 #include <cmath>
 #include <string>
@@ -32,7 +34,89 @@ TEST_CASE(PFlashDrafterIpcFixture, compress2_round_trips_paper_ratio_budget) {
     REQUIRE((int) std::floor(120000.0 * (double) parsed.keep_ratio) == 16384);
     REQUIRE(parsed.score_query_end == 119900);
     REQUIRE(parsed.score_query_tokens == 128);
+    REQUIRE(parsed.required_instruction_spans.empty());
     REQUIRE(parsed.path == "/tmp/pflash ids.bin");
+}
+
+TEST_CASE(PFlashDrafterIpcFixture, compress3_round_trips_ordered_instruction_spans) {
+    const float keep = 16384.0f / 120000.0f;
+    const std::vector<PFlashTokenSpan> instructions{{0, 384}, {4096, 4352}};
+    std::string line;
+    std::string error;
+
+    REQUIRE(format_pflash_drafter_ipc_compress_command(
+        keep, 119900, 128, instructions,
+        "/tmp/pflash ids.bin", line, error));
+    REQUIRE(error.empty());
+    REQUIRE(line.rfind("compress3 ", 0) == 0);
+
+    PFlashDrafterIpcCompressCommand parsed;
+    REQUIRE(parse_pflash_drafter_ipc_compress_command(line, parsed, error));
+    REQUIRE(error.empty());
+    REQUIRE(parsed.keep_ratio == keep);
+    REQUIRE(parsed.score_query_end == 119900);
+    REQUIRE(parsed.score_query_tokens == 128);
+    REQUIRE(parsed.required_instruction_spans == instructions);
+    REQUIRE(parsed.path == "/tmp/pflash ids.bin");
+}
+
+TEST_CASE(PFlashDrafterIpcFixture, compress3_matches_the_local_selector_contract) {
+    ModelBackend::CompressRequest local;
+    local.input_ids.resize(32);
+    local.keep_ratio = 0.5f;
+    local.score_query_end = 32;
+    local.score_query_tokens = 4;
+    local.required_instruction_spans = {{0, 4}, {12, 14}};
+
+    std::string line;
+    std::string error;
+    REQUIRE(format_pflash_drafter_ipc_compress_command(
+        local.keep_ratio, local.score_query_end, local.score_query_tokens,
+        local.required_instruction_spans, "/tmp/ids.bin", line, error));
+    PFlashDrafterIpcCompressCommand remote;
+    REQUIRE(parse_pflash_drafter_ipc_compress_command(line, remote, error));
+    REQUIRE(remote.keep_ratio == local.keep_ratio);
+    REQUIRE(remote.score_query_end == local.score_query_end);
+    REQUIRE(remote.score_query_tokens == local.score_query_tokens);
+    REQUIRE(remote.required_instruction_spans == local.required_instruction_spans);
+
+    const auto select = [&] (const std::vector<PFlashTokenSpan> & spans) {
+        std::vector<dflash::qwen3::PFlashSelectionCandidate> candidates;
+        constexpr double scores[]{0.0, 9.0, 1.0, 0.0, 2.0, 3.0, 4.0, 0.0};
+        for (int chunk = 0; chunk < 8; ++chunk) {
+            const int begin = chunk * 4;
+            const int end = begin + 4;
+            candidates.push_back({
+                (size_t) chunk, begin, end, scores[chunk],
+                dflash::qwen3::pflash_chunk_is_structurally_required(
+                    begin, end, 28, 32, 32, spans),
+            });
+        }
+        return dflash::qwen3::select_pflash_candidates(
+            candidates, {16, 0.95},
+            dflash::qwen3::PFlashSelectionMode::BudgetOnly);
+    };
+    const auto local_result = select(local.required_instruction_spans);
+    const auto remote_result = select(remote.required_instruction_spans);
+    REQUIRE(local_result.ok);
+    REQUIRE(remote_result.ok);
+    REQUIRE(local_result.ordinals == remote_result.ordinals);
+    REQUIRE(local_result.retained_tokens == remote_result.retained_tokens);
+    REQUIRE(local_result.stop == remote_result.stop);
+
+    const std::vector<PFlashTokenSpan> out_of_range{{0, 33}};
+    std::string local_error;
+    std::string remote_error;
+    REQUIRE(!dflash::qwen3::validate_pflash_instruction_spans(
+        out_of_range, (int) local.input_ids.size(), local_error));
+    REQUIRE(format_pflash_drafter_ipc_compress_command(
+        local.keep_ratio, local.score_query_end, local.score_query_tokens,
+        out_of_range, "/tmp/ids.bin", line, error));
+    REQUIRE(parse_pflash_drafter_ipc_compress_command(line, remote, error));
+    REQUIRE(!dflash::qwen3::validate_pflash_instruction_spans(
+        remote.required_instruction_spans, (int) local.input_ids.size(),
+        remote_error));
+    REQUIRE(local_error == remote_error);
 }
 
 TEST_CASE(PFlashDrafterIpcFixture, legacy_x1000_parser_is_supported_but_quantized) {
@@ -61,6 +145,11 @@ TEST_CASE(PFlashDrafterIpcFixture, parser_rejects_malformed_values) {
         "compress 1001 10 8 /tmp/ids.bin",
         "compress -1 10 8 /tmp/ids.bin",
         "compress 500 10 0 /tmp/ids.bin",
+        "compress3 0.5 10 8 -1 /tmp/ids.bin",
+        "compress3 0.5 10 8 1 0 /tmp/ids.bin",
+        "compress3 0.5 10 8 1 4 4 /tmp/ids.bin",
+        "compress3 0.5 10 8 2 0 4 3 6 /tmp/ids.bin",
+        "compress3 0.5 10 8 65 /tmp/ids.bin",
         "unknown 0.5 10 8 /tmp/ids.bin",
     };
 

--- a/server/test/test_pflash_selection.cpp
+++ b/server/test/test_pflash_selection.cpp
@@ -1,0 +1,415 @@
+#include "CppUnitTestFramework.hpp"
+
+#include "qwen3/pflash_selection.h"
+#include "scoped_env.h"
+
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace dflash::qwen3;
+
+namespace {
+
+constexpr const char * kModeEnv = "PFLASH_LONGATTNCOMP_MODE";
+constexpr const char * kChunkEnv = "PFLASH_LONGATTNCOMP_CHUNK_SIZE";
+constexpr const char * kQueryEnv = "PFLASH_LONGATTNCOMP_QUERY_TOKENS";
+constexpr const char * kQueryParserEnv = "PFLASH_LONGATTNCOMP_QUERY_PARSER";
+constexpr const char * kTopPEnv = "PFLASH_LONGATTNCOMP_TOP_P";
+
+struct CleanPFlashEnv {
+    luce_test::ScopedEnvVar mode{kModeEnv, nullptr};
+    luce_test::ScopedEnvVar chunk{kChunkEnv, nullptr};
+    luce_test::ScopedEnvVar query{kQueryEnv, nullptr};
+    luce_test::ScopedEnvVar query_parser{kQueryParserEnv, nullptr};
+    luce_test::ScopedEnvVar top_p{kTopPEnv, nullptr};
+};
+
+void set_env(const char * name, const char * value) {
+#if defined(_WIN32)
+    _putenv_s(name, value ? value : "");
+#else
+    if (value) {
+        setenv(name, value, 1);
+    } else {
+        unsetenv(name);
+    }
+#endif
+}
+
+PFlashSelectionCandidate candidate(
+        size_t ordinal,
+        int begin,
+        int end,
+        double score,
+        bool mandatory = false) {
+    return {ordinal, begin, end, score, mandatory};
+}
+
+void require_ordinals(
+        const PFlashSelectionResult & result,
+        const std::vector<size_t> & expected) {
+    if (result.ordinals.size() != expected.size()) {
+        throw std::runtime_error("unexpected selected ordinal count");
+    }
+    for (size_t index = 0; index < expected.size(); ++index) {
+        if (result.ordinals[index] != expected[index]) {
+            throw std::runtime_error("unexpected selected ordinal");
+        }
+    }
+}
+
+PFlashLongAttnCompConfig resolve_or_fail(int input_tokens, int legacy_chunk) {
+    PFlashLongAttnCompConfig config;
+    std::string error;
+    if (!resolve_pflash_longattncomp(
+            input_tokens, legacy_chunk, config, error)) {
+        throw std::runtime_error(error);
+    }
+    if (!error.empty()) throw std::runtime_error(error);
+    return config;
+}
+
+struct PFlashSelectionFixture : CppUnitTestFramework::CommonFixture {
+    using CppUnitTestFramework::CommonFixture::CommonFixture;
+};
+
+} // namespace
+
+TEST_CASE(PFlashSelectionFixture, structural_suffix_only_chunk_is_mandatory_and_charged) {
+    constexpr int input_tokens = 101;
+    constexpr int query_begin = 80;
+    constexpr int query_end = 90;
+    REQUIRE(!pflash_chunk_is_structurally_required(
+        0, 64, query_begin, query_end, input_tokens));
+    REQUIRE(pflash_chunk_is_structurally_required(
+        64, 96, query_begin, query_end, input_tokens));
+    REQUIRE(pflash_chunk_is_structurally_required(
+        96, 101, query_begin, query_end, input_tokens));
+
+    const std::vector<PFlashSelectionCandidate> candidates{
+        candidate(0, 0, 64, 100.0),
+        candidate(1, 64, 96, 0.0,
+                  pflash_chunk_is_structurally_required(
+                      64, 96, query_begin, query_end, input_tokens)),
+        candidate(2, 96, 101, 0.0,
+                  pflash_chunk_is_structurally_required(
+                      96, 101, query_begin, query_end, input_tokens)),
+    };
+    const auto result = select_pflash_candidates(
+        candidates, {37, 0.95}, PFlashSelectionMode::BudgetOnly);
+
+    REQUIRE(result.ok);
+    REQUIRE(result.retained_tokens == 37);
+    REQUIRE(result.stop == PFlashSelectionStop::BudgetReached);
+    require_ordinals(result, {1, 2});
+}
+
+TEST_CASE(PFlashSelectionFixture, cumulative_top_p_is_scale_invariant_and_keeps_crossing_chunk) {
+    const std::vector<PFlashSelectionCandidate> base{
+        candidate(0, 0, 4, 6.0),
+        candidate(1, 4, 8, 3.0),
+        candidate(2, 8, 12, 1.0),
+    };
+    auto scaled = base;
+    for (auto & item : scaled) item.score *= 100.0;
+
+    const PFlashSelectionPolicy policy{12, 0.8};
+    const auto base_result = select_pflash_candidates(
+        base, policy, PFlashSelectionMode::CumulativeTopP);
+    const auto scaled_result = select_pflash_candidates(
+        scaled, policy, PFlashSelectionMode::CumulativeTopP);
+
+    REQUIRE(base_result.ok);
+    REQUIRE(scaled_result.ok);
+    REQUIRE(base_result.stop == PFlashSelectionStop::TopPReached);
+    REQUIRE(scaled_result.stop == PFlashSelectionStop::TopPReached);
+    require_ordinals(base_result, {0, 1});
+    require_ordinals(scaled_result, {0, 1});
+    REQUIRE(std::abs(base_result.retained_mass - 0.9) < 1e-12);
+    REQUIRE(std::abs(scaled_result.retained_mass - 0.9) < 1e-12);
+}
+
+TEST_CASE(PFlashSelectionFixture, zero_and_negative_scores_use_equal_mass_and_ordinal_ties) {
+    const std::vector<PFlashSelectionCandidate> candidates{
+        candidate(2, 8, 12, -8.0),
+        candidate(0, 0, 4, -2.0),
+        candidate(1, 4, 8, 0.0),
+    };
+
+    const auto result = select_pflash_candidates(
+        candidates, {12, 0.5}, PFlashSelectionMode::CumulativeTopP);
+
+    REQUIRE(result.ok);
+    REQUIRE(result.stop == PFlashSelectionStop::TopPReached);
+    require_ordinals(result, {0, 1});
+    REQUIRE(std::abs(result.retained_mass - 2.0 / 3.0) < 1e-12);
+}
+
+TEST_CASE(PFlashSelectionFixture, budget_only_disables_only_the_mass_stop) {
+    const std::vector<PFlashSelectionCandidate> candidates{
+        candidate(0, 0, 4, 6.0),
+        candidate(1, 4, 8, 3.0),
+        candidate(2, 8, 12, 1.0),
+    };
+
+    const auto result = select_pflash_candidates(
+        candidates, {12, 0.1}, PFlashSelectionMode::BudgetOnly);
+
+    REQUIRE(result.ok);
+    REQUIRE(result.stop == PFlashSelectionStop::CandidatesExhausted);
+    require_ordinals(result, {0, 1, 2});
+    REQUIRE(result.retained_tokens == 12);
+    REQUIRE(std::abs(result.retained_mass - 1.0) < 1e-12);
+}
+
+TEST_CASE(PFlashSelectionFixture, mandatory_scores_do_not_enter_optional_mass) {
+    const std::vector<PFlashSelectionCandidate> candidates{
+        candidate(0, 0, 1, 1.0e30, true),
+        candidate(1, 1, 2, 6.0),
+        candidate(2, 2, 3, 3.0),
+        candidate(3, 3, 4, 1.0),
+    };
+
+    const auto result = select_pflash_candidates(
+        candidates, {4, 0.8}, PFlashSelectionMode::CumulativeTopP);
+
+    REQUIRE(result.ok);
+    REQUIRE(result.stop == PFlashSelectionStop::TopPReached);
+    require_ordinals(result, {0, 1, 2});
+    REQUIRE(std::abs(result.retained_mass - 0.9) < 1e-12);
+}
+
+TEST_CASE(PFlashSelectionFixture, real_ranges_charge_a_short_final_chunk) {
+    const std::vector<PFlashSelectionCandidate> candidates{
+        candidate(0, 0, 4, 2.0),
+        candidate(1, 4, 6, 1.0),
+    };
+
+    const auto result = select_pflash_candidates(
+        candidates, {6, 1.0}, PFlashSelectionMode::BudgetOnly);
+
+    REQUIRE(result.ok);
+    REQUIRE(result.stop == PFlashSelectionStop::CandidatesExhausted);
+    require_ordinals(result, {0, 1});
+    REQUIRE(result.retained_tokens == 6);
+}
+
+TEST_CASE(PFlashSelectionFixture, mandatory_overflow_has_a_distinct_failure) {
+    const std::vector<PFlashSelectionCandidate> candidates{
+        candidate(0, 0, 4, 0.0, true),
+        candidate(1, 4, 6, 1.0),
+    };
+
+    const auto result = select_pflash_candidates(
+        candidates, {3, 0.95}, PFlashSelectionMode::CumulativeTopP);
+
+    REQUIRE(!result.ok);
+    REQUIRE(result.stop == PFlashSelectionStop::MandatoryQueryExceedsBudget);
+    REQUIRE(result.ordinals.empty());
+    REQUIRE(result.retained_tokens == 0);
+    REQUIRE(!result.error.empty());
+}
+
+TEST_CASE(PFlashSelectionFixture, budget_stop_does_not_skip_to_a_smaller_candidate) {
+    const std::vector<PFlashSelectionCandidate> candidates{
+        candidate(0, 0, 2, 0.0, true),
+        candidate(1, 2, 6, 10.0),
+        candidate(2, 6, 9, 1.0),
+    };
+
+    const auto result = select_pflash_candidates(
+        candidates, {5, 1.0}, PFlashSelectionMode::BudgetOnly);
+
+    REQUIRE(result.ok);
+    REQUIRE(result.stop == PFlashSelectionStop::BudgetReached);
+    require_ordinals(result, {0});
+    REQUIRE(result.retained_tokens == 2);
+}
+
+TEST_CASE(PFlashSelectionFixture, output_ordinals_are_in_source_order) {
+    const std::vector<PFlashSelectionCandidate> candidates{
+        candidate(42, 8, 12, 10.0),
+        candidate(7, 0, 4, 1.0),
+        candidate(99, 4, 8, 99.0, true),
+    };
+
+    const auto result = select_pflash_candidates(
+        candidates, {12, 1.0}, PFlashSelectionMode::BudgetOnly);
+
+    REQUIRE(result.ok);
+    require_ordinals(result, {7, 99, 42});
+}
+
+TEST_CASE(PFlashSelectionFixture, invalid_selector_inputs_fail_closed) {
+    const PFlashSelectionPolicy valid_policy{16, 0.95};
+    const auto nan_result = select_pflash_candidates(
+        {candidate(0, 0, 4, std::numeric_limits<double>::quiet_NaN())},
+        valid_policy,
+        PFlashSelectionMode::CumulativeTopP);
+    REQUIRE(!nan_result.ok);
+    REQUIRE(nan_result.stop == PFlashSelectionStop::InvalidInput);
+
+    const auto inf_result = select_pflash_candidates(
+        {candidate(0, 0, 4, std::numeric_limits<double>::infinity())},
+        valid_policy,
+        PFlashSelectionMode::CumulativeTopP);
+    REQUIRE(!inf_result.ok);
+
+    const auto overlap_result = select_pflash_candidates(
+        {candidate(0, 0, 4, 1.0), candidate(1, 3, 6, 2.0)},
+        valid_policy,
+        PFlashSelectionMode::CumulativeTopP);
+    REQUIRE(!overlap_result.ok);
+
+    const auto duplicate_result = select_pflash_candidates(
+        {candidate(0, 0, 4, 1.0), candidate(0, 4, 8, 2.0)},
+        valid_policy,
+        PFlashSelectionMode::CumulativeTopP);
+    REQUIRE(!duplicate_result.ok);
+
+    REQUIRE(!select_pflash_candidates(
+        {}, {0, 0.95}, PFlashSelectionMode::BudgetOnly).ok);
+    REQUIRE(!select_pflash_candidates(
+        {}, {1, 0.0}, PFlashSelectionMode::BudgetOnly).ok);
+    REQUIRE(!select_pflash_candidates(
+        {}, {1, 1.01}, PFlashSelectionMode::BudgetOnly).ok);
+}
+
+TEST_CASE(PFlashSelectionFixture, resolver_defaults_to_legacy_arguments) {
+    CleanPFlashEnv env;
+    const auto config = resolve_or_fail(500, 32);
+
+    REQUIRE(!config.configured);
+    REQUIRE(!config.selection_active);
+    REQUIRE(config.mode == PFlashSelectionMode::Legacy);
+    REQUIRE(config.query_parser == PFlashQueryParser::SemanticUser);
+    REQUIRE(config.chunk_size == 32);
+    REQUIRE(config.query_tokens == 8);
+    REQUIRE(std::abs(config.top_p - 0.95) < 1e-12);
+}
+
+TEST_CASE(PFlashSelectionFixture, resolver_applies_chunk_and_query_without_enabling_selection) {
+    CleanPFlashEnv env;
+    set_env(kChunkEnv, "64");
+    set_env(kQueryEnv, "32");
+
+    const auto config = resolve_or_fail(500, 32);
+    REQUIRE(config.configured);
+    REQUIRE(!config.selection_active);
+    REQUIRE(config.mode == PFlashSelectionMode::Legacy);
+    REQUIRE(config.chunk_size == 64);
+    REQUIRE(config.query_tokens == 32);
+}
+
+TEST_CASE(PFlashSelectionFixture, any_longattncomp_environment_is_observable_before_resolution) {
+    CleanPFlashEnv env;
+    REQUIRE(!has_pflash_longattncomp_environment());
+
+    const std::pair<const char *, const char *> values[] = {
+        {kModeEnv, "budget_only"},
+        {kChunkEnv, "1024"},
+        {kQueryEnv, "128"},
+        {kQueryParserEnv, "arbitrary_tail"},
+        {kTopPEnv, "0.95"},
+    };
+    for (const auto & [name, value] : values) {
+        set_env(name, value);
+        REQUIRE(has_pflash_longattncomp_environment());
+        PFlashLongAttnCompConfig config;
+        std::string error;
+        REQUIRE(resolve_pflash_longattncomp(120000, 32, config, error));
+        REQUIRE(config.configured);
+        set_env(name, nullptr);
+    }
+
+    set_env(kQueryEnv, "");
+    REQUIRE(has_pflash_longattncomp_environment());
+    PFlashLongAttnCompConfig config;
+    std::string error;
+    REQUIRE(!resolve_pflash_longattncomp(120000, 32, config, error));
+}
+
+TEST_CASE(PFlashSelectionFixture, resolver_selects_explicit_query_parser) {
+    CleanPFlashEnv env;
+    set_env(kQueryParserEnv, "arbitrary_tail");
+    const auto arbitrary = resolve_or_fail(120000, 32);
+    REQUIRE(arbitrary.configured);
+    REQUIRE(arbitrary.query_parser == PFlashQueryParser::ArbitraryTail);
+
+    set_env(kQueryParserEnv, "latest_user");
+    const auto latest_user = resolve_or_fail(120000, 32);
+    REQUIRE(latest_user.query_parser == PFlashQueryParser::SemanticUser);
+}
+
+TEST_CASE(PFlashSelectionFixture, strict_mode_uses_length_schedule_without_chunk_override) {
+    CleanPFlashEnv env;
+    set_env(kModeEnv, "top_p");
+
+    REQUIRE(resolve_or_fail(499, 32).chunk_size == 128);
+    REQUIRE(resolve_or_fail(500, 32).chunk_size == 512);
+    REQUIRE(resolve_or_fail(2999, 32).chunk_size == 512);
+    const auto large = resolve_or_fail(3000, 32);
+    REQUIRE(large.chunk_size == 1024);
+    REQUIRE(large.configured);
+    REQUIRE(large.selection_active);
+    REQUIRE(large.mode == PFlashSelectionMode::CumulativeTopP);
+
+    set_env(kModeEnv, "budget_only");
+    const auto budget = resolve_or_fail(3000, 32);
+    REQUIRE(budget.selection_active);
+    REQUIRE(budget.mode == PFlashSelectionMode::BudgetOnly);
+
+    set_env(kChunkEnv, "256");
+    REQUIRE(resolve_or_fail(3000, 32).chunk_size == 256);
+}
+
+TEST_CASE(PFlashSelectionFixture, resolver_rejects_invalid_environment_values) {
+    CleanPFlashEnv env;
+    struct InvalidValue {
+        const char * name;
+        const char * value;
+    };
+    const InvalidValue invalid_values[] = {
+        {kModeEnv, "legacy"},
+        {kModeEnv, "TOP_P"},
+        {kChunkEnv, "0"},
+        {kChunkEnv, "12x"},
+        {kQueryEnv, "0"},
+        {kQueryEnv, "513"},
+        {kQueryParserEnv, "last_128"},
+        {kTopPEnv, "0"},
+        {kTopPEnv, "1.01"},
+        {kTopPEnv, "nan"},
+    };
+
+    for (const auto & invalid : invalid_values) {
+        set_env(invalid.name, invalid.value);
+        PFlashLongAttnCompConfig config;
+        std::string error;
+        REQUIRE(!resolve_pflash_longattncomp(500, 32, config, error));
+        REQUIRE(!error.empty());
+        set_env(invalid.name, nullptr);
+    }
+
+    set_env(kTopPEnv, "1");
+    REQUIRE(std::abs(resolve_or_fail(500, 32).top_p - 1.0) < 1e-12);
+}
+
+TEST_CASE(PFlashSelectionFixture, mode_and_stop_names_are_stable) {
+    REQUIRE(std::string(pflash_selection_mode_name(PFlashSelectionMode::Legacy)) == "legacy");
+    REQUIRE(std::string(pflash_selection_mode_name(PFlashSelectionMode::BudgetOnly)) == "budget_only");
+    REQUIRE(std::string(pflash_selection_mode_name(PFlashSelectionMode::CumulativeTopP)) == "top_p");
+    REQUIRE(std::string(pflash_selection_stop_name(PFlashSelectionStop::TopPReached)) == "top_p_reached");
+    REQUIRE(std::string(pflash_selection_stop_name(PFlashSelectionStop::BudgetReached)) == "budget_reached");
+    REQUIRE(std::string(pflash_selection_stop_name(PFlashSelectionStop::CandidatesExhausted)) == "candidates_exhausted");
+    REQUIRE(std::string(pflash_selection_stop_name(PFlashSelectionStop::InvalidInput)) == "invalid_input");
+    REQUIRE(std::string(pflash_selection_stop_name(PFlashSelectionStop::MandatoryQueryExceedsBudget)) ==
+        "mandatory_query_exceeds_budget");
+    REQUIRE(std::string(pflash_query_parser_name(PFlashQueryParser::SemanticUser)) == "latest_user");
+    REQUIRE(std::string(pflash_query_parser_name(PFlashQueryParser::ArbitraryTail)) == "arbitrary_tail");
+}

--- a/server/test/test_pflash_selection.cpp
+++ b/server/test/test_pflash_selection.cpp
@@ -109,6 +109,64 @@ TEST_CASE(PFlashSelectionFixture, structural_suffix_only_chunk_is_mandatory_and_
     require_ordinals(result, {1, 2});
 }
 
+TEST_CASE(PFlashSelectionFixture, instruction_overlap_is_mandatory_without_changing_optional_ranking) {
+    constexpr int input_tokens = 120000;
+    constexpr int query_begin = 119872;
+    constexpr int query_end = 120000;
+    const std::vector<dflash::common::PFlashTokenSpan> instructions{
+        {0, 384},
+        {4096, 4352},
+    };
+    std::string error;
+    REQUIRE(validate_pflash_instruction_spans(
+        instructions, input_tokens, error));
+    REQUIRE(error.empty());
+    REQUIRE(pflash_chunk_is_structurally_required(
+        0, 1024, query_begin, query_end, input_tokens, instructions));
+    REQUIRE(pflash_chunk_is_structurally_required(
+        4096, 5120, query_begin, query_end, input_tokens, instructions));
+    REQUIRE(!pflash_chunk_is_structurally_required(
+        1024, 2048, query_begin, query_end, input_tokens, instructions));
+
+    const std::vector<PFlashSelectionCandidate> candidates{
+        candidate(0, 0, 1024, 0.0, true),
+        candidate(1, 1024, 2048, 10.0),
+        candidate(2, 2048, 3072, 1.0),
+        candidate(3, 4096, 5120, 0.0, true),
+        candidate(4, 119872, 120000, 0.0, true),
+    };
+    const auto result = select_pflash_candidates(
+        candidates, {3200, 0.95}, PFlashSelectionMode::BudgetOnly);
+
+    REQUIRE(result.ok);
+    REQUIRE(result.stop == PFlashSelectionStop::BudgetReached);
+    REQUIRE(result.retained_tokens == 3200);
+    require_ordinals(result, {0, 1, 3, 4});
+}
+
+TEST_CASE(PFlashSelectionFixture, invalid_instruction_spans_fail_closed) {
+    constexpr int input_tokens = 32;
+    const std::vector<std::vector<dflash::common::PFlashTokenSpan>> invalid{
+        {{-1, 2}},
+        {{4, 4}},
+        {{4, 3}},
+        {{0, 4}, {3, 6}},
+        {{8, 12}, {0, 4}},
+        {{0, 33}},
+    };
+    for (const auto & spans : invalid) {
+        std::string error;
+        REQUIRE(!validate_pflash_instruction_spans(
+            spans, input_tokens, error));
+        REQUIRE(!error.empty());
+    }
+    std::vector<dflash::common::PFlashTokenSpan> too_many(65, {0, 1});
+    std::string error;
+    REQUIRE(!validate_pflash_instruction_spans(
+        too_many, input_tokens, error));
+    REQUIRE(!error.empty());
+}
+
 TEST_CASE(PFlashSelectionFixture, cumulative_top_p_is_scale_invariant_and_keeps_crossing_chunk) {
     const std::vector<PFlashSelectionCandidate> base{
         candidate(0, 0, 4, 6.0),

--- a/server/test/test_pflash_selection.cpp
+++ b/server/test/test_pflash_selection.cpp
@@ -1,6 +1,7 @@
 #include "CppUnitTestFramework.hpp"
 
 #include "qwen3/pflash_selection.h"
+#include "qwen3/qwen3_drafter_model.h"
 #include "scoped_env.h"
 
 #include <cmath>
@@ -470,4 +471,26 @@ TEST_CASE(PFlashSelectionFixture, mode_and_stop_names_are_stable) {
         "mandatory_query_exceeds_budget");
     REQUIRE(std::string(pflash_query_parser_name(PFlashQueryParser::SemanticUser)) == "latest_user");
     REQUIRE(std::string(pflash_query_parser_name(PFlashQueryParser::ArbitraryTail)) == "arbitrary_tail");
+}
+
+TEST_CASE(PFlashSelectionFixture, longattncomp_token_mass_averages_heads_and_queries) {
+    // ggml layout [n_keys=3, n_queries=2, n_heads=2]: key index fastest.
+    const std::vector<float> probs = {
+        0.2f, 0.3f, 0.5f,   // head 0, query 0
+        0.6f, 0.4f, 0.0f,   // head 0, query 1
+        0.0f, 0.0f, 1.0f,   // head 1, query 0
+        1.0f, 0.0f, 0.0f,   // head 1, query 1
+    };
+    std::vector<float> mass;
+    dflash::common::longattncomp_mean_token_mass(probs.data(), 3, 2, 2, mass);
+    REQUIRE(mass.size() == 3u);
+    CHECK(std::fabs(mass[0] - 0.45f) < 1e-6f);
+    CHECK(std::fabs(mass[1] - 0.175f) < 1e-6f);
+    CHECK(std::fabs(mass[2] - 0.375f) < 1e-6f);
+    double total = 0.0;
+    for (float value : mass) total += value;
+    CHECK(std::fabs(total - 1.0) < 1e-6);
+
+    dflash::common::longattncomp_mean_token_mass(probs.data(), 0, 2, 2, mass);
+    CHECK(mass.empty());
 }

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -166,6 +166,22 @@ TEST_CASE(ServerUnitFixture, test_pflash_score_validation_counts_nan_and_inf) {
     TEST_ASSERT(count_nonfinite_scores(values, 1) == 0);
 }
 
+TEST_CASE(ServerUnitFixture, test_pflash_query_capture_splits_across_chunks) {
+    const auto first = query_capture_slice(4093, 4101, 0, 4096);
+    TEST_ASSERT(first.valid());
+    TEST_ASSERT(first.chunk_offset == 4093);
+    TEST_ASSERT(first.query_offset == 0);
+    TEST_ASSERT(first.tokens == 3);
+
+    const auto second = query_capture_slice(4093, 4101, 4096, 4096);
+    TEST_ASSERT(second.valid());
+    TEST_ASSERT(second.chunk_offset == 0);
+    TEST_ASSERT(second.query_offset == 3);
+    TEST_ASSERT(second.tokens == 5);
+
+    TEST_ASSERT(!query_capture_slice(4093, 4101, 8192, 4096).valid());
+}
+
 TEST_CASE(ServerUnitFixture, test_daemon_io_external_cancellation_latches) {
     bool cancel = false;
     DaemonIO io;

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -110,6 +110,62 @@ TEST_CASE(ServerUnitFixture, test_api_format_names_are_total) {
     CHECK(std::string(api_format_name(ApiFormat::COMPLETIONS)) == "completions");
 }
 
+TEST_CASE(ServerUnitFixture, test_pflash_scorer_uses_user_query_before_chat_suffix) {
+    const std::vector<int32_t> query{
+        90, 91, 100, 101, 102, 103, 104, 105, 106, 107,
+    };
+    const std::vector<int32_t> rendered{
+        1, 2, 100, 101, 102, 103, 104, 105, 106, 107,
+        200, 201, 202, 203, 204, 205, 206, 207,
+    };
+
+    const auto window = http_detail::find_pflash_query_window(rendered, query);
+
+    TEST_ASSERT(window.valid());
+    TEST_ASSERT(window.tokens == 8);
+    TEST_ASSERT(window.end == 10);
+    TEST_ASSERT((int)rendered.size() - window.end == 8);
+}
+
+TEST_CASE(ServerUnitFixture, test_pflash_query_mapping_tolerates_one_bpe_boundary_token) {
+    const std::vector<int32_t> query{10, 11, 12, 13, 14, 15, 16, 17};
+    const std::vector<int32_t> rendered{
+        1, 2, 999, 11, 12, 13, 14, 15, 16, 17, 200, 201,
+    };
+
+    const auto window = http_detail::find_pflash_query_window(rendered, query);
+
+    TEST_ASSERT(window.valid());
+    TEST_ASSERT(window.tokens == 7);
+    TEST_ASSERT(window.end == 10);
+}
+
+TEST_CASE(ServerUnitFixture, test_pflash_query_mapping_rejects_weak_punctuation_match) {
+    const std::vector<int32_t> query{10, 11, 12, 13, 14, 15, 16, 17};
+    const std::vector<int32_t> rendered{1, 2, 15, 16, 17, 200, 201};
+    TEST_ASSERT(!http_detail::find_pflash_query_window(rendered, query).valid());
+
+    const std::vector<int32_t> short_query{30, 31, 32};
+    const std::vector<int32_t> short_rendered{1, 30, 31, 32, 200};
+    const auto short_window =
+        http_detail::find_pflash_query_window(short_rendered, short_query);
+    TEST_ASSERT(short_window.valid());
+    TEST_ASSERT(short_window.tokens == 3);
+    TEST_ASSERT(short_window.end == 4);
+}
+
+TEST_CASE(ServerUnitFixture, test_pflash_score_validation_counts_nan_and_inf) {
+    const float values[]{
+        0.0f,
+        std::numeric_limits<float>::quiet_NaN(),
+        std::numeric_limits<float>::infinity(),
+        -std::numeric_limits<float>::infinity(),
+        1.0f,
+    };
+    TEST_ASSERT(count_nonfinite_scores(values, 5) == 3);
+    TEST_ASSERT(count_nonfinite_scores(values, 1) == 0);
+}
+
 TEST_CASE(ServerUnitFixture, test_daemon_io_external_cancellation_latches) {
     bool cancel = false;
     DaemonIO io;

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -7,6 +7,7 @@
 // Run:   ./test_server_unit
 
 #include "CppUnitTestFramework.hpp"
+#include "scoped_env.h"
 
 #include "server/sse_emitter.h"
 #include "server/tool_parser.h"
@@ -82,6 +83,14 @@ std::vector<ChatMessage> normalize_chat_messages(
     const json & messages,
     ApiFormat format,
     ToolMemory & tool_memory);
+
+struct HttpServerTestAccess {
+    static std::string apply_pflash_compression(
+            HttpServer & server, const ParsedRequest & req) {
+        HttpServer::PreparedPrompt prepared;
+        return server.apply_pflash_compression(req, prepared);
+    }
+};
 }
 
 namespace {
@@ -273,6 +282,17 @@ TEST_CASE(ServerUnitFixture, test_pflash_responses_string_tails_only_raw_content
     TEST_ASSERT(window.end == 7);
     TEST_ASSERT(window.tokens == 5);
     TEST_ASSERT(window.end - window.tokens == 2);
+}
+
+TEST_CASE(ServerUnitFixture, test_compress_result_fails_closed_on_empty_ids) {
+    const auto failed = ModelBackend::CompressResult::from_compressed_ids({});
+    const auto succeeded =
+        ModelBackend::CompressResult::from_compressed_ids({11, 12});
+
+    TEST_ASSERT(!failed.ok);
+    TEST_ASSERT(failed.compressed_ids.empty());
+    TEST_ASSERT(succeeded.ok);
+    TEST_ASSERT(succeeded.compressed_ids == std::vector<int32_t>({11, 12}));
 }
 
 TEST_CASE(ServerUnitFixture, test_pflash_parser_fingerprint_has_fixed_encoding) {
@@ -4644,6 +4664,53 @@ struct MockBackend : ModelBackend {
     void free_drafter() override {}
     void shutdown() override {}
 };
+
+struct MockPflashCompressBackend : MockBackend {
+    int compress_calls = 0;
+    CompressRequest last_request;
+
+    CompressResult compress(const CompressRequest & request) override {
+        ++compress_calls;
+        last_request = request;
+        return CompressResult::from_compressed_ids(request.input_ids);
+    }
+};
+
+TEST_CASE(ServerUnitFixture, test_pflash_default_raw_text_maps_user_query) {
+    luce_test::ScopedEnvVar mode{"PFLASH_LONGATTNCOMP_MODE", nullptr};
+    luce_test::ScopedEnvVar chunk{"PFLASH_LONGATTNCOMP_CHUNK_SIZE", nullptr};
+    luce_test::ScopedEnvVar query{"PFLASH_LONGATTNCOMP_QUERY_TOKENS", nullptr};
+    luce_test::ScopedEnvVar parser{"PFLASH_LONGATTNCOMP_QUERY_PARSER", nullptr};
+    luce_test::ScopedEnvVar top_p{"PFLASH_LONGATTNCOMP_TOP_P", nullptr};
+
+    const std::string tokenizer_path =
+        write_deepseek_marker_tokenizer_fixture();
+    Tokenizer tokenizer;
+    TEST_ASSERT(tokenizer.load_from_gguf(tokenizer_path.c_str()));
+
+    MockPflashCompressBackend backend;
+    ServerConfig config;
+    config.prefix_cache_cap = 0;
+    config.prefill_cache_cap = 0;
+    {
+        HttpServer server(backend, tokenizer, config);
+        server.set_drafter_tokenizer(&tokenizer);
+
+        ParsedRequest request;
+        request.format = ApiFormat::RESPONSES;
+        request.messages = "x";
+        request.prompt_tokens = tokenizer.encode("x");
+
+        const std::string error =
+            HttpServerTestAccess::apply_pflash_compression(server, request);
+        TEST_ASSERT_MSG(error.empty(), error);
+    }
+
+    TEST_ASSERT(backend.compress_calls == 1);
+    TEST_ASSERT(backend.last_request.score_query_end == 1);
+    TEST_ASSERT(backend.last_request.score_query_tokens == 1);
+    unlink(tokenizer_path.c_str());
+}
 
 struct MockBatchCompressBackend : MockBackend {
     int compress_calls = 0;

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -46,6 +46,7 @@
 #include <nlohmann/json.hpp>
 
 #include <filesystem>
+#include <algorithm>
 #include <cmath>
 #include <cerrno>
 #include <cstdio>
@@ -127,6 +128,24 @@ TEST_CASE(ServerUnitFixture, test_pflash_scorer_uses_user_query_before_chat_suff
     TEST_ASSERT((int)rendered.size() - window.end == 8);
 }
 
+TEST_CASE(ServerUnitFixture, test_pflash_scorer_maps_last_128_user_tokens) {
+    std::vector<int32_t> query;
+    for (int token = 0; token < 160; ++token) {
+        query.push_back(1000 + token);
+    }
+    std::vector<int32_t> rendered{1, 2};
+    rendered.insert(rendered.end(), query.begin(), query.end());
+    rendered.insert(rendered.end(), {200, 201, 202, 203});
+
+    const auto window =
+        http_detail::find_pflash_query_window(rendered, query, 128);
+
+    TEST_ASSERT(window.valid());
+    TEST_ASSERT(window.tokens == 128);
+    TEST_ASSERT(window.end == 162);
+    TEST_ASSERT((int)rendered.size() - window.end == 4);
+}
+
 TEST_CASE(ServerUnitFixture, test_pflash_query_mapping_tolerates_one_bpe_boundary_token) {
     const std::vector<int32_t> query{10, 11, 12, 13, 14, 15, 16, 17};
     const std::vector<int32_t> rendered{
@@ -138,6 +157,193 @@ TEST_CASE(ServerUnitFixture, test_pflash_query_mapping_tolerates_one_bpe_boundar
     TEST_ASSERT(window.valid());
     TEST_ASSERT(window.tokens == 7);
     TEST_ASSERT(window.end == 10);
+}
+
+TEST_CASE(ServerUnitFixture, test_pflash_query_mapping_stays_before_latest_user_boundary) {
+    const std::vector<int32_t> query{10, 11, 12, 13, 14, 15, 16, 17};
+    const std::vector<int32_t> rendered{
+        1, 2, 999, 11, 12, 13, 14, 15, 16, 17,
+        200, 201, 10, 11, 12, 13, 14, 15, 16, 17, 202,
+    };
+    // The sentinel changes the token at the user end, but the later template
+    // and assistant tokens remain stable. The common suffix establishes the
+    // semantic boundary after the original complete user suffix.
+    const std::vector<int32_t> sentinel_rendered{
+        1, 2, 999, 11, 12, 13, 14, 15, 16, 9999,
+        200, 201, 10, 11, 12, 13, 14, 15, 16, 17, 202,
+    };
+
+    const int search_end = http_detail::pflash_query_search_end_from_sentinel(
+        rendered, sentinel_rendered);
+    const auto bounded =
+        http_detail::find_pflash_query_window(rendered, query, 8, search_end);
+    const auto unbounded = http_detail::find_pflash_query_window(rendered, query);
+
+    TEST_ASSERT(search_end == 10);
+    TEST_ASSERT(bounded.valid());
+    TEST_ASSERT(bounded.tokens == 7);
+    TEST_ASSERT(bounded.end == 10);
+    TEST_ASSERT(unbounded.valid());
+    TEST_ASSERT(unbounded.tokens == 8);
+    TEST_ASSERT(unbounded.end == 20);
+    TEST_ASSERT(http_detail::pflash_query_search_end_from_sentinel(
+        rendered, std::vector<int32_t>{42}) < 0);
+}
+
+TEST_CASE(ServerUnitFixture, test_pflash_bounded_mapping_prefers_latest_shortened_suffix) {
+    const std::vector<int32_t> query{10, 11, 12, 13, 14, 15, 16, 17};
+    const std::vector<int32_t> rendered{
+        1, 10, 11, 12, 13, 14, 15, 16, 17,
+        900, 11, 12, 13, 14, 15, 16, 17, 200, 201,
+    };
+
+    const auto bounded =
+        http_detail::find_pflash_query_window(rendered, query, 8, 17);
+    const auto unbounded = http_detail::find_pflash_query_window(rendered, query, 8);
+
+    TEST_ASSERT(bounded.valid());
+    TEST_ASSERT(bounded.end == 17);
+    TEST_ASSERT(bounded.tokens == 7);
+    // The compatibility path remains width-first when there is no semantic
+    // boundary, so the earlier exact duplicate still wins there.
+    TEST_ASSERT(unbounded.valid());
+    TEST_ASSERT(unbounded.end == 9);
+    TEST_ASSERT(unbounded.tokens == 8);
+}
+
+TEST_CASE(ServerUnitFixture, test_pflash_bounded_mapping_rejects_earlier_duplicate) {
+    const std::vector<int32_t> query{10, 11, 12, 13, 14, 15, 16, 17};
+    const std::vector<int32_t> rendered{
+        1, 10, 11, 12, 13, 14, 15, 16, 17,
+        900, 11, 12, 13, 14, 15, 16, 999, 200,
+    };
+
+    const auto bounded =
+        http_detail::find_pflash_query_window(rendered, query, 8, 18);
+    const auto unbounded =
+        http_detail::find_pflash_query_window(rendered, query, 8);
+
+    TEST_ASSERT(!bounded.valid());
+    TEST_ASSERT(unbounded.valid());
+    TEST_ASSERT(unbounded.end == 9);
+    TEST_ASSERT(unbounded.tokens == 8);
+}
+
+TEST_CASE(ServerUnitFixture, test_pflash_bounded_mapping_stays_inside_content_start) {
+    const std::vector<int32_t> query{10, 11, 12, 13, 14, 15, 16, 17};
+    const std::vector<int32_t> rendered{
+        1, 2, 3, 4, 10, 11, 12, 13, 14, 15, 16, 17, 200,
+    };
+
+    const auto bounded = http_detail::find_pflash_query_window(
+        rendered, query, 8, 12, 5);
+
+    TEST_ASSERT(bounded.valid());
+    TEST_ASSERT(bounded.end == 12);
+    TEST_ASSERT(bounded.tokens == 7);
+    TEST_ASSERT(bounded.end - bounded.tokens == 5);
+}
+
+TEST_CASE(ServerUnitFixture, test_pflash_maps_content_start_from_leading_sentinel) {
+    const std::vector<int32_t> rendered{1, 2, 10, 11, 12, 13, 20};
+    const std::vector<int32_t> sentinel_rendered{
+        1, 2, 999, 10, 11, 12, 13, 20,
+    };
+
+    TEST_ASSERT(http_detail::pflash_query_search_begin_from_sentinel(
+        rendered, sentinel_rendered) == 2);
+    TEST_ASSERT(http_detail::pflash_query_search_begin_from_sentinel(
+        rendered, rendered) < 0);
+}
+
+TEST_CASE(ServerUnitFixture, test_pflash_responses_string_tails_only_raw_content) {
+    ToolMemory tool_memory;
+    const auto normalized = normalize_chat_messages(
+        json("raw completion input"), ApiFormat::RESPONSES, tool_memory);
+    TEST_ASSERT(normalized.size() == 1);
+    TEST_ASSERT(normalized[0].role == "user");
+    TEST_ASSERT(normalized[0].content == "raw completion input");
+
+    const std::vector<int32_t> rendered{
+        1, 2, 10, 11, 12, 13, 14, 200, 201,
+    };
+    const auto window = http_detail::pflash_tail_query_window(
+        rendered, 128, /*query_end=*/7, /*query_begin=*/2);
+    TEST_ASSERT(window.valid());
+    TEST_ASSERT(window.end == 7);
+    TEST_ASSERT(window.tokens == 5);
+    TEST_ASSERT(window.end - window.tokens == 2);
+}
+
+TEST_CASE(ServerUnitFixture, test_pflash_parser_fingerprint_has_fixed_encoding) {
+    const std::vector<int32_t> ids{1, -2, 2147483647};
+    TEST_ASSERT(http_detail::pflash_token_fingerprint(ids) ==
+                "45409a0b0f44c5fd");
+}
+
+TEST_CASE(ServerUnitFixture, test_pflash_tail_query_window) {
+    const auto empty = http_detail::pflash_tail_query_window({}, 128);
+    TEST_ASSERT(!empty.valid());
+
+    const std::vector<int32_t> short_prompt{1, 2, 3};
+    const auto short_tail =
+        http_detail::pflash_tail_query_window(short_prompt, 128);
+    TEST_ASSERT(short_tail.valid());
+    TEST_ASSERT(short_tail.end == 3);
+    TEST_ASSERT(short_tail.tokens == 3);
+
+    std::vector<int32_t> long_prompt(200);
+    const auto capped_tail =
+        http_detail::pflash_tail_query_window(long_prompt, 128);
+    TEST_ASSERT(capped_tail.valid());
+    TEST_ASSERT(capped_tail.end == 200);
+    TEST_ASSERT(capped_tail.tokens == 128);
+    const auto bounded_tail =
+        http_detail::pflash_tail_query_window(long_prompt, 128, 150);
+    TEST_ASSERT(bounded_tail.valid());
+    TEST_ASSERT(bounded_tail.end == 150);
+    TEST_ASSERT(bounded_tail.tokens == 128);
+    TEST_ASSERT(!http_detail::pflash_tail_query_window(long_prompt, 0).valid());
+    TEST_ASSERT(!http_detail::pflash_tail_query_window(long_prompt, 128, 0).valid());
+    TEST_ASSERT(!http_detail::pflash_tail_query_window(long_prompt, 128, 201).valid());
+}
+
+TEST_CASE(ServerUnitFixture, test_pflash_normalizes_multipart_latest_user_for_reverse_lookup) {
+    ToolMemory tool_memory;
+    const json messages = json::array({
+        {{"role", "user"}, {"content", "older user"}},
+        {{"role", "assistant"}, {"content", "assistant before latest"}},
+        {{"role", "user"}, {"content", json::array({
+            {{"type", "input_text"}, {"text", "input-"}},
+            {{"type", "input_image"}, {"image_url", "ignored"}},
+            {{"type", "text"}, {"text", "text"}}
+        })}},
+        {{"role", "assistant"}, {"content", "assistant after latest"}},
+        {{"role", "tool"}, {"content", "tool after latest"}}
+    });
+
+    const auto normalized = normalize_chat_messages(
+        messages, ApiFormat::OPENAI_CHAT, tool_memory);
+    const auto latest_user = std::find_if(
+        normalized.rbegin(), normalized.rend(),
+        [](const ChatMessage & message) { return message.role == "user"; });
+    TEST_ASSERT(latest_user != normalized.rend());
+    if (latest_user != normalized.rend()) {
+        TEST_ASSERT(latest_user->content == "input-text");
+    }
+}
+
+TEST_CASE(ServerUnitFixture, test_pflash_longattncomp_cache_and_continuation_policy) {
+    TEST_ASSERT(http_detail::pflash_full_cache_restore_allowed(false));
+    TEST_ASSERT(!http_detail::pflash_full_cache_restore_allowed(true));
+    TEST_ASSERT(!http_detail::pflash_continuation_must_fail_closed(false));
+    TEST_ASSERT(http_detail::pflash_continuation_must_fail_closed(true));
+}
+
+TEST_CASE(ServerUnitFixture, test_pflash_target_token_ceiling_floors) {
+    TEST_ASSERT(http_detail::pflash_target_token_ceiling(7, 0.5) == 3);
+    TEST_ASSERT(http_detail::pflash_target_token_ceiling(120000, 16384.0 / 120000.0) == 16384);
+    TEST_ASSERT(http_detail::pflash_target_token_ceiling(-1, 0.5) < 0);
 }
 
 TEST_CASE(ServerUnitFixture, test_pflash_query_mapping_rejects_weak_punctuation_match) {

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -199,6 +199,25 @@ TEST_CASE(ServerUnitFixture, test_pflash_query_mapping_stays_before_latest_user_
         rendered, std::vector<int32_t>{42}) < 0);
 }
 
+TEST_CASE(ServerUnitFixture, test_pflash_explicit_query_matches_before_trailing_content) {
+    // An explicit query sits before trailing instructions inside the latest
+    // user content; anchored matching (message tail) must fail, unanchored
+    // matching must find its latest occurrence and tolerate a leading-token
+    // boundary difference from tokenizing the query on its own.
+    const std::vector<int32_t> query{5, 10, 11, 12, 13, 14};   // 5 = boundary drift
+    const std::vector<int32_t> rendered{
+        1, 2, 3, 10, 11, 12, 13, 14, 300, 301, 302, 303, 304, 305, 306, 307,
+    };
+    const auto anchored = http_detail::find_pflash_query_window(rendered, query, 8, 16, 1);
+    const auto explicit_window = http_detail::find_pflash_query_window(rendered, query, 8, 16, 1, false);
+    TEST_ASSERT(!anchored.valid());
+    TEST_ASSERT(explicit_window.valid());
+    TEST_ASSERT(explicit_window.end == 8);
+    TEST_ASSERT(explicit_window.tokens == 5);
+    const auto out_of_window = http_detail::find_pflash_query_window(rendered, query, 8, 16, 9, false);
+    TEST_ASSERT(!out_of_window.valid());
+}
+
 TEST_CASE(ServerUnitFixture, test_pflash_bounded_mapping_prefers_latest_shortened_suffix) {
     const std::vector<int32_t> query{10, 11, 12, 13, 14, 15, 16, 17};
     const std::vector<int32_t> rendered{

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -218,6 +218,33 @@ TEST_CASE(ServerUnitFixture, test_pflash_explicit_query_matches_before_trailing_
     TEST_ASSERT(!out_of_window.valid());
 }
 
+TEST_CASE(ServerUnitFixture, test_pflash_explicit_query_tolerates_merged_trailing_token) {
+    // The query's last token merges with the prompt's following newline
+    // ("  " alone vs "  \n" in context): the unanchored match drops that
+    // trailing token, the untrimmed match still wins when it exists, and
+    // anchored (message tail) matching keeps its exact-suffix contract.
+    const std::vector<int32_t> query{10, 11, 12, 13, 14, 77};   // 77 = "  "
+    const std::vector<int32_t> rendered{
+        1, 2, 3, 10, 11, 12, 13, 14, 78, 300, 301, 302,   // 78 = "  \n"
+    };
+    const auto trimmed = http_detail::find_pflash_query_window(rendered, query, 8, 12, 1, false);
+    TEST_ASSERT(trimmed.valid());
+    TEST_ASSERT(trimmed.end == 8);
+    TEST_ASSERT(trimmed.tokens == 5);
+    TEST_ASSERT(trimmed.trailing_trimmed == 1);
+    const std::vector<int32_t> exact{1, 10, 11, 12, 13, 14, 77, 2, 10, 11, 12, 13, 14, 78};
+    const auto untrimmed = http_detail::find_pflash_query_window(exact, query, 8, 14, 0, false);
+    TEST_ASSERT(untrimmed.valid());
+    TEST_ASSERT(untrimmed.end == 7);
+    TEST_ASSERT(untrimmed.tokens == 6);
+    TEST_ASSERT(untrimmed.trailing_trimmed == 0);
+    const auto anchored = http_detail::find_pflash_query_window(rendered, query, 8, 12, 1);
+    TEST_ASSERT(!anchored.valid());
+    const std::vector<int32_t> short_query{10, 11, 12, 77};
+    const auto too_short = http_detail::find_pflash_query_window(rendered, short_query, 8, 12, 1, false);
+    TEST_ASSERT(!too_short.valid());
+}
+
 TEST_CASE(ServerUnitFixture, test_pflash_bounded_mapping_prefers_latest_shortened_suffix) {
     const std::vector<int32_t> query{10, 11, 12, 13, 14, 15, 16, 17};
     const std::vector<int32_t> rendered{

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -265,6 +265,155 @@ TEST_CASE(ServerUnitFixture, test_pflash_maps_content_start_from_leading_sentine
         rendered, rendered) < 0);
 }
 
+TEST_CASE(ServerUnitFixture, test_pflash_instruction_plan_covers_tools_and_late_developer_roles) {
+    const std::vector<ChatMessage> messages{
+        {"system", "system instruction", ""},
+        {"developer", "leading developer instruction", ""},
+        {"user", "document text", ""},
+        {"assistant", "prior answer", ""},
+        {"developer", "late developer instruction", ""},
+        {"tool", "tool result is history", "call-1"},
+        {"user", "latest query", ""},
+    };
+    const auto plan = http_detail::plan_pflash_instruction_messages(messages);
+
+    TEST_ASSERT(plan.instruction_messages ==
+                std::vector<size_t>({0, 1, 4}));
+}
+
+TEST_CASE(ServerUnitFixture, test_pflash_instruction_plan_handles_empty_instructions) {
+    const std::vector<ChatMessage> tool_only{
+        {"user", "use the tool", ""},
+    };
+    const auto tool_plan =
+        http_detail::plan_pflash_instruction_messages(tool_only);
+    TEST_ASSERT(tool_plan.instruction_messages.empty());
+
+    const std::vector<ChatMessage> empty_instruction{
+        {"system", "", ""},
+        {"user", "plain query", ""},
+    };
+    const auto empty_plan =
+        http_detail::plan_pflash_instruction_messages(empty_instruction);
+    TEST_ASSERT(empty_plan.instruction_messages.empty());
+}
+
+TEST_CASE(ServerUnitFixture, test_pflash_tool_span_follows_arbitrary_jinja_placement) {
+    static const char TPL[] =
+        "{%- for m in messages -%}{{ m.content }}{%- endfor -%}"
+        "{%- if tools -%}|TOOLS:{{ tools[0].function.name }}{%- endif -%}";
+    const std::vector<ChatMessage> messages{{"user", "query-first", ""}};
+    const std::string tools =
+        R"([{"type":"function","function":{"name":"late_lookup"}}])";
+    const std::string with_tools = render_chat_template_jinja(
+        TPL, messages, "", "", true, false, tools);
+    const std::string without_tools = render_chat_template_jinja(
+        TPL, messages, "", "", true, false, "[]");
+    const std::vector<int32_t> original(with_tools.begin(), with_tools.end());
+    const std::vector<int32_t> variant(without_tools.begin(), without_tools.end());
+
+    const PFlashTokenSpan span =
+        http_detail::pflash_changed_token_span(original, variant);
+    TEST_ASSERT(span.begin >= (int) messages[0].content.size());
+    TEST_ASSERT(span.end == (int) original.size());
+    TEST_ASSERT(with_tools.substr(
+        (size_t) span.begin, (size_t) (span.end - span.begin)).find(
+            "late_lookup") != std::string::npos);
+}
+
+TEST_CASE(ServerUnitFixture, test_pflash_instruction_span_follows_reordered_jinja_message) {
+    static const char TPL[] =
+        "{%- for m in messages -%}{%- if m.role == 'user' -%}"
+        "<{{ m.role }}>{{ m.content }}</{{ m.role }}>"
+        "{%- endif -%}{%- endfor -%}"
+        "{%- for m in messages -%}{%- if m.role == 'system' -%}"
+        "<{{ m.role }}>{{ m.content }}</{{ m.role }}>"
+        "{%- endif -%}{%- endfor -%}";
+    const std::vector<ChatMessage> messages{
+        {"system", "retain this rule", ""},
+        {"user", "question first", ""},
+    };
+    const std::string rendered = render_chat_template_jinja(
+        TPL, messages, "", "", true, false);
+    auto without_system = messages;
+    without_system.erase(without_system.begin());
+    const std::string variant_rendered = render_chat_template_jinja(
+        TPL, without_system, "", "", true, false);
+    const std::vector<int32_t> original(rendered.begin(), rendered.end());
+    const std::vector<int32_t> variant(
+        variant_rendered.begin(), variant_rendered.end());
+
+    const PFlashTokenSpan span =
+        http_detail::pflash_changed_token_span(original, variant);
+    TEST_ASSERT(span.begin > (int) messages[1].content.size());
+    const std::string retained = rendered.substr(
+        (size_t) span.begin, (size_t) (span.end - span.begin));
+    TEST_ASSERT(retained.find("<system>") != std::string::npos);
+    TEST_ASSERT(retained.find(messages[0].content) != std::string::npos);
+    TEST_ASSERT(retained.find("</system>") != std::string::npos);
+}
+
+TEST_CASE(ServerUnitFixture, test_pflash_instruction_spans_are_canonicalized) {
+    const auto spans = http_detail::canonicalize_pflash_token_spans(
+        {{12, 20}, {0, 4}, {3, 8}, {20, 24}});
+    TEST_ASSERT(spans == std::vector<PFlashTokenSpan>({{0, 8}, {12, 24}}));
+}
+
+TEST_CASE(ServerUnitFixture, test_pflash_qwen_tool_prefix_boundary_covers_schema) {
+    const std::vector<ChatMessage> messages{{"user", "find weather", ""}};
+    const std::string tools =
+        R"([{"type":"function","function":{"name":"lookup_weather"}}])";
+    const std::string sentinel = "__PFLASH_BEGIN_02C47F91__";
+    const std::string rendered = render_chat_template(
+        messages, ChatFormat::QWEN3, true, false, tools);
+    auto marked_messages = messages;
+    marked_messages[0].content = sentinel + marked_messages[0].content;
+    const std::string marked = render_chat_template(
+        marked_messages, ChatFormat::QWEN3, true, false, tools);
+    const std::vector<int32_t> rendered_ids(rendered.begin(), rendered.end());
+    const std::vector<int32_t> marked_ids(marked.begin(), marked.end());
+
+    const int prefix_end = http_detail::pflash_query_search_begin_from_sentinel(
+        rendered_ids, marked_ids);
+    TEST_ASSERT(prefix_end > 0);
+    TEST_ASSERT(rendered.substr(0, (size_t) prefix_end).find("lookup_weather") !=
+                std::string::npos);
+    TEST_ASSERT(rendered.substr(0, (size_t) prefix_end).find("find weather") ==
+                std::string::npos);
+}
+
+TEST_CASE(ServerUnitFixture, test_pflash_qwen_late_developer_span_covers_role_envelope) {
+    const std::vector<ChatMessage> messages{
+        {"user", std::string(930, 'u'), ""},
+        {"assistant", "history", ""},
+        {"developer", std::string(180, 'd'), ""},
+        {"user", "latest query", ""},
+    };
+    const std::string rendered = render_chat_template(
+        messages, ChatFormat::QWEN3, true, false);
+    auto without_developer = messages;
+    without_developer.erase(without_developer.begin() + 2);
+    const std::string without_developer_rendered = render_chat_template(
+        without_developer, ChatFormat::QWEN3, true, false);
+    const std::vector<int32_t> ids(rendered.begin(), rendered.end());
+    const std::vector<int32_t> variant(
+        without_developer_rendered.begin(), without_developer_rendered.end());
+
+    const PFlashTokenSpan span =
+        http_detail::pflash_changed_token_span(ids, variant);
+    const size_t content_begin = rendered.find(messages[2].content);
+    TEST_ASSERT(content_begin != std::string::npos);
+    TEST_ASSERT(span.begin >= 0);
+    TEST_ASSERT((size_t) span.begin < content_begin);
+    TEST_ASSERT((size_t) span.end > content_begin + messages[2].content.size());
+    TEST_ASSERT(span.begin < 1024);
+    TEST_ASSERT(span.end > 1024);
+    TEST_ASSERT(rendered.substr(
+        (size_t) span.begin,
+        (size_t) (span.end - span.begin)).find("developer") !=
+        std::string::npos);
+}
+
 TEST_CASE(ServerUnitFixture, test_pflash_responses_string_tails_only_raw_content) {
     ToolMemory tool_memory;
     const auto normalized = normalize_chat_messages(

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -7048,6 +7048,19 @@ TEST_CASE(ServerUnitFixture, test_flowkv_session_keep_ratio_override) {
 
     TEST_ASSERT(std::fabs(static_ratio - configured_ratio) < 1e-6f);
     TEST_ASSERT(std::fabs(adaptive_ratio - 0.09f) < 1e-6f);
+
+    // A session without feedback keeps the configured (curve) ratio, and its
+    // first feedback adapts from that ratio rather than the fixed default:
+    // 0.1875 (the 16K real-use budget) minus one small step at high acceptance.
+    const float curve_ratio = 0.1875f;
+    TEST_ASSERT(std::fabs(http_detail::resolve_pflash_keep_ratio(
+        curve_ratio, "fresh", sessions) - curve_ratio) < 1e-6f);
+    sessions.update("fresh", 0.95f, curve_ratio);
+    TEST_ASSERT(std::fabs(http_detail::resolve_pflash_keep_ratio(
+        curve_ratio, "fresh", sessions) - (curve_ratio - 0.01f)) < 1e-6f);
+    // Seeds are clamped to the controller's range like every later step.
+    sessions.update("wide", 0.50f, 0.30f);
+    TEST_ASSERT(std::fabs(sessions.get_keep_ratio("wide") - 0.20f) < 1e-6f);
 }
 
 // ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
> Draft on upstream, opened from the fork branch `Graffioh:codex/pflash-qwen35-hybrid` (fork PR Graffioh/lucebox-hub#28). It carries the LongAttnComp core commits (`codex/pflash-longattncomp-core`, 10 commits) it is stacked on plus the Qwen3.5 hybrid drafter; the branch merges cleanly into `main` (dry-run merge, no conflicts) and is not yet rebased on it.

## Evaluation of 10 September 2026 (full prefill vs Qwen3.5 PFlash)

Qwen3.6-27B target, real-use ratio budget (16K → ~3K, 120K → ~16K), 256-token chunks for QA and 1,024 for code, explicit question as scorer query, 8K output cap.

| case set | full prefill | no head (original scorer) | untrained block-15 head | LongAttnComp-trained head (512 QA examples) |
|---|---|---|---|---|
| 20 trial-0076 cases: QA 12 / code 8 | 10 / 6 | 3 / 0 (5 code answered) | 10 / 6 | 10 / 6 |
| 12 differential cases: QA 4 / code 8 | 4 / 7 | – | 4 / 5 | 4 / 4 |
| 16 wide InfiniteBench CodeDebug cases | 16 | – | 12 | 13 |
| median time to first token QA / code | 34 s / 215 s | 15 s / 71 s | 13 s / 43 s | 13 s / 43 s |

QA never loses a case to compression. CodeDebug losses (full 29/32, heads 23/32) come from the gold function not being selected (4 cases) or from a distractor definition cut by a 1,024-token chunk boundary, after which the target picks the truncated function (7 of 8 wrong-with-evidence answers). Offline, definition-aligned segment boundaries cut those truncations from 9 cases to 1 at the same budget; that runtime change is the next step on this branch. The original all-layer scorer on the Qwen3.5 backbone drops the evidence on nearly every case; the block-15 head is what makes the backbone viable.

## Summary

PFlash can now use **Qwen3.5-0.8B as its drafter with the LongAttnComp attention-mass scorer**, the same selection mechanism the Qwen3-0.6B block-13 head uses. Under strict selection (`PFLASH_LONGATTNCOMP_MODE=budget_only` etc.) a Qwen3.5 drafter runs only its first 15 blocks (12 GatedDeltaNet + 3 full attention), then scores every context token against the query window with block 15's own NoPE Q/K projections: softmax over the keys before the query, mean over heads and query tokens, chunk-mass fill to the token budget. Qwen3.5's 262K native context covers the complete 76-97K-token CodeDebug inputs that the Qwen3-0.6B scorer cannot score inside its 32K window, and it shares the Qwen3.6 target tokenizer.

Runtime counterpart of the Python retention screen (trial 0075: untrained Qwen3.5 hybrid head 36/36 QA support retained vs 35/36 for both Qwen3 heads, 7/8 CodeDebug gold functions vs blocked for Qwen3).

Stacked on `codex/pflash-longattncomp-core` (merge base c927a59b). The first commit carries, verbatim, the uncommitted research patches from the `pflash-longattncomp-quality-probe` worktree that trials 0023-0074 executed against (Qwen3 head loader, strict selection plumbing); every arm below runs on that state plus this branch.

## What changed

- `server/src/qwen3/qwen3_drafter.cpp`
  - `qwen35_longattncomp_score_and_compress`: 15-block prefix, block-15 NoPE Q/K scoring, keys projected in 8K chunks (any tensor with the sequence length in a HIP grid y/z dimension aborts above 65,535 tokens; this failed at 87K before), one softmax over `[S, query, heads]`, CPU mean reduction, then the shared `select_longattncomp_chunks` with direct chunk mass. Routed when strict selection is active; `PFLASH_QWEN35_LEGACY_SCORER=1` keeps the old all-layer running-max scorer.
  - `PFLASH_LONGATTNCOMP_HEAD_GGUF` for this architecture: schema `qwen3_5_0_8b_nope_qk_mass_v1`, feature tap `post_block14_residual_before_block15`, query-only `[1024,2048]` and `[1024,512]` F32 tensors, drafter sha256 pin; fails closed on any mismatch, like the Qwen3 loader.
  - Drafter load plan skips the lm_head (tied-embedding Qwen3.5-0.8B exports omit `output.weight`; the old Qwen3.5 drafter branch could not load the 0.8B GGUF at all).
  - Causal mask builder memsets visible rows; `DFLASH27B_KV_TQ3` guard is one RAII helper shared by both Qwen3.5 scorers.
- `server/src/qwen35/gguf_target_loader.cpp`: missing `output.weight` is only fatal when the load plan needs the lm_head.
- `server/src/qwen3/qwen3_drafter_model.h`: `longattncomp_mean_token_mass` helper (unit-tested in `test_pflash_selection.cpp`).
- `server/README.md`: drafter documentation.

Not in this PR: block-sparse FlashPrefill for head dimension 256 (Qwen3.5 attention runs dense `ggml_flash_attn_ext`), a trained Qwen3.5 head (the exporter lives in the training package), and drafter forward-pass optimisation (per-ubatch graph rebuilds; see timings).

## Explicit scorer query (added after the comparison)

`pflash_query` (top level or `extra_body`) tells the compressor which text to score the context against, replacing the last-128-token message-tail heuristic; it must occur inside the latest user content and is matched unanchored with leading-token drift tolerance. Trial 0077 measured why this matters with the same untrained head at real-use budgets: the message tail keeps complete support on 24/36 QA and 5/8 CodeDebug gold functions, the explicit question keeps 32/36 and 7/8, and the retrieval-instruction prefix makes no difference. Runtime check on the ten flipping cases: the query window shrank from 128 tokens to the 11-37-token question and CodeDebug explicit choices went from 1/3 to 2/3 correct. The benches in luce_box PR #107 now send the recorded question per case.

## Follow-ups on this branch (10 September 2026)

- **Explicit query with a merged trailing token** (135779b8): a question ending in whitespace tokenizes to a trailing token on its own that merges with the prompt's newline in context; the unanchored window search only trimmed the query's leading tokens, so the mapping failed and the request was refused. Up to two trailing query tokens may now be dropped (untrimmed match preferred), and the expected query ids come from the matched range. Unit test added.
- **Adaptive session keep ratio on this path** (78e2530e): the per-session acceptance-rate controller (`adaptive_keep_ratio.h`) already applies to the Qwen3.5 drafter, since the resolved ratio sizes the strict selector's budget and the feedback runs after every speculative turn. A new session started from a fixed 10% and ignored `--prefill-keep-ratio` / `--prefill-curve`; it now keeps the configured ratio until its first feedback and adapts from there within the same 2.5-20% range. README documents the behaviour and the caveat that acceptance is a proxy, not a retention measurement.
- 502 unit tests pass (`test_server_unit`, HIP gfx1201 build).

## Verification

- 501 unit tests pass (`test_server_unit`), including the reduction, query-field and unanchored-query tests.
- Daemon smoke with `Qwen3.5-0.8B-BF16.gguf` (converted from the pinned HF revision `2fc06364…`; norms already stored as 1+w): 31K-token QA case forward 4.1 s, chunk masses vs the Python head Pearson 0.999, top-16 chunk overlap 14/16; 87K-token CodeDebug case forward 21.5 s, gold function chunk retained, top-16 overlap 14/16.
- Head loader: exporting the native block-15 projections as a head GGUF and loading it through `PFLASH_LONGATTNCOMP_HEAD_GGUF` reproduces the head-less selection exactly (chunk-score difference 1.4e-4, identical chunks).

## Quality and time comparison (trial 0076)

Target Qwen3.6-27B-Q4_K_M, hip:0, q4_0 KV, `--max-ctx 137408`, temperature 0, seed 20260908, thinking off, QA `max_tokens` 256, CodeDebug 2,048. Cases: reviewed development QA from the 0074 suite and the 8 complete CodeDebug cases (76-91K tokens). Arms: full prefill; Qwen3.5-0.8B hybrid (this PR, untrained head); Qwen3-0.6B PFlash with its native tail scorer under the same strict selection (the current runtime drafter). The Qwen3 trained-head arm was skipped to save time. Official benchmark scoring plus per-answer error-factor flags (luce_box PR #107). W&B run with per-answer tables: https://wandb.ai/logberto-na/lucebox/runs/ay4u28ti

**Ratio policy** (`--prefill-curve 16384:0.1875 120000:0.1365`, i.e. 16K→3K and 120K→16K; chunk 256 for QA, 1,024 for code). Accuracy is the official benchmark metric; "flagged" counts answers produced under an external error factor (request error or output cap), whose scores still count:

| cohort | arm | official accuracy | flagged | median TTFT | median target prefill | median drafter | effective prompt tokens |
|---|---|---|---|---|---|---|---|
| QA (12) | Full prefill | 10/12 | 0 | 34.1 s | 33.9 s | n/a | 23,024 |
| QA (12) | **Qwen3.5 hybrid** | **10/12** | 0 | **13.3 s** | 5.2 s | 2.4 s | 4,112 |
| QA (12) | Qwen3-0.6B native | 5/12 | 2 request errors | 28.1 s | 5.1 s | 10-23 s | 4,106 |
| CodeDebug (8) | Full prefill | 4/8 | 2 output-capped | 235.1 s | 234.7 s | n/a | 92,813 |
| CodeDebug (8) | **Qwen3.5 hybrid** | 3/8 | 4 output-capped | **46.3 s** | 17.4 s | 23.0 s | 13,376 |
| CodeDebug (8) | Qwen3-0.6B native | 3/8 | 7 output-capped | 197.7 s | 17.1 s | 137-200 s | 13,243 |

**16K-budget policy** (campaign protocol, constant 16,384-token budget, chunk 1,024; 30 reviewed QA cases): full prefill 27/30, Qwen3.5 hybrid 27/30 with the same per-case verdicts and no flags, median TTFT 44.0 s vs 29.6 s (1.1x median speedup, 0.78x on 17K prompts and 1.5x on 29K, because this budget barely compresses these prompts while a fixed 8-9 s compression cost is paid). Qwen3 arms were not run at this policy.

What the numbers say:

- **QA quality.** The untrained Qwen3.5 head reproduces the full-prefill official verdict on every QA case it ran on (42 cases across both policies), at 5x compression under the ratio policy with 2.6x lower TTFT. The Qwen3 native scorer loses half the answers at that budget.
- **Qwen3 tokenizer mismatch.** Two Qwen3 QA requests failed with `final prompt exceeds target-token ceiling (5272 > 5253)`: the Qwen3 drafter tokenizer differs from the Qwen3.6 target tokenizer, so re-tokenized compressed text can overshoot by a few tokens and the server fails closed. Qwen3.5 shares the target tokenizer and cannot hit this.
- **CodeDebug, stated explicitly.** The runtime Qwen3-0.6B drafter does accept the 76-97K prompts, but that is beyond its documented 32,768-token context (40,960 configured positions); the offline Qwen3 scorer refuses them and trial 0069 found 0/8 gold functions retained there. Its rows are what the current runtime does, not a validated capability. The flagged CodeDebug answers all hit the 2,048-token output cap before an explicit choice (full 2/8, Qwen3.5 4/8, Qwen3 7/8), so code answer quality is confounded by the cap; on unflagged answers only, full prefill is 2/6 and Qwen3.5 1/4. Trial 0075 showed the hybrid head keeps the gold function on 7/8 of these inputs, so the gap to full prefill is mostly output truncation on compressed context. A rerun with a larger cap is needed before a code-quality conclusion.
- **Time.** In the native runtime the Qwen3.5 drafter is the faster one: 1.7-3 s forward on 17-29K prompts and 20-23 s on 76-97K, versus 10-23 s and 137-200 s for Qwen3-0.6B, whose time is almost entirely the sparse FlashPrefill HIP dispatch over 28 layers plus a 28-layer tail score. This reverses the Python-side speed gate (trial 0038), where Qwen3.5 lacked a GatedDeltaNet kernel. On CodeDebug Qwen3.5 PFlash is 5.1x faster than full prefill end to end (46 s vs 235 s).
- **Remaining cost.** Qwen3.5 CodeDebug TTFT is 23 s drafter forward + 17 s target prefill + about 6 s fixed overhead (drafter-tokenizer round trip, query mapping, re-tokenization). The forward rebuilds a graph per (layer, 1,024-token ubatch); that and the fixed overhead are the next targets. Block-sparse attention for head dimension 256 is not recommended before a profile shows attention dominating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2xwWvXuXfzi7ZionCHKdk



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

