### PR TITLE
fix(laguna): guard prefix-cache restore against hybrid MoE-offload mode

### DIFF
--- a/server/src/laguna/laguna_backend.cpp
+++ b/server/src/laguna/laguna_backend.cpp
@@ -451,6 +451,12 @@ bool LagunaBackend::ensure_slot(int slot) {
 }
 
 bool LagunaBackend::snapshot_save(int slot) {
+    // hybrid MoE-offload mode never loads expert tensors into w_ (see the
+    // hybrid_mode_ check in restore_and_generate_impl below), so a snapshot
+    // saved here could never be restored correctly. Skip the save instead of
+    // paying for a CPU-resident copy that restore_and_generate_impl will
+    // just refuse later.
+    if (hybrid_mode_) return false;
     // kvflash: snapshots copy rows assuming identity layout, which breaks
     // after the first page-out relocates a chunk. [TAG_SWA_RING] ring-cached
     // SWA layers hold only the trailing window, so prefix snapshots are
@@ -1572,6 +1578,22 @@ GenerateResult LagunaBackend::restore_and_generate_impl(int slot,
     DaemonIO out_io = io.with_token_callback(req.on_token);
     if (out_io.is_cancelled()) {
         result.succeed();
+        return result;
+    }
+    // Prefix-cache restore always decodes through laguna_step(), which builds
+    // its graph with gi.hybrid = nullptr and so reads expert weights straight
+    // out of `w_`. In hybrid MoE-offload mode w_ never has them: init_hybrid_mode()
+    // loads with skip_expert_tensors=true and keeps experts only in moe_hybrid_'s
+    // hot/cold storage (see laguna_target_loader.cpp). generate_impl() avoids this
+    // by routing hybrid-mode requests to generate_hybrid() instead, but the
+    // generic HTTP/prefix-cache path (finalize_generation_cache -> snapshot_save,
+    // later restore_and_generate -> here) has no knowledge of hybrid_mode_ and
+    // will call this path for any backend. Fail clearly instead of building a
+    // graph against missing expert tensors.
+    if (hybrid_mode_) {
+        result.fail(GenerateErrorCode::BackendSpecific,
+                    "snapshot restore is not supported for a Laguna model "
+                    "loaded in hybrid MoE-offload mode");
         return result;
     }
     sampler_ = req.sampler;


### PR DESCRIPTION
## Summary

- The recently-merged prefix-cache/snapshot-restore feature is wired generically in `http_server.cpp` against the abstract `ModelBackend` interface (`finalize_generation_cache` → `ModelBackend::snapshot_save`, later `ModelBackend::restore_and_generate` → `restore_and_generate_impl`), with no per-backend awareness of any backend's internal state.
- `LagunaBackend::restore_and_generate_impl()` always decodes the restored diff through `laguna_step()`, which builds its ggml graph with `gi.hybrid = nullptr` (confirmed by reading `laguna_step`'s body in `laguna_target_graph.cpp`, roughly lines 1296-2108, ending right before the separate `laguna_step_hybrid` starts at line 2109) and therefore reads expert FFN weights straight out of `w_`.
- When a Laguna model is loaded **without** a draft path, `init_hybrid_mode()` may partial-load the target GGUF with `skip_expert_tensors = true` (`laguna_target_loader.cpp:109`: `if (plan.skip_expert_tensors && is_laguna_expert_tensor(name)) return false;`) and keep expert weights only in `moe_hybrid_`'s hot/cold storage, setting `hybrid_mode_ = true`. In that state, `w_` has **no** per-layer expert tensors for `laguna_step()` to read.
- `generate_impl()` already knows about this split — it routes hybrid-mode requests to `generate_hybrid()` instead (the function fixed for `do_sample`/seeding in #726). `restore_and_generate_impl()` has no equivalent check, so a snapshot-restore request against a hybrid-mode Laguna backend would build a decode graph against expert tensors that were never loaded.

## Fix

- Added an explicit `hybrid_mode_` guard at the top of `restore_and_generate_impl()` that fails the request cleanly with `GenerateErrorCode::BackendSpecific` instead of proceeding into `laguna_step()`.
- Added the same guard to `snapshot_save()`: a snapshot taken while `hybrid_mode_` is true could never be restored correctly anyway, so there's no reason to pay for the CPU-resident copy. This mirrors the existing early-bail pattern already in that function for the kvflash-incompatible case right below it.
- The guard in `restore_and_generate_impl()` covers every path that could reach it (a snapshot saved by this same backend instance, or one adopted from a disk-staged/cross-process snapshot via `snapshot_adopt`), since it checks the *restoring* instance's own `hybrid_mode_`, not how the slot was populated.

## Why I'm confident this is real

- Traced the invariant end-to-end: every place that sets `hybrid_mode_ = true` (`laguna_backend.cpp:2097`, `:2122`) is reached only after a partial load with `skip_expert_tensors = true`; the one place that reloads full weights into `w_` (`:2061-2069`, "all experts fit in VRAM, loading fully to GPU") returns before ever setting `hybrid_mode_ = true`, and the two places that flip it back to `false` (`:166`, `:393`) both do a full `load_target_gguf_laguna` first. So `hybrid_mode_ == true` reliably implies `w_` lacks expert tensors.
- Confirmed no backend-level capability flag (`supports_kvflash()`, etc.) lets a backend opt out of the prefix-cache path, and `http_server.cpp` calls `backend_.snapshot_save(...)` / `backend_.restore_and_generate(...)` generically for any backend — nothing upstream is hybrid-mode-aware.
- No existing test exercises this combination (grepped `server/test` and `server/tests` for `restore_and_generate`/`hybrid_mode_` together with Laguna — no hits), consistent with this being a real, previously-unexercised gap rather than something already guarded elsewhere.

## Testing

As with #726, I could not build or run this — no CUDA/HIP toolchain/GPU available, verification is by code reading only (traced the tensor-loading invariant and the graph-building code path as described above). This is a pure early-return guard with no change to any code path that isn't hybrid-mode, so the blast radius on working configurations should be zero, but I'd appreciate a maintainer with a Laguna hybrid-offload setup confirming (a) a restore attempt against a hybrid-mode backend now fails cleanly instead of crashing/misbehaving, and (b) non-hybrid Laguna snapshot/restore is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox/pull/727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

