### PR TITLE
fix(laguna): honor do_sample in hybrid decode loop

### DIFF
--- a/server/src/laguna/laguna_backend.cpp
+++ b/server/src/laguna/laguna_backend.cpp
@@ -2423,7 +2423,8 @@ static bool build_laguna_layer_prefn_step(
 
 bool LagunaBackend::hybrid_forward_one_token(int32_t tok, int kv_pos,
                                               std::vector<float> & act_cur,
-                                              int32_t & argmax_out) {
+                                              int32_t & argmax_out,
+                                              std::vector<float> * out_logits) {
     const int hidden = w_.n_embd;
     const int vocab = w_.embedder.n_vocab;
     using _pclk = std::chrono::steady_clock;
@@ -2486,6 +2487,7 @@ bool LagunaBackend::hybrid_forward_one_token(int32_t tok, int kv_pos,
         for (size_t i = 1; i < _sg_logits.size(); ++i)
             if (_sg_logits[i] > _bv) { _bv = _sg_logits[i]; _best = (int)i; }
         argmax_out = _best;
+        if (out_logits) *out_logits = _sg_logits;
         return true;
     }
 
@@ -2701,6 +2703,7 @@ bool LagunaBackend::hybrid_forward_one_token(int32_t tok, int kv_pos,
                 argmax_out = j;
             }
         }
+        if (out_logits) *out_logits = std::move(logits_buf);
     }
     if (_prof) {
         g_logits += _pus(_t_logits, _pnow());
@@ -3110,21 +3113,16 @@ GenerateResult LagunaBackend::generate_hybrid(const GenerateRequest & req,
 
         // Hybrid forward: one token through all layers
         int32_t argmax_tok = 0;
-        if (!hybrid_forward_one_token(next_tok, cache_.cur_pos, act_cur, argmax_tok)) {
+        std::vector<float> step_logits;
+        if (!hybrid_forward_one_token(next_tok, cache_.cur_pos, act_cur, argmax_tok,
+                                      req.do_sample ? &step_logits : nullptr)) {
             result.fail(GenerateErrorCode::DecodeFailed);
             break;
         }
         cache_.cur_pos++;
         kvflash_maybe_reselect(history, s + 1);
 
-        if (req.do_sample) {
-            // For sampling, we need full logits — project from act_cur
-            // (hybrid_forward_one_token already computed argmax; for sampling
-            // we re-project — FIXME: return logits from forward to avoid double projection)
-            next_tok = argmax_tok;  // For now, use argmax even in sample mode as fallback
-        } else {
-            next_tok = argmax_tok;
-        }
+        next_tok = req.do_sample ? pick(step_logits) : argmax_tok;
     }
     auto t_g1 = std::chrono::steady_clock::now();
     result.decode_s = std::chrono::duration<double>(t_g1 - t_g0).count();

--- a/server/src/laguna/laguna_backend.cpp
+++ b/server/src/laguna/laguna_backend.cpp
@@ -2751,6 +2751,9 @@ GenerateResult LagunaBackend::generate_hybrid(const GenerateRequest & req,
     DaemonIO out_io = io.with_token_callback(req.on_token);
     const bool should_emit = req.stream || (bool)out_io.on_token;
     const int N = (int)req.prompt.size();
+    if (req.do_sample && req.sampler.seed != 0) {
+        sampler_rng_.seed(req.sampler.seed);
+    }
 
     if (N + req.n_gen > args_.max_ctx) {
         result.fail(GenerateErrorCode::ContextOverflow);

--- a/server/src/laguna/laguna_backend.h
+++ b/server/src/laguna/laguna_backend.h
@@ -188,7 +188,8 @@ private:
     GenerateResult generate_hybrid(const GenerateRequest & req, const DaemonIO & io);
     bool hybrid_forward_one_token(int32_t tok, int kv_pos,
                                   std::vector<float> & act_cur,
-                                  int32_t & argmax_out);
+                                  int32_t & argmax_out,
+                                  std::vector<float> * out_logits = nullptr);
     void maybe_post_request_swap();
 
     bool load_decode_draft();


### PR DESCRIPTION
## Summary

- `generate_hybrid()` in `laguna_backend.cpp` ignored `req.do_sample` and always advanced decoding with the greedy argmax token, even when the client requested sampling (temperature/top-p/top-k). A `FIXME` comment right at the spot already flagged this: *"return logits from forward to avoid double projection"* / *"For now, use argmax even in sample mode as fallback"*.
- Root cause: `hybrid_forward_one_token()` already computes the full vocab-size logits internally in both of its code paths (single-graph hybrid decode and the per-layer fallback), but only ever returned the argmax token to the caller, so the caller had nothing to sample from and silently fell back to greedy decoding regardless of what the request asked for.
- Fix: `hybrid_forward_one_token()` now takes an optional `out_logits` pointer and fills it in both branches only when the caller asks for it (copy on the `static` single-graph logits buffer, to preserve its reuse-across-calls allocation optimization; `std::move` on the per-call fallback buffer, which is always freshly allocated). The decode loop in `generate_hybrid()` passes `&step_logits` only when `req.do_sample` is set, and reuses the same `pick()` / `sample_logits()` path already used by the non-hybrid decode loops elsewhere in this file (e.g. around lines ~1441 and ~1677), instead of forcing argmax.
- The greedy path (`req.do_sample == false`, the common case) is unaffected: `out_logits` stays `nullptr`, so no extra copy or projection happens there.

## Why this matters

This path backs the hybrid MoE offload mode used for the Laguna model family (e.g. the documented Laguna XS 2.1 33B / RTX 3090 setup), so any generation request against a Laguna model in hybrid mode with sampling enabled was actually being served as deterministic greedy decoding.

## Testing

I was not able to build or run this change: I don't have access to a CUDA/HIP toolchain/GPU to compile `dflash_server` or exercise `harness/`. This fix was produced and verified by close reading of the existing code paths only:
- Confirmed both branches of `hybrid_forward_one_token()` already compute full logits locally before this change (`_sg_logits` in the single-graph path, `logits_buf` in the per-layer fallback), so no new computation is introduced — just exposing what was already being thrown away.
- Confirmed the `pick()` / `sample_logits()` pattern used in the fix already exists and is exercised elsewhere in the same file for the non-hybrid decode loops, so this reuses a known-working code path rather than adding new sampling logic.
- Checked that `out_logits` is never written on any early-failure return in either branch, so the caller only reads `step_logits` after a successful call, and only when `req.do_sample` requested it.

Given the lack of hardware to validate end-to-end, it would be good for someone with a Laguna-hybrid-capable GPU to sanity check that sampling now actually varies output across repeated identical requests with `do_sample=true` (e.g. via `harness/clients/`), before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

