### PR TITLE
docs(server): fix quick-start paths and build prerequisites

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,14 +31,14 @@ The script is idempotent and configures `nvcc` on PATH for both bash and zsh. Fo
 | Tool | Min version |
 |------|------------|
 | GCC / G++ | 11 |
-| CMake | 3.18 |
+| CMake | 3.21 |
 | Git | 2.x |
 | git-lfs | any |
 | CUDA Toolkit | 12.0+ |
 | huggingface-cli | any |
 | uv | 0.11+ (Python deps) |
 
-After setup:
+After setup, run these commands from the repository root:
 
 ```bash
 git submodule update --init --recursive
@@ -51,7 +51,7 @@ uv sync --extra megakernel    # also compile the megakernel CUDA extension
 bash scripts/check_uv_workspace.sh  # lockfile + frozen-sync import smoke
 
 # C++/CUDA decoder
-cmake -B server/build -S dflash -DCMAKE_BUILD_TYPE=Release
+cmake -B server/build -S server -DCMAKE_BUILD_TYPE=Release
 cmake --build server/build --target test_dflash -j
 ```
 
@@ -87,7 +87,7 @@ If you want to contribute benchmarks but don't have the hardware:
 ## Getting help
 
 - [Discord](https://discord.gg/yHfswqZmJQ) — fastest feedback
-- [Issues](https://github.com/Luce-Org/lucebox-hub/issues) — for bugs and proposals
+- [Issues](https://github.com/Luce-Org/lucebox/issues) — for bugs and proposals
 - Mention `@Luce-Org/maintainers` on a PR when it's ready for review
 
 ## Licensing

--- a/server/README.md
+++ b/server/README.md
@@ -1,5 +1,5 @@
 <p align="left">
-  <a href="../README.md">← lucebox-hub</a>
+  <a href="../README.md">← lucebox</a>
 </p>
 
 <p align="center">
@@ -743,7 +743,7 @@ Correctness: `test_vs_oracle` validates the draft graph at cos sim 0.999812 vs t
 
 ## Contributing
 
-Open an issue or PR against `Luce-Org/lucebox-hub`. Good first picks:
+Open an issue or PR against `Luce-Org/lucebox`. Good first picks:
 
 - **Leviathan-style rejection sampling** on each DDTree branch (the current implementation samples only the committed token; full prob-matching across the tree is the next step)
 - **Full llama.cpp integration**: new arch, `llama-speculative-dflash.cpp`, `llama-cli` / `llama-server` wiring
@@ -754,7 +754,7 @@ Open an issue or PR against `Luce-Org/lucebox-hub`. Good first picks:
 @software{luce_dflash_2026,
   title  = {Luce DFlash: GGUF port of block-diffusion speculative decoding for Qwen3.5-27B on consumer GPUs},
   author = {Lucebox},
-  url    = {https://github.com/Luce-Org/lucebox-hub/tree/main/dflash},
+  url    = {https://github.com/Luce-Org/lucebox/tree/main/server},
   year   = {2026}
 }
 

--- a/server/README.md
+++ b/server/README.md
@@ -558,10 +558,10 @@ tokens) is the path to bring code recall to the same ratio as prose.
 ## Quick start
 
 ```bash
-git clone --recurse-submodules https://github.com/Luce-Org/lucebox-hub
-cd lucebox-hub/dflash
+git clone --recurse-submodules https://github.com/Luce-Org/lucebox.git
+cd lucebox/server
 
-# Build (CUDA 12+, CMake 3.18+, sm_60+ GPU including Pascal; CUDA 13+ required for Jetson AGX Thor sm_110)
+# Build (CUDA 12+, CMake 3.21+, sm_60+ GPU including Pascal; CUDA 13+ required for Jetson AGX Thor sm_110)
 # Pass -DCMAKE_CUDA_ARCHITECTURES matching your GPU. Common values:
 #   60;61 = Pascal P100/P40 (scalar flashprefill fallback, no WMMA)
 #   70 = V100 (F16 WMMA kernels, BF16 draft → FP16 at load)
@@ -575,7 +575,7 @@ cd lucebox-hub/dflash
 # which compiles Pascal (scalar), Volta/Turing (F16 WMMA), and Ampere+ (BF16 WMMA)
 # flashprefill paths.
 cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_ARCHITECTURES=86
-cmake --build build --target test_dflash -j
+cmake --build build --target test_dflash dflash_server -j
 
 # Fetch models: ~16 GB target + 0.98 GB Lucebox Q4_K_M GGUF DFlash draft.
 # Quickstart pins to Qwen3.6-27B (latest release). For Qwen3.5-27B swap in
@@ -621,7 +621,7 @@ nvcc --version
 
 ```bash
 nvcc --version  # must show >= 12.9
-git clone --recurse-submodules https://github.com/Luce-Org/lucebox-hub && cd lucebox-hub/server
+git clone --recurse-submodules https://github.com/Luce-Org/lucebox.git && cd lucebox/server
 cmake -B build -S . -DCMAKE_BUILD_TYPE=Release   # CMake auto-adds sm_121
 cmake --build build --target test_dflash dflash_server -j
 ```
@@ -632,7 +632,7 @@ On GB10 (128 GB unified), re-sweep `--ddtree-budget` (larger tree = more verify 
 
 ```bash
 nvcc --version  # must show >= 13.0
-git clone --recurse-submodules https://github.com/Luce-Org/lucebox-hub && cd lucebox-hub/server
+git clone --recurse-submodules https://github.com/Luce-Org/lucebox.git && cd lucebox/server
 cmake -B build -S . -DCMAKE_BUILD_TYPE=Release   # CMake auto-adds Thor arch
 cmake --build build --target test_dflash dflash_server -j
 ```
@@ -670,7 +670,7 @@ HumanEval runs (+3.1%), HumanEval+ pass@1 145/164 versus 143/164, with all ten
 short A/B replies and 133/164 full-suite replies byte-identical.
 
 ```bash
-git clone --recurse-submodules https://github.com/Luce-Org/lucebox-hub && cd lucebox-hub/server
+git clone --recurse-submodules https://github.com/Luce-Org/lucebox.git && cd lucebox/server
 
 # Ubuntu/ROCm build dependencies used by ggml's HIP backend.
 sudo apt-get update


### PR DESCRIPTION
﻿A fresh checkout cannot follow the documented CUDA quick start: `cd lucebox-hub/dflash` points to a removed directory, and the build command only produces `test_dflash` before the instructions try to launch `dflash_server`. The contributor guide also configures CMake with the removed `dflash` source directory and advertises CMake 3.18, below the 3.21 minimum enforced by `server/CMakeLists.txt`.

This documentation-only change:
- Uses the canonical clone URL and `lucebox/server` in the CUDA, GB10, Thor, and HIP setup examples.
- Builds both `test_dflash` and `dflash_server` in the CUDA quick start.
- Fixes the contributor CMake source path, states the working directory, aligns the CMake minimum, and updates the issue tracker link.

Validation: `git diff --check` passed. Checked documented source paths, helper scripts, minimum CMake version, and both executable targets against the checkout. No GPU build or inference benchmark was run; no executable code changed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

